### PR TITLE
fix issue with list styling in markdown editor

### DIFF
--- a/static/scss/site-page.scss
+++ b/static/scss/site-page.scss
@@ -29,11 +29,6 @@ $menu-spacing: 20px;
 
   .content {
     flex-grow: 1;
-
-    ul {
-      padding: 0;
-      list-style: none;
-    }
   }
 
   .ck.ck-content.ck-editor__editable {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #147 

#### What's this PR do?

removes unnecessary styling of all `<ul>` under `.site-page .content`, to fix an issue where lists in ckeditor looked odd (see attached issue for details).

#### How should this be manually tested?

go to `/sites/$sitename` and then go to add a new page. first, on main, confirm that if you add a list to the editor it doesn't look like one. then confirm that this branch fixes the issue.

#### Screenshots (if appropriate)

![Screenshot from 2021-03-24 15-50-23](https://user-images.githubusercontent.com/6207644/112375020-2440d880-8cb9-11eb-9726-dcb3a5298d0d.png)
