### PR TITLE
Implement conditional fields

### DIFF
--- a/localdev/starters/site-config-override.yml
+++ b/localdev/starters/site-config-override.yml
@@ -38,3 +38,8 @@ course:
           "widget": "boolean",
           "help": "Whether the course includes fries or not."
           }
+        - { "label": "Tags", "default": ["Design"], "max": 3, "min": 1, "multiple": true, "name": "tags", "options": ["Design", "UX", "Dev"], "widget": "select" }
+        - { label: "Align Content", name: "align", widget: "select", options: ["left", "center", "right"]}
+        - {
+          label: "Extra information",
+          name: "extra", widget: "markdown", default: "Extra details go here", "condition": { field: title, equals: extra } }

--- a/localdev/starters/site-config-override.yml
+++ b/localdev/starters/site-config-override.yml
@@ -38,8 +38,6 @@ course:
           "widget": "boolean",
           "help": "Whether the course includes fries or not."
           }
-        - { "label": "Tags", "default": ["Design"], "max": 3, "min": 1, "multiple": true, "name": "tags", "options": ["Design", "UX", "Dev"], "widget": "select" }
-        - { label: "Align Content", name: "align", widget: "select", options: ["left", "center", "right"]}
         - {
           label: "Extra information",
           name: "extra", widget: "markdown", default: "Extra details go here", "condition": { field: title, equals: extra } }

