### PR TITLE
Fix typo in webpack-related environment variable

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -7,7 +7,8 @@ services:
     environment:
       DEBUG: 'True'
       NODE_ENV: 'development'
-      OCW_STUDIO_USE_WEBPACK_DEV_SERVER: 'True'
+      WEBPACK_USE_DEV_SERVER: 'True'
+      WEBPACK_DEV_SERVER_PORT: 8042
 
   celery:
     volumes:
@@ -16,7 +17,8 @@ services:
     environment:
       DEBUG: 'True'
       NODE_ENV: 'development'
-      OCW_STUDIO_USE_WEBPACK_DEV_SERVER: 'True'
+      WEBPACK_USE_DEV_SERVER: 'True'
+      WEBPACK_DEV_SERVER_PORT: 8042
 
   nginx:
     volumes:

--- a/main/views_test.py
+++ b/main/views_test.py
@@ -24,7 +24,7 @@ def test_webpack_url(mocker, settings, client):
     settings.GA_TRACKING_ID = "fake"
     settings.ENVIRONMENT = "test"
     settings.VERSION = "4.5.6"
-    settings.USE_WEBPACK_DEV_SERVER = False
+    settings.WEBPACK_USE_DEV_SERVER = False
     get_bundle = mocker.patch("mitol.common.templatetags.render_bundle._get_bundle")
 
     response = client.get(reverse("main-index"))


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Updates environment variables for changes from #36 

#### How should this be manually tested?
On master, go to / and you should see just the text "Hi, I'm ocw_studio". On this PR you should also see a blue border and "Hello cookiecutter!" message, which indicates that the CSS and JS bundles are loading properly.
