### PR TITLE
Turn off pagination for website content API

### DIFF
--- a/websites/views.py
+++ b/websites/views.py
@@ -246,7 +246,6 @@ class WebsiteContentViewSet(
     """Viewset for WebsiteContent"""
 
     permission_classes = (HasWebsiteContentPermission,)
-    pagination_class = DefaultPagination
     lookup_field = "uuid"
 
     def get_queryset(self):

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -670,14 +670,14 @@ def test_websites_content_list(drf_client, filter_type, permission_groups):
         ),
         {"type": filter_type},
     )
-    assert resp.data["count"] == (num_pages if filter_type else num_pages + 1)
+    assert len(resp.data) == (num_pages if filter_type else num_pages + 1)
 
     for idx, content in enumerate(
         reversed(sorted(contents, key=lambda _content: _content.updated_on))
     ):
-        assert content.title == resp.data["results"][idx]["title"]
-        assert str(content.uuid) == resp.data["results"][idx]["uuid"]
-        assert content.type == resp.data["results"][idx]["type"]
+        assert content.title == resp.data[idx]["title"]
+        assert str(content.uuid) == resp.data[idx]["uuid"]
+        assert content.type == resp.data[idx]["type"]
 
 
 def test_websites_content_detail(drf_client, permission_groups):

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -654,10 +654,10 @@ def test_websites_content_list(drf_client, filter_type, permission_groups):
     drf_client.force_login(permission_groups.global_admin)
     content = WebsiteContentFactory.create(type="other")
     website = content.website
-    num_pages = 5
+    num_results = 5
     contents = [
         WebsiteContentFactory.create(type="page", website=website)
-        for _ in range(num_pages)
+        for _ in range(num_results)
     ]
     if not filter_type:
         contents += [content]
@@ -670,7 +670,7 @@ def test_websites_content_list(drf_client, filter_type, permission_groups):
         ),
         {"type": filter_type},
     )
-    assert len(resp.data) == (num_pages if filter_type else num_pages + 1)
+    assert len(resp.data) == (num_results if filter_type else num_results + 1)
 
     for idx, content in enumerate(
         reversed(sorted(contents, key=lambda _content: _content.updated_on))


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Part of #52 

#### What's this PR do?
Removes pagination so all website content results will be in one request. This will simplify work in #52. I'm not 100% sure but I doubt there will be too much data being sent here since it's only returning the `uuid`, `title`, and `type` for each item, not the content itself.

#### How should this be manually tested?
Go to `/api/websites/website-name-here/content/`. You should not see a `count` or `results` field, just the results themselves.

