### PR TITLE
Added common widget options (required flag and help text)

### DIFF
--- a/localdev/starters/site-config-override.yml
+++ b/localdev/starters/site-config-override.yml
@@ -5,22 +5,28 @@ course:
       category: Content
       folder: content
       fields:
-        - {"label": "Title", "name": "title", "widget": "string"}
-        - {"label": "Content", "name": "content", "widget": "markdown"}
+        - {"label": "Title", "name": "title", "widget": "string", "required": true}
+        - {"label": "Content", "name": "content", "widget": "markdown", "required": true}
 
     - name: resource
       label: Resource
       category: Content
       folder: content
       fields:
-        - {"label": "Title", "name": "title", "widget": "string"}
-        - {"label": "Description", "name": "description", "widget": "text"}
-        - {"label": "File", "name": "file", "widget": "file"}
+        - {"label": "Title", "name": "title", "widget": "string", "required": true}
+        - {"label": "Description", "name": "description", "widget": "text", "required": true}
+        - {"label": "File", "name": "file", "widget": "file", "required": true}
 
     - name: metadata
       label: Site Metadata
       category: Settings
       file: data/metadata.json
       fields:
-        - { label: "Course Title", name: "title", widget: "text" }
-        - { label: "Course Description", name: "description", widget: "markdown", minimal: true }
+        - { "label": "Course Title", "name": "title", "widget": "text", "required": true }
+        - {
+          "label": "Course Description",
+          "name": "description",
+          "widget": "markdown",
+          "minimal": true,
+          "help": "A description of the course that will be shown on the course site home page."
+        }

--- a/static/js/components/forms/FormError.tsx
+++ b/static/js/components/forms/FormError.tsx
@@ -1,0 +1,13 @@
+import React, { ReactNode } from "react"
+
+interface ErrorComponentProps {
+  children?: string | ReactNode | null | undefined
+}
+
+export const FormError: React.FunctionComponent = (
+  props: ErrorComponentProps
+) => {
+  return props.children ? (
+    <div className="form-error">{props.children}</div>
+  ) : null
+}

--- a/static/js/components/forms/SiteAddContentForm.test.tsx
+++ b/static/js/components/forms/SiteAddContentForm.test.tsx
@@ -1,14 +1,17 @@
 import React from "react"
+import * as yup from "yup"
 import sinon, { SinonSandbox, SinonStub } from "sinon"
 import { shallow } from "enzyme"
 
 import SiteAddContentForm from "./SiteAddContentForm"
-
-import { ConfigItem } from "../../types/websites"
 import { defaultFormikChildProps } from "../../test_util"
 
 jest.mock("../../lib/site_content")
 import { componentFromWidget } from "../../lib/site_content"
+jest.mock("./validation")
+import { getContentSchema } from "./validation"
+
+import { ConfigItem } from "../../types/websites"
 
 describe("SiteAddContentForm", () => {
   let sandbox: SinonSandbox,
@@ -101,5 +104,14 @@ describe("SiteAddContentForm", () => {
         isSubmitting
       )
     })
+  })
+
+  it("has the correct validation schema", () => {
+    const mockValidationSchema = yup.object().shape({})
+    // @ts-ignore
+    getContentSchema.mockReturnValueOnce(mockValidationSchema)
+    const formik = renderForm().find("Formik")
+    const validationSchema = formik.prop("validationSchema")
+    expect(validationSchema).toStrictEqual(mockValidationSchema)
   })
 })

--- a/static/js/components/forms/SiteAddContentForm.tsx
+++ b/static/js/components/forms/SiteAddContentForm.tsx
@@ -1,18 +1,10 @@
 import React from "react"
 import { Form, Formik, FormikHelpers } from "formik"
-import * as yup from "yup"
 
 import SiteContentField from "./SiteContentField"
+import { getContentSchema } from "./validation"
 
 import { ConfigItem } from "../../types/websites"
