### PR TITLE
Integrate permissions with WebsiteViewSet

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -96,7 +96,10 @@ INSTALLED_APPS = (
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.sites",
+    "compat",
     "guardian",
+    "hijack",
+    "hijack_admin",
     "server_status",
     # django-robots
     "rest_framework",
@@ -564,3 +567,8 @@ REST_FRAMEWORK = {
     ),
     "TEST_REQUEST_DEFAULT_FORMAT": "json",
 }
+
+HIJACK_LOGIN_REDIRECT_URL = "/"
+HIJACK_LOGOUT_REDIRECT_URL = "/admin/users/user/"
+HIJACK_REGISTER_ADMIN = False
+HIJACK_ALLOW_GET_REQUESTS = True

--- a/main/templates/base.html
+++ b/main/templates/base.html
@@ -3,9 +3,11 @@
   <head>
     {% spaceless %}
     {% load static %}
+    {% load hijack_tags %}
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" href="{% static 'images/favicon.ico' %}" />
+    <link rel="stylesheet" type="text/css" href="{% static 'hijack/hijack-styles.css' %}" />
     <script type="text/javascript">
     var SETTINGS = {{ js_settings_json|safe }};
     </script>
@@ -19,6 +21,7 @@
     {% endspaceless %}
   </head>
   <body class="{% block bodyclass %}{% endblock %}">
+    {% hijack_notification %}
     {% block content %}
     {% endblock %}
   </body>

--- a/main/urls.py
+++ b/main/urls.py
@@ -14,7 +14,7 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.conf import settings
-from django.conf.urls import include
+from django.conf.urls import include, url
 from django.contrib import admin
 from django.urls import path
 
@@ -25,6 +25,7 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("status/", include("server_status.urls")),
     path("robots.txt", include("robots.urls")),
+    url(r"^hijack/", include("hijack.urls", namespace="hijack")),
     # Example view
     path("", index, name="main-index"),
     path("", include("news.urls")),

--- a/requirements.in
+++ b/requirements.in
@@ -4,6 +4,8 @@ boto3
 celery
 dj-database-url
 django-guardian
+django-hijack
+django-hijack-admin
 django-redis
 djangorestframework==3.12.2
 django-robots

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,8 +41,18 @@ decorator==4.4.2
     #   traitlets
 dj-database-url==0.5.0
     # via -r requirements.in
+django-compat==1.0.15
+    # via
+    #   django-hijack
+    #   django-hijack-admin
 django-guardian==2.3.0
     # via -r requirements.in
+django-hijack-admin==2.1.10
+    # via -r requirements.in
+django-hijack==2.2.1
+    # via
+    #   -r requirements.in
+    #   django-hijack-admin
 django-redis==4.12.1
     # via -r requirements.in
 django-robots==4.0
@@ -57,6 +67,7 @@ django==3.1
     # via
     #   -r requirements.in
     #   django-guardian
+    #   django-hijack
     #   django-redis
     #   djangorestframework
     #   mitol-django-common
@@ -130,6 +141,7 @@ sentry-sdk==0.16.5
 six==1.15.0
     # via
     #   cryptography
+    #   django-compat
     #   django-server-status
     #   pyopenssl
     #   python-dateutil

--- a/users/admin.py
+++ b/users/admin.py
@@ -2,8 +2,8 @@
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as ContribUserAdmin
 from django.utils.translation import gettext_lazy as _
-from mitol.common.admin import TimestampedModelAdmin
 from hijack_admin.admin import HijackUserAdminMixin
+from mitol.common.admin import TimestampedModelAdmin
 
 from users.models import User
 

--- a/users/admin.py
+++ b/users/admin.py
@@ -3,11 +3,12 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as ContribUserAdmin
 from django.utils.translation import gettext_lazy as _
 from mitol.common.admin import TimestampedModelAdmin
+from hijack_admin.admin import HijackUserAdminMixin
 
 from users.models import User
 
 
-class UserAdmin(ContribUserAdmin, TimestampedModelAdmin):
+class UserAdmin(ContribUserAdmin, TimestampedModelAdmin, HijackUserAdminMixin):
     """Admin views for user"""
 
     include_created_on_in_list = True
@@ -34,6 +35,7 @@ class UserAdmin(ContribUserAdmin, TimestampedModelAdmin):
         "name",
         "is_staff",
         "last_login",