--- a/static/js/components/SiteSidebar.test.tsx
+++ b/static/js/components/SiteSidebar.test.tsx
@@ -66,10 +66,11 @@ describe("SiteSidebar", () => {
   })
 
   it("should pad all .config-sections excepting the last one", async () => {
-    website.starter!.config!.collections = times(5).map(idx =>
-      makeWebsiteConfigItem(`foobar${idx}`)
-    )
+    website.starter!.config!.collections = times(5).map(idx => ({
+      ...makeWebsiteConfigItem(`foobar${idx}`, `category${idx}`)
+    }))
     const { wrapper } = await render()
+    console.log("wrapper", wrapper.debug())
     expect(
       wrapper
         .find("SidebarSection")

--- a/static/js/components/SiteSidebar.test.tsx
+++ b/static/js/components/SiteSidebar.test.tsx
@@ -66,9 +66,9 @@ describe("SiteSidebar", () => {
   })
 
   it("should pad all .config-sections excepting the last one", async () => {
-    website.starter!.config!.collections = times(5).map(idx => ({
-      ...makeWebsiteConfigItem(`foobar${idx}`, `category${idx}`)
-    }))
+    website.starter!.config!.collections = times(5).map(idx =>
+      makeWebsiteConfigItem(`foobar${idx}`, `category${idx}`)
+    )
     const { wrapper } = await render()
     console.log("wrapper", wrapper.debug())
     expect(

--- a/static/js/components/SiteSidebar.test.tsx
+++ b/static/js/components/SiteSidebar.test.tsx
@@ -66,8 +66,8 @@ describe("SiteSidebar", () => {
   })
 
   it("should pad all .config-sections excepting the last one", async () => {
-    website.starter!.config!.collections = times(5).map(() =>
-      makeWebsiteConfigItem("foobar")
+    website.starter!.config!.collections = times(5).map(idx =>
+      makeWebsiteConfigItem(`foobar${idx}`)
     )
     const { wrapper } = await render()
     expect(

--- a/static/js/components/forms/SiteAddContentForm.test.tsx
+++ b/static/js/components/forms/SiteAddContentForm.test.tsx
@@ -7,7 +7,7 @@ import SiteAddContentForm from "./SiteAddContentForm"
 import { defaultFormikChildProps } from "../../test_util"
 
 jest.mock("../../lib/site_content")
-import { componentFromWidget } from "../../lib/site_content"
+import { componentFromWidget, fieldIsVisible } from "../../lib/site_content"
 jest.mock("./validation")
 import { getContentSchema } from "./validation"
 
@@ -68,6 +68,8 @@ describe("SiteAddContentForm", () => {
     const widget = "fakeWidgetComponent"
     // @ts-ignore
     componentFromWidget.mockImplementation(() => widget)
+    // @ts-ignore
+    fieldIsVisible.mockImplementation(() => true)
 
     const fieldGroups = [
       configItem.fields.filter(
@@ -81,14 +83,8 @@ describe("SiteAddContentForm", () => {
     for (const fieldGroup of fieldGroups) {
       for (const field of fieldGroup) {
         const fieldWrapper = form.find("SiteContentField").at(idx)
-        const setFieldValue =
-          field.widget === WidgetVariant.Markdown ?
-            undefined :
-            setFieldValueStub
-        expect(fieldWrapper.find("SiteContentField").prop("field")).toBe(field)
-        expect(
-          fieldWrapper.find("SiteContentField").prop("setFieldValue")
-        ).toBe(setFieldValue)
+        expect(fieldWrapper.prop("field")).toBe(field)
+        expect(fieldWrapper.prop("setFieldValue")).toBe(setFieldValueStub)
         idx++
       }
     }

--- a/static/js/components/forms/SiteAddContentForm.tsx
+++ b/static/js/components/forms/SiteAddContentForm.tsx
@@ -3,7 +3,7 @@ import { Form, Formik, FormikHelpers } from "formik"
 
 import SiteContentField from "./SiteContentField"
 import { getContentSchema } from "./validation"
-import { newInitialValues } from "../../lib/site_content"
+import { fieldIsVisible, newInitialValues } from "../../lib/site_content"
 
 import { ConfigItem, WidgetVariant } from "../../types/websites"
 
@@ -23,10 +23,8 @@ export default function SiteAddContentForm({
   const initialValues = newInitialValues(fields)
   const schema = getContentSchema(configItem)
 
-  const fieldsByColumn = [
-    fields.filter(field => field.widget === WidgetVariant.Markdown),
-    fields.filter(field => field.widget !== WidgetVariant.Markdown)
-  ]
+  const leftColumn = fields.filter(field => field.widget === WidgetVariant.Markdown)
+  const rightColumn = fields.filter(field => field.widget !== WidgetVariant.Markdown)
 
   return (
     <Formik
@@ -34,21 +32,29 @@ export default function SiteAddContentForm({
       validationSchema={schema}
       initialValues={initialValues}
     >
-      {({ isSubmitting, status, setFieldValue }) => (
+      {({ isSubmitting, status, setFieldValue, values }) => (
         <Form className="row">
           <div className="col-6">
-            {fieldsByColumn[0].map(configField => (
-              <SiteContentField key={configField.name} field={configField} />
-            ))}
+            {leftColumn.map(field =>
+              fieldIsVisible(field, values) ? (
+                <SiteContentField
+                  key={field.name}
+                  field={field}
+                  setFieldValue={setFieldValue}
+                />
+              ) : null
+            )}
           </div>
           <div className="col-6">
-            {fieldsByColumn[1].map(configField => (
-              <SiteContentField
-                key={configField.name}
-                field={configField}
-                setFieldValue={setFieldValue}
-              />
-            ))}
+            {rightColumn.map(field =>
+              fieldIsVisible(field, values) ? (
+                <SiteContentField
+                  key={field.name}
+                  field={field}
+                  setFieldValue={setFieldValue}
+                />
+              ) : null
+            )}
             <div className="form-group d-flex justify-content-end">
               <button
                 type="submit"

--- a/static/js/components/forms/SiteAddContentForm.tsx
+++ b/static/js/components/forms/SiteAddContentForm.tsx
@@ -23,8 +23,12 @@ export default function SiteAddContentForm({
   const initialValues = newInitialValues(fields)
   const schema = getContentSchema(configItem)
 
-  const leftColumn = fields.filter(field => field.widget === WidgetVariant.Markdown)
-  const rightColumn = fields.filter(field => field.widget !== WidgetVariant.Markdown)
+  const leftColumn = fields.filter(
+    field => field.widget === WidgetVariant.Markdown
+  )
+  const rightColumn = fields.filter(
+    field => field.widget !== WidgetVariant.Markdown
+  )
 
   return (
     <Formik

--- a/static/js/components/forms/SiteContentField.tsx
+++ b/static/js/components/forms/SiteContentField.tsx
@@ -8,7 +8,7 @@ import { ConfigField, WidgetVariant } from "../../types/websites"
 
 interface Props {
   field: ConfigField
-  setFieldValue?: (key: string, value: File | null) => void
+  setFieldValue: (key: string, value: File | null) => void
 }
 
 /**

--- a/static/js/components/forms/SiteEditContentForm.test.tsx
+++ b/static/js/components/forms/SiteEditContentForm.test.tsx
@@ -15,7 +15,7 @@ import { componentFromWidget, fieldIsVisible } from "../../lib/site_content"
 jest.mock("./validation")
 import { getContentSchema } from "./validation"
 
-import { ConfigItem, WebsiteContent, WidgetVariant } from "../../types/websites"
+import { ConfigItem, WebsiteContent } from "../../types/websites"
 
 describe("SiteEditContentForm", () => {
   let sandbox: SinonSandbox,

--- a/static/js/components/forms/SiteEditContentForm.test.tsx
+++ b/static/js/components/forms/SiteEditContentForm.test.tsx
@@ -11,7 +11,7 @@ import {
   makeWebsiteConfigItem
 } from "../../util/factories/websites"
 jest.mock("../../lib/site_content")
-import { componentFromWidget } from "../../lib/site_content"
+import { componentFromWidget, fieldIsVisible } from "../../lib/site_content"
 jest.mock("./validation")
 import { getContentSchema } from "./validation"
 
@@ -61,26 +61,15 @@ describe("SiteEditContentForm", () => {
     const widget = "fakeWidgetComponent"
     // @ts-ignore
     componentFromWidget.mockImplementation(() => widget)
+    // @ts-ignore
+    fieldIsVisible.mockImplementation(() => true)
 
     const form = renderInnerForm({ setFieldValue: setFieldValueStub })
     let idx = 0
     for (const field of configItem.fields) {
       const fieldWrapper = form.find("SiteContentField").at(idx)
-      const setFieldValue =
-        fieldWrapper.find("SiteContentField").prop("name") ===
-        WidgetVariant.Markdown ?
-          undefined :
-          setFieldValueStub
-      expect(fieldWrapper.find("SiteContentField").prop("field")).toBe(field)
-      expect(fieldWrapper.find("SiteContentField").prop("field")).toBe(field)
-      if (
-        fieldWrapper.find("SiteContentField").prop("name") !==
-        WidgetVariant.Markdown
-      ) {
-        expect(
-          fieldWrapper.find("SiteContentField").prop("setFieldValue")
-        ).toBe(setFieldValue)
-      }
+      expect(fieldWrapper.prop("field")).toBe(field)
+      expect(fieldWrapper.prop("setFieldValue")).toBe(setFieldValueStub)
       idx++
     }
   })

--- a/static/js/components/forms/SiteEditContentForm.tsx
+++ b/static/js/components/forms/SiteEditContentForm.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { Formik, Form, FormikHelpers } from "formik"
 
 import SiteContentField from "./SiteContentField"
-import { contentInitialValues } from "../../lib/site_content"
+import { contentInitialValues, fieldIsVisible } from "../../lib/site_content"
 import { getContentSchema } from "./validation"
 
 import { ConfigItem, WebsiteContent } from "../../types/websites"
@@ -35,15 +35,17 @@ export default function SiteEditContentForm({
       validationSchema={schema}
       initialValues={initialValues}
     >
-      {({ isSubmitting, status, setFieldValue }) => (
+      {({ isSubmitting, status, setFieldValue, values }) => (
         <Form>
-          {fields.map(field => (
-            <SiteContentField
-              field={field}
-              key={field.name}
-              setFieldValue={setFieldValue}
-            />
-          ))}
+          {fields.map(field =>
+            fieldIsVisible(field, values) ? (
+              <SiteContentField
+                field={field}
+                key={field.name}
+                setFieldValue={setFieldValue}
+              />
+            ) : null
+          )}
           <div className="form-group d-flex justify-content-end">
             <button
               type="submit"

--- a/static/js/lib/site_content.test.ts
+++ b/static/js/lib/site_content.test.ts
@@ -22,7 +22,11 @@ import {
 import { MAIN_PAGE_CONTENT_FIELD } from "../constants"
 import { isIf, shouldIf } from "../test_util"
 
-import { ConfigField, FieldCondition, WidgetVariant } from "../types/websites"
+import {
+  ConfigField,
+  FieldValueCondition,
+  WidgetVariant
+} from "../types/websites"
 
 describe("site_content", () => {
   describe("contentFormValuesToPayload", () => {
@@ -261,7 +265,7 @@ describe("site_content", () => {
         hasCondition
         // @ts-ignore
       )} existing and value is a ${values.conditionField}`, () => {
-        const condition: FieldCondition = {
+        const condition: FieldValueCondition = {
           field:  "conditionField",
           equals: "matching value"
         }

--- a/static/js/test_util.ts
+++ b/static/js/test_util.ts
@@ -11,3 +11,5 @@ export const defaultFormikChildProps: FormikState<any> = {
 }
 
 export const isIf = (tf: boolean): string => (tf ? "is" : "is not")
+
+export const shouldIf = (tf: boolean) => (tf ? "should" : "should not")

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -8,7 +8,7 @@ export enum WidgetVariant {
   String = "string",
   Select = "select"
 }
-export interface FieldCondition {
+export interface FieldValueCondition {
   field: string
   equals: string
 }
@@ -25,7 +25,7 @@ export interface ConfigField {
   max?: number
   options?: string[]
   multiple?: boolean
-  condition?: FieldCondition
+  condition?: FieldValueCondition
 }
 
 export interface ConfigItem {

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -8,6 +8,10 @@ export enum WidgetVariant {
   String = "string",
   Select = "select"
 }
+export interface FieldCondition {
+  field: string
+  equals: string
+}
 
 export interface ConfigField {
   name: string
@@ -21,6 +25,7 @@ export interface ConfigField {
   max?: number
   options?: string[]
   multiple?: boolean
+  condition?: FieldCondition
 }
 
 export interface ConfigItem {

--- a/static/js/util/factories/websites.ts
+++ b/static/js/util/factories/websites.ts
@@ -1,5 +1,5 @@
 import casual from "casual-browserify"
-import { times, cloneDeep } from "lodash"
+import { cloneDeep, times } from "lodash"
 
 import incrementer from "../incrementer"
 import {
@@ -12,15 +12,15 @@ import {
 } from "../../constants"
 
 import {
-  ConfigItem,
   ConfigField,
-  WidgetVariant,
+  ConfigItem,
   Website,
   WebsiteCollaborator,
   WebsiteContent,
   WebsiteContentListItem,
   WebsiteStarter,
-  WebsiteStarterConfig
+  WebsiteStarterConfig,
+  WidgetVariant
 } from "../../types/websites"
 
 const incr = incrementer()
@@ -37,6 +37,12 @@ export const makeWebsiteConfigField = (
     ...props
   }
 }
+
+export const makeConfigField = (): ConfigField => ({
+  name:   casual.word,
+  label:  casual.text,
+  widget: WidgetVariant.String
+})
 
 export const makeWebsiteConfigItem = (name: string): ConfigItem => ({
   fields: [

--- a/static/js/util/factories/websites.ts
+++ b/static/js/util/factories/websites.ts
@@ -44,7 +44,10 @@ export const makeConfigField = (): ConfigField => ({
   widget: WidgetVariant.String
 })
 
-export const makeWebsiteConfigItem = (name: string): ConfigItem => ({
+export const makeWebsiteConfigItem = (
+  name: string,
+  category?: string
+): ConfigItem => ({
   fields: [
     {
       label:  "Title",
@@ -60,7 +63,7 @@ export const makeWebsiteConfigItem = (name: string): ConfigItem => ({
   folder:   casual.word,
   label:    casual.word,
   name:     name || casual.word,
-  category: casual.word
+  category: category || casual.word
 })
 
 export const makeWebsiteStarterConfig = (): WebsiteStarterConfig =>

--- a/websites/config_schema/site-config-schema.yml
+++ b/websites/config_schema/site-config-schema.yml
@@ -28,3 +28,8 @@ field:
     max: int(required=False)
     options: list(str(), required=False)
     default: any(required=False)
+    condition: include('field_condition', required=False)
+---
+field_condition:
+    field: str()
+    equals: str()


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #159

#### What's this PR do?
Adds support for conditional fields. If the condition property is set for in the field config, 

#### How should this be manually tested?
 - Run `./manage.py override_site_configs`
 - Go to the form to add a new piece of site metadata for some course. Type "extra" in the title field and you should see an extra markdown field appear. If you click save and the field exists, the content should be saved and retrieved correctly.
 - Change the title field so that it's not "extra" anymore, then click save. Click "Edit" to see the content you saved, and type "extra" in the title field. You should see the markdown field appear but there should be no text.
 - Adding and editing content should otherwise work the same as it did before. There shouldn't be any regressions.