### PR TITLE
Implement hidden field

### DIFF
--- a/localdev/starters/site-config-override.yml
+++ b/localdev/starters/site-config-override.yml
@@ -40,4 +40,11 @@ course:
           }
         - {
           label: "Extra information",
-          name: "extra", widget: "markdown", default: "Extra details go here", "condition": { field: title, equals: extra } }
+          name: "extra", widget: "markdown", default: "Extra details go here", "condition": { field: title, equals: extra }
+          }
+        - {
+          label: "Hidden Field",
+          name: "hidden",
+          widget: "hidden",
+          default: "hidden-value-here"
+          }

--- a/static/js/lib/site_content.test.ts
+++ b/static/js/lib/site_content.test.ts
@@ -15,6 +15,7 @@ import {
   componentFromWidget,
   contentFormValuesToPayload,
   contentInitialValues,
+  fieldHasData,
   fieldIsVisible,
   newInitialValues,
   widgetExtraProps
@@ -201,7 +202,8 @@ describe("site_content", () => {
         [WidgetVariant.String, "input"],
         [WidgetVariant.Boolean, BooleanField],
         [WidgetVariant.Markdown, MarkdownEditor],
-        [WidgetVariant.Text, "textarea"]
+        [WidgetVariant.Text, "textarea"],
+        [WidgetVariant.Hidden, null]
       ].forEach(([widget, expected]) => {
         const field = makeWebsiteConfigField({
           widget: widget as WidgetVariant
@@ -252,30 +254,40 @@ describe("site_content", () => {
     })
   })
 
-  describe("fieldIsVisible", () => {
+  describe("fieldIsVisible and fieldHasData", () => {
     [
-      [true, { conditionField: "matching value" }, true],
-      [true, { conditionField: "non-matching value" }, false],
-      [false, { conditionField: "matching value" }, true],
-      [false, { conditionField: "non-matching value" }, true]
-    ].forEach(([hasCondition, values, expected]) => {
-      // @ts-ignore
-      it(`${isIf(expected)} visible if the condition ${isIf(
+      [true, "input", { conditionField: "matching value" }, true, true],
+      [true, "input", { conditionField: "non-matching value" }, false, false],
+      [false, "input", { conditionField: "matching value" }, true, true],
+      [false, "input", { conditionField: "non-matching value" }, true, true],
+      [true, "hidden", { conditionField: "matching value" }, false, true],
+      [true, "hidden", { conditionField: "non-matching value" }, false, false],
+      [false, "hidden", { conditionField: "matching value" }, false, true],
+      [false, "hidden", { conditionField: "non-matching value" }, false, true]
+    ].forEach(
+      ([hasCondition, widget, values, expectedVisible, expectedHasData]) => {
         // @ts-ignore
-        hasCondition
-        // @ts-ignore
-      )} existing and value is a ${values.conditionField}`, () => {
-        const condition: FieldValueCondition = {
-          field:  "conditionField",
-          equals: "matching value"
-        }
-        const field = makeConfigField()
-        if (hasCondition) {
-          field.condition = condition
-        }
-        // @ts-ignore
-        expect(fieldIsVisible(field, values)).toBe(expected)
-      })
-    })
+        it(`${isIf(expectedVisible)} visible if the condition ${isIf(
+          // @ts-ignore
+          hasCondition
+          // @ts-ignore
+        )} existing and value is a ${values.conditionField}`, () => {
+          const condition: FieldValueCondition = {
+            field:  "conditionField",
+            equals: "matching value"
+          }
+          const field = makeConfigField()
+          // @ts-ignore
+          field.widget = widget
+          if (hasCondition) {
+            field.condition = condition
+          }
+          // @ts-ignore
+          expect(fieldIsVisible(field, values)).toBe(expectedVisible)
+          // @ts-ignore
+          expect(fieldHasData(field, values)).toBe(expectedHasData)
+        })
+      }
+    )
   })
 })

--- a/static/js/test_util.ts
+++ b/static/js/test_util.ts
@@ -12,4 +12,4 @@ export const defaultFormikChildProps: FormikState<any> = {
 
 export const isIf = (tf: boolean): string => (tf ? "is" : "is not")
 
-export const shouldIf = (tf: boolean) => (tf ? "should" : "should not")
+export const shouldIf = (tf: boolean): string => (tf ? "should" : "should not")

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -6,7 +6,8 @@ export enum WidgetVariant {
   Boolean = "boolean",
   Text = "text",
   String = "string",
-  Select = "select"
+  Select = "select",
+  Hidden = "hidden"
 }
 export interface FieldValueCondition {
   field: string

--- a/websites/config_schema/site-config-schema.yml
+++ b/websites/config_schema/site-config-schema.yml
@@ -16,7 +16,7 @@ inner_content_item:
     file: str(required=False)
 ---
 field:
-    widget: enum('string', 'text', 'markdown', 'file', 'select', 'boolean')
+    widget: enum('string', 'text', 'markdown', 'file', 'select', 'boolean', 'hidden')
     label: str()
     name: str()
     minimal: bool(required=False)


### PR DESCRIPTION
**Note**: rebased on #161 

#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #163 

#### What's this PR do?
Implements a hidden field

#### How should this be manually tested?
Run `./manage.py override_site_configs`. Add a new piece of site metadata. In the network tab you should see a parameter `hidden` with the value `hidden-value-here` in the `metadata` dict.