### PR TITLE
first round of styling changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,15 +114,19 @@ This command will only work if you have the following:
 1. The name of the AWS bucket which contains the course data. Ask a fellow developer for this.
 1. Valid settings for `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. As with other settings, these should be
    specified in your `.env` file. You can copy these from heroku, or ask a fellow developer for them.
-   
+
 Some example commands:
+
 ```bash
 # List the data file names of all available course sites
 manage.py import_ocw_course_sites -b <bucket_name> --list
+
 # List the data file names of all course sites that match a filter
 manage.py import_ocw_course_sites -b <bucket_name> --filter frameworks-of-urban-governance --list 
+
 # Import course sites with a data file name that matches a filter
 manage.py import_ocw_course_sites -b <bucket_name> --filter frameworks-of-urban-governance 
+
 # Import ALL course sites (this will take quite a while)
 manage.py import_ocw_course_sites -b <bucket_name>
 ```

--- a/main/templates/base.html
+++ b/main/templates/base.html
@@ -10,6 +10,8 @@
     <link rel="stylesheet" type="text/css" href="{% static 'hijack/hijack-styles.css' %}" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap"
           media="none" onload="if(media!='all') media='all'">     
+    <link rel="preconnect" href="https://fonts.gstatic.com">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap" rel="stylesheet">
     <script type="text/javascript">
     var SETTINGS = {{ js_settings_json|safe }};
     </script>

--- a/package.json
+++ b/package.json
@@ -132,8 +132,8 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "repl": "node --require ./scripts/repl.js",
-    "fmt": "LOG_LEVEL= prettier-eslint --write --no-semi --ignore $PWD/'static/js/types/*.d.ts' $PWD/'static/js/**/*.ts' $PWD/'static/js/**/*.tsx'",
-    "fmt:check": "LOG_LEVEL= prettier-eslint --list-different --no-semi --ignore $PWD/'static/js/types/*.d.ts' $PWD/'static/js/**/*.ts' $PWD/'static/js/**/*.tsx'",
+    "fmt": "LOG_LEVEL= prettier-eslint --write --no-semi --ignore $PWD/'static/js/types/*.d.ts' $PWD/'static/js/**/*.ts' $PWD/'static/js/**/*.tsx' $PWD/'static/scss/**/*.scss'",
+    "fmt:check": "LOG_LEVEL= prettier-eslint --list-different --no-semi --ignore $PWD/'static/js/types/*.d.ts' $PWD/'static/js/**/*.ts' $PWD/'static/js/**/*.tsx' $PWD/'static/scss/**/*.scss'",
     "typescript": "rm -rf dist && rm -f .tsbuildinfo && tsc",
     "typecheck": "tsc --noEmit",
     "build": "webpack --config webpack.config.prod.js --bail"

--- a/static/js/components/Card.tsx
+++ b/static/js/components/Card.tsx
@@ -1,0 +1,15 @@
+import React from "react"
+
+interface Props {
+  children: React.ReactNode
+}
+
+export default function Card(props: Props): JSX.Element {
+  const { children } = props
+
+  return (
+    <div className="studio-card h-100">
+      <div className="card-contents p-4">{children}</div>
+    </div>
+  )
+}

--- a/static/js/components/Header.tsx
+++ b/static/js/components/Header.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 export default function Header(): JSX.Element {
   return (
-    <header className="p-3">
-      <h3 className="p-0 m-0">OCW Studio</h3>
+    <header className="p-3 m-3">
+      <h2 className="p-0 m-0 pl-2">OCW Studio</h2>
     </header>
   )
 }

--- a/static/js/components/PaginationControls.tsx
+++ b/static/js/components/PaginationControls.tsx
@@ -1,0 +1,28 @@
+import React from "react"
+import { Link } from "react-router-dom"
+
+interface Props {
+  previous: string
+  next: string
+  listing: any
+}
+
+export default function PaginationControls(props: Props): JSX.Element {
+  const { previous, next, listing } = props
+
+  return (
+    <div className="pagination pt-2 justify-content-center">
+      {listing.previous ? (
+        <Link to={previous} className="previous">
+          <i className="material-icons">keyboard_arrow_left</i>
+        </Link>
+      ) : null}
+      &nbsp;
+      {listing.next ? (
+        <Link to={next} className="next">
+          <i className="material-icons">keyboard_arrow_right</i>
+        </Link>
+      ) : null}
+    </div>
+  )
+}

--- a/static/js/components/SiteAddContent.tsx
+++ b/static/js/components/SiteAddContent.tsx
@@ -1,10 +1,11 @@
 import React from "react"
-import { useRouteMatch, RouteComponentProps } from "react-router-dom"
+import { useRouteMatch, useHistory } from "react-router-dom"
 import { useSelector } from "react-redux"
 import { FormikHelpers } from "formik"
 import { useMutation } from "redux-query-react"
 
 import SiteAddContentForm from "./forms/SiteAddContentForm"
+import Card from "./Card"
 
 import { contentFormValuesToPayload } from "../lib/site_content"
 import { siteContentListingUrl } from "../lib/urls"
@@ -21,10 +22,12 @@ interface MatchParams {
   contenttype: string
   name: string
 }
-type Props = RouteComponentProps<Record<string, never>>
-export default function SiteAddContent({ history }: Props): JSX.Element | null {
+
+export default function SiteAddContent(): JSX.Element | null {
   const match = useRouteMatch<MatchParams>()
+  const history = useHistory()
   const { contenttype, name } = match.params
+
   const website = useSelector(getWebsiteDetailCursor)(name)
   const [
     { isPending },
@@ -81,11 +84,11 @@ export default function SiteAddContent({ history }: Props): JSX.Element | null {
   }
 
   return (
-    <div>
+    <Card>
       <h3>New {configItem.label}</h3>
       <div>
         <SiteAddContentForm onSubmit={onSubmitForm} configItem={configItem} />
       </div>
-    </div>
+    </Card>
   )
 }

--- a/static/js/components/SiteCollaboratorAddPanel.test.tsx
+++ b/static/js/components/SiteCollaboratorAddPanel.test.tsx
@@ -26,7 +26,6 @@ describe("SiteCollaboratorAddPanel", () => {
   let helper: IntegrationTestHelper,
     render: TestRenderer,
     website: Website,
-    historyPushStub: SinonStub,
     formikStubs: { [key: string]: SinonStub },
     createCollaboratorStub: SinonStub
 
@@ -35,7 +34,6 @@ describe("SiteCollaboratorAddPanel", () => {
   beforeEach(() => {
     helper = new IntegrationTestHelper()
     website = makeWebsiteDetail()
-    historyPushStub = sinon.stub()
     const params = { name: website.name }
     mockUseRouteMatch.mockImplementation(() => ({
       params
@@ -48,9 +46,7 @@ describe("SiteCollaboratorAddPanel", () => {
     render = helper.configureRenderer(
       // @ts-ignore
       SiteCollaboratorAddPanel,
-      {
-        history: { push: historyPushStub }
-      },
+      {},
       {
         entities: {
           collaborators: {
@@ -99,8 +95,7 @@ describe("SiteCollaboratorAddPanel", () => {
     })
     sinon.assert.calledOnce(createCollaboratorStub)
     sinon.assert.calledOnceWithExactly(formikStubs.setSubmitting, false)
-    sinon.assert.calledOnceWithExactly(
-      historyPushStub,
+    expect(helper.browserHistory.location.pathname).toBe(
       siteCollaboratorsUrl.param({ name: website.name }).toString()
     )
   })
@@ -139,7 +134,7 @@ describe("SiteCollaboratorAddPanel", () => {
     sinon.assert.calledOnceWithExactly(formikStubs.setErrors, {
       ...errorResp.errors
     })
-    sinon.assert.notCalled(historyPushStub)
+    expect(helper.browserHistory.location.pathname).toBe("/")
   })
 
   it("sets form error if the API request fails with a string error message", async () => {
@@ -171,6 +166,6 @@ describe("SiteCollaboratorAddPanel", () => {
     })
     sinon.assert.calledOnce(createCollaboratorStub)
     sinon.assert.calledOnceWithExactly(formikStubs.setStatus, errorMsg)
-    sinon.assert.notCalled(historyPushStub)
+    expect(helper.browserHistory.location.pathname).toBe("/")
   })
 })

--- a/static/js/components/SiteCollaboratorAddPanel.tsx
+++ b/static/js/components/SiteCollaboratorAddPanel.tsx
@@ -1,9 +1,10 @@
 import React from "react"
 import { useMutation, useRequest } from "redux-query-react"
-import { RouteComponentProps, useRouteMatch } from "react-router-dom"
+import { useRouteMatch, useHistory } from "react-router-dom"
 import { FormikHelpers } from "formik"
 import { is } from "ramda"
 
+import Card from "./Card"
 import SiteCollaboratorForm from "./forms/SiteCollaboratorForm"
 import { siteCollaboratorsUrl } from "../lib/urls"
 import { getResponseBodyError, isErrorResponse } from "../lib/util"
@@ -19,13 +20,10 @@ interface MatchParams {
   name: string
 }
 
-type Props = RouteComponentProps<Record<string, never>>
-
-export default function SiteCollaboratorAddPanel({
-  history
-}: Props): JSX.Element | null {
+export default function SiteCollaboratorAddPanel(): JSX.Element | null {
   const match = useRouteMatch<MatchParams>()
   const { name } = match.params
+  const history = useHistory()
 
   const [{ isPending }] = useRequest(websiteCollaboratorsRequest(name))
   const [collaboratorQueryState, addCollaborator] = useMutation(
@@ -71,10 +69,12 @@ export default function SiteCollaboratorAddPanel({
 
   return (
     <div className="narrow-page-body m-3">
-      <h3>Add Collaborator</h3>
-      <div className="form-container m-3 p-3">
-        <SiteCollaboratorForm onSubmit={onSubmit}></SiteCollaboratorForm>
-      </div>
+      <Card>
+        <h3>Add Collaborator</h3>
+        <div className="form-container m-3 p-3">
+          <SiteCollaboratorForm onSubmit={onSubmit}></SiteCollaboratorForm>
+        </div>
+      </Card>
     </div>
   )
 }

--- a/static/js/components/SiteCollaboratorEditPanel.test.tsx
+++ b/static/js/components/SiteCollaboratorEditPanel.test.tsx
@@ -30,7 +30,6 @@ describe("SiteCollaboratorEditPanel", () => {
   let helper: IntegrationTestHelper,
     render: TestRenderer,
     website: Website,
-    historyPushStub: SinonStub,
     formikStubs: { [key: string]: SinonStub },
     editCollaboratorStub: SinonStub,
     collaborator: WebsiteCollaborator
@@ -41,7 +40,6 @@ describe("SiteCollaboratorEditPanel", () => {
     helper = new IntegrationTestHelper()
     website = makeWebsiteDetail()
     collaborator = makeWebsiteCollaborator()
-    historyPushStub = sinon.stub()
     const params = { username: collaborator.username, name: website.name }
     mockUseRouteMatch.mockImplementation(() => ({
       params
@@ -54,9 +52,7 @@ describe("SiteCollaboratorEditPanel", () => {
     render = helper.configureRenderer(
       // @ts-ignore
       SiteCollaboratorEditPanel,
-      {
-        history: { push: historyPushStub }
-      },
+      {},
       {
         entities: {
           collaborators: {
@@ -118,11 +114,11 @@ describe("SiteCollaboratorEditPanel", () => {
     })
     sinon.assert.calledOnce(editCollaboratorStub)
     sinon.assert.calledOnceWithExactly(formikStubs.setSubmitting, false)
-    sinon.assert.calledOnceWithExactly(
-      historyPushStub,
+    expect(helper.browserHistory.location.pathname).toBe(
       siteCollaboratorsUrl.param({ name: website.name }).toString()
     )
   })
+
   it("sets form errors if the API request fails", async () => {
     const errorResp = {
       errors: {
@@ -161,7 +157,7 @@ describe("SiteCollaboratorEditPanel", () => {
     sinon.assert.calledOnceWithExactly(formikStubs.setErrors, {
       ...errorResp.errors
     })
-    sinon.assert.notCalled(historyPushStub)
+    expect(helper.browserHistory.location.pathname).toBe("/")
   })
 
   it("sets form errors if the API request fails with a string error message", async () => {
@@ -197,6 +193,6 @@ describe("SiteCollaboratorEditPanel", () => {
     })
     sinon.assert.calledOnce(editCollaboratorStub)
     sinon.assert.calledOnceWithExactly(formikStubs.setStatus, errorMsg)
-    sinon.assert.notCalled(historyPushStub)
+    expect(helper.browserHistory.location.pathname).toBe("/")
   })
 })

--- a/static/js/components/SiteCollaboratorEditPanel.tsx
+++ b/static/js/components/SiteCollaboratorEditPanel.tsx
@@ -1,11 +1,13 @@
 import React from "react"
 import { useMutation, useRequest } from "redux-query-react"
-import { RouteComponentProps, useRouteMatch } from "react-router-dom"
+import { useRouteMatch, useHistory } from "react-router-dom"
 import { useSelector } from "react-redux"
 import { FormikHelpers } from "formik"
 import { is } from "ramda"
 
 import SiteCollaboratorForm from "./forms/SiteCollaboratorForm"
+import Card from "./Card"
+
 import { siteCollaboratorsUrl } from "../lib/urls"
 import { getResponseBodyError, isErrorResponse } from "../lib/util"
 import {
@@ -24,13 +26,11 @@ interface MatchParams {
   name: string
 }
 
-type Props = RouteComponentProps<Record<string, never>>
-
-export default function SiteCollaboratorEditPanel({
-  history
-}: Props): JSX.Element | null {
+export default function SiteCollaboratorEditPanel(): JSX.Element | null {
   const match = useRouteMatch<MatchParams>()
   const { username, name } = match.params
+  const history = useHistory()
+
   const [{ isPending }] = useRequest(websiteCollaboratorsRequest(name))
   const [collaboratorQueryState, updateCollaboratorRole] = useMutation(
     editWebsiteCollaboratorMutation
@@ -87,13 +87,15 @@ export default function SiteCollaboratorEditPanel({
 
   return (
     <div className="narrow-page-body m-3">
-      <h3>Edit role for {collaborator.name}</h3>
-      <div className="form-container m-3 p-3">
-        <SiteCollaboratorForm
-          collaborator={collaborator}
-          onSubmit={onSubmit}
-        ></SiteCollaboratorForm>
-      </div>
+      <Card>
+        <h3>Edit role for {collaborator.name}</h3>
+        <div className="form-container m-3 p-3">
+          <SiteCollaboratorForm
+            collaborator={collaborator}
+            onSubmit={onSubmit}
+          ></SiteCollaboratorForm>
+        </div>
+      </Card>
     </div>
   )
 }

--- a/static/js/components/SiteCollaboratorList.test.tsx
+++ b/static/js/components/SiteCollaboratorList.test.tsx
@@ -34,21 +34,17 @@ describe("SiteCollaboratorList", () => {
     website: Website,
     collaborators: WebsiteCollaborator[],
     permanentAdmins: WebsiteCollaborator[],
-    historyPushStub: SinonStub,
     deleteCollaboratorStub: SinonStub
 
   beforeEach(() => {
     helper = new IntegrationTestHelper()
-    historyPushStub = sinon.stub()
     website = makeWebsiteDetail()
     collaborators = makeWebsiteCollaborators()
     permanentAdmins = [makePermanentWebsiteCollaborator()]
     render = helper.configureRenderer(
       // @ts-ignore
       SiteCollaboratorList,
-      {
-        history: { push: historyPushStub }
-      },
+      {},
       {
         entities: {
           websites:      { website },
@@ -101,14 +97,12 @@ describe("SiteCollaboratorList", () => {
 
   it("the edit collaborator icon sends the user to the correct url", async () => {
     const { wrapper } = await render()
-    const editIcon = wrapper
+    const editLink = wrapper
       .find("tr")
       .at(0)
-      .find("i")
+      .find(".edit-link")
       .at(0)
-    editIcon.simulate("click")
-    sinon.assert.calledOnceWithExactly(
-      historyPushStub,
+    expect(editLink.prop("to")).toBe(
       siteCollaboratorsDetailUrl
         .param({
           name:     website.name,
@@ -160,13 +154,11 @@ describe("SiteCollaboratorList", () => {
 
   it("the add collaborator button sends the user to the correct url", async () => {
     const { wrapper } = await render()
-    wrapper
-      .find(".collaborator-add-btn")
-      .find("button")
-      .simulate("click")
-    sinon.assert.calledOnceWithExactly(
-      historyPushStub,
-      siteCollaboratorsAddUrl.param({ name: website.name }).toString()
-    )
+    expect(
+      wrapper
+        .find(".collaborator-add-btn")
+        .at(0)
+        .prop("to")
+    ).toBe(siteCollaboratorsAddUrl.param({ name: website.name }).toString())
   })
 })

--- a/static/js/components/SiteCollaboratorList.tsx
+++ b/static/js/components/SiteCollaboratorList.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from "react"
-import { RouteComponentProps, useRouteMatch } from "react-router-dom"
+import { useRouteMatch, Link } from "react-router-dom"
 import { useSelector } from "react-redux"
 import { QueryConfig } from "redux-query"
 import { useMutation, useRequest } from "redux-query-react"
 
 import Dialog from "./Dialog"
+import Card from "./Card"
+
 import { EDITABLE_ROLES, ROLE_LABELS } from "../constants"
 import {
   siteCollaboratorsAddUrl,
@@ -22,13 +24,10 @@ interface MatchParams {
   name: string
 }
 
-type Props = RouteComponentProps<Record<string, never>>
-
-export default function SiteCollaboratorList({
-  history
-}: Props): JSX.Element | null {
+export default function SiteCollaboratorList(): JSX.Element | null {
   const match = useRouteMatch<MatchParams>()
   const { name } = match.params
+
   const [{ isPending }] = useRequest(websiteCollaboratorsRequest(name))
   const collaborators = useSelector(getWebsiteCollaboratorsCursor)(name)
 
@@ -66,65 +65,61 @@ export default function SiteCollaboratorList({
 
   return (
     <div className="collaborator-list">
-      <h3>Collaborators</h3>
-      <div className="collaborator-add-btn">
-        <button
-          type="submit"
-          onClick={() =>
-            history.push(siteCollaboratorsAddUrl.param({ name }).toString())
-          }
-        >
-          Add collaborator
-        </button>
-      </div>
-      <div className="narrow-page-body pb-5">
-        <table className="table table-striped collaborator-table">
-          <tbody>
-            {collaborators.map(
-              (collaborator: WebsiteCollaborator, i: number) => (
-                <tr key={i}>
-                  <td className="pr-5">
-                    {collaborator.name || collaborator.email}
-                  </td>
-                  <td className="pr-5">
-                    {ROLE_LABELS[collaborator.role]}&nbsp;
-                  </td>
-                  <td>
-                    {EDITABLE_ROLES.includes(collaborator.role) ? (
-                      <>
-                        <i
-                          className="material-icons"
-                          onClick={() =>
-                            history.push(
-                              siteCollaboratorsDetailUrl
-                                .param({
-                                  name,
-                                  username: collaborator.username
-                                })
-                                .toString()
-                            )
-                          }
-                        >
-                          edit
-                        </i>
-                        <i
-                          className="material-icons"
-                          onClick={() => {
-                            setSelectedCollaborator(collaborator)
-                            toggleDeleteModal()
-                          }}
-                        >
-                          delete_outline
-                        </i>
-                      </>
-                    ) : null}
-                  </td>
-                </tr>
-              )
-            )}
-          </tbody>
-        </table>
-      </div>
+      <Card>
+        <div className="d-flex justify-content-between align-items-center pb-3">
+          <h3>Collaborators</h3>
+          <Link
+            className="collaborator-add-btn btn blue-button"
+            to={siteCollaboratorsAddUrl.param({ name }).toString()}
+          >
+            Add collaborator
+          </Link>
+        </div>
+        <div className="narrow-page-body pb-5">
+          <table className="table collaborator-table">
+            <tbody>
+              {collaborators.map(
+                (collaborator: WebsiteCollaborator, i: number) => (
+                  <tr key={i}>
+                    <td className="pr-5">
+                      {collaborator.name || collaborator.email}
+                    </td>
+                    <td className="pr-5 gray">
+                      {ROLE_LABELS[collaborator.role]}&nbsp;
+                    </td>
+                    <td className="gray">
+                      {EDITABLE_ROLES.includes(collaborator.role) ? (
+                        <>
+                          <Link
+                            className="edit-link"
+                            to={siteCollaboratorsDetailUrl
+                              .param({
+                                name,
+                                username: collaborator.username
+                              })
+                              .toString()}
+                          >
+                            <i className="material-icons">edit</i>
+                          </Link>
+                          <i
+                            className="material-icons"
+                            onClick={() => {
+                              setSelectedCollaborator(collaborator)
+                              toggleDeleteModal()
+                            }}
+                          >
+                            delete_outline
+                          </i>
+                        </>
+                      ) : null}
+                    </td>
+                  </tr>
+                )
+              )}
+            </tbody>
+          </table>
+        </div>
+      </Card>
       <Dialog
         open={deleteModal}
         toggleModal={toggleDeleteModal}

--- a/static/js/components/SiteContentListing.test.tsx
+++ b/static/js/components/SiteContentListing.test.tsx
@@ -213,11 +213,10 @@ describe("SiteContentListing", () => {
             body:   response,
             status: 200
           })
-        const { wrapper } = await render({
-          location: {
-            search: `offset=${startingOffset}`
-          }
-        })
+
+        helper.browserHistory.push({ search: `offset=${startingOffset}` })
+
+        const { wrapper } = await render()
 
         const prevWrapper = wrapper.find(".pagination Link.previous")
         expect(prevWrapper.exists()).toBe(hasPrevLink)

--- a/static/js/components/SiteContentListing.tsx
+++ b/static/js/components/SiteContentListing.tsx
@@ -1,14 +1,11 @@
 import React, { MouseEvent as ReactMouseEvent, useState } from "react"
-import {
-  useRouteMatch,
-  NavLink,
-  RouteComponentProps,
-  Link
-} from "react-router-dom"
+import { useRouteMatch, NavLink, useLocation } from "react-router-dom"
 import { useRequest } from "redux-query-react"
 import { useSelector } from "react-redux"
 
 import SiteEditContent from "./SiteEditContent"
+import PaginationControls from "./PaginationControls"
+import Card from "./Card"
 
 import { WEBSITE_CONTENT_PAGE_SIZE } from "../constants"
 import { siteAddContentUrl, siteContentListingUrl } from "../lib/urls"
@@ -27,15 +24,12 @@ interface MatchParams {
   contenttype: string
   name: string
 }
-export default function SiteContentListing(
-  props: RouteComponentProps<Record<string, never>>
-): JSX.Element | null {
+export default function SiteContentListing(): JSX.Element | null {
   const match = useRouteMatch<MatchParams>()
-  const {
-    location: { search }
-  } = props
+  const { search } = useLocation()
   const offset = Number(new URLSearchParams(search).get("offset") ?? 0)
   const { contenttype, name } = match.params
+
   const website = useSelector(getWebsiteDetailCursor)(name)
   const [{ isPending: contentListingPending }] = useRequest(
     websiteContentListingRequest(name, contenttype, offset)
@@ -82,69 +76,57 @@ export default function SiteContentListing(
           toggleVisibility={toggleEditVisibility}
         />
       ) : null}
-      <div className="px-4">
-        <div className="d-flex flex-direction-row align-items-center justify-content-between pb-3">
-          <h3>
+      <div>
+        <Card>
+          <div className="d-flex flex-direction-row align-items-center justify-content-between pb-3">
+            <h3>
+              <NavLink
+                to={siteContentListingUrl
+                  .param({ name, contentType: contenttype })
+                  .toString()}
+              >
+                {configItem.label}
+              </NavLink>
+            </h3>
             <NavLink
-              to={siteContentListingUrl
+              className="btn blue-button"
+              to={siteAddContentUrl
                 .param({ name, contentType: contenttype })
                 .toString()}
             >
-              {configItem.label}
+              Add {configItem.label}
             </NavLink>
-          </h3>
-          <NavLink
-            to={siteAddContentUrl
-              .param({ name, contentType: contenttype })
-              .toString()}
-          >
-            Add {configItem.label}
-          </NavLink>
-        </div>
-        <ul>
-          {listing.results.map((item: WebsiteContentListItem) => (
-            <li key={item.uuid}>
-              <div className="d-flex flex-direction-row align-items-center justify-content-between">
-                <span>{item.title}</span>
-                <a className="edit" onClick={startEdit(item.uuid)}>
-                  Edit
-                </a>
-              </div>
-              <hr />
-            </li>
-          ))}
-        </ul>
-        <div className="pagination justify-content-center">
-          {listing.previous ? (
-            <Link
-              to={siteContentListingUrl
-                .param({
-                  name,
-                  contentType: contenttype
-                })
-                .query({ offset: offset - WEBSITE_CONTENT_PAGE_SIZE })
-                .toString()}
-              className="previous"
-            >
-              <i className="material-icons">keyboard_arrow_left</i>
-            </Link>
-          ) : null}
-          &nbsp;
-          {listing.next ? (
-            <Link
-              to={siteContentListingUrl
-                .param({
-                  name,
-                  contentType: contenttype
-                })
-                .query({ offset: offset + WEBSITE_CONTENT_PAGE_SIZE })
-                .toString()}
-              className="next"
-            >
-              <i className="material-icons">keyboard_arrow_right</i>
-            </Link>
-          ) : null}
-        </div>
+          </div>
+          <ul className="ruled-list">
+            {listing.results.map((item: WebsiteContentListItem) => (
+              <li key={item.uuid} className="py-3">
+                <div className="d-flex flex-direction-row align-items-center justify-content-between">
+                  <span>{item.title}</span>
+                  <a className="edit" onClick={startEdit(item.uuid)}>
+                    Edit
+                  </a>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </Card>
+        <PaginationControls
+          listing={listing}
+          previous={siteContentListingUrl
+            .param({
+              name,
+              contentType: contenttype
+            })
+            .query({ offset: offset - WEBSITE_CONTENT_PAGE_SIZE })
+            .toString()}
+          next={siteContentListingUrl
+            .param({
+              name,
+              contentType: contenttype
+            })
+            .query({ offset: offset + WEBSITE_CONTENT_PAGE_SIZE })
+            .toString()}
+        />
       </div>
     </>
   )

--- a/static/js/components/SiteEditContent.tsx
+++ b/static/js/components/SiteEditContent.tsx
@@ -27,8 +27,10 @@ interface Props {
   site: Website
   configItem: ConfigItem
 }
+
 export default function SiteEditContent(props: Props): JSX.Element | null {
   const { visibility, configItem, uuid, toggleVisibility, site } = props
+
   const [
     { isPending: editIsPending },
     editWebsiteContent
@@ -86,11 +88,13 @@ export default function SiteEditContent(props: Props): JSX.Element | null {
           Edit {configItem.name}
         </ModalHeader>
         <ModalBody>
-          <SiteEditContentForm
-            onSubmit={onSubmitForm}
-            configItem={configItem}
-            content={content}
-          />
+          <div className="m-3">
+            <SiteEditContentForm
+              onSubmit={onSubmitForm}
+              configItem={configItem}
+              content={content}
+            />
+          </div>
         </ModalBody>
       </Modal>
     </div>

--- a/static/js/components/SiteSidebar.test.tsx
+++ b/static/js/components/SiteSidebar.test.tsx
@@ -1,22 +1,28 @@
-import React from "react"
-import { shallow } from "enzyme"
-
 import SiteSidebar from "./SiteSidebar"
 
 import { makeWebsiteDetail } from "../util/factories/websites"
 import { siteCollaboratorsUrl, siteContentListingUrl } from "../lib/urls"
+import IntegrationTestHelper, {
+  TestRenderer
+} from "../util/integration_test_helper"
 
 import { Website } from "../types/websites"
 
 describe("SiteSidebar", () => {
-  let website: Website
+  let website: Website, helper: IntegrationTestHelper, render: TestRenderer
 
   beforeEach(() => {
     website = makeWebsiteDetail()
+    helper = new IntegrationTestHelper()
+    render = helper.configureRenderer(SiteSidebar, { website })
   })
 
-  it("renders some links", () => {
-    const wrapper = shallow(<SiteSidebar website={website} />)
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("renders some links", async () => {
+    const { wrapper } = await render()
 
     const links = wrapper
       .find("NavLink")
@@ -55,9 +61,9 @@ describe("SiteSidebar", () => {
     expect(links).toEqual(expect.arrayContaining(expected))
   })
 
-  it("renders a collaborators link if the user is an admin for the given website", () => {
+  it("renders a collaborators link if the user is an admin for the given website", async () => {
     website.is_admin = true
-    const wrapper = shallow(<SiteSidebar website={website} />)
+    const { wrapper } = await render()
 
     const collaboratorLinkUrl = siteCollaboratorsUrl
       .param({ name: website.name })

--- a/static/js/components/SiteSidebar.tsx
+++ b/static/js/components/SiteSidebar.tsx
@@ -6,48 +6,62 @@ import { siteContentListingUrl } from "../lib/urls"
 import { ConfigItem, Website } from "../types/websites"
 import { addToMapList } from "../lib/util"
 
-interface MenuLink {
-  label: string
-  name: string
+const buildConfigMap = (website: Website, configItems: ConfigItem[]) => {
+  // Create a map with all defined categories mapped to the config items in that category.
+  // ex: {"Content": [<config item>, <config item>], "Settings": [<config item>]}
+  // Using a Map to maintain the order of insertion for keys.
+  const configMap = new Map<string, Array<ConfigItem>>()
+  configItems.forEach((configItem: ConfigItem) => {
+    addToMapList(configMap, configItem.category, configItem)
+  })
+
+  if (website.is_admin) {
+    addToMapList(configMap, "Settings", {
+      name:     "collaborators",
+      label:    "Collaborators",
+      category: "Settings",
+      fields:   []
+    })
+  }
+
+  return configMap
 }
 
-type NavMenuItem = ConfigItem | MenuLink
+interface SectionProps {
+  category: string
+  website: Website
+  configItems: ConfigItem[]
+}
+
+function SidebarSection(props: SectionProps): JSX.Element {
+  const { website, configItems, category } = props
+
+  const iconName = category === "Settings" ? "settings" : "create"
+
+  return (
+    <>
+      <h4 className="d-flex align-items-center">
+        <i className="material-icons pr-2">{iconName}</i>
+        {category}
+      </h4>
+      {configItems.map((item: ConfigItem) => (
+        <NavLink
+          key={item.name}
+          exact
+          className="font-weight-light my-2"
+          to={siteContentListingUrl
+            .param({ name: website.name, contentType: item.name })
+            .toString()}
+        >
+          {item.label}
+        </NavLink>
+      ))}
+    </>
+  )
+}
 
 interface Props {
   website: Website
-}
-
-const collaboratorMenuItem: MenuLink = {
-  name:  "collaborators",
-  label: "Collaborators"
-}
-
-const renderCategoryConfigs = (
-  website: Website,
-  configItems: Array<NavMenuItem>
-): JSX.Element | null => {
-  if (configItems.length === 0) {
-    return null
-  }
-  return (
-    <ul>
-      {configItems.map((configItem: NavMenuItem) => (
-        <li key={configItem.name}>
-          <NavLink
-            exact
-            to={siteContentListingUrl
-              .param({
-                name:        website.name,
-                contentType: configItem.name
-              })
-              .toString()}
-          >
-            {configItem.label}
-          </NavLink>
-        </li>
-      ))}
-    </ul>
-  )
 }
 
 export default function SiteSidebar(props: Props): JSX.Element {
@@ -55,25 +69,18 @@ export default function SiteSidebar(props: Props): JSX.Element {
 
   const configItems: ConfigItem[] = website.starter?.config?.collections ?? []
 
-  // Create a map with all defined categories mapped to the config items in that category.
-  //   ex: {"Content": [<config item>, <config item>], "Settings": [<config item>]}
-  // Using a Map to maintain the order of insertion for keys.
-  const configMap = new Map<string, Array<ConfigItem>>()
-  configItems.forEach((configItem: ConfigItem) => {
-    addToMapList(configMap, configItem.category, configItem)
-  })
-  if (website.is_admin) {
-    addToMapList(configMap, "Settings", collaboratorMenuItem)
-  }
+  const configSections = [...buildConfigMap(website, configItems).entries()]
 
   return (
-    <ul>
-      {Array.from(configMap.entries()).map(([category, configItems]) => (
-        <li key={category}>
-          <span>{category}</span>
-          {renderCategoryConfigs(website, configItems)}
-        </li>
+    <div className="sidebar">
+      {configSections.map(([category, configItems]) => (
+        <SidebarSection
+          category={category}
+          key={category}
+          website={website}
+          configItems={configItems}
+        />
       ))}
-    </ul>
+    </div>
   )
 }

--- a/static/js/components/forms/SiteAddContentForm.tsx
+++ b/static/js/components/forms/SiteAddContentForm.tsx
@@ -58,11 +58,11 @@ export default function SiteAddContentForm({
                 setFieldValue={setFieldValue}
               />
             ))}
-            <div className="form-group">
+            <div className="form-group d-flex justify-content-end">
               <button
                 type="submit"
                 disabled={isSubmitting}
-                className="mx-auto d-block px-5"
+                className="px-5 btn blue-button"
               >
                 Save
               </button>

--- a/static/js/components/forms/SiteCollaboratorForm.tsx
+++ b/static/js/components/forms/SiteCollaboratorForm.tsx
@@ -69,9 +69,7 @@ export default function SiteCollaboratorForm({
             </div>
           )}
           <div className="form-group">
-            <label htmlFor="role" className="font-weight-bold">
-              Role*
-            </label>
+            <label htmlFor="role">Role*</label>
             <Field
               component="select"
               name="role"
@@ -87,8 +85,12 @@ export default function SiteCollaboratorForm({
             </Field>
             <ErrorMessage name="role" />
           </div>
-          <div className="form-group">
-            <button type="submit" disabled={isSubmitting}>
+          <div className="form-group d-flex justify-content-end">
+            <button
+              type="submit"
+              className="btn blue-button"
+              disabled={isSubmitting}
+            >
               Save
             </button>
           </div>

--- a/static/js/components/forms/SiteContentField.tsx
+++ b/static/js/components/forms/SiteContentField.tsx
@@ -17,9 +17,7 @@ export default function SiteContentField({
   const extraProps = field.widget === "file" ? { setFieldValue } : {}
   return (
     <div className="form-group">
-      <label htmlFor={field.name} className="font-weight-bold">
-        {field.label}
-      </label>
+      <label htmlFor={field.name}>{field.label}</label>
       <Field
         as={componentFromWidget(field)}
         name={field.name}

--- a/static/js/components/forms/SiteEditContentForm.tsx
+++ b/static/js/components/forms/SiteEditContentForm.tsx
@@ -52,7 +52,11 @@ export default function SiteEditContentForm({
             />
           ))}
           <div className="form-group d-flex justify-content-end">
-            <button type="submit" disabled={isSubmitting} className="px-5">
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="px-5 btn blue-button"
+            >
               Save
             </button>
           </div>

--- a/static/js/components/forms/SiteForm.tsx
+++ b/static/js/components/forms/SiteForm.tsx
@@ -43,16 +43,12 @@ export const SiteForm = ({
       {({ isSubmitting, status }) => (
         <Form>
           <div className="form-group">
-            <label htmlFor="title" className="font-weight-bold">
-              Title*
-            </label>
+            <label htmlFor="title">Title*</label>
             <Field type="text" name="title" className="form-control" />
             <ErrorMessage name="title" component="div" />
           </div>
           <div className="form-group">
-            <label htmlFor="starter" className="font-weight-bold">
-              Starter*
-            </label>
+            <label htmlFor="starter">Starter*</label>
             <Field component="select" name="starter" className="form-control">
               {websiteStarters.length > 0 ? (
                 websiteStarters.map((starter, i) => (
@@ -67,8 +63,12 @@ export const SiteForm = ({
             </Field>
             <ErrorMessage name="starter" component="div" />
           </div>
-          <div className="form-group">
-            <button type="submit" disabled={isSubmitting}>
+          <div className="form-group d-flex justify-content-end">
+            <button
+              type="submit"
+              className="btn blue-button"
+              disabled={isSubmitting}
+            >
               Submit
             </button>
           </div>

--- a/static/js/pages/App.tsx
+++ b/static/js/pages/App.tsx
@@ -14,14 +14,16 @@ export default function App(): JSX.Element {
   return (
     <div className="app">
       <Header />
-      <Switch>
-        <Route exact path="/new-site" component={SiteCreationPage} />
-        <Route exact path="/sites" component={SitesDashboard} />
-        <Route path="/sites/:name" component={SitePage} />
-        <Route path="/markdown-editor">
-          <MarkdownEditorTestPage />
-        </Route>
-      </Switch>
+      <div className="page-content">
+        <Switch>
+          <Route exact path="/new-site" component={SiteCreationPage} />
+          <Route exact path="/sites" component={SitesDashboard} />
+          <Route path="/sites/:name" component={SitePage} />
+          <Route path="/markdown-editor">
+            <MarkdownEditorTestPage />
+          </Route>
+        </Switch>
+      </div>
     </div>
   )
 }

--- a/static/js/pages/SiteCreationPage.tsx
+++ b/static/js/pages/SiteCreationPage.tsx
@@ -5,6 +5,7 @@ import { RouteComponentProps } from "react-router-dom"
 import { FormikHelpers } from "formik"
 
 import { SiteForm, SiteFormValues } from "../components/forms/SiteForm"
+import Card from "../components/Card"
 
 import {
   getTransformedWebsiteName,
@@ -71,18 +72,18 @@ export default function SiteCreationPage({
 
   if (starterQueryState.isPending) {
     return (
-      <div className="sites-dashboard narrow-page-body container mt-3">
-        Loading...
-      </div>
+      <div className="new-site narrow-page-body container mt-3">Loading...</div>
     )
   }
 
   return (
-    <div className="sites-dashboard narrow-page-body container mt-3">
-      <h4>Create a New Site</h4>
-      <div className="form-container mv-3 p-3">
-        <SiteForm onSubmit={onSubmitForm} websiteStarters={websiteStarters} />
-      </div>
+    <div className="new-site narrow-page-body container mt-5">
+      <h4 className="font-weight-light">Add Course</h4>
+      <Card>
+        <div className="p-5">
+          <SiteForm onSubmit={onSubmitForm} websiteStarters={websiteStarters} />
+        </div>
+      </Card>
     </div>
   )
 }

--- a/static/js/pages/SitePage.tsx
+++ b/static/js/pages/SitePage.tsx
@@ -9,6 +9,7 @@ import SiteCollaboratorList from "../components/SiteCollaboratorList"
 import SiteCollaboratorEditPanel from "../components/SiteCollaboratorEditPanel"
 import SiteCollaboratorAddPanel from "../components/SiteCollaboratorAddPanel"
 import SiteAddContent from "../components/SiteAddContent"
+import Card from "../components/Card"
 
 import { websiteDetailRequest } from "../query-configs/websites"
 import { getWebsiteDetailCursor } from "../selectors/websites"
@@ -19,6 +20,7 @@ interface MatchParams {
 export default function SitePage(): JSX.Element | null {
   const match = useRouteMatch<MatchParams>()
   const { name } = match.params
+
   const [{ isPending }] = useRequest(websiteDetailRequest(name))
   const website = useSelector(getWebsiteDetailCursor)(name)
   if (!website) {
@@ -33,33 +35,26 @@ export default function SitePage(): JSX.Element | null {
     <div className="site-page std-page-body container">
       <h3>{website.title}</h3>
       <div className="content-container">
-        <div className="sidebar">
+        <Card>
           <SiteSidebar website={website} />
-        </div>
-        <div className="content">
+        </Card>
+        <div className="content pl-3">
           <Switch>
-            <Route
-              path={`${match.path}/collaborators/add/`}
-              component={SiteCollaboratorAddPanel}
-            />
-            <Route
-              path={`${match.path}/collaborators/:username/`}
-              component={SiteCollaboratorEditPanel}
-            />
-            <Route
-              path={`${match.path}/collaborators/`}
-              component={SiteCollaboratorList}
-            />
-            <Route
-              exact
-              path={`${match.path}/:contenttype`}
-              component={SiteContentListing}
-            />
-            <Route
-              exact
-              path={`${match.path}/:contenttype/add/`}
-              component={SiteAddContent}
-            />
+            <Route path={`${match.path}/collaborators/new/`}>
+              <SiteCollaboratorAddPanel />
+            </Route>
+            <Route path={`${match.path}/collaborators/:username/`}>
+              <SiteCollaboratorEditPanel />
+            </Route>
+            <Route path={`${match.path}/collaborators/`}>
+              <SiteCollaboratorList />
+            </Route>
+            <Route exact path={`${match.path}/:contenttype`}>
+              <SiteContentListing />
+            </Route>
+            <Route exact path={`${match.path}/:contenttype/add/`}>
+              <SiteAddContent />
+            </Route>
           </Switch>
         </div>
       </div>

--- a/static/js/pages/SitesDashboard.tsx
+++ b/static/js/pages/SitesDashboard.tsx
@@ -3,6 +3,9 @@ import { useSelector } from "react-redux"
 import { useRequest } from "redux-query-react"
 import { Link, RouteComponentProps } from "react-router-dom"
 
+import Card from "../components/Card"
+import PaginationControls from "../components/PaginationControls"
+
 import {
   websiteListingRequest,
   WebsiteListingResponse
@@ -43,44 +46,34 @@ export default function SitesDashboard(
       <div className="content">
         <div className="d-flex flex-direction-row align-items-center justify-content-between pb-3">
           <h3>Sites</h3>
-          <Link className="add-new" to={newSiteUrl.toString()}>
+          <Link className="btn blue-button add-new" to={newSiteUrl.toString()}>
             Add New
           </Link>
         </div>
-        <ul className="listing">
-          {listing.results.map((site: Website) => (
-            <li key={site.name}>
-              <Link to={siteDetailUrl.param({ name: site.name }).toString()}>
-                {site.title}
-              </Link>
-              <div className="site-description">{siteDescription(site)}</div>
-              <hr />
-            </li>
-          ))}
-        </ul>
-        <div className="pagination justify-content-center">
-          {listing.previous ? (
-            <Link
-              to={sitesBaseUrl
-                .query({ offset: offset - WEBSITES_PAGE_SIZE })
-                .toString()}
-              className="previous"
-            >
-              <i className="material-icons">keyboard_arrow_left</i>
-            </Link>
-          ) : null}
-          &nbsp;
-          {listing.next ? (
-            <Link
-              to={sitesBaseUrl
-                .query({ offset: offset + WEBSITES_PAGE_SIZE })
-                .toString()}
-              className="next"
-            >
-              <i className="material-icons">keyboard_arrow_right</i>
-            </Link>
-          ) : null}
-        </div>
+        <Card>
+          <ul className="listing ruled-list">
+            {listing.results.map((site: Website) => (
+              <li className="py-3" key={site.name}>
+                <Link
+                  className="site-link"
+                  to={siteDetailUrl.param({ name: site.name }).toString()}
+                >
+                  {site.title}
+                </Link>
+                <div className="site-description">{siteDescription(site)}</div>
+              </li>
+            ))}
+          </ul>
+        </Card>
+        <PaginationControls
+          listing={listing}
+          previous={sitesBaseUrl
+            .query({ offset: offset - WEBSITES_PAGE_SIZE })
+            .toString()}
+          next={sitesBaseUrl
+            .query({ offset: offset + WEBSITES_PAGE_SIZE })
+            .toString()}
+        />
       </div>
     </div>
   )

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -1,4 +1,11 @@
 $light-gray-bg: #eeeeee;
 $error-red: #db312a;
-$std-max-width: 1447px;  // arbitrary value, copied from ocw-next
-$narrow-max-width: 600px;
+$std-max-width: 1447px; // arbitrary value, copied from ocw-next
+$narrow-max-width: 800px;
+
+$studio-blue: #3f87e5;
+$studio-green: #00bc87;
+$studio-background: #f7fafc;
+$studio-black: #030303;
+$studio-text-gray: #b3b3b3;
+$studio-gray: #e4e4e4;

--- a/static/scss/button.scss
+++ b/static/scss/button.scss
@@ -1,0 +1,7 @@
+.blue-button {
+  background-color: $studio-blue;
+  color: white;
+  font-size: 14px;
+  border-radius: 8px;
+  padding: 6px 16px;
+}

--- a/static/scss/card.scss
+++ b/static/scss/card.scss
@@ -1,0 +1,4 @@
+.studio-card {
+  background-color: white;
+  border-radius: 17px;
+}

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -4,10 +4,23 @@
 @import "site-page";
 @import "sites-dashboard";
 @import "site-collaborators";
+@import "card";
+@import "pagination";
+@import "button";
+@import "list";
+
+body {
+  font-family: "Roboto", sans-serif;
+  background-color: $studio-background;
+  // default font color
+  color: $studio-black;
+}
 
 .app {
-  max-width: $std-max-width;
-  margin: 0 auto;
+  .page-content {
+    max-width: $std-max-width;
+    margin: 0 auto;
+  }
 }
 
 .std-page-body {
@@ -19,11 +32,7 @@
 }
 
 header {
-  border: 1px solid black;  // for visibility, remove when we migrate away from wireframe
-}
-
-.form-container {
-  background-color: $light-gray-bg;
+  background-color: white;
 }
 
 .form-error {
@@ -32,6 +41,11 @@ header {
 
 a {
   cursor: pointer;
+  color: $studio-black;
+
+  &:hover {
+    color: $studio-black;
+  }
 }
 
 // modal as sidebar CSS adapted from https://codepen.io/bootpen/pen/jbbaRa

--- a/static/scss/list.scss
+++ b/static/scss/list.scss
@@ -1,0 +1,18 @@
+.ruled-list {
+  padding: 0;
+  list-style: none;
+
+  li {
+    &:first-child {
+      padding-top: 0 !important;
+    }
+
+    &:last-child {
+      padding-bottom: 0 !important;
+    }
+
+    &:not(:last-child) {
+      border-bottom: 1px solid $studio-gray;
+    }
+  }
+}

--- a/static/scss/pagination.scss
+++ b/static/scss/pagination.scss
@@ -1,0 +1,6 @@
+.pagination {
+  i {
+    font-size: 45px;
+    color: $studio-blue;
+  }
+}

--- a/static/scss/site-collaborators.scss
+++ b/static/scss/site-collaborators.scss
@@ -1,22 +1,24 @@
 .collaborator-list {
-  padding: 10px;
   position: relative;
   max-width: $narrow-max-width;
-
-  .collaborator-add-btn {
-    position: absolute;
-    top: 0px;
-    right: 0px;
-    padding: 10px;
-  }
 
   .collaborator-table {
     i {
       vertical-align: middle;
       padding-right: 10px;
       cursor: pointer;
-      color: black;
+    }
+
+    tr {
+      border: 1px solid $studio-gray;
+
+      td.gray {
+        color: $studio-gray;
+
+        a {
+          color: $studio-gray;
+        }
+      }
     }
   }
 }
-

--- a/static/scss/site-page.scss
+++ b/static/scss/site-page.scss
@@ -1,5 +1,5 @@
 $sidebar-width: 200px;
-$menu-spacing: 15px;
+$menu-spacing: 20px;
 
 .site-page {
   .content-container {
@@ -8,28 +8,27 @@ $menu-spacing: 15px;
   }
 
   .sidebar {
-    background-color: $light-gray-bg;
-    border: 1px solid black;
     border-right-style: none;
-    padding: $menu-spacing $menu-spacing 0 $menu-spacing;
     width: $sidebar-width;
 
-    ul {
-      list-style: none;
-      margin: 0;
-      padding: 0;
+    a {
+      color: $studio-black;
+      display: block;
+
+      &.active {
+        color: $studio-green;
+      }
     }
 
-    ul > li > ul {
-      margin: 0 0 10px 0;
-      padding-left: 10px;
+    h4 {
+      i {
+        color: $studio-green;
+      }
     }
   }
 
   .content {
     flex-grow: 1;
-    border: 1px solid black;
-    padding: 15px;
 
     ul {
       padding: 0;

--- a/static/scss/sites-dashboard.scss
+++ b/static/scss/sites-dashboard.scss
@@ -1,12 +1,10 @@
 .sites-dashboard {
   .content {
     flex-grow: 1;
-    border: 1px solid black;
     padding: 15px;
+  }
 
-    ul {
-      padding: 0;
-      list-style: none;
-    }
+  .site-description {
+    color: $studio-text-gray;
   }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #115 

#### What's this PR do?

This brings the site more in line with the mockups. It doesn't implement every single thing in he mockups (notably the different header style shown therein on the site pages) but it gets most of the site in shape.

- background colors
- text styling (Abdul recommended going with Google Roboto for our basic font)
- button styling
- adding content cards to wrap forms and so on

and a few more random enhancements besides.

#### How should this be manually tested?

check out the mocks, and then click around the site. Make sure that no functionality has been compromised anywhere. Then check that all butons are switched over, and that all the gray elements have been eliminated.



#### Screenshots (if appropriate)

![Screenshot from 2021-03-19 11-01-21](https://user-images.githubusercontent.com/6207644/111800567-78efe800-88a2-11eb-8b98-0f9a11c20e25.png)
![Screenshot from 2021-03-19 11-01-15](https://user-images.githubusercontent.com/6207644/111800568-79887e80-88a2-11eb-9e81-16a02c478a6d.png)
![Screenshot from 2021-03-19 11-01-11](https://user-images.githubusercontent.com/6207644/111800570-79887e80-88a2-11eb-8940-ebd93a2da5d4.png)
![Screenshot from 2021-03-19 11-01-05](https://user-images.githubusercontent.com/6207644/111800571-79887e80-88a2-11eb-9209-241675c4bd9b.png)
![Screenshot from 2021-03-19 11-00-59](https://user-images.githubusercontent.com/6207644/111800572-7a211500-88a2-11eb-9aaf-4055a75ded72.png)
![Screenshot from 2021-03-19 11-00-54](https://user-images.githubusercontent.com/6207644/111800573-7a211500-88a2-11eb-9ec4-9f6fdc9f8b66.png)
![Screenshot from 2021-03-19 11-00-50](https://user-images.githubusercontent.com/6207644/111800574-7a211500-88a2-11eb-8f5d-0418c141a339.png)
![Screenshot from 2021-03-19 11-00-40](https://user-images.githubusercontent.com/6207644/111800575-7a211500-88a2-11eb-9abd-b934c67964e3.png)
![Screenshot from 2021-03-19 11-10-29](https://user-images.githubusercontent.com/6207644/111801885-c28d0280-88a3-11eb-9323-61e4a2fde6fa.png)
