### PR TITLE
Add select_related to fix n+1 query

### DIFF
--- a/websites/views.py
+++ b/websites/views.py
@@ -61,10 +61,10 @@ class WebsiteViewSet(
             queryset = Website.objects.all()
         else:
             # Other authenticated users should get a list of websites they are editors/admins/owners for.
-            queryset = get_objects_for_user(user, PERMISSION_VIEW).order_by(ordering)
+            queryset = get_objects_for_user(user, PERMISSION_VIEW)
         if website_type is not None:
             queryset = queryset.filter(starter__slug=website_type)
-        return queryset.order_by(ordering)
+        return queryset.select_related("starter").order_by(ordering)
 
     def get_serializer_class(self):
         if self.action == "list":


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #75 

#### What's this PR do?
Adds a `select_related` to fix an n+1 query on the `WebsiteViewSet` list. I also removed a redundant `order_by(...)` which is already added at the bottom of the function

#### How should this be manually tested?
Go to `/api/websites/` and view the logs. You should see a bunch of n+1 query warnings on master, but no similar warnings on this branch
