### PR TITLE
API view for new courses

### DIFF
--- a/fixtures/__init__.py
+++ b/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""fixtures module"""

--- a/fixtures/common.py
+++ b/fixtures/common.py
@@ -1,0 +1,10 @@
+""" Common fixtures for ocw-studio """
+import pytest
+
+from rest_framework.test import APIClient
+
+
+@pytest.fixture
+def drf_client():
+    """DRF API anonymous test client"""
+    return APIClient()

--- a/main/constants.py
+++ b/main/constants.py
@@ -1,0 +1,3 @@
+""" Constants for ocw-studio """
+
+ISO_8601_FORMAT = "%Y-%m-%dT%H:%M:%SZ"

--- a/main/permissions.py
+++ b/main/permissions.py
@@ -1,0 +1,23 @@
+"""Custom permissions"""
+from rest_framework import permissions
+
+
+def is_readonly(request):
+    """
+    Returns True if the request uses a readonly verb
+
+    Args:
+        request (HTTPRequest): A request
+
+    Returns:
+        bool: True if the request method is readonly
+    """
+    return request.method in permissions.SAFE_METHODS
+
+
+class ReadonlyPermission(permissions.BasePermission):
+    """Allows read-only requests through for any user"""
+
+    def has_permission(self, request, view):
+        """Return true if the request is read-only"""
+        return request.method in permissions.SAFE_METHODS

--- a/main/permissions_test.py
+++ b/main/permissions_test.py
@@ -10,7 +10,7 @@ from main.permissions import ReadonlyPermission
     "method,result",
     [("GET", True), ("HEAD", True), ("OPTIONS", True), ("POST", False), ("PUT", False)],
 )
-def test_anonymous_readonly(method, result, mocker):
+def test_anonymous_readonly(mocker, method, result):
     """
     Test that anonymous users are allowed for readonly verbs
     """

--- a/main/permissions_test.py
+++ b/main/permissions_test.py
@@ -1,0 +1,19 @@
+"""Tests for permissions"""
+import pytest
+
+from django.contrib.auth.models import AnonymousUser
+
+from main.permissions import ReadonlyPermission
+
+
+@pytest.mark.parametrize(
+    "method,result",
+    [("GET", True), ("HEAD", True), ("OPTIONS", True), ("POST", False), ("PUT", False)],
+)
+def test_anonymous_readonly(method, result, mocker):
+    """
+    Test that anonymous users are allowed for readonly verbs
+    """
+    perm = ReadonlyPermission()
+    request = mocker.Mock(user=AnonymousUser(), method=method)
+    assert perm.has_permission(request, mocker.Mock()) is result

--- a/main/settings.py
+++ b/main/settings.py
@@ -83,6 +83,7 @@ INSTALLED_APPS = (
     "django.contrib.sites",
     "server_status",
     # django-robots
+    "rest_framework",
     "robots",
     # Put our apps after this point
     "main",
@@ -416,3 +417,11 @@ MANDATORY_SETTINGS = [
     "MAILGUN_KEY",
     "SECRET_KEY",
 ]
+
+REST_FRAMEWORK = {
+    "DEFAULT_PERMISSION_CLASSES": ("rest_framework.permissions.IsAuthenticated",),
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        "rest_framework.authentication.SessionAuthentication",
+    ),
+    "TEST_REQUEST_DEFAULT_FORMAT": "json",
+}

--- a/main/urls.py
+++ b/main/urls.py
@@ -14,10 +14,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.conf import settings
-from django.conf.urls import include
+from django.conf.urls import include, url
 from django.contrib import admin
 from django.urls import path
-
 from main.views import index
 
 
@@ -35,4 +34,5 @@ if settings.DEBUG:
 
     urlpatterns += [
         path("__debug__/", include(debug_toolbar.urls)),
+        url(r"", include("websites.urls")),
     ]

--- a/main/urls.py
+++ b/main/urls.py
@@ -27,6 +27,7 @@ urlpatterns = [
     # Example view
     path("", index, name="main-index"),
     path("", include("news.urls")),
+    path("", include("websites.urls")),
 ]
 
 if settings.DEBUG:
@@ -34,5 +35,4 @@ if settings.DEBUG:
 
     urlpatterns += [
         path("__debug__/", include(debug_toolbar.urls)),
-        url(r"", include("websites.urls")),
     ]

--- a/main/urls.py
+++ b/main/urls.py
@@ -14,7 +14,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.conf import settings
-from django.conf.urls import include, url
+from django.conf.urls import include
 from django.contrib import admin
 from django.urls import path
 from main.views import index

--- a/requirements.in
+++ b/requirements.in
@@ -4,6 +4,7 @@ boto3
 celery
 dj-database-url
 django-redis
+djangorestframework==3.12.2
 django-robots
 django-server-status
 django-webpack-loader

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,8 @@ django-redis==4.12.1      # via -r requirements.in
 django-robots==4.0        # via -r requirements.in
 django-server-status==0.6.0  # via -r requirements.in
 django-webpack-loader==0.7.0  # via -r requirements.in
-django==3.1               # via -r requirements.in, django-redis
+django==3.1               # via -r requirements.in, django-redis, djangorestframework
+djangorestframework==3.12.2  # via -r requirements.in
 elasticsearch==7.8.1      # via django-server-status
 factory-boy==3.0.1        # via -r requirements.in
 faker==4.1.2              # via -r requirements.in, factory-boy

--- a/websites/factories.py
+++ b/websites/factories.py
@@ -13,7 +13,6 @@ class WebsiteFactory(DjangoModelFactory):
 
     title = FuzzyText()
     url_path = factory.Faker("uri_path")
-    uuid = factory.Faker("uuid4")
     type = FuzzyChoice((WEBSITE_TYPE_COURSE, "other"))
 
     metadata = factory.Faker("json")
@@ -21,10 +20,10 @@ class WebsiteFactory(DjangoModelFactory):
 
     class Meta:
         model = Website
-        django_get_or_create = ("type",)
 
     class Params:
         is_course = factory.Trait(type=WEBSITE_TYPE_COURSE)
+        not_course = factory.Trait(type="other")
         published = factory.Trait(
             publish_date=factory.Faker("past_datetime", tzinfo=pytz.utc)
         )

--- a/websites/factories.py
+++ b/websites/factories.py
@@ -2,7 +2,7 @@
 import pytz
 import factory
 from factory.django import DjangoModelFactory
-from factory.fuzzy import FuzzyChoice, FuzzyText
+from factory.fuzzy import FuzzyChoice
 
 from websites.constants import WEBSITE_TYPE_COURSE
 from websites.models import Website
@@ -11,8 +11,8 @@ from websites.models import Website
 class WebsiteFactory(DjangoModelFactory):
     """Factory for WebsiteFactory"""
 
-    title = FuzzyText()
-    url_path = factory.Faker("uri_path")
+    title = factory.Sequence(lambda n: "OCW Course %s" % n)
+    url_path = factory.Sequence(lambda n: "/ocw_site_x/%s" % n)
     type = FuzzyChoice((WEBSITE_TYPE_COURSE, "other"))
 
     metadata = factory.Faker("json")

--- a/websites/factories.py
+++ b/websites/factories.py
@@ -1,0 +1,34 @@
+""" Factories for websites """
+import pytz
+import factory
+from factory.django import DjangoModelFactory
+from factory.fuzzy import FuzzyChoice, FuzzyText
+
+from websites.constants import WEBSITE_TYPE_COURSE
+from websites.models import Website
+
+
+class WebsiteFactory(DjangoModelFactory):
+    """Factory for WebsiteFactory"""
+
+    title = FuzzyText()
+    url_path = factory.Faker("uri_path")
+    uuid = factory.Faker("uuid4")
+    type = FuzzyChoice((WEBSITE_TYPE_COURSE, "other"))
+
+    metadata = factory.Faker("json")
+    publish_date = factory.Faker("date_time", tzinfo=pytz.utc)
+
+    class Meta:
+        model = Website
+        django_get_or_create = ("type",)
+
+    class Params:
+        is_course = factory.Trait(type=WEBSITE_TYPE_COURSE)
+        published = factory.Trait(
+            publish_date=factory.Faker("past_datetime", tzinfo=pytz.utc)
+        )
+        unpublished = factory.Trait(publish_date=None)
+        future_publish = factory.Trait(
+            publish_date=factory.Faker("future_datetime", tzinfo=pytz.utc)
+        )

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -1,0 +1,12 @@
+""" Serializers for websites """
+from rest_framework import serializers
+
+from websites.models import Website
+
+
+class WebsiteSerializer(serializers.ModelSerializer):
+    """ Serializer for websites """
+
+    class Meta:
+        model = Website
+        fields = "__all__"

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -15,5 +15,7 @@ def test_serialize_website_course():
     serializer = WebsiteSerializer(course)
     assert serializer.data["type"] == WEBSITE_TYPE_COURSE
     assert serializer.data["url_path"] == course.url_path
-    # assert serializer.data["publish_date"] == course.publish_date
+    assert serializer.data["publish_date"] == course.publish_date.strftime(
+        "%Y-%m-%dT%H:%M:%SZ"
+    )
     assert serializer.data["metadata"] == course.metadata

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -1,0 +1,19 @@
+""" Tests for websites.serializers """
+import pytest
+
+from websites.constants import WEBSITE_TYPE_COURSE
+from websites.factories import WebsiteFactory
+from websites.serializers import WebsiteSerializer
+
+
+@pytest.mark.django_db
+def test_serialize_website_course():
+    """
+    Verify that a serialized website course contains expected fields
+    """
+    course = WebsiteFactory(is_course=True)
+    serializer = WebsiteSerializer(course)
+    assert serializer.data["type"] == WEBSITE_TYPE_COURSE
+    assert serializer.data["url_path"] == course.url_path
+    # assert serializer.data["publish_date"] == course.publish_date
+    assert serializer.data["metadata"] == course.metadata

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -1,6 +1,7 @@
 """ Tests for websites.serializers """
 import pytest
 
+from main.constants import ISO_8601_FORMAT
 from websites.constants import WEBSITE_TYPE_COURSE
 from websites.factories import WebsiteFactory
 from websites.serializers import WebsiteSerializer
@@ -16,6 +17,6 @@ def test_serialize_website_course():
     assert serializer.data["type"] == WEBSITE_TYPE_COURSE
     assert serializer.data["url_path"] == course.url_path
     assert serializer.data["publish_date"] == course.publish_date.strftime(
-        "%Y-%m-%dT%H:%M:%SZ"
+        ISO_8601_FORMAT
     )
     assert serializer.data["metadata"] == course.metadata

--- a/websites/urls.py
+++ b/websites/urls.py
@@ -2,13 +2,13 @@
 """
 from django.conf.urls import url
 from django.urls import include
