### PR TITLE
Fix black formatting check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,3 @@
----
-labels: "Work in Progress"
-name: "Pull Request"
-about: "Regular Pull Request"
----
-
 #### Pre-Flight checklist
 
 - [ ] Screenshots and design review for any changes that affect layout or styling

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           PYTHONPATH: "."
 
       - name: Black
-        run: black .
+        run: black --check .
 
       # Configurations required for elasticsearch.
       - name: Configure sysctl limits

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -52,6 +52,8 @@ def test_websites_endpoint(drf_client, website_type, websites):
 
 def test_websites_endpoint_sorting(drf_client, websites):
     """ Response should be sorted according to query parameter """
-    resp = drf_client.get(reverse("websites_api-list"), {"sort": "title", "type": WEBSITE_TYPE_COURSE})
+    resp = drf_client.get(
+        reverse("websites_api-list"), {"sort": "title", "type": WEBSITE_TYPE_COURSE}
+    )
     for idx, course in enumerate(sorted(websites.courses, key=lambda site: site.title)):
         assert resp.data.get("results")[idx]["uuid"] == str(course.uuid)


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
CI hasn't been running black formatting checks correctly. It used `black .` which did the reformatting rather than `black --check .` which errors when the formatting is not correct. I also made a quick fix to the pull request template.

#### How should this be manually tested?
Tests should pass