### PR TITLE
Use resource for content type instead of file

### DIFF
--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -9,7 +9,7 @@ import yaml
 from dateutil import parser as dateparser
 
 from main.s3_utils import get_s3_object_and_read, get_s3_resource
-from websites.constants import CONTENT_TYPE_FILE, CONTENT_TYPE_PAGE, COURSE_HOME
+from websites.constants import CONTENT_TYPE_PAGE, CONTENT_TYPE_RESOURCE, COURSE_HOME
 from websites.models import Website, WebsiteContent
 
 
@@ -75,7 +75,7 @@ def import_ocw2hugo_content(bucket, prefix, website):  # pylint:disable=too-many
                     # This is a file
                     uuid = content_json.get("uid")
                     parent_uuid = content_json.get("parent", None)
-                    content_type = CONTENT_TYPE_FILE
+                    content_type = CONTENT_TYPE_RESOURCE
                 if parent_uuid:
                     parent, _ = WebsiteContent.objects.get_or_create(
                         website=website, uuid=parent_uuid

--- a/ocw_import/api_test.py
+++ b/ocw_import/api_test.py
@@ -33,8 +33,8 @@ def test_import_ocw2hugo_course(settings):
         assert json.dumps(website.metadata, sort_keys=True) == json.dumps(
             json.load(infile), sort_keys=True
         )
-    assert WebsiteContent.objects.filter(type="page").count() == 6
-    assert WebsiteContent.objects.filter(type="file").count() == 8
+    assert WebsiteContent.objects.filter(type=CONTENT_TYPE_PAGE).count() == 6
+    assert WebsiteContent.objects.filter(type=CONTENT_TYPE_RESOURCE).count() == 8
 
     home_page = WebsiteContent.objects.get(uuid=website.uuid)
     assert home_page.type == CONTENT_TYPE_PAGE

--- a/ocw_import/api_test.py
+++ b/ocw_import/api_test.py
@@ -11,7 +11,7 @@ from ocw_import.conftest import (
     TEST_OCW2HUGO_PREFIX,
     setup_s3,
 )
-from websites.constants import CONTENT_TYPE_FILE, CONTENT_TYPE_PAGE
+from websites.constants import CONTENT_TYPE_PAGE, CONTENT_TYPE_RESOURCE
 from websites.factories import WebsiteStarterFactory
 from websites.models import Website, WebsiteContent
 
@@ -51,7 +51,7 @@ def test_import_ocw2hugo_course(settings):
     )
 
     lecture_pdf = WebsiteContent.objects.get(uuid="7f91d52457aaef8093c58a43f10a099b")
-    assert lecture_pdf.type == CONTENT_TYPE_FILE
+    assert lecture_pdf.type == CONTENT_TYPE_RESOURCE
     assert lecture_pdf.metadata.get("file_type") == "application/pdf"
     assert (
         lecture_pdf.hugo_filepath

--- a/websites/constants.py
+++ b/websites/constants.py
@@ -1,7 +1,7 @@
 """ Constants for websites """
 
 CONTENT_TYPE_PAGE = "page"
-CONTENT_TYPE_FILE = "file"
+CONTENT_TYPE_RESOURCE = "resource"
 
 COURSE_HOME = "course-home"
 

--- a/websites/factories.py
+++ b/websites/factories.py
@@ -5,7 +5,7 @@ from factory.django import DjangoModelFactory
 from factory.fuzzy import FuzzyChoice
 
 from users.factories import UserFactory
-from websites.constants import CONTENT_TYPE_FILE, CONTENT_TYPE_PAGE, STARTER_SOURCES
+from websites.constants import CONTENT_TYPE_PAGE, CONTENT_TYPE_RESOURCE, STARTER_SOURCES
 from websites.models import Website, WebsiteContent, WebsiteStarter
 
 
@@ -64,7 +64,7 @@ class WebsiteContentFactory(DjangoModelFactory):
     """Factory for WebsiteContent"""
 
     title = factory.Sequence(lambda n: "OCW Site Content %s" % n)
-    type = FuzzyChoice((CONTENT_TYPE_PAGE, CONTENT_TYPE_FILE))
+    type = FuzzyChoice((CONTENT_TYPE_PAGE, CONTENT_TYPE_RESOURCE))
     markdown = factory.Faker("text")
     metadata = factory.Faker("json")
     hugo_filepath = factory.Sequence(lambda n: "/sites/ocw_site_x/%s" % n)

--- a/websites/migrations/0009_resource.py
+++ b/websites/migrations/0009_resource.py
@@ -1,0 +1,28 @@
+from django.db import migrations
+
+
+def convert_to_resource(apps, schema_editor):
+    """
+    Convert file to resource in WebsiteContent
+    """
+    WebsiteContent = apps.get_model("websites", "WebsiteContent")
+    WebsiteContent.objects.filter(type="file").update(type="resource")
+
+
+def convert_to_file(apps, schema_editor):
+    """
+    Convert resource to file in WebsiteContent
+    """
+    WebsiteContent = apps.get_model("websites", "WebsiteContent")
+    WebsiteContent.objects.filter(type="resource").update(type="file")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("websites", "0008_site_permissions"),
+    ]
+
+    operations = [
+        migrations.RunPython(convert_to_resource, convert_to_file),
+    ]


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Migrations
  - [x] Migration is backwards-compatible with current production code

#### What are the relevant tickets?
Part of #52 

#### What's this PR do?
Updates `file` to `resource` in `WebsiteContent.type` and adds a migration to make that change for backpopulated content in the database.

#### How should this be manually tested?
Migration should work, and you should be able to reverse it. There is no user facing code for `WebsiteContent` yet (that's in #84)
