### PR TITLE
Added params to backpopulate_ocw_courses command

### DIFF
--- a/websites/api.py
+++ b/websites/api.py
@@ -15,6 +15,29 @@ from websites.models import Website, WebsiteContent
 log = logging.getLogger(__name__)
 
 
+def fetch_ocw2hugo_course_paths(bucket_name, prefix="", filter_str=""):
+    """
+    Generator that yields the path to every course JSON document in the S3 bucket matching
+    a prefix and filter (or all of them if no prefix or filter is provided)
+
+    Args:
+        bucket_name (str): S3 bucket name
+        prefix (str): (Optional) S3 prefix before start of course_id path
+        filter_str (str): (Optional) If specified, only yield course paths containing this string
+
+    Yields:
+        str: The path to a course JSON document in S3
+    """
+    s3 = get_s3_resource()
+    bucket = s3.Bucket(bucket_name)
+    paginator = bucket.meta.client.get_paginator("list_objects")
+    for resp in paginator.paginate(Bucket=bucket.name, Prefix=f"{prefix}data/courses/"):
+        for obj in resp["Contents"]:
+            key = obj["Key"]
+            if key.endswith(".json") and (not filter_str or filter_str in key):
+                yield key
+
+
 def import_ocw2hugo_content(bucket, prefix, website):  # pylint:disable=too-many-locals
     """
     Import all content files for an ocw course from hugo2ocw output
@@ -89,7 +112,7 @@ def import_ocw2hugo_course(bucket_name, prefix, key):
     Extract OCW course content for a course
 
     Args:
-        bucket (s3.Bucket): An s3 bucket
+        bucket_name (str): An s3 bucket name
         prefix (str): S3 prefix before start of course_id path
         key (str): The S3 prefix for the course homepage.
     """

--- a/websites/management/commands/backpopulate_ocw_courses.py
+++ b/websites/management/commands/backpopulate_ocw_courses.py
@@ -1,7 +1,10 @@
 """ Backpopulate OCW courses and content via ocw2hugo output """
+import pydoc
+
 from django.core.management import BaseCommand
 
 from main.utils import now_in_utc
+from websites.api import fetch_ocw2hugo_course_paths
 from websites.tasks import import_ocw2hugo_courses
 
 
@@ -33,17 +36,45 @@ class Command(BaseCommand):
             type=int,
             help="Number of courses to process per celery task (default 250)",
         )
+        parser.add_argument(
+            "-l",
+            "--list",
+            dest="list",
+            action="store_true",
+            help="List the course paths instead of importing them",
+        )
+        parser.add_argument(
+            "--filter",
+            dest="filter",
+            default="",
+            help="If specified, only import courses that contain this filter text",
+        )
         super().add_arguments(parser)
 
     def handle(self, *args, **options):
-        self.stdout.write("Importing OCW courses from ocw2hugo bucket")
         prefix = options["prefix"]
         if prefix:
             # make sure it ends with a '/'
             prefix = prefix.rstrip("/") + "/"
+        bucket_name = options["bucket"]
+        filter_str = options["filter"]
+
+        if options["list"] is True:
+            course_paths = list(
+                fetch_ocw2hugo_course_paths(
+                    bucket_name, prefix=prefix, filter_str=filter_str
+                )
+            )
+            pydoc.pager("\n".join(course_paths))
+            return
+
+        self.stdout.write(f"Importing OCW courses from '{bucket_name}' bucket")
         start = now_in_utc()
         task = import_ocw2hugo_courses.delay(
-            prefix=prefix, bucket=options["bucket"], chunk_size=options["chunks"]
+            bucket_name=bucket_name,
+            prefix=prefix,
+            filter_str=filter_str,
+            chunk_size=options["chunks"],
         )
         task.get()
         total_seconds = (now_in_utc() - start).total_seconds()

--- a/websites/tasks_test.py
+++ b/websites/tasks_test.py
@@ -32,7 +32,9 @@ def test_import_ocw2hugo_courses(
     mock_import_paths = mocker.patch("websites.tasks.import_ocw2hugo_course_paths.si")
     with pytest.raises(mocked_celery.replace_exception_class):
         import_ocw2hugo_courses.delay(
-            bucket=MOCK_BUCKET_NAME, prefix=TEST_OCW2HUGO_PREFIX, chunk_size=chunk_size
+            bucket_name=MOCK_BUCKET_NAME,
+            prefix=TEST_OCW2HUGO_PREFIX,
+            chunk_size=chunk_size,
         )
     assert mock_import_paths.call_count == call_count
 
@@ -42,6 +44,6 @@ def test_import_ocw2hugo_courses_nobucket(mocker):
     mock_import_paths = mocker.patch("websites.tasks.import_ocw2hugo_course_paths.si")
     with pytest.raises(TypeError):
         import_ocw2hugo_courses.delay(  # pylint:disable=no-value-for-parameter
-            bucket=None, prefix=TEST_OCW2HUGO_PREFIX, chunk_size=100
+            bucket_name=None, prefix=TEST_OCW2HUGO_PREFIX, chunk_size=100
         )
     assert mock_import_paths.call_count == 0

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -52,6 +52,8 @@ def test_websites_endpoint(drf_client, website_type, websites):
 
 def test_websites_endpoint_sorting(drf_client, websites):
     """ Response should be sorted according to query parameter """
-    resp = drf_client.get(reverse("websites_api-list"), {"sort": "title", "type": WEBSITE_TYPE_COURSE})
+    resp = drf_client.get(
+        reverse("websites_api-list"), {"sort": "title", "type": WEBSITE_TYPE_COURSE}
+    )
     for idx, course in enumerate(sorted(websites.courses, key=lambda site: site.title)):
         assert resp.data.get("results")[idx]["uuid"] == str(course.uuid)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
Adds params to the `backpopulate_ocw_courses` command that allow you to (a) list the course paths instead of importing them, and (b) import specific course paths that match a given filter

#### How should this be manually tested?
Try commands like these:
```bash
backpopulate_ocw_courses -b ocw-to-hugo-output-qa --list --filter "esd-7"
backpopulate_ocw_courses -b ocw-to-hugo-output-qa --list --filter data/courses/esd-71-engineering-systems-analysis-for-design-fall-2008.json
backpopulate_ocw_courses -b ocw-to-hugo-output-qa --filter data/courses/esd-71-engineering-systems-analysis-for-design-fall-2008.json
```

#### Screenshots (if appropriate)
![ss 2021-01-20 at 17 42 44 ](https://user-images.githubusercontent.com/14932219/105250143-3f6f5a80-5b47-11eb-98ec-b0253d5ce706.png)

