### PR TITLE
fix issue with turndown when editor is instantiated twice

### DIFF
--- a/static/js/lib/ckeditor/plugins/Markdown.test.ts
+++ b/static/js/lib/ckeditor/plugins/Markdown.test.ts
@@ -1,6 +1,7 @@
 import Markdown, { MarkdownDataProcessor } from "./Markdown"
 
 import { createTestEditor, markdownTest } from "./test_util"
+import { turndownService } from "../turndown"
 
 import { TEST_MARKDOWN, TEST_HTML } from "../../../test_constants"
 
@@ -10,6 +11,12 @@ describe("Markdown CKEditor plugin", () => {
   })
 
   describe("basic Markdown support", () => {
+    it("should set custom rules flag after instantiation", async () => {
+      await createTestEditor([Markdown])
+      // @ts-ignore
+      expect(turndownService._customRulesSet).toBeTruthy()
+    })
+
     it("should set editor.data.processor", async () => {
       const editor = await createTestEditor([Markdown])
       expect(editor.data.processor).toBeInstanceOf(MarkdownDataProcessor)

--- a/static/js/lib/ckeditor/plugins/Markdown.ts
+++ b/static/js/lib/ckeditor/plugins/Markdown.ts
@@ -80,9 +80,14 @@ export default class Markdown extends MarkdownConfigPlugin {
       extensions: showdownExtensions
     })
 
-    turndownRules.forEach(({ name, rule }) =>
-      turndownService.addRule(name, rule)
-    )
+    // @ts-ignore
+    if (!turndownService._customRulesSet) {
+      turndownRules.forEach(({ name, rule }) =>
+        turndownService.addRule(name, rule)
+      )
+      // @ts-ignore
+      turndownService._customRulesSet = true
+    }
 
     function md2html(md: string): string {
       return converter.makeHtml(md)

--- a/static/js/lib/ckeditor/plugins/MarkdownMediaEmbed.test.ts
+++ b/static/js/lib/ckeditor/plugins/MarkdownMediaEmbed.test.ts
@@ -11,6 +11,8 @@ describe("MarkdownMediaEmbed plugin", () => {
     turndownService.rules.array = turndownService.rules.array.filter(
       (rule: any) => rule.filter !== "figure"
     )
+    // @ts-ignore
+    turndownService._customRulesSet = undefined
   })
 
   it("should output youtube shortcode when given youtube shortcode", async () => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?

closes #142 
 
#### What's this PR do?

this fixes an issue relating to adding turndown rules - basically, when the editor is instantiated and destroyed more than once while the application is running we need to have a way to ensure that we only set turndown rules once, lest we run into issues. I added a little check to make sure this isn't done.

#### How should this be manually tested?

Follow the repro steps on the issue, and confirm that this fixes the problem.
