### PR TITLE
Move render_bundle_test.py out of the templatetags folder

### DIFF
--- a/main/render_bundle_test.py
+++ b/main/render_bundle_test.py
@@ -1,5 +1,5 @@
 """
-Tests for render_bundle
+Tests for main.templatetags.render_bundle
 """
 from django.test.client import RequestFactory
 import pytest


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

N/A

#### What's this PR do?

Moves `render_bundle_test.py` out of the `templatetags` folder to avoid errors on heroku deployment

#### How should this be manually tested?
Tests should pass