-from rest_framework.routers import DefaultRouter
+from rest_framework.routers import SimpleRouter
 
 from websites import views
 
-router = DefaultRouter()
+router = SimpleRouter()
 
-router.register(r"websites", views.WebsiteViewSet, basename="websites")
+router.register(r"websites", views.WebsiteViewSet, basename="websites_api")
 
 urlpatterns = [
     url(r"^api/", include(router.urls)),

--- a/websites/urls.py
+++ b/websites/urls.py
@@ -1,0 +1,15 @@
+""" websites URL Configuration
+"""
+from django.conf.urls import url
+from django.urls import include
+from rest_framework.routers import DefaultRouter
+
+from websites import views
+
+router = DefaultRouter()
+
+router.register(r"websites", views.WebsiteViewSet, basename="websites")
+
+urlpatterns = [
+    url(r"^api/", include(router.urls)),
+]

--- a/websites/views.py
+++ b/websites/views.py
@@ -1,11 +1,9 @@
 """ Views for websites """
 from rest_framework import viewsets, mixins
-from rest_framework.decorators import action
 from rest_framework.pagination import LimitOffsetPagination
 
 from main.permissions import ReadonlyPermission
 from main.utils import now_in_utc
-from websites.constants import WEBSITE_TYPE_COURSE
 from websites.models import Website
 from websites.serializers import WebsiteSerializer
 
@@ -22,7 +20,8 @@ class DefaultPagination(LimitOffsetPagination):
 class WebsiteViewSet(
     mixins.ListModelMixin,
     mixins.CreateModelMixin,
-    viewsets.GenericViewSet,):
+    viewsets.GenericViewSet,
+):
     """
     Viewset for Websites
     """
