### PR TITLE
Added website starter API endpoints and feature flag

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -6,3 +6,27 @@ import pytest
 def default_settings(settings):
     """Set default settings for all tests"""
     settings.DISABLE_WEBPACK_LOADER_STATS = True
+
+
+def pytest_addoption(parser):
+    """Pytest hook that adds command line parameters"""
+    parser.addoption(
+        "--simple",
+        action="store_true",
+        help="Run tests only (no cov, warning output silenced)",
+    )
+
+
+def pytest_configure(config):
+    """Pytest hook to perform some initial configuration"""
+    if getattr(config.option, "simple") is True:
+        # NOTE: These plugins are already configured by the time the pytest_cmdline_main hook is run, so we can't
+        #       simply add/alter the command line options in that hook. This hook is being used to
+        #       reconfigure/unregister plugins that we can't change via the pytest_cmdline_main hook.
+        # Switch off coverage plugin
+        cov = config.pluginmanager.get_plugin("_cov")
+        cov.options.no_cov = True
+        # Remove warnings plugin to suppress warnings
+        if config.pluginmanager.has_plugin("warnings"):
+            warnings_plugin = config.pluginmanager.get_plugin("warnings")
+            config.pluginmanager.unregister(warnings_plugin)

--- a/main/features.py
+++ b/main/features.py
@@ -1,0 +1,44 @@
+"""OCW Studio feature flags"""
+from functools import wraps
+from django.conf import settings
+
+USE_LOCAL_STARTERS = "USE_LOCAL_STARTERS"
+
+
+def is_enabled(name, default=None):
+    """
+    Returns True if the feature flag is enabled
+
+    Args:
+        name (str): feature flag name
+        default (bool): default value if not set in settings
+
+    Returns:
+        bool: True if the feature flag is enabled
+    """
+    return settings.FEATURES.get(name, default or settings.FEATURES_DEFAULT)
+
+
+def if_feature_enabled(name, default=None):
+    """
+    Wrapper that results in a no-op if the given feature isn't enabled, and otherwise
+    runs the wrapped function as normal.
+
+    Args:
+        name (str): Feature flag name
+        default (bool): default value if not set in settings
+    """
+
+    def if_feature_enabled_inner(func):  # pylint: disable=missing-docstring
+        @wraps(func)
+        def wrapped_func(*args, **kwargs):  # pylint: disable=missing-docstring
+            if not is_enabled(name, default):
+                # If the given feature name is not enabled, do nothing (no-op).
+                return
+            else:
+                # If the given feature name is enabled, call the function and return as normal.
+                return func(*args, **kwargs)
+
+        return wrapped_func
+
+    return if_feature_enabled_inner

--- a/main/settings.py
+++ b/main/settings.py
@@ -388,6 +388,12 @@ FEATURES = {
     for key in get_all_config_keys()
     if key.startswith(OCW_STUDIO_FEATURES_PREFIX)
 }
