### PR TITLE
Increase z-index for ckeditor balloons

### DIFF
--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -62,3 +62,13 @@ $modal-sidebar-width: 540px;
 .modal.right.fade.show .modal-dialog {
   right: 0;
 }
+
+// from https://ckeditor.com/docs/ckeditor5/latest/builds/guides/integration/frameworks/css.html
+/*
+ * Configure the z-index of the ckeditor UI, so when inside a Bootstrap
+ * modal, it will be rendered over the modal.
+ */
+:root {
+  --ck-z-default: 10000 !important;
+  --ck-z-modal: calc(var(--ck-z-default) + 999);
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #121 

#### What's this PR do?
Updates ckeditor's zindex CSS variable so that it's higher than the bootstrap modal

#### How should this be manually tested?
In a site, click the resource or page link. Edit one of the existing pieces of content and create a new link. A field should pop up for you to edit the link, and the keyboard focus should be in the textbox.