### PR TITLE
Lookup websites by name instead of uuid

### DIFF
--- a/websites/views.py
+++ b/websites/views.py
@@ -40,6 +40,7 @@ class WebsiteViewSet(
     serializer_class = WebsiteSerializer
     pagination_class = DefaultPagination
     permission_classes = (HasWebsitePermission,)
+    lookup_field = "name"
 
     def get_queryset(self):
         """

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -120,7 +120,7 @@ def test_websites_endpoint_detail(drf_client):
     """Test new websites endpoint for details"""
     website = WebsiteFactory.create()
     drf_client.force_login(website.owner)
-    resp = drf_client.get(reverse("websites_api-detail", kwargs={"pk": website.uuid}))
+    resp = drf_client.get(reverse("websites_api-detail", kwargs={"name": website.name}))
     assert resp.json() == WebsiteDetailSerializer(instance=website).data
 
 
@@ -132,7 +132,7 @@ def test_websites_endpoint_detail_methods_denied(drf_client, method, status):
     website = WebsiteFactory.create()
     drf_client.force_login(UserFactory.create(is_superuser=True))
     client_func = getattr(drf_client, method)
-    resp = client_func(reverse("websites_api-detail", kwargs={"pk": website.uuid}))
+    resp = client_func(reverse("websites_api-detail", kwargs={"name": website.name}))
     assert resp.status_code == status
 
 
@@ -144,7 +144,7 @@ def test_websites_endpoint_detail_update(drf_client):
     drf_client.force_login(admin_user)
     new_title = "New Title"
     resp = drf_client.patch(
-        reverse("websites_api-detail", kwargs={"pk": website.uuid}),
+        reverse("websites_api-detail", kwargs={"name": website.name}),
         data={"title": new_title, "owner": admin_user.id},
     )
     assert resp.status_code == 200
@@ -159,10 +159,10 @@ def test_websites_endpoint_detail_update_denied(drf_client):
     editor = UserFactory.create()
     editor.groups.add(website.editor_group)
     drf_client.force_login(editor)
-    resp = drf_client.get(reverse("websites_api-detail", kwargs={"pk": website.uuid}))
+    resp = drf_client.get(reverse("websites_api-detail", kwargs={"name": website.name}))
     assert resp.status_code == 200
     resp = drf_client.patch(
-        reverse("websites_api-detail", kwargs={"pk": website.uuid}),
+        reverse("websites_api-detail", kwargs={"name": website.name}),
         data={"title": "New"},
     )
     assert resp.status_code == 403
@@ -175,7 +175,7 @@ def test_websites_endpoint_detail_get_denied(drf_client):
             drf_client.force_login(user)
         website = WebsiteFactory.create()
         resp = drf_client.get(
-            reverse("websites_api-detail", kwargs={"pk": website.uuid})
+            reverse("websites_api-detail", kwargs={"name": website.name})
         )
         assert resp.status_code == 403 if not user else 404
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to #71 

#### What's this PR do?
Changes the website detail API to return websites by `name` instead of `uuid`. This means we can have `/sites/name-goes-here` and look up the website info by the same name in the URL path.

#### How should this be manually tested?
Go to `/api/websites`, pick a site which you have permission to view, then go to `/api/websites/<name>/` where the name comes from the `name` field in the website.
