### PR TITLE
Add pagination to content UI

### DIFF
--- a/static/js/components/SiteAddContent.test.tsx
+++ b/static/js/components/SiteAddContent.test.tsx
@@ -5,7 +5,7 @@ import sinon, { SinonStub } from "sinon"
 
 import SiteAddContent from "./SiteAddContent"
 
-import { siteApiContentUrl } from "../lib/urls"
+import { siteApiContentCreateUrl } from "../lib/urls"
 import IntegrationTestHelper, {
   TestRenderer
 } from "../util/integration_test_helper"
@@ -80,7 +80,7 @@ describe("SiteAddContent", () => {
   it("submits content via the form", async () => {
     const content = makeWebsiteContentDetail()
     helper.handleRequestStub
-      .withArgs(siteApiContentUrl(website.name), "POST")
+      .withArgs(siteApiContentCreateUrl(website.name), "POST")
       .returns({
         body:   content,
         status: 201
@@ -98,7 +98,7 @@ describe("SiteAddContent", () => {
     })
     sinon.assert.calledWith(
       helper.handleRequestStub,
-      siteApiContentUrl(website.name),
+      siteApiContentCreateUrl(website.name),
       "POST",
       {
         body: {
@@ -115,7 +115,7 @@ describe("SiteAddContent", () => {
   it("handles field errors", async () => {
     const errorObj = { title: "uh oh" }
     helper.handleRequestStub
-      .withArgs(siteApiContentUrl(website.name), "POST")
+      .withArgs(siteApiContentCreateUrl(website.name), "POST")
       .returns({
         body:   errorObj,
         status: 500
@@ -133,7 +133,7 @@ describe("SiteAddContent", () => {
   it("handles non-field errors", async () => {
     const errorMessage = "uh oh"
     helper.handleRequestStub
-      .withArgs(siteApiContentUrl(website.name), "POST")
+      .withArgs(siteApiContentCreateUrl(website.name), "POST")
       .returns({
         body:   errorMessage,
         status: 500

--- a/static/js/components/SiteAddContent.tsx
+++ b/static/js/components/SiteAddContent.tsx
@@ -76,7 +76,7 @@ export default function SiteAddContent({ history }: Props): JSX.Element | null {
     setSubmitting(false)
 
     // Redirect to the site listing if it was successfully created
-    history.push(siteContentListingUrl(name, contenttype))
+    history.push(siteContentListingUrl(name, contenttype, 0))
   }
 
   return (

--- a/static/js/components/SiteEditContent.test.tsx
+++ b/static/js/components/SiteEditContent.test.tsx
@@ -5,7 +5,6 @@ import sinon, { SinonStub } from "sinon"
 
 import SiteEditContent from "./SiteEditContent"
 
-import { contentListingKey } from "../query-configs/websites"
 import { siteApiContentDetailUrl } from "../lib/urls"
 import IntegrationTestHelper, {
   TestRenderer
@@ -69,9 +68,6 @@ describe("SiteEditContent", () => {
         entities: {
           websiteDetails: {
             [website.name]: website
-          },
-          websiteContentListing: {
-            [contentListingKey(website.name, configItem.name)]: [content]
           },
           websiteContentDetails: {
             [content.uuid]: content

--- a/static/js/components/SiteSidebar.test.tsx
+++ b/static/js/components/SiteSidebar.test.tsx
@@ -24,8 +24,11 @@ describe("SiteSidebar", () => {
       .map(link => [link.text(), link.prop("to")])
 
     const expected = [
-      ["Page", siteContentListingUrl(website.name, CONTENT_TYPE_PAGE)],
-      ["Resource", siteContentListingUrl(website.name, CONTENT_TYPE_RESOURCE)]
+      ["Page", siteContentListingUrl(website.name, CONTENT_TYPE_PAGE, 0)],
+      [
+        "Resource",
+        siteContentListingUrl(website.name, CONTENT_TYPE_RESOURCE, 0)
+      ]
     ]
 
     expect(links).toEqual(expect.arrayContaining(expected))

--- a/static/js/components/SiteSidebar.tsx
+++ b/static/js/components/SiteSidebar.tsx
@@ -17,7 +17,7 @@ export default function SiteSidebar(props: Props): JSX.Element {
     <ul>
       {configItems.map(item => (
         <li key={item.name}>
-          <NavLink exact to={siteContentListingUrl(website.name, item.name)}>
+          <NavLink exact to={siteContentListingUrl(website.name, item.name, 0)}>
             {item.label}
           </NavLink>
         </li>

--- a/static/js/constants.ts
+++ b/static/js/constants.ts
@@ -19,6 +19,7 @@ export const CONTENT_TYPE_RESOURCE = "resource"
 export const CONTENT_TYPES = [CONTENT_TYPE_PAGE, CONTENT_TYPE_RESOURCE]
 
 export const WEBSITES_PAGE_SIZE = 10
+export const WEBSITE_CONTENT_PAGE_SIZE = 10
 
 export const exampleSiteConfig: WebsiteStarterConfig = {
   collections: [

--- a/static/js/lib/urls.test.ts
+++ b/static/js/lib/urls.test.ts
@@ -1,8 +1,9 @@
 import {
   newSiteUrl,
   siteAddContentUrl,
+  siteApiContentCreateUrl,
   siteApiContentDetailUrl,
-  siteApiContentUrl,
+  siteApiContentListingUrl,
   siteApiDetailUrl,
   siteApiListingUrl,
   siteContentListingUrl,
@@ -30,10 +31,17 @@ describe("urls", () => {
     expect(siteDetailUrl("course-name")).toBe("/sites/course-name/")
   })
 
-  it("renders a site listing URL", () => {
-    expect(siteContentListingUrl("course-name", CONTENT_TYPE_RESOURCE)).toBe(
-      "/sites/course-name/resource/"
-    )
+  //
+  ;[
+    [0, "site-name", "page", "/sites/site-name/page/"],
+    [20, "course-name", "resource", "/sites/course-name/resource/?offset=20"]
+  ].forEach(([offset, siteName, contentType, expectedLink]) => {
+    it(`renders a site listing URL with offset=${offset}`, () => {
+      // @ts-ignore
+      expect(siteContentListingUrl(siteName, contentType, offset)).toBe(
+        expectedLink
+      )
+    })
   })
 
   it("renders a URL for adding new content", () => {
@@ -51,15 +59,23 @@ describe("urls", () => {
       expect(siteApiDetailUrl("course-name")).toBe("/api/websites/course-name/")
     })
 
-    it("renders a URL for site content listing", () => {
-      expect(siteApiContentUrl("course-name")).toBe(
-        "/api/websites/course-name/content/"
+    it(`renders a URL for site content listing`, () => {
+      expect(
+        siteApiContentListingUrl("course-name", CONTENT_TYPE_RESOURCE, 20)
+      ).toBe(
+        "/api/websites/course-name/content/?type=resource&limit=10&offset=20"
       )
     })
 
     it("renders a URL for site content detail", () => {
       expect(siteApiContentDetailUrl("course-name", "uuid")).toBe(
         "/api/websites/course-name/content/uuid/"
+      )
+    })
+
+    it("renders a URL for creating new sites", () => {
+      expect(siteApiContentCreateUrl("site-name")).toBe(
+        "/api/websites/site-name/content/"
       )
     })
   })

--- a/static/js/lib/urls.ts
+++ b/static/js/lib/urls.ts
@@ -1,4 +1,4 @@
-import { WEBSITES_PAGE_SIZE } from "../constants"
+import { WEBSITE_CONTENT_PAGE_SIZE, WEBSITES_PAGE_SIZE } from "../constants"
 
 export const newSiteUrl = (): string => "/new-site/"
 export const siteListingUrl = (offset: number): string =>
@@ -6,8 +6,12 @@ export const siteListingUrl = (offset: number): string =>
 export const siteDetailUrl = (name: string): string => `/sites/${name}/`
 export const siteContentListingUrl = (
   name: string,
-  contentType: string
-): string => `/sites/${name}/${contentType}/`
+  contentType: string,
+  offset: number
+): string => {
+  const base = `/sites/${name}/${contentType}/`
+  return offset ? `${base}?offset=${offset}` : base
+}
 
 export const siteCollaboratorsUrl = (name: string): string =>
   `/sites/${name}/settings/collaborators/`
@@ -33,7 +37,15 @@ export const siteApiCollaboratorsDetailUrl = (
 export const siteAddContentUrl = (name: string, contentType: string): string =>
   `/sites/${name}/${contentType}/add/`
 
-export const siteApiContentUrl = (name: string): string =>
-  `${siteApiDetailUrl(name)}content/`
+export const siteApiContentListingUrl = (
+  name: string,
+  type: string,
+  offset: number
+): string =>
+  `${siteApiDetailUrl(
+    name
+  )}content/?type=${type}&limit=${WEBSITE_CONTENT_PAGE_SIZE}&offset=${offset}`
 export const siteApiContentDetailUrl = (name: string, uuid: string): string =>
-  `${siteApiContentUrl(name)}${uuid}/`
+  `${siteApiDetailUrl(name)}content/${uuid}/`
+export const siteApiContentCreateUrl = (name: string): string =>
+  `${siteApiDetailUrl(name)}content/`

--- a/static/js/pages/SitesDashboard.test.tsx
+++ b/static/js/pages/SitesDashboard.test.tsx
@@ -102,12 +102,16 @@ describe("SitesDashboard", () => {
     [true, false].forEach(hasNextLink => {
       it(`shows the right links when there ${isIf(
         hasPrevLink
-      )} a previous link and ${isIf(
-        hasNextLink
-      )} has a next link`, async () => {
+      )} a previous link and ${isIf(hasNextLink)} a next link`, async () => {
         response.next = hasNextLink ? "next" : null
         response.previous = hasPrevLink ? "prev" : null
-        const startingOffset = 0
+        const startingOffset = 20
+        helper.handleRequestStub
+          .withArgs(siteApiListingUrl(startingOffset), "GET")
+          .returns({
+            body:   response,
+            status: 200
+          })
         const { wrapper } = await render({
           location: {
             search: `offset=${startingOffset}`

--- a/static/js/selectors/websites.ts
+++ b/static/js/selectors/websites.ts
@@ -44,16 +44,26 @@ export const getWebsiteCollaboratorDetailCursor = createSelector(
     )
 )
 
-export const getWebsiteContentListingCursor = createSelector(
-  (state: ReduxState) => state.entities?.websiteContentListing ?? {},
-  listing =>
-    memoize(
-      (name: string, type: string) => listing[contentListingKey(name, type)],
-      (name, type) => `${name}-${type}`
-    )
-)
-
 export const getWebsiteContentDetailCursor = createSelector(
   (state: ReduxState) => state.entities?.websiteContentDetails ?? {},
   content => memoize((uuid: string) => content[uuid])
+)
+
+export const getWebsiteContentListingCursor = createSelector(
+  (state: ReduxState) => state.entities?.websiteContentListing ?? {},
+  getWebsiteContentDetailCursor,
+  (listing, websiteContentDetailCursor) =>
+    memoize(
+      (name: string, type: string, offset: number) => {
+        const response = listing[contentListingKey(name, type, offset)] ?? {}
+        const uuids = response?.results ?? []
+        const items = uuids.map(websiteContentDetailCursor)
+
+        return {
+          ...response,
+          results: items
+        }
+      },
+      (name, type, offset: number) => contentListingKey(name, type, offset)
+    )
 )

--- a/websites/views.py
+++ b/websites/views.py
@@ -250,6 +250,7 @@ class WebsiteContentViewSet(
     """Viewset for WebsiteContent"""
 
     permission_classes = (HasWebsiteContentPermission,)
+    pagination_class = DefaultPagination
     lookup_field = "uuid"
 
     def get_queryset(self):

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -690,14 +690,15 @@ def test_websites_content_list(drf_client, filter_type, permission_groups):
         ),
         {"type": filter_type},
     )
-    assert len(resp.data) == (num_results if filter_type else num_results + 1)
+    results = resp.data["results"]
+    assert len(results) == (num_results if filter_type else num_results + 1)
 
     for idx, content in enumerate(
         reversed(sorted(contents, key=lambda _content: _content.updated_on))
     ):
-        assert content.title == resp.data[idx]["title"]
-        assert str(content.uuid) == resp.data[idx]["uuid"]
-        assert content.type == resp.data[idx]["type"]
+        assert content.title == results[idx]["title"]
+        assert str(content.uuid) == results[idx]["uuid"]
+        assert content.type == results[idx]["type"]
 
 
 def test_websites_content_detail(drf_client, permission_groups):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #96 

#### What's this PR do?
Adds back pagination to the content API, and implements pagination for the content listing UI similar to how we are doing it for #108. 

#### How should this be manually tested?
Go to the content listing of a site by clicking the "page" or "resource" link in the sidebar. You should see 10 or less results, possibly with pagination arrows below the results. `/sites/6-262-discrete-stochastic-processes-spring-2011/resource/` should have enough resources for pagination as an example.

 - You should be able to go back and forward between pages without seeing any issues. The arrows should only show up at the beginning or end of results.
 - When a content item's title is edited, you should see the change show up immediately in the listing. 
 - You might be able to create a new item and see it show up in the list after saving, however the content list is in most recent order at the moment so you would need to be on the first page to see this change.

#### Screenshots (if appropriate)
![Screenshot from 2021-03-16 16-59-58](https://user-images.githubusercontent.com/863262/111379073-17006a00-8679-11eb-8efd-9a1b5d420796.png)