+FEATURES_DEFAULT = get_bool(
+    "FEATURES_DEFAULT",
+    False,
+    dev_only=True,
+    description="The default value for all feature flags",
+)
 
 MIDDLEWARE_FEATURE_FLAG_QS_PREFIX = get_string(
     "MIDDLEWARE_FEATURE_FLAG_QS_PREFIX", None

--- a/websites/factories.py
+++ b/websites/factories.py
@@ -4,12 +4,20 @@ import factory
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyChoice
 
-from websites.constants import WEBSITE_TYPE_COURSE
-from websites.models import Website
+from websites.constants import WEBSITE_TYPE_COURSE, STARTER_SOURCES
+from websites.models import Website, WebsiteStarter
+
+EXAMPLE_SITE_CONFIG = """
+collections:
+  - label: "Page"
+    name: "page"
+    fields:
+      - {label: "Title", name: "title", widget: "string"}
+"""
 
 
 class WebsiteFactory(DjangoModelFactory):
-    """Factory for WebsiteFactory"""
+    """Factory for Website"""
 
     title = factory.Sequence(lambda n: "OCW Course %s" % n)
     url_path = factory.Sequence(lambda n: "/ocw_site_x/%s" % n)
@@ -31,3 +39,16 @@ class WebsiteFactory(DjangoModelFactory):
         future_publish = factory.Trait(
             publish_date=factory.Faker("future_datetime", tzinfo=pytz.utc)
         )
+
+
+class WebsiteStarterFactory(DjangoModelFactory):
+    """Factory for WebsiteStarter"""
+
+    path = factory.Faker("uri")
+    name = factory.Faker("domain_word")
+    source = factory.fuzzy.FuzzyChoice(STARTER_SOURCES)
+    commit = factory.Faker("md5")
+    config = EXAMPLE_SITE_CONFIG
+
+    class Meta:
+        model = WebsiteStarter

--- a/websites/models.py
+++ b/websites/models.py
@@ -12,7 +12,7 @@ from websites.constants import WEBSITE_TYPE_COURSE, STARTER_SOURCES
 def validate_yaml(value):
     """Validator function to ensure that the value is YAML-formatted"""
     try:
-        yaml.load(value)
+        yaml.load(value, Loader=yaml.Loader)
     except yaml.YAMLError as exc:
         raise ValidationError("Value must be YAML-formatted.") from exc
 

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -1,7 +1,8 @@
 """ Serializers for websites """
+import yaml
 from rest_framework import serializers
 
-from websites.models import Website
+from websites.models import Website, WebsiteStarter
 
 
 class WebsiteSerializer(serializers.ModelSerializer):
@@ -10,3 +11,25 @@ class WebsiteSerializer(serializers.ModelSerializer):
     class Meta:
         model = Website
         fields = "__all__"
+
+
+class WebsiteStarterSerializer(serializers.ModelSerializer):
+    """ Serializer for website starters """
+
+    class Meta:
+        model = WebsiteStarter
+        fields = ["id", "name", "path", "source", "commit"]
+
+
+class WebsiteStarterDetailSerializer(serializers.ModelSerializer):
+    """ Serializer for website starters with serialized config """
+
+    config = serializers.SerializerMethodField()
+
+    def get_config(self, instance):
+        """Returns parsed YAML config"""
+        return yaml.load(instance.config, Loader=yaml.Loader)
+
+    class Meta:
+        model = WebsiteStarter
+        fields = WebsiteStarterSerializer.Meta.fields + ["config"]

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -1,22 +1,55 @@
 """ Tests for websites.serializers """
 import pytest
+import yaml
 
 from main.constants import ISO_8601_FORMAT
 from websites.constants import WEBSITE_TYPE_COURSE
-from websites.factories import WebsiteFactory
-from websites.serializers import WebsiteSerializer
+from websites.factories import (
+    WebsiteFactory,
+    WebsiteStarterFactory,
+    EXAMPLE_SITE_CONFIG,
+)
+from websites.serializers import (
+    WebsiteSerializer,
+    WebsiteStarterSerializer,
+    WebsiteStarterDetailSerializer,
+)
 
 
 @pytest.mark.django_db
 def test_serialize_website_course():
     """
-    Verify that a serialized website course contains expected fields
+    Verify that a serialized website contains expected fields
     """
-    course = WebsiteFactory(is_course=True)
-    serializer = WebsiteSerializer(course)
+    site = WebsiteFactory(is_course=True)
+    serializer = WebsiteSerializer(site)
     assert serializer.data["type"] == WEBSITE_TYPE_COURSE
-    assert serializer.data["url_path"] == course.url_path
-    assert serializer.data["publish_date"] == course.publish_date.strftime(
+    assert serializer.data["url_path"] == site.url_path
+    assert serializer.data["publish_date"] == site.publish_date.strftime(
         ISO_8601_FORMAT
     )
-    assert serializer.data["metadata"] == course.metadata
+    assert serializer.data["metadata"] == site.metadata
+
+
+def test_website_starter_serializer():
+    """WebsiteStarterSerializer should serialize a WebsiteStarter object with the correct fields"""
+    starter = WebsiteStarterFactory.build()
+    serialized_data = WebsiteStarterSerializer(instance=starter).data
+    assert serialized_data["name"] == starter.name
+    assert serialized_data["path"] == starter.path
+    assert serialized_data["source"] == starter.source
+    assert serialized_data["commit"] == starter.commit
+    assert "config" not in serialized_data
+
+
+def test_website_starter_detail_serializer():
+    """WebsiteStarterDetailSerializer should serialize a WebsiteStarter object with the correct fields"""
+    starter = WebsiteStarterFactory.build(config=EXAMPLE_SITE_CONFIG)
+    serialized_data = WebsiteStarterDetailSerializer(instance=starter).data
+    assert serialized_data["name"] == starter.name
+    assert serialized_data["path"] == starter.path
+    assert serialized_data["source"] == starter.source
+    assert serialized_data["commit"] == starter.commit
+    assert serialized_data["config"] == yaml.load(
+        EXAMPLE_SITE_CONFIG, Loader=yaml.Loader
+    )

--- a/websites/urls.py
+++ b/websites/urls.py
@@ -9,6 +9,9 @@ from websites import views
 router = SimpleRouter()
 
 router.register(r"websites", views.WebsiteViewSet, basename="websites_api")
+router.register(
+    r"starters", views.WebsiteStarterViewSet, basename="website_starters_api"
+)
 
 urlpatterns = [
     url(r"^api/", include(router.urls)),

--- a/websites/views.py
+++ b/websites/views.py
@@ -2,10 +2,16 @@
 from rest_framework import viewsets, mixins
 from rest_framework.pagination import LimitOffsetPagination
 
+from main import features
 from main.permissions import ReadonlyPermission
 from main.utils import now_in_utc
-from websites.models import Website
-from websites.serializers import WebsiteSerializer
+from websites.constants import STARTER_SOURCE_GITHUB
+from websites.models import Website, WebsiteStarter
+from websites.serializers import (
+    WebsiteSerializer,
+    WebsiteStarterSerializer,
+    WebsiteStarterDetailSerializer,
+)
 
 
 class DefaultPagination(LimitOffsetPagination):
@@ -40,3 +46,28 @@ class WebsiteViewSet(
         if website_type is not None:
             queryset = queryset.filter(type=website_type)
         return queryset
+
+
+class WebsiteStarterViewSet(
+    mixins.ListModelMixin,
+    mixins.RetrieveModelMixin,
+    viewsets.GenericViewSet,
+):
+    """
+    Viewset for WebsiteStarters
+    """
+
+    pagination_class = DefaultPagination
+    permission_classes = (ReadonlyPermission,)
+
+    def get_queryset(self):
+        if features.is_enabled(features.USE_LOCAL_STARTERS):
+            return WebsiteStarter.objects.all()
+        else:
+            return WebsiteStarter.objects.filter(source=STARTER_SOURCE_GITHUB)
+
+    def get_serializer_class(self):
+        if self.action == "list":
+            return WebsiteStarterSerializer
+        else:
+            return WebsiteStarterDetailSerializer


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Closes #37

#### What's this PR do?
- Adds list and detail endpoints for fetching `WebsiteStarter` records (see #41)
- Adds a feature flag which can optionally include `WebsiteStarter` records that were loaded from the local fs

#### How should this be manually tested?
- Set `FEATURES_USE_LOCAL_STARTERS=True` in your .env
- Run the management command to load the local starter project (`manage.py populate_local_starters`)
- Run a shell and make an API call to fetch the serialized starter info:
    ```python
    from django.test.client import Client
    client = Client()
    client.force_login(user)
    resp = client.get("/api/starters/", follow=True)
    print(resp.json())
    ```