+        "hijack_field",
     )
     list_filter = ("is_staff", "is_superuser", "is_active", "groups")
     search_fields = ("username", "name", "email")

--- a/websites/factories.py
+++ b/websites/factories.py
@@ -4,6 +4,7 @@ import pytz
 from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyChoice
 
+from users.factories import UserFactory
 from websites.constants import CONTENT_TYPE_FILE, CONTENT_TYPE_PAGE, STARTER_SOURCES
 from websites.models import Website, WebsiteContent, WebsiteStarter
 
@@ -44,6 +45,7 @@ class WebsiteFactory(DjangoModelFactory):
     metadata = factory.Faker("json")
     publish_date = factory.Faker("date_time", tzinfo=pytz.utc)
     starter = factory.SubFactory(WebsiteStarterFactory)
+    owner = factory.SubFactory(UserFactory)
 
     class Meta:
         model = Website

--- a/websites/permissions.py
+++ b/websites/permissions.py
@@ -191,7 +191,7 @@ class HasWebsitePermission(BasePermission):
         if request.method == "POST":
             # Only global editors and admins can create new Websites
             return request.user.has_perm(constants.PERMISSION_ADD)
-        return False
+        return request.user.is_authenticated
 
     def has_object_permission(self, request, view, obj):
         user = request.user

--- a/websites/permissions_test.py
+++ b/websites/permissions_test.py
@@ -1,6 +1,6 @@
 """ Tests for websites permissions"""
 import pytest
-from django.contrib.auth.models import Group, Permission
+from django.contrib.auth.models import AnonymousUser, Group, Permission
 from guardian.shortcuts import remove_perm
 
 from users.factories import UserFactory
@@ -67,11 +67,12 @@ def test_can_view_edit_preview_website(mocker, permission_groups, method):
         permission_groups.global_author,
         permission_groups.site_admin,
         permission_groups.websites[0].owner,
