### PR TITLE
Skip noncourse files, log error on missing uuid

### DIFF
--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -2,7 +2,6 @@
 import json
 import logging
 import re
-from uuid import uuid4
 
 import yaml
 from dateutil import parser as dateparser
@@ -20,6 +19,17 @@ from websites.models import Website, WebsiteContent
 
 
 log = logging.getLogger(__name__)
+
+NON_COURSE_IDS = [
+    "biology",
+    "chemistry",
+    "engineering",
+    "humanities-and-social-sciences",
+    "iit-jee",
+    "mathematics",
+    "more",
+    "physics",
+]
 
 
 def fetch_ocw2hugo_course_paths(bucket_name, prefix="", filter_str=""):
@@ -111,12 +121,7 @@ def import_ocw2hugo_content(bucket, prefix, website):  # pylint:disable=too-many
                 }
                 try:
                     if not uuid:
-                        # create a new uuid if necessary
-                        WebsiteContent.objects.update_or_create(
-                            website=website,
-                            hugo_filepath=filepath,
-                            defaults={**base_defaults, "uuid": uuid4()},
-                        )
+                        log.error("No UUID: %s", obj["Key"])
                     else:
                         WebsiteContent.objects.update_or_create(
                             website=website,
@@ -141,6 +146,8 @@ def import_ocw2hugo_course(bucket_name, prefix, path, starter_id=None):
     bucket = s3.Bucket(bucket_name)
     s3_content = json.loads(get_s3_object_and_read(bucket.Object(path)).decode())
     name = s3_content.get("course_id")
+    if name in NON_COURSE_IDS:
+        return
     try:
         publish_date = dateparser.parse(s3_content.get("publishdate", None))
     except ValueError:

--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -20,7 +20,7 @@ from websites.models import Website, WebsiteContent
 
 log = logging.getLogger(__name__)
 
-NON_COURSE_IDS = [
+NON_ID_COURSE_NAMES = [
     "biology",
     "chemistry",
     "engineering",
@@ -146,7 +146,7 @@ def import_ocw2hugo_course(bucket_name, prefix, path, starter_id=None):
     bucket = s3.Bucket(bucket_name)
     s3_content = json.loads(get_s3_object_and_read(bucket.Object(path)).decode())
     name = s3_content.get("course_id")
-    if name in NON_COURSE_IDS:
+    if name in NON_ID_COURSE_NAMES:
         return
     try:
         publish_date = dateparser.parse(s3_content.get("publishdate", None))

--- a/ocw_import/tasks_test.py
+++ b/ocw_import/tasks_test.py
@@ -27,7 +27,7 @@ def test_import_ocw2hugo_course_paths(mocker, paths, course_starter):
 
 
 @mock_s3
-@pytest.mark.parametrize("chunk_size, call_count", [[1, 2], [2, 1]])
+@pytest.mark.parametrize("chunk_size, call_count", [[1, 3], [2, 2]])
 def test_import_ocw2hugo_courses(
     settings, mocked_celery, mocker, chunk_size, call_count
 ):

--- a/test_hugo2ocw/output/biology/content/_index.md
+++ b/test_hugo2ocw/output/biology/content/_index.md
@@ -1,0 +1,7 @@
+---
+uid: ''
+title: ''
+type: course
+layout: course_home
+course_id: biology
+---

--- a/test_hugo2ocw/output/biology/data/course.json
+++ b/test_hugo2ocw/output/biology/data/course.json
@@ -1,0 +1,18 @@
+{
+  "course_id": "biology",
+  "course_title": "Biology",
+  "course_image_url": "",
+  "course_thumbnail_image_url": "",
+  "course_image_alternate_text": "",
+  "course_image_caption_text": "",
+  "publishdate": "2012-01-12T14:12:55+00:00",
+  "instructors": [],
+  "departments": [],
+  "course_features": [],
+  "topics": [],
+  "course_numbers": [
+    "."
+  ],
+  "term": "null null",
+  "level": null
+}


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #18 

#### What's this PR do?
- Introduces a list of S3 prefixes to skip based on [NON_COURSE_DIRECTORIES](https://github.com/mitodl/open-discussions/blob/master/course_catalog/constants.py#L91-L101) from open-discussions.
- Logs an error if any content file is missing a uuid.

#### How should this be manually tested?
Running `manage.py import_ocw_course_sites` should complete without any errors in the celery log.
Tests should pass
