### PR TITLE
add underlining to CKEditor

### DIFF
--- a/static/js/lib/ckeditor/CKEditor.ts
+++ b/static/js/lib/ckeditor/CKEditor.ts
@@ -4,6 +4,7 @@ import UploadAdapterPlugin from "@ckeditor/ckeditor5-adapter-ckfinder/src/upload
 import AutoformatPlugin from "@ckeditor/ckeditor5-autoformat/src/autoformat"
 import BoldPlugin from "@ckeditor/ckeditor5-basic-styles/src/bold"
 import ItalicPlugin from "@ckeditor/ckeditor5-basic-styles/src/italic"
+import UnderlinePlugin from "@ckeditor/ckeditor5-basic-styles/src/underline"
 import BlockQuotePlugin from "@ckeditor/ckeditor5-block-quote/src/blockquote"
 import EasyImagePlugin from "@ckeditor/ckeditor5-easy-image/src/easyimage"
 import HeadingPlugin from "@ckeditor/ckeditor5-heading/src/heading"
@@ -24,6 +25,7 @@ ClassicEditor.builtinPlugins = [
   AutoformatPlugin,
   BoldPlugin,
   ItalicPlugin,
+  UnderlinePlugin,
   BlockQuotePlugin,
   EasyImagePlugin,
   HeadingPlugin,
@@ -44,6 +46,7 @@ ClassicEditor.defaultConfig = {
       "|",
       "bold",
       "italic",
+      "underline",
       "link",
       "bulletedList",
       "numberedList",

--- a/static/js/types/ckeditor.d.ts
+++ b/static/js/types/ckeditor.d.ts
@@ -26,6 +26,8 @@ declare module '@ckeditor/ckeditor5-basic-styles/src/italic';
 
 declare module '@ckeditor/ckeditor5-basic-styles/src/bold';
 
+declare module '@ckeditor/ckeditor5-basic-styles/src/underline';
+
 declare module '@ckeditor/ckeditor5-autoformat/src/autoformat';
 
 declare module '@ckeditor/ckeditor5-essentials/src/essentials';


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

part of #39 

#### What's this PR do?

this adds the 'underlining' plugin, which @gsidebo noted was absent.

#### How should this be manually tested?

check out the editor, you should be able to underline to your heart's content.

#### Screenshots (if appropriate)

![Screenshot from 2021-02-25 13-20-26](https://user-images.githubusercontent.com/6207644/109198574-620b1980-776c-11eb-8008-466be96161ec.png)