+        AnonymousUser(),
     ]:
         request = mocker.Mock(user=user, method=method)
         assert permissions.HasWebsitePermission().has_permission(
             request, mocker.Mock()
-        ) is (method == "GET")
+        ) is (method == "GET" or request.user.is_authenticated)
         for permission_class in (
             permissions.HasWebsitePermission(),
             permissions.HasWebsitePreviewPermission(),

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -1,8 +1,6 @@
 """ Serializers for websites """
-from django.db import transaction
 from rest_framework import serializers
 
-from users.models import User
 from websites.models import Website, WebsiteStarter
 
 
@@ -48,15 +46,6 @@ class WebsiteDetailSerializer(serializers.ModelSerializer):
     """ Serializer for websites with serialized config """
 
     starter = WebsiteStarterDetailSerializer(read_only=True)
-
-    def create(self, validated_data):
-        """Ensure that the website is created by the requesting user"""
-        request = self.context.get("request")
-        if request and hasattr(request, "user") and isinstance(request.user, User):
-            validated_data["owner"] = request.user
-            with transaction.atomic():
-                website = super().create(validated_data)
-            return website
 
     class Meta:
         model = Website

--- a/websites/views.py
+++ b/websites/views.py
@@ -1,12 +1,14 @@
 """ Views for websites """
+from guardian.shortcuts import get_objects_for_user
 from mitol.common.utils.datetime import now_in_utc
 from rest_framework import mixins, viewsets
 from rest_framework.pagination import LimitOffsetPagination
 
 from main import features
 from main.permissions import ReadonlyPermission
-from websites.constants import STARTER_SOURCE_GITHUB
+from websites.constants import STARTER_SOURCE_GITHUB, PERMISSION_VIEW
 from websites.models import Website, WebsiteStarter
+from websites.permissions import HasWebsitePermission, is_global_admin
 from websites.serializers import (
     WebsiteDetailSerializer,
     WebsiteSerializer,
@@ -28,6 +30,7 @@ class WebsiteViewSet(
     mixins.ListModelMixin,
     mixins.RetrieveModelMixin,
     mixins.CreateModelMixin,
+    mixins.UpdateModelMixin,
     viewsets.GenericViewSet,
 ):
     """
@@ -36,18 +39,31 @@ class WebsiteViewSet(
 
     serializer_class = WebsiteSerializer
     pagination_class = DefaultPagination
-    permission_classes = (ReadonlyPermission,)
+    permission_classes = (HasWebsitePermission,)
 
     def get_queryset(self):
-        """ Generate a QuerySet for fetching published websites """
-        ordering = self.request.query_params.get("sort", "-publish_date")
+        """
+        Generate a QuerySet for fetching websites.
+        Anonymous users should get a list of all published websites (used for ocw-www carousel)
+        Global admins should get a list of all websites, published or not.
+        Other authenticated users should get a list of websites they are editors/admins/owners for.
+        """
+        ordering = self.request.query_params.get("sort", "-updated_on")
         website_type = self.request.query_params.get("type", None)
-        queryset = Website.objects.filter(
-            publish_date__lte=now_in_utc(),
-        ).order_by(ordering)
+
+        user = self.request.user
+        if self.request.user.is_anonymous:
+            ordering = "-publish_date"
+            queryset = Website.objects.filter(
+                publish_date__lte=now_in_utc(),
+            )
+        elif is_global_admin(user):
+            queryset = Website.objects.all()
+        else:
+            queryset = get_objects_for_user(user, PERMISSION_VIEW).order_by(ordering)
         if website_type is not None:
             queryset = queryset.filter(starter__slug=website_type)
-        return queryset
+        return queryset.order_by(ordering)
 
     def get_serializer_class(self):
         if self.action == "list":

--- a/websites/views.py
+++ b/websites/views.py
@@ -6,6 +6,7 @@ from rest_framework.pagination import LimitOffsetPagination
 
 from main import features
 from main.permissions import ReadonlyPermission
+from users.models import User
 from websites.constants import STARTER_SOURCE_GITHUB, PERMISSION_VIEW
 from websites.models import Website, WebsiteStarter
 from websites.permissions import HasWebsitePermission, is_global_admin
@@ -70,6 +71,17 @@ class WebsiteViewSet(
             return WebsiteSerializer
         else:
             return WebsiteDetailSerializer
+
+    def create(self, request, *args, **kwargs):
+        """Ensure that the website is created by the requesting user"""
+        if hasattr(self.request, "user") and isinstance(self.request.user, User):
+            self.request.data.update({"owner": self.request.user.id})
+        return super().create(request, *args, **kwargs)
+
+    def update(self, request, *args, **kwargs):
+        """Ensure that the website owner is removed if present in the data"""
+        self.request.data.pop("owner", None)
+        return super().update(request, *args, **kwargs)
 
 
 class WebsiteStarterViewSet(

--- a/websites/views.py
+++ b/websites/views.py
@@ -7,7 +7,7 @@ from rest_framework.pagination import LimitOffsetPagination
 from main import features
 from main.permissions import ReadonlyPermission
 from users.models import User
-from websites.constants import STARTER_SOURCE_GITHUB, PERMISSION_VIEW
+from websites.constants import PERMISSION_VIEW, STARTER_SOURCE_GITHUB
 from websites.models import Website, WebsiteStarter
 from websites.permissions import HasWebsitePermission, is_global_admin
 from websites.serializers import (
@@ -45,22 +45,22 @@ class WebsiteViewSet(
     def get_queryset(self):
         """
         Generate a QuerySet for fetching websites.
-        Anonymous users should get a list of all published websites (used for ocw-www carousel)
-        Global admins should get a list of all websites, published or not.
-        Other authenticated users should get a list of websites they are editors/admins/owners for.
         """
         ordering = self.request.query_params.get("sort", "-updated_on")
         website_type = self.request.query_params.get("type", None)
 
         user = self.request.user
         if self.request.user.is_anonymous:
+            # Anonymous users should get a list of all published websites (used for ocw-www carousel)
             ordering = "-publish_date"
             queryset = Website.objects.filter(
                 publish_date__lte=now_in_utc(),
             )
         elif is_global_admin(user):
+            # Global admins should get a list of all websites, published or not.
             queryset = Website.objects.all()
         else:
+            # Other authenticated users should get a list of websites they are editors/admins/owners for.
             queryset = get_objects_for_user(user, PERMISSION_VIEW).order_by(ordering)
         if website_type is not None:
             queryset = queryset.filter(starter__slug=website_type)

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -8,12 +8,14 @@ from mitol.common.utils.datetime import now_in_utc
 
 from main import features
 from main.constants import ISO_8601_FORMAT
+from users.factories import UserFactory
 from websites.constants import (
     COURSE_STARTER_SLUG,
     STARTER_SOURCE_GITHUB,
     STARTER_SOURCE_LOCAL,
 )
 from websites.factories import WebsiteFactory, WebsiteStarterFactory
+from websites.models import Website
 from websites.serializers import (
     WebsiteDetailSerializer,
     WebsiteStarterDetailSerializer,
@@ -62,15 +64,122 @@ def test_websites_endpoint_list(drf_client, website_type, websites):
         )
 
 
+def test_websites_endpoint_list_permissions(drf_client, permission_groups):
+    """Authenticated users should only see the websites they have permissions for"""
+    for [user, count] in [
+        [permission_groups.global_admin, 2],
+        [permission_groups.global_author, 0],
+        [permission_groups.site_admin, 1],
+        [permission_groups.websites[0].owner, 2],
+    ]:
+        drf_client.force_login(user)
+        resp = drf_client.get(reverse("websites_api-list"))
+        assert resp.data.get("count") == count
+        if count == 1:
+            assert (
+                resp.data.get("results")[0]["name"]
+                == permission_groups.websites[0].name
+            )
+        if count == 2:
+            assert (
+                resp.data.get("results")[0]["updated_on"]
+                >= resp.data.get("results")[1]["updated_on"]
+            )
+
+
+def test_websites_endpoint_list_create(drf_client, permission_groups):
+    """Only global admins and authors should be able to send a POST request"""
+    for [user, has_perm] in [
+        [permission_groups.global_admin, True],
+        [permission_groups.global_author, True],
+        [permission_groups.site_admin, False],
+        [permission_groups.websites[0].owner, False],
+    ]:
+        drf_client.force_login(user)
+        resp = drf_client.post(
+            reverse("websites_api-list"),
+            data={"name": f"{user.username}_site", "title": "Fake"},
+        )
+        assert resp.status_code == (201 if has_perm else 403)
+        if has_perm:
+            assert Website.objects.get(name=f"{user.username}_site").owner == user
+
+
+@pytest.mark.parametrize("method", ["put", "patch", "delete"])
+def test_websites_endpoint_list_forbidden_methods(drf_client, method):
+    """No put, patch, or delete requests allowed at this endpoint"""
+    drf_client.force_login(UserFactory.create(is_superuser=True))
+    client_func = getattr(drf_client, method)
+    resp = client_func(
+        reverse("websites_api-list"), data={"name": "fakename", "title": "Fake Title"}
+    )
+    assert resp.status_code == 405
+
+
 def test_websites_endpoint_detail(drf_client):
     """Test new websites endpoint for details"""
     website = WebsiteFactory.create()
+    drf_client.force_login(website.owner)
     resp = drf_client.get(reverse("websites_api-detail", kwargs={"pk": website.uuid}))
     assert resp.json() == WebsiteDetailSerializer(instance=website).data
 
 
+@pytest.mark.parametrize(
+    "method,status", [["post", 405], ["put", 403], ["delete", 405]]
+)
+def test_websites_endpoint_detail_methods_denied(drf_client, method, status):
+    """Certain request methods should always be denied"""
+    website = WebsiteFactory.create()
+    drf_client.force_login(UserFactory.create(is_superuser=True))
+    client_func = getattr(drf_client, method)
+    resp = client_func(reverse("websites_api-detail", kwargs={"pk": website.uuid}))
+    assert resp.status_code == status
+
+
+def test_websites_endpoint_detail_update(drf_client):
+    """A user with admin permissions should be able to edit a website"""
+    website = WebsiteFactory.create()
+    admin_user = UserFactory.create()
+    admin_user.groups.add(website.admin_group)
+    drf_client.force_login(admin_user)
+    resp = drf_client.patch(
+        reverse("websites_api-detail", kwargs={"pk": website.uuid}),
+        data={"title": "New"},
+    )
+    assert resp.status_code == 200
+
+
+def test_websites_endpoint_detail_update_denied(drf_client):
+    """A user with editor permissions should be able to view but not edit a website"""
+    website = WebsiteFactory.create()
+    editor = UserFactory.create()
+    editor.groups.add(website.editor_group)
+    drf_client.force_login(editor)
+    resp = drf_client.get(reverse("websites_api-detail", kwargs={"pk": website.uuid}))
+    assert resp.status_code == 200
+    resp = drf_client.patch(
+        reverse("websites_api-detail", kwargs={"pk": website.uuid}),
+        data={"title": "New"},
+    )
+    assert resp.status_code == 403
+
+
+def test_websites_endpoint_detail_get_denied(drf_client):
+    """Anonymous user or user without permissions should not be able to view the site"""
+    for user in (None, UserFactory.create()):
+        if user:
+            drf_client.force_login(user)
+        website = WebsiteFactory.create()
+        resp = drf_client.get(
+            reverse("websites_api-detail", kwargs={"pk": website.uuid})
+        )
+        assert resp.status_code == 403 if not user else 404
+
+
 def test_websites_endpoint_sorting(drf_client, websites):
     """ Response should be sorted according to query parameter """
+    superuser = UserFactory.create(is_superuser=True)
+    drf_client.force_login(superuser)
     resp = drf_client.get(
         reverse("websites_api-list"), {"sort": "title", "type": COURSE_STARTER_SLUG}
     )

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -137,16 +137,20 @@ def test_websites_endpoint_detail_methods_denied(drf_client, method, status):
 
 
 def test_websites_endpoint_detail_update(drf_client):
-    """A user with admin permissions should be able to edit a website"""
+    """A user with admin permissions should be able to edit a website but not change website owner"""
     website = WebsiteFactory.create()
     admin_user = UserFactory.create()
     admin_user.groups.add(website.admin_group)
     drf_client.force_login(admin_user)
+    new_title = "New Title"
     resp = drf_client.patch(
         reverse("websites_api-detail", kwargs={"pk": website.uuid}),
-        data={"title": "New"},
+        data={"title": new_title, "owner": admin_user.id},
     )
     assert resp.status_code == 200
+    updated_site = Website.objects.get(uuid=website.uuid)
+    assert updated_site.title == new_title
+    assert updated_site.owner == website.owner
 
 
 def test_websites_endpoint_detail_update_denied(drf_client):


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #63 

#### What's this PR do?
- replaces `ReadOnlyPermission` with `HasWebsitePermission` for `WebsiteViewSet` and adds `UpdateModelMixin`
- tweaks `WebsiteDetailSerializer` to set the owner to the request user if present
- adds django-hijack

#### How should this be manually tested?
In a shell, create a test website and users with various permissions:
```
from websites.models import Website
from users.models import User
from django.contrib.auth.models import Group

for i in range(1,7):
     User.objects.update_or_create(username=f"fakeuser{i}", email=f"fakeuser{i}.mit.edu", is_active=True)
owner = User.objects.get(username="fakeuser3")
website = Website.objects.create(name="9999_fake_course", title="Fake Course", owner=owner)

User.objects.get(username="fakeuser1").groups.add(website.admin_group)
User.objects.get(username="fakeuser2").groups.add(website.editor_group)
User.objects.get(username="fakeuser4").groups.add(Group.objects.get(name="global_admin"))
User.objects.get(username="fakeuser5").groups.add(Group.objects.get(name="global_author"))
```

Go to `../api/websites/` in a browser without logging in.  You should get a list of published websites sorted by publishing date.

Go to `../api/websites/<website_uuid>` for any particular website.  You should not be able to view it.  

From django admin, hijack fakeuser1 through fakeuser6.

Go to `../api/websites/`:
  - The website created above should be the only one listed for fakeuser1,2,3,4
  - fakeuser5 and 6 should not be able to view any websites (initially, see below)
  - Only fakeuser4 and fakeuser5 (global admin, global author) should have the option to create a new website at the bottom of the page.  Give it a try (name is mandatory), a new website should be created with that user as the owner.  If you refresh the page the new website should be the first one in the list.
  
Go to `../api/websites/<website_uuid>`:
  - fakeuser1,2,3,4 should be able to view the details for this website
  - fakeuser1,3,4 (site admin, site owner, global admin) should be able to edit (patch) the website details at the bottom, give it a try.  fakeuser2 should not be able to.
  - fakeuser5,6 should get a 404
  - fakeuser5 should be able to view the details for the other website created above

