### PR TITLE
fix spacing between sidebar sections

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
   rules: {
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-unused-vars": [
       "error",
       { argsIgnorePattern: "_" }

--- a/static/js/components/SiteSidebar.test.tsx
+++ b/static/js/components/SiteSidebar.test.tsx
@@ -1,6 +1,10 @@
 import SiteSidebar from "./SiteSidebar"
 
-import { makeWebsiteDetail } from "../util/factories/websites"
+import {
+  makeWebsiteDetail,
+  makeWebsiteConfigItem
+} from "../util/factories/websites"
+import { times } from "lodash"
 import { siteCollaboratorsUrl, siteContentListingUrl } from "../lib/urls"
 import IntegrationTestHelper, {
   TestRenderer
@@ -59,6 +63,24 @@ describe("SiteSidebar", () => {
     ]
 
     expect(links).toEqual(expect.arrayContaining(expected))
+  })
+
+  it("should pad all .config-sections excepting the last one", async () => {
+    website.starter!.config!.collections = times(5).map(() =>
+      makeWebsiteConfigItem("foobar")
+    )
+    const { wrapper } = await render()
+    expect(
+      wrapper
+        .find("SidebarSection")
+        .map(wrapper => wrapper.find("div").prop("className"))
+    ).toEqual([
+      "sidebar-section pb-4",
+      "sidebar-section pb-4",
+      "sidebar-section pb-4",
+      "sidebar-section pb-4",
+      "sidebar-section"
+    ])
   })
 
   it("renders a collaborators link if the user is an admin for the given website", async () => {

--- a/static/js/components/SiteSidebar.tsx
+++ b/static/js/components/SiteSidebar.tsx
@@ -31,15 +31,18 @@ interface SectionProps {
   category: string
   website: Website
   configItems: ConfigItem[]
+  bottomPadding: boolean
 }
 
 function SidebarSection(props: SectionProps): JSX.Element {
-  const { website, configItems, category } = props
+  const { website, configItems, category, bottomPadding } = props
 
   const iconName = category === "Settings" ? "settings" : "create"
 
+  const className = bottomPadding ? "sidebar-section pb-4" : "sidebar-section"
+
   return (
-    <>
+    <div className={className}>
       <h4 className="d-flex align-items-center">
         <i className="material-icons pr-2">{iconName}</i>
         {category}
@@ -56,7 +59,7 @@ function SidebarSection(props: SectionProps): JSX.Element {
           {item.label}
         </NavLink>
       ))}
-    </>
+    </div>
   )
 }
 
@@ -74,12 +77,13 @@ export default function SiteSidebar(props: Props): JSX.Element {
   return (
     <div className="sidebar">
       <h2 className="pb-5 border-bottom-gray mb-3">OCW Studio</h2>
-      {configSections.map(([category, configItems]) => (
+      {configSections.map(([category, configItems], idx) => (
         <SidebarSection
           category={category}
           key={category}
           website={website}
           configItems={configItems}
+          bottomPadding={idx !== configSections.length - 1}
         />
       ))}
     </div>

--- a/static/js/lib/ckeditor/turndown.ts
+++ b/static/js/lib/ckeditor/turndown.ts
@@ -35,8 +35,6 @@ turndownService.rules.blankRule.replacement = (
 
   if (matchingRules.length === 1) {
     const [rule] = matchingRules
-
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return rule.replacement!(content, node, options)
   } else {
     return "\n\n"
@@ -47,8 +45,6 @@ turndownService.rules.blankRule.replacement = (
 // extra spaces to the beginning of a list item. So it maps
 // "<ul><li>item</li></ul>" -> "-   item" instead of "- item"
 // see https://github.com/domchristie/turndown/issues/291
-//
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 turndownService.rules.array.find(rule => rule.filter === "li")!.replacement = (
   content: string,
   node: Turndown.Node,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #149

#### What's this PR do?

This adds some `padding-bottom` to the sidebar sections, except for the final one.

#### How should this be manually tested?

Check out the branch and make sure it looks alright!

#### Screenshots (if appropriate)

![Screenshot from 2021-03-24 15-34-14](https://user-images.githubusercontent.com/6207644/112372710-83511e00-8cb6-11eb-9d50-bfd9becdf502.png)
