### PR TITLE
add minimal config for editor

### DIFF
--- a/static/js/components/MarkdownEditor.tsx
+++ b/static/js/components/MarkdownEditor.tsx
@@ -1,28 +1,31 @@
 import React from "react"
 import { CKEditor } from "@ckeditor/ckeditor5-react"
 
-import OurEditor from "../lib/ckeditor/CKEditor"
+import ClassicEditor from "@ckeditor/ckeditor5-editor-classic/src/classiceditor"
+
+import { FullEditorConfig, MinimalEditorConfig } from "../lib/ckeditor/CKEditor"
 
 export interface Props {
   value?: string
   name?: string
   onChange?: (event: { target: { value: string; name: string } }) => void
   children?: React.ReactNode
+  minimal?: boolean
 }
 
 /**
  * A component for editing Markdown using CKEditor.
  */
 export default function MarkdownEditor(props: Props): JSX.Element {
-  const { value, name, onChange } = props
+  const { value, name, onChange, minimal } = props
 
   return (
     <CKEditor
-      editor={OurEditor}
+      editor={ClassicEditor}
+      config={minimal ? MinimalEditorConfig : FullEditorConfig}
       data={value ?? ""}
       onChange={(event: any, editor: any) => {
         const data = editor.getData()
-
         if (onChange) {
           onChange({ target: { name: name ?? "", value: data } })
         }

--- a/static/js/components/forms/SiteContentField.tsx
+++ b/static/js/components/forms/SiteContentField.tsx
@@ -8,6 +8,7 @@ import { ConfigField } from "../../types/websites"
 interface Props {
   field: ConfigField
 }
+
 export default function SiteContentField({ field }: Props): JSX.Element {
   return (
     <div className="form-group">

--- a/static/js/lib/ckeditor/CKEditor.ts
+++ b/static/js/lib/ckeditor/CKEditor.ts
@@ -1,4 +1,3 @@
-import ClassicEditorBase from "@ckeditor/ckeditor5-editor-classic/src/classiceditor"
 import EssentialsPlugin from "@ckeditor/ckeditor5-essentials/src/essentials"
 import UploadAdapterPlugin from "@ckeditor/ckeditor5-adapter-ckfinder/src/uploadadapter"
 import AutoformatPlugin from "@ckeditor/ckeditor5-autoformat/src/autoformat"
@@ -20,31 +19,28 @@ import ParagraphPlugin from "@ckeditor/ckeditor5-paragraph/src/paragraph"
 import Markdown from "./plugins/Markdown"
 import MarkdownMediaEmbed from "./plugins/MarkdownMediaEmbed"
 
-class ClassicEditor extends ClassicEditorBase {}
-
-ClassicEditor.builtinPlugins = [
-  EssentialsPlugin,
-  UploadAdapterPlugin,
-  AutoformatPlugin,
-  BoldPlugin,
-  ItalicPlugin,
-  UnderlinePlugin,
-  BlockQuotePlugin,
-  EasyImagePlugin,
-  HeadingPlugin,
-  ImagePlugin,
-  ImageCaptionPlugin,
-  ImageStylePlugin,
-  ImageToolbarPlugin,
-  ImageUploadPlugin,
-  LinkPlugin,
-  ListPlugin,
-  ParagraphPlugin,
-  MarkdownMediaEmbed,
-  Markdown
-]
-
-ClassicEditor.defaultConfig = {
+export const FullEditorConfig = {
+  plugins: [
+    EssentialsPlugin,
+    UploadAdapterPlugin,
+    AutoformatPlugin,
+    BoldPlugin,
+    ItalicPlugin,
+    UnderlinePlugin,
+    BlockQuotePlugin,
+    EasyImagePlugin,
+    HeadingPlugin,
+    ImagePlugin,
+    ImageCaptionPlugin,
+    ImageStylePlugin,
+    ImageToolbarPlugin,
+    ImageUploadPlugin,
+    LinkPlugin,
+    ListPlugin,
+    ParagraphPlugin,
+    MarkdownMediaEmbed,
+    Markdown
+  ],
   toolbar: {
     items: [
       "heading",
@@ -80,4 +76,32 @@ ClassicEditor.defaultConfig = {
   }
 }
 
-export default ClassicEditor
+export const MinimalEditorConfig = {
+  plugins: [
+    EssentialsPlugin,
+    UploadAdapterPlugin,
+    AutoformatPlugin,
+    BoldPlugin,
+    ItalicPlugin,
+    UnderlinePlugin,
+    BlockQuotePlugin,
+    LinkPlugin,
+    ListPlugin,
+    ParagraphPlugin,
+    Markdown
+  ],
+  toolbar: {
+    items: [
+      "bold",
+      "italic",
+      "underline",
+      "link",
+      "bulletedList",
+      "numberedList",
+      "blockQuote",
+      "undo",
+      "redo"
+    ]
+  },
+  language: "en"
+}

--- a/static/js/pages/MarkdownEditorTestPage.tsx
+++ b/static/js/pages/MarkdownEditorTestPage.tsx
@@ -1,10 +1,56 @@
 import React, { useState } from "react"
+import { TabContent, TabPane, Nav, NavItem, NavLink } from "reactstrap"
 
 import MarkdownEditor from "../components/MarkdownEditor"
 
 import { TEST_MARKDOWN } from "../test_constants"
 
 export default function MarkdownEditorTestPage(): JSX.Element {
+  const [activeTab, setActiveTab] = useState("1")
+
+  const toggle = (tab: string) => {
+    if (activeTab !== tab) setActiveTab(tab)
+  }
+
+  return (
+    <div>
+      <Nav tabs>
+        <NavItem>
+          <NavLink
+            className={activeTab === "1" ? "active" : ""}
+            onClick={() => toggle("1")}
+          >
+            Minimal Editor
+          </NavLink>
+        </NavItem>
+        <NavItem>
+          <NavLink
+            className={activeTab === "2" ? "active" : ""}
+            onClick={() => toggle("2")}
+          >
+            Full Editor
+          </NavLink>
+        </NavItem>
+      </Nav>
+      <TabContent activeTab={activeTab}>
+        <TabPane tabId="1">
+          <MarkdownEditorTestWrapper minimal={true} />
+        </TabPane>
+        <TabPane tabId="2">
+          <MarkdownEditorTestWrapper minimal={false} />
+        </TabPane>
+      </TabContent>
+    </div>
+  )
+}
+
+interface Props {
+  minimal: boolean
+}
+
+function MarkdownEditorTestWrapper(props: Props) {
+  const { minimal } = props
+
   const [data, setData] = useState(TEST_MARKDOWN)
 
   return (
@@ -15,6 +61,7 @@ export default function MarkdownEditorTestPage(): JSX.Element {
           value={data}
           name="markdown"
           onChange={(event: any) => setData(event.target.value)}
+          minimal={minimal}
         />
       </div>
       <div className="w-75 m-auto">

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -22,10 +22,6 @@ header {
   border: 1px solid black;  // for visibility, remove when we migrate away from wireframe
 }
 
-.active {
-  font-weight: bold;
-}
-
 .form-container {
   background-color: $light-gray-bg;
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested
 
#### What are the relevant tickets?

closes #111 

#### What's this PR do?

This adds a minimal version of CKEditor. I think we'll want this in a few places, but not sure exactly where yet, so just implementing the minimal version itself.

Basically, now you can pass a `minimal` boolean prop to the `MarkdownEditor` component. When this is passed it will enable fewer editing features (i.e. no image or media insertion, no headers).

I also added this to the test page (http://localhost:8043/markdown-editor) with a tabbed UI with the full editor in one tab and the minimal editor in another.

#### How should this be manually tested?

test it out on the test page and make sure it works as you think it should.

#### Screenshots (if appropriate)

![Screenshot from 2021-03-15 11-35-57](https://user-images.githubusercontent.com/6207644/111179643-a6772180-8582-11eb-85ef-5ebdbeea5a9b.png)
