### PR TITLE
fix site sidebar to match design

### DIFF
--- a/static/js/components/SiteSidebar.tsx
+++ b/static/js/components/SiteSidebar.tsx
@@ -73,6 +73,7 @@ export default function SiteSidebar(props: Props): JSX.Element {
 
   return (
     <div className="sidebar">
+      <h2 className="pb-5 border-bottom-gray mb-3">OCW Studio</h2>
       {configSections.map(([category, configItems]) => (
         <SidebarSection
           category={category}

--- a/static/js/pages/App.tsx
+++ b/static/js/pages/App.tsx
@@ -13,7 +13,9 @@ export default function App(): JSX.Element {
 
   return (
     <div className="app">
-      <Header />
+      <Route path={["/", "/new-site", "/sites", "/markdown-editor"]} exact>
+        <Header />
+      </Route>
       <div className="page-content">
         <Switch>
           <Route exact path="/new-site" component={SiteCreationPage} />

--- a/static/js/pages/SitePage.test.tsx
+++ b/static/js/pages/SitePage.test.tsx
@@ -56,5 +56,6 @@ describe("SitePage", () => {
   it("renders the sidebar", async () => {
     const { wrapper } = await render()
     expect(wrapper.find("SiteSidebar").prop("website")).toBe(website)
+    expect(wrapper.find("h3").text()).toBe(website.title)
   })
 })

--- a/static/js/pages/SitePage.tsx
+++ b/static/js/pages/SitePage.tsx
@@ -17,12 +17,14 @@ import { getWebsiteDetailCursor } from "../selectors/websites"
 interface MatchParams {
   name: string
 }
+
 export default function SitePage(): JSX.Element | null {
   const match = useRouteMatch<MatchParams>()
   const { name } = match.params
 
   const [{ isPending }] = useRequest(websiteDetailRequest(name))
   const website = useSelector(getWebsiteDetailCursor)(name)
+
   if (!website) {
     return null
   }
@@ -32,13 +34,13 @@ export default function SitePage(): JSX.Element | null {
   }
 
   return (
-    <div className="site-page std-page-body container">
-      <h3>{website.title}</h3>
+    <div className="site-page std-page-body container pt-3">
       <div className="content-container">
         <Card>
           <SiteSidebar website={website} />
         </Card>
         <div className="content pl-3">
+          <h3 className="py-5">{website.title}</h3>
           <Switch>
             <Route path={`${match.path}/collaborators/new/`}>
               <SiteCollaboratorAddPanel />

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -48,6 +48,10 @@ a {
   }
 }
 
+.border-bottom-gray {
+  border-bottom: 1px solid $studio-gray;
+}
+
 // modal as sidebar CSS adapted from https://codepen.io/bootpen/pen/jbbaRa
 $modal-sidebar-width: 540px;
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

follow-up to #115 

#### What's this PR do?

gets rid of the existing header on the site pages (`/site/my-site`, etc)

#### How should this be manually tested?

check out the homepage, `/sites`, and `/new-site`. On these pages you should see the same site header as on main. then check out a site page - there you should see a design like the screenshots below which is in-line with the mockups.

#### Screenshots (if appropriate)

![Screenshot from 2021-03-23 11-38-52](https://user-images.githubusercontent.com/6207644/112173929-63ddc680-8bcc-11eb-9e07-2a416c42f318.png)
![Screenshot from 2021-03-23 11-38-42](https://user-images.githubusercontent.com/6207644/112173930-63ddc680-8bcc-11eb-8365-02457eed622f.png)
![Screenshot from 2021-03-23 11-38-34](https://user-images.githubusercontent.com/6207644/112173931-63ddc680-8bcc-11eb-85d2-df2900b91b4c.png)


#### What GIF best describes this PR or how it makes you feel?
(Optional)
