### PR TITLE
backpopulate_ocw_courses command modifications

### DIFF
--- a/test_hugo2ocw/output/content/courses/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/sections/syllabus.md
+++ b/test_hugo2ocw/output/content/courses/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/sections/syllabus.md
@@ -5,7 +5,7 @@ type: course
 layout: course_section
 menu:
   1-201j-transportation-systems-analysis-demand-and-economics-fall-2008:
-    identifier: 4bb2e8f1277b108211e3471c42e948f3
+    identifier: ''
     name: Syllabus
     weight: 10
 ---

--- a/websites/api_test.py
+++ b/websites/api_test.py
@@ -53,3 +53,49 @@ def test_import_ocw2hugo_course(settings):
         lecture_pdf.hugo_filepath
         == "content/courses/1-050-engineering-mechanics-i-fall-2007/sections/lecture-notes/lec1.md"
     )
+
+
+@mock_s3
+@pytest.mark.django_db
+def test_import_ocw2hugo_course_bad_date(mocker, settings):
+    """ Website publish date should be null if the JSON date can't be parsed """
+    setup_s3(settings)
+    url_path = "1-050-engineering-mechanics-i-fall-2007"
+    s3_key = f"{TEST_OCW2HUGO_PREFIX}data/courses/{url_path}.json"
+    mocker.patch(
+        "websites.api.dateparser.parse", side_effect=["2021-01-01", ValueError()]
+    )
+    import_ocw2hugo_course(MOCK_BUCKET_NAME, TEST_OCW2HUGO_PREFIX, s3_key)
+    website = Website.objects.get(url_path=url_path)
+    assert website.publish_date is None
+
+
+@mock_s3
+@pytest.mark.django_db
+def test_import_ocw2hugo_course_log_exception(mocker, settings):
+    """ Log an exception if the website cannot be saved/updated """
+    setup_s3(settings)
+    url_path = "1-050-engineering-mechanics-i-fall-2007"
+    s3_key = f"{TEST_OCW2HUGO_PREFIX}data/courses/{url_path}.json"
+    mocker.patch("websites.api.dateparser.parse", return_value="Invalid date")
+    mock_log = mocker.patch("websites.api.log.exception")
+    import_ocw2hugo_course(MOCK_BUCKET_NAME, TEST_OCW2HUGO_PREFIX, s3_key)
+    assert Website.objects.filter(url_path=url_path).first() is None
+    mock_log.assert_called_once_with("Error saving website %s", s3_key)
+
+
+@mock_s3
+@pytest.mark.django_db
+def test_import_ocw2hugo_content_log_exception(mocker, settings):
+    """ Log an exception if the website content cannot be saved/updated """
+    setup_s3(settings)
+    url_path = "1-201j-transportation-systems-analysis-demand-and-economics-fall-2008"
+    s3_key = f"{TEST_OCW2HUGO_PREFIX}data/courses/{url_path}.json"
+    mocker.patch("websites.api.uuid4", return_value="Invalid uuid")
+    mock_log = mocker.patch("websites.api.log.exception")
+    import_ocw2hugo_course(MOCK_BUCKET_NAME, TEST_OCW2HUGO_PREFIX, s3_key)
+    assert mock_log.call_count == 1
+    mock_log.assert_called_once_with(
+        "Error saving WebsiteContent for %s",
+        f"{TEST_OCW2HUGO_PREFIX}content/courses/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/sections/syllabus.md",
+    )


### PR DESCRIPTION
Closes #25 

- Adds try-catch blocks around typical failure points and logs the error
- Treats invalid dates as null dates (https://github.com/mitodl/ocw-data-parser/pull/121)