@@ -31,25 +30,13 @@ class WebsiteViewSet(
     pagination_class = DefaultPagination
     permission_classes = (ReadonlyPermission,)
 
-    def _get_base_queryset(self, *args, **kwargs):
-        """Return the base queryset for all actions & exclude unpublished sites"""
-        return Website.objects.filter(
-            *args,
-            **kwargs,
-            publish_date__lte=now_in_utc(),
-        )
-
     def get_queryset(self):
-        """Generate a QuerySet for fetching valid courses"""
-        return self._get_base_queryset()
-
-    @action(methods=["GET"], detail=False, url_path=r"courses/new")
-    def new_courses(self, request):
-        """
-        Get new courses
-        """
-        page = self.paginate_queryset(
-            self._get_base_queryset(type=WEBSITE_TYPE_COURSE).order_by("-publish_date")
-        )
-        serializer = self.get_serializer(page, many=True)
-        return self.get_paginated_response(serializer.data)
+        """ Generate a QuerySet for fetching published websites """
+        ordering = self.request.query_params.get("sort", "-publish_date")
+        website_type = self.request.query_params.get("type", None)
+        queryset = Website.objects.filter(
+            publish_date__lte=now_in_utc(),
+        ).order_by(ordering)
+        if website_type is not None:
+            queryset = queryset.filter(type=website_type)
+        return queryset

--- a/websites/views.py
+++ b/websites/views.py
@@ -1,0 +1,52 @@
+""" Views for websites """
+from rest_framework import viewsets
+from rest_framework.decorators import action
+from rest_framework.pagination import LimitOffsetPagination
+
+from main.permissions import ReadonlyPermission
+from main.utils import now_in_utc
+from websites.constants import WEBSITE_TYPE_COURSE
+from websites.models import Website
+from websites.serializers import WebsiteSerializer
+
+
+class DefaultPagination(LimitOffsetPagination):
+    """
+    Pagination class for websites viewsets
+    """
+
+    default_limit = 10
+    max_limit = 100
+
+
+class WebsiteViewSet(viewsets.ReadOnlyModelViewSet):
+    """
+    Viewset for Websites
+    """
+
+    serializer_class = WebsiteSerializer
+    pagination_class = DefaultPagination
+    permission_classes = (ReadonlyPermission,)
+
+    def _get_base_queryset(self, *args, **kwargs):
+        """Return the base queryset for all actions & exclude unpublished sites"""
+        return Website.objects.filter(
+            *args,
+            **kwargs,
+            publish_date__lte=now_in_utc(),
+        )
+
+    def get_queryset(self):
+        """Generate a QuerySet for fetching valid courses"""
+        return self._get_base_queryset()
+
+    @action(methods=["GET"], detail=False, url_path=r"courses/new")
+    def new_courses(self, request):
+        """
+        Get new courses
+        """
+        page = self.paginate_queryset(
+            self._get_base_queryset(type=WEBSITE_TYPE_COURSE).order_by("-publish_date")
+        )
+        serializer = self.get_serializer(page, many=True)
+        return self.get_paginated_response(serializer.data)

--- a/websites/views.py
+++ b/websites/views.py
@@ -1,5 +1,5 @@
 """ Views for websites """
-from rest_framework import viewsets
+from rest_framework import viewsets, mixins
 from rest_framework.decorators import action
 from rest_framework.pagination import LimitOffsetPagination
 
@@ -19,7 +19,10 @@ class DefaultPagination(LimitOffsetPagination):
     max_limit = 100
 
 
-class WebsiteViewSet(viewsets.ReadOnlyModelViewSet):
+class WebsiteViewSet(
+    mixins.ListModelMixin,
+    mixins.CreateModelMixin,
+    viewsets.GenericViewSet,):
     """
     Viewset for Websites
     """

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -1,0 +1,31 @@
+""" Tests for websites views """
+import pytest
+from django.urls import reverse
+
+from main.utils import now_in_utc
+from websites.factories import WebsiteFactory
+from fixtures.common import drf_client  # pylint: disable=unused-import
+
+# pylint:disable=redefined-outer-name
+
+
+@pytest.mark.django_db
+def test_new_courses_endpoint(drf_client):
+    """Test new course websites endpoint"""
+    new_courses = sorted(
+        WebsiteFactory.create_batch(3, published=True, is_course=True),
+        reverse=True,
+        key=lambda course: course.publish_date,
+    )
+    now = now_in_utc()
+
+    # These should not be returned
+    WebsiteFactory.create(is_published=True, is_course=True)
+    WebsiteFactory.create(future_publish=True, is_course=True)
+    WebsiteFactory.create(published=True, is_course=False)
+
+    resp = drf_client.get(reverse("websites-list") + "courses/new/")
+    assert resp.data.get("count") == 3
+    for idx, course in enumerate(new_courses):
+        assert resp.data.get("results")[idx]["uuid"] == course.uuid
+        assert resp.data.get("results")[idx]["publish_date"] <= now

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -3,6 +3,7 @@ import pytest
 from django.urls import reverse
 
 from main.utils import now_in_utc
+from websites.constants import WEBSITE_TYPE_COURSE
 from websites.factories import WebsiteFactory
 from fixtures.common import drf_client  # pylint: disable=unused-import
 
@@ -20,12 +21,13 @@ def test_new_courses_endpoint(drf_client):
     now = now_in_utc()
 
     # These should not be returned
-    WebsiteFactory.create(is_published=True, is_course=True)
+    WebsiteFactory.create(unpublished=True, is_course=True)
     WebsiteFactory.create(future_publish=True, is_course=True)
-    WebsiteFactory.create(published=True, is_course=False)
+    WebsiteFactory.create(published=True, not_course=True)
 
-    resp = drf_client.get(reverse("websites-list") + "courses/new/")
+    resp = drf_client.get(reverse("websites_api-list") + "courses/new/")
     assert resp.data.get("count") == 3
     for idx, course in enumerate(new_courses):
-        assert resp.data.get("results")[idx]["uuid"] == course.uuid
-        assert resp.data.get("results")[idx]["publish_date"] <= now
+        assert resp.data.get("results")[idx]["uuid"] == str(course.uuid)
+        assert resp.data.get("results")[idx]["type"] == WEBSITE_TYPE_COURSE
+        assert resp.data.get("results")[idx]["publish_date"] <= now.strftime("%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

Closes #19 

#### What's this PR do?

Creates a DRF API view for getting the newest published course websites.

#### How should this be manually tested?
- You'll need to import the OCW courses first (`manage.py backpopulate_ocw_courses`), I can send you the AWS credentials and S3 bucket.  It can take awhile to do the whole thing so you can interrupt it after a few have been imported.
- Go to `http://localhost:8043/api/websites/courses/new/`, you should get a list of the most recently published `Website` objects of type 'course'