-
-export const websiteValidation = yup.object().shape({
-  title: yup
-    .string()
-    .label("Title")
-    .trim()
-    .required()
-})
 
 interface Props {
   onSubmit: (
@@ -31,6 +23,7 @@ export default function SiteAddContentForm({
     // set to empty string to treat as a controlled component
     initialValues[field.name] = ""
   }
+  const schema = getContentSchema(configItem)
 
   const fieldsByColumn = [
     fields.filter(field => field.widget === "markdown"),
@@ -40,7 +33,7 @@ export default function SiteAddContentForm({
   return (
     <Formik
       onSubmit={onSubmit}
-      validationSchema={websiteValidation}
+      validationSchema={schema}
       initialValues={initialValues}
     >
       {({ isSubmitting, status, setFieldValue }) => (

--- a/static/js/components/forms/SiteCollaboratorForm.tsx
+++ b/static/js/components/forms/SiteCollaboratorForm.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { Formik, Form, ErrorMessage, Field, FormikHelpers } from "formik"
 import * as yup from "yup"
 
+import { FormError } from "./FormError"
 import { EDITABLE_ROLES, ROLE_LABELS } from "../../constants"
 
 import {
@@ -65,7 +66,7 @@ export default function SiteCollaboratorForm({
                 type="email"
                 value={values.email}
               />
-              <ErrorMessage name="email" />
+              <ErrorMessage name="email" component={FormError} />
             </div>
           )}
           <div className="form-group">
@@ -83,7 +84,7 @@ export default function SiteCollaboratorForm({
                 </option>
               ))}
             </Field>
-            <ErrorMessage name="role" />
+            <ErrorMessage name="role" component={FormError} />
           </div>
           <div className="form-group d-flex justify-content-end">
             <button

--- a/static/js/components/forms/SiteContentField.tsx
+++ b/static/js/components/forms/SiteContentField.tsx
@@ -1,6 +1,7 @@
 import { ErrorMessage, Field } from "formik"
 import React from "react"
 
+import { FormError } from "./FormError"
 import { componentFromWidget } from "../../lib/site_content"
 
 import { ConfigField } from "../../types/websites"
@@ -24,7 +25,8 @@ export default function SiteContentField({
         className="form-control"
         {...extraProps}
       />
-      <ErrorMessage name={field.name} component="div" />
+      {field.help && <span className="help-text">{field.help}</span>}
+      <ErrorMessage name={field.name} component={FormError} />
     </div>
   )
 }

--- a/static/js/components/forms/SiteEditContentForm.test.tsx
+++ b/static/js/components/forms/SiteEditContentForm.test.tsx
@@ -1,18 +1,21 @@
 import React from "react"
+import * as yup from "yup"
 import sinon, { SinonSandbox, SinonStub } from "sinon"
 import { shallow } from "enzyme"
 
 import SiteEditContentForm from "./SiteEditContentForm"
 
 import { defaultFormikChildProps } from "../../test_util"
-import { componentFromWidget } from "../../lib/site_content"
 import {
   makeWebsiteContentDetail,
   makeWebsiteConfigItem
 } from "../../util/factories/websites"
-import { ConfigItem, WebsiteContent } from "../../types/websites"
-
 jest.mock("../../lib/site_content")
+import { componentFromWidget } from "../../lib/site_content"
+jest.mock("./validation")
+import { getContentSchema } from "./validation"
+
+import { ConfigItem, WebsiteContent } from "../../types/websites"
 
 describe("SiteEditContentForm", () => {
   let sandbox: SinonSandbox,
@@ -92,5 +95,14 @@ describe("SiteEditContentForm", () => {
         isSubmitting
       )
     })
+  })
+
+  it("has the correct validation schema", () => {
+    const mockValidationSchema = yup.object().shape({})
+    // @ts-ignore
+    getContentSchema.mockReturnValueOnce(mockValidationSchema)
+    const formik = renderForm().find("Formik")
+    const validationSchema = formik.prop("validationSchema")
+    expect(validationSchema).toStrictEqual(mockValidationSchema)
   })
 })

--- a/static/js/components/forms/SiteEditContentForm.tsx
+++ b/static/js/components/forms/SiteEditContentForm.tsx
@@ -1,11 +1,11 @@
 import * as React from "react"
 import { Formik, Form, FormikHelpers } from "formik"
-import * as yup from "yup"
 
+import SiteContentField from "./SiteContentField"
 import { contentInitialValues } from "../../lib/site_content"
+import { getContentSchema } from "./validation"
 
 import { ConfigItem, WebsiteContent } from "../../types/websites"
-import SiteContentField from "./SiteContentField"
 
 export type SiteFormValues = {
   [key: string]: string
@@ -20,14 +20,6 @@ type Props = {
   content: WebsiteContent
 }
 
-export const websiteValidation = yup.object().shape({
-  title: yup
-    .string()
-    .label("Title")
-    .trim()
-    .required()
-})
-
 export default function SiteEditContentForm({
   onSubmit,
   configItem,
@@ -35,11 +27,12 @@ export default function SiteEditContentForm({
 }: Props): JSX.Element {
   const fields = configItem.fields
   const initialValues: SiteFormValues = contentInitialValues(content, fields)
+  const schema = getContentSchema(configItem)
 
   return (
     <Formik
       onSubmit={onSubmit}
-      validationSchema={websiteValidation}
+      validationSchema={schema}
       initialValues={initialValues}
     >
       {({ isSubmitting, status, setFieldValue }) => (

--- a/static/js/components/forms/SiteForm.tsx
+++ b/static/js/components/forms/SiteForm.tsx
@@ -2,6 +2,8 @@ import * as React from "react"
 import { Formik, Form, ErrorMessage, Field, FormikHelpers } from "formik"
 import * as yup from "yup"
 
+import { FormError } from "./FormError"
+
 import { WebsiteStarter } from "../../types/websites"
 
 export interface SiteFormValues {
@@ -45,7 +47,7 @@ export const SiteForm = ({
           <div className="form-group">
             <label htmlFor="title">Title*</label>
             <Field type="text" name="title" className="form-control" />
-            <ErrorMessage name="title" component="div" />
+            <ErrorMessage name="title" component={FormError} />
           </div>
           <div className="form-group">
             <label htmlFor="starter">Starter*</label>
@@ -61,7 +63,7 @@ export const SiteForm = ({
                 <option key={0} value={0} />
               )}
             </Field>
-            <ErrorMessage name="starter" component="div" />
+            <ErrorMessage name="starter" component={FormError} />
           </div>
           <div className="form-group d-flex justify-content-end">
             <button

--- a/static/js/components/forms/validation.test.ts
+++ b/static/js/components/forms/validation.test.ts
@@ -1,0 +1,115 @@
+import * as yup from "yup"
+import { getContentSchema } from "./validation"
+
+import { ConfigItem } from "../../types/websites"
+
+describe("form validation util", () => {
+  const yupFileFieldSchema = yup.object().shape({
+    name: yup.string().required()
+  })
+  const partialConfigItem = {
+    folder:   "content",
+    label:    "Page",
+    name:     "page",
+    category: "Content"
+  }
+  const partialField = {
+    name:  "myfield",
+    label: "My Field"
+  }
+  let configItem: ConfigItem
+
+  it("produces a validation schema for fields regardless of whether they're required or not", () => {
+    configItem = {
+      ...partialConfigItem,
+      fields: [
+        {
+          ...partialField,
+          widget: "string"
+        }
+      ]
+    }
+    const schema = getContentSchema(configItem)
+    expect(schema.toString()).toStrictEqual(
+      yup
+        .object()
+        .shape({
+          [partialField.name]: yup
+            .string()
+            .label(partialField.label)
+            .required()
+        })
+        .toString()
+    )
+  })
+
+  //
+  ;[
+    ["string", yup.string()],
+    ["text", yup.string()],
+    ["markdown", yup.string()],
+    ["file", yupFileFieldSchema]
+  ].forEach(([widget, expectedYupField]) => {
+    it(`produces the correct validation schema for a required '${widget}' field`, () => {
+      configItem = {
+        ...partialConfigItem,
+        fields: [
+          {
+            ...partialField,
+            widget:   widget.toString(),
+            required: true
+          }
+        ]
+      }
+      const schema = getContentSchema(configItem)
+      expect(schema.toString()).toStrictEqual(
+        yup
+          .object()
+          .shape({
+            [partialField.name]: expectedYupField
+              // @ts-ignore
+              .label(partialField.label)
+              .required()
+          })
+          .toString()
+      )
+    })
+  })
+
+  it("produces the correct validation schema for multiple fields", () => {
+    configItem = {
+      ...partialConfigItem,
+      fields: [
+        {
+          name:     "myfield",
+          label:    "My Field",
+          widget:   "string",
+          required: true
+        },
+        {
+          name:     "myfield2",
+          label:    "My Second Field",
+          widget:   "string",
+          required: true
+        }
+      ]
+    }
+    const schema = getContentSchema(configItem)
+    // @ts-ignore
+    expect(schema.fields.myfield.toString()).toStrictEqual(
+      yup
+        .string()
+        .label("My Field")
+        .required()
+        .toString()
+    )
+    // @ts-ignore
+    expect(schema.fields.myfield2.toString()).toStrictEqual(
+      yup
+        .string()
+        .label("My Second Field")
+        .required()
+        .toString()
+    )
+  })
+})

--- a/static/js/components/forms/validation.ts
+++ b/static/js/components/forms/validation.ts
@@ -1,0 +1,42 @@
+import * as yup from "yup"
+import { SchemaOf, setLocale } from "yup"
+
+import { ConfigItem } from "../../types/websites"
+
+// This is added to properly handle file fields, which can have a "null" value
+setLocale({
+  mixed: {
+    notType: "${path} is a required field."
+  }
+})
+
+const defaultYupField = yup.string()
+const widgetToYupMap = {
+  string:   yup.string(),
+  text:     yup.string(),
+  markdown: yup.string(),
+  file:     yup.object().shape({
+    name: yup.string()
+  })
+}
+
+export const getContentSchema = (configItem: ConfigItem): SchemaOf<any> => {
+  const yupObjectShape = {}
+  configItem.fields.forEach(field => {
+    const yupField = widgetToYupMap[field.widget] || defaultYupField
+    yupObjectShape[field.name] = yupField.label(field.label)
+    if (field.required) {
+      switch (field.widget) {
+      case "file":
+        yupObjectShape[field.name] = yupObjectShape[field.name].fields.name
+          .label(field.label)
+          .required()
+        break
+      default:
+        yupObjectShape[field.name] = yupObjectShape[field.name].required()
+        break
+      }
+    }
+  })
+  return yup.object().shape(yupObjectShape)
+}

--- a/static/js/constants.ts
+++ b/static/js/constants.ts
@@ -32,12 +32,14 @@ export const exampleSiteConfig: WebsiteStarterConfig = {
         {
           label: "Title",
           name: "title",
-          widget: "string"
+          widget: "string",
+          required: true
         },
         {
           label: "Content",
           name: "content",
-          widget: "markdown"
+          widget: "markdown",
+          required: true
         }
       ],
       folder: "content",
@@ -50,18 +52,21 @@ export const exampleSiteConfig: WebsiteStarterConfig = {
         {
           label: "Title",
           name: "title",
-          widget: "string"
+          widget: "string",
+          required: true
         },
         {
           label: "Description",
           name: "description",
           widget: "markdown",
-          minimal: true
+          minimal: true,
+          required: true
         },
         {
           label: "File",
           name: "file",
-          widget: "file"
+          widget: "file",
+          required: true
         }
       ],
       folder: "content",
@@ -74,12 +79,15 @@ export const exampleSiteConfig: WebsiteStarterConfig = {
         {
           label: "Course Title",
           name: "title",
-          widget: "text"
+          widget: "text",
+          required: true
         },
         {
           label: "Course Description",
           name: "description",
-          widget: "markdown"
+          widget: "markdown",
+          help:
+            "A description of the course that will be shown on the course site home page."
         }
       ],
       file: "data/metadata.json",

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -5,6 +5,8 @@ export interface ConfigField {
   label: string
   widget: string
   minimal?: boolean
+  help?: string
+  required?: boolean
 }
 
 export interface ConfigItem {

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -1,8 +1,12 @@
-$light-gray-bg: #eeeeee;
-$error-red: #db312a;
 $std-max-width: 1447px; // arbitrary value, copied from ocw-next
 $narrow-max-width: 800px;
 
+$std-font-size: 1rem;
+$caption-font-size: 0.8rem;
+
+$light-gray-bg: #eeeeee;
+$slate-gray: rgb(112, 128, 144);
+$error-red: #db312a;
 $studio-blue: #3f87e5;
 $studio-green: #00bc87;
 $studio-background: #f7fafc;

--- a/static/scss/forms.scss
+++ b/static/scss/forms.scss
@@ -1,0 +1,8 @@
+.form-error {
+  color: $error-red;
+}
+
+.help-text {
+  font-size: $caption-font-size;
+  color: $slate-gray;
+}

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -4,6 +4,7 @@
 @import "site-page";
 @import "sites-dashboard";
 @import "site-collaborators";
+@import "forms";
 @import "card";
 @import "pagination";
 @import "button";
@@ -14,6 +15,7 @@ body {
   background-color: $studio-background;
   // default font color
   color: $studio-black;
+  font-size: $std-font-size;
 }
 
 .app {
@@ -33,10 +35,6 @@ body {
 
 header {
   background-color: white;
-}
-
-.form-error {
-  color: $error-red;
 }
 
 a {

--- a/websites/config_schema/site-config-schema.yml
+++ b/websites/config_schema/site-config-schema.yml
@@ -16,8 +16,10 @@ inner_content_item:
     file: str(required=False)
 ---
 field:
+    widget: enum('string', 'text', 'markdown', 'file')
     label: str()
     name: str()
-    widget: enum('string', 'text', 'markdown', 'file')
     minimal: bool(required=False)
+    required: bool(required=False)
+    help: str(required=False)
     fields: list(include('field'), required=False)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #153 

#### What's this PR do?
Adds "help" and "required" as common widget options. `required: true` will result in a field being rejected as invalid on the front-end if it is left blank, and `help: "<some help text>"` will show some text under an input in the same way that you might see in Django admin

#### How should this be manually tested?
Override your local config with the management command, then check that required fields behave as expected, and help text-enabled fields show the correct help text

#### Screenshots (if appropriate)
![ss 2021-03-26 at 13 37 09 ](https://user-images.githubusercontent.com/14932219/112671302-62b0d180-8e38-11eb-982d-eecfbd26696e.png)
![ss 2021-03-26 at 13 34 16 ](https://user-images.githubusercontent.com/14932219/112671304-63e1fe80-8e38-11eb-9960-d5061ed2739d.png)


