### PR TITLE
fix bug relating to turndown 'li' rule

### DIFF
--- a/static/js/lib/ckeditor/turndown.test.ts
+++ b/static/js/lib/ckeditor/turndown.test.ts
@@ -25,4 +25,17 @@ describe("turndown service", () => {
     })
     turndownTest("<figure></figure>", "This rule is being used")
   })
+
+  it("supports a two-item list", () => {
+    turndownTest(
+      "<ul><li>first item</li><li>second item</li></ul>",
+      "- first item\n- second item"
+    )
+  })
+
+  // regression test for the bug documented in
+  // https://github.com/mitodl/ocw-studio/issues/113
+  it("shouldn't blow up if there's an empty list item", () => {
+    turndownTest("<ul><li>first item</li><li></li></ul>", "- first item\n-")
+  })
 })

--- a/static/js/lib/ckeditor/turndown.ts
+++ b/static/js/lib/ckeditor/turndown.ts
@@ -48,28 +48,27 @@ turndownService.rules.blankRule.replacement = (
 // extra spaces to the beginning of a list item. So it maps
 // "<ul><li>item</li></ul>" -> "-   item" instead of "- item"
 // see https://github.com/domchristie/turndown/issues/291
-turndownService.addRule("listItem", {
-  filter:      "li",
-  replacement: (
-    content: string,
-    node: Turndown.Node,
-    options: Turndown.Options
-  ) => {
-    content = content
-      .replace(/^\n+/, "") // remove leading newlines
-      .replace(/\n+$/, "\n") // replace trailing newlines with just a single one
-      .replace(/\n/gm, "\n    ") // indent
+//
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+turndownService.rules.array.find(rule => rule.filter === "li")!.replacement = (
+  content: string,
+  node: Turndown.Node,
+  options: Turndown.Options
+) => {
+  content = content
+    .replace(/^\n+/, "") // remove leading newlines
+    .replace(/\n+$/, "\n") // replace trailing newlines with just a single one
+    .replace(/\n/gm, "\n    ") // indent
 
-    let prefix = `${options.bulletListMarker} `
-    const parent = node.parentNode
-    if (parent && parent.nodeName === "OL") {
-      // @ts-ignore
-      const start: string = parent.getAttribute("start")
-      const index = Array.prototype.indexOf.call(parent.children, node)
-      prefix = `${start ? Number(start) + index : index + 1}. `
-    }
-    return (
-      prefix + content + (node.nextSibling && !/\n$/.test(content) ? "\n" : "")
-    )
+  let prefix = `${options.bulletListMarker} `
+  const parent = node.parentNode
+  if (parent && parent.nodeName === "OL") {
+    // @ts-ignore
+    const start: string = parent.getAttribute("start")
+    const index = Array.prototype.indexOf.call(parent.children, node)
+    prefix = `${start ? Number(start) + index : index + 1}. `
   }
-})
+  return (
+    prefix + content + (node.nextSibling && !/\n$/.test(content) ? "\n" : "")
+  )
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #113

#### What's this PR do?

this fixes an issue with the patch I made to the turndown rule for list items. Basically, I should have patched it by modifying the rule in place, instead of adding another rule. I updated it to modify the rule in place by changing the `replacement` function for `li` tags instead of adding a new rule, and it fixes the issue.

#### How should this be manually tested?

You should be able to add new list items to the editor without error.