### PR TITLE
add Boolean widget

### DIFF
--- a/localdev/starters/site-config-override.yml
+++ b/localdev/starters/site-config-override.yml
@@ -29,6 +29,12 @@ course:
           "widget": "markdown",
           "minimal": true,
           "help": "A description of the course that will be shown on the course site home page."
-        }
+          }
         - { "label": "Tags", "default": ["Design"], "max": 3, "min": 1, "multiple": true, "name": "tags", "options": ["Design", "UX", "Dev"], "widget": "select" }
         - { label: "Align Content", name: "align", widget: "select", options: ["left", "center", "right"]}
+        - {
+          "label": "Comes with fries",
+          "name": "fries",
+          "widget": "boolean",
+          "help": "Whether the course includes fries or not."
+          }

--- a/static/js/components/SiteAddContent.test.tsx
+++ b/static/js/components/SiteAddContent.test.tsx
@@ -1,5 +1,6 @@
 const mockUseRouteMatch = jest.fn()
 
+import React from "react"
 import { act } from "react-dom/test-utils"
 import sinon, { SinonStub } from "sinon"
 
@@ -21,8 +22,16 @@ jest.mock("react-router-dom", () => ({
   ...jest.requireActual("react-router-dom"),
   useRouteMatch: mockUseRouteMatch
 }))
+
 // ckeditor is not working properly in tests, but we don't need to test it here so just mock it away
-jest.mock("./widgets/MarkdownEditor", () => "div")
+function mocko() {
+  return <div>mock</div>
+}
+
+jest.mock("./widgets/MarkdownEditor", () => ({
+  __esModule: true,
+  default:    mocko
+}))
 
 describe("SiteAddContent", () => {
   let helper: IntegrationTestHelper,

--- a/static/js/components/SiteContentListing.test.tsx
+++ b/static/js/components/SiteContentListing.test.tsx
@@ -1,5 +1,6 @@
 const mockUseRouteMatch = jest.fn()
 
+import React from "react"
 import { act } from "react-dom/test-utils"
 
 import SiteContentListing from "./SiteContentListing"
@@ -33,7 +34,14 @@ jest.mock("react-router-dom", () => ({
 }))
 
 // ckeditor is not working properly in tests, but we don't need to test it here so just mock it away
-jest.mock("./widgets/MarkdownEditor", () => "div")
+function mocko() {
+  return <div>mock</div>
+}
+
+jest.mock("./widgets/MarkdownEditor", () => ({
+  __esModule: true,
+  default:    mocko
+}))
 
 describe("SiteContentListing", () => {
   let helper: IntegrationTestHelper,

--- a/static/js/components/SiteEditContent.test.tsx
+++ b/static/js/components/SiteEditContent.test.tsx
@@ -1,5 +1,6 @@
 const mockUseRouteMatch = jest.fn()
 
+import React from "react"
 import { act } from "react-dom/test-utils"
 import sinon, { SinonStub } from "sinon"
 
@@ -21,8 +22,16 @@ jest.mock("react-router-dom", () => ({
   ...jest.requireActual("react-router-dom"),
   useRouteMatch: mockUseRouteMatch
 }))
+
 // ckeditor is not working properly in tests, but we don't need to test it here so just mock it away
-jest.mock("./widgets/MarkdownEditor", () => "div")
+function mocko() {
+  return <div>mock</div>
+}
+
+jest.mock("./widgets/MarkdownEditor", () => ({
+  __esModule: true,
+  default:    mocko
+}))
 
 describe("SiteEditContent", () => {
   let helper: IntegrationTestHelper,

--- a/static/js/components/forms/SiteAddContentForm.test.tsx
+++ b/static/js/components/forms/SiteAddContentForm.test.tsx
@@ -11,7 +11,7 @@ import { componentFromWidget } from "../../lib/site_content"
 jest.mock("./validation")
 import { getContentSchema } from "./validation"
 
-import { ConfigItem } from "../../types/websites"
+import { ConfigItem, WidgetVariant } from "../../types/websites"
 
 describe("SiteAddContentForm", () => {
   let sandbox: SinonSandbox,
@@ -27,12 +27,12 @@ describe("SiteAddContentForm", () => {
         {
           label:  "Title",
           name:   "title",
-          widget: "string"
+          widget: WidgetVariant.String
         },
         {
           label:  "Content",
           name:   "content",
-          widget: "markdown"
+          widget: WidgetVariant.Markdown
         }
       ],
       folder:   "content",

--- a/static/js/components/forms/SiteAddContentForm.tsx
+++ b/static/js/components/forms/SiteAddContentForm.tsx
@@ -14,6 +14,7 @@ interface Props {
   ) => void | Promise<any>
   configItem: ConfigItem
 }
+
 export default function SiteAddContentForm({
   onSubmit,
   configItem

--- a/static/js/components/forms/SiteContentField.test.tsx
+++ b/static/js/components/forms/SiteContentField.test.tsx
@@ -7,6 +7,7 @@ import SiteContentField from "./SiteContentField"
 
 import { componentFromWidget } from "../../lib/site_content"
 import { makeWebsiteStarterConfig } from "../../util/factories/websites"
+import { WidgetVariant } from "../../types/websites"
 
 describe("SiteContentField", () => {
   let sandbox: SinonSandbox, setFieldValueStub: SinonStub
@@ -34,9 +35,12 @@ describe("SiteContentField", () => {
       const props = wrapper.find("Field").props()
       expect(props["as"]).toBe(componentFromWidget(field))
       expect(props["name"]).toBe(field.name)
-      expect(props["setFieldValue"]).toBe(
-        field.widget === "file" ? setFieldValueStub : undefined
-      )
+      if (
+        field.widget === WidgetVariant.File ||
+        field.widget === WidgetVariant.Boolean
+      ) {
+        expect(props["setFieldValue"]).toBe(setFieldValueStub)
+      }
       if (field.widget === "select") {
         expect(props["min"]).toBe(field.min)
         expect(props["max"]).toBe(field.max)

--- a/static/js/components/forms/SiteContentField.tsx
+++ b/static/js/components/forms/SiteContentField.tsx
@@ -2,33 +2,29 @@ import { ErrorMessage, Field } from "formik"
 import React from "react"
 
 import { FormError } from "./FormError"
-import { componentFromWidget } from "../../lib/site_content"
+import { componentFromWidget, widgetExtraProps } from "../../lib/site_content"
 
-import { ConfigField } from "../../types/websites"
+import { ConfigField, WidgetVariant } from "../../types/websites"
 
 interface Props {
   field: ConfigField
   setFieldValue?: (key: string, value: File | null) => void
 }
 
+/**
+ * Field for editing any type of site content
+ */
 export default function SiteContentField({
   field,
   setFieldValue
 }: Props): JSX.Element {
-  let extraProps
-  switch (field.widget) {
-  case "file":
-    extraProps = { setFieldValue }
-    break
-  case "select":
-    extraProps = {}
-    for (const fieldName of ["options", "multiple", "max", "min"]) {
-      extraProps[fieldName] = field[fieldName]
-    }
-    break
-  default:
-    extraProps = {}
-    break
+  const extraProps = widgetExtraProps(field)
+
+  if (
+    field.widget === WidgetVariant.File ||
+    field.widget === WidgetVariant.Boolean
+  ) {
+    extraProps.setFieldValue = setFieldValue
   }
 
   return (

--- a/static/js/components/forms/validation.test.ts
+++ b/static/js/components/forms/validation.test.ts
@@ -1,7 +1,7 @@
 import * as yup from "yup"
 import { getContentSchema } from "./validation"
 
-import { ConfigItem } from "../../types/websites"
+import { ConfigItem, WidgetVariant } from "../../types/websites"
 
 describe("form validation util", () => {
   const yupFileFieldSchema = yup.object().shape({
@@ -25,7 +25,7 @@ describe("form validation util", () => {
       fields: [
         {
           ...partialField,
-          widget: "string"
+          widget: WidgetVariant.String
         }
       ]
     }
@@ -56,7 +56,7 @@ describe("form validation util", () => {
         fields: [
           {
             ...partialField,
-            widget:   widget.toString(),
+            widget:   widget as WidgetVariant,
             required: true
           }
         ]
@@ -83,13 +83,13 @@ describe("form validation util", () => {
         {
           name:     "myfield",
           label:    "My Field",
-          widget:   "string",
+          widget:   WidgetVariant.String,
           required: true
         },
         {
           name:     "myfield2",
           label:    "My Second Field",
-          widget:   "string",
+          widget:   WidgetVariant.String,
           required: true
         }
       ]

--- a/static/js/components/widgets/BooleanField.test.tsx
+++ b/static/js/components/widgets/BooleanField.test.tsx
@@ -1,0 +1,58 @@
+import React from "react"
+import { shallow } from "enzyme"
+
+import BooleanField from "./BooleanField"
+
+describe("BooleanField", () => {
+  let setFieldValueStub: any, render: any
+
+  beforeEach(() => {
+    setFieldValueStub = jest.fn()
+
+    render = (props = {}) =>
+      shallow(
+        <BooleanField
+          name="name"
+          value={false}
+          setFieldValue={setFieldValueStub}
+          {...props}
+        />
+      )
+  })
+
+  it("should render two radio inputs", () => {
+    const wrapper = render()
+    wrapper.find("input").map((input: any) => {
+      const { name, type, id, value } = input.props()
+      expect(name).toBe("name")
+      expect(type).toBe("radio")
+      expect(id).toBe(value === "true" ? "name_true" : "name_false")
+    })
+  })
+
+  it("should set 'checked' prop on the radio corresponding to current value", () => {
+    [true, false].forEach(value => {
+      const wrapper = render({ value })
+      expect(
+        wrapper.find(`#name_${value.toString()}`).prop("checked")
+      ).toBeTruthy()
+      expect(
+        wrapper.find(`#name_${(!value).toString()}`).prop("checked")
+      ).toBeFalsy()
+    })
+  })
+
+  it("clicking on a radio option should call setFieldValue", () => {
+    const wrapper = render()
+    wrapper
+      .find("input")
+      .at(0)
+      .simulate("change")
+    expect(setFieldValueStub).toHaveBeenCalledWith("name", true)
+    wrapper
+      .find("input")
+      .at(1)
+      .simulate("change")
+    expect(setFieldValueStub).toHaveBeenCalledWith("name", false)
+  })
+})

--- a/static/js/components/widgets/BooleanField.tsx
+++ b/static/js/components/widgets/BooleanField.tsx
@@ -1,0 +1,48 @@
+import React from "react"
+
+const radioOptionId = (name: string, bool: boolean): string =>
+  `${name}_${String(bool)}`
+
+interface Props {
+  name: string
+  value: boolean
+  setFieldValue: (key: string, value: File | boolean | null) => void
+}
+
+/**
+ * A widget for editing boolean values
+ */
+export default function BooleanField(props: Props): JSX.Element {
+  const { name, value, setFieldValue } = props
+
+  return (
+    <div>
+      <input
+        type="radio"
+        id={radioOptionId(name, true)}
+        name={name}
+        value="true"
+        checked={value === true}
+        onChange={() => {
+          setFieldValue(name, true)
+        }}
+      />
+      <label className="px-2" htmlFor={radioOptionId(name, true)}>
+        True
+      </label>
+      <input
+        type="radio"
+        id={radioOptionId(name, false)}
+        name={name}
+        value="false"
+        checked={value === false}
+        onChange={() => {
+          setFieldValue(name, false)
+        }}
+      />
+      <label className="px-2" htmlFor={radioOptionId(name, false)}>
+        False
+      </label>
+    </div>
+  )
+}

--- a/static/js/components/widgets/FileUploadField.tsx
+++ b/static/js/components/widgets/FileUploadField.tsx
@@ -1,18 +1,18 @@
 import React from "react"
 import { filenameFromPath } from "../../lib/util"
 
-/**
- * A component for uploading files
- */
-
 export interface Props {
   name?: string
   value?: string | File | null
   setFieldValue: (key: string, value: File | null) => void
 }
 
+/**
+ * A component for uploading files
+ */
 export default function FileUploadField(props: Props): JSX.Element {
   const { name, value, setFieldValue } = props
+
   return (
     <div>
       <input

--- a/static/js/components/widgets/MarkdownEditor.tsx
+++ b/static/js/components/widgets/MarkdownEditor.tsx
@@ -18,8 +18,10 @@ export interface Props {
 
 /**
  * A component for editing Markdown using CKEditor.
+ *
+ * pass minimal: true to get a minimal version.
  */
-export function MarkdownEditor(props: Props): JSX.Element {
+export default function MarkdownEditor(props: Props): JSX.Element {
   const { value, name, onChange, minimal } = props
 
   return (
@@ -35,8 +37,4 @@ export function MarkdownEditor(props: Props): JSX.Element {
       }}
     />
   )
-}
-
-export function MinimalMarkdownEditor(props: Props): JSX.Element {
-  return <MarkdownEditor {...props} minimal={true} />
 }

--- a/static/js/constants.ts
+++ b/static/js/constants.ts
@@ -1,4 +1,5 @@
 import { WebsiteStarterConfig } from "./types/websites"
+import { WidgetVariant } from "./types/websites"
 
 export const ROLE_ADMIN = "admin"
 export const ROLE_EDITOR = "editor"
@@ -32,13 +33,13 @@ export const exampleSiteConfig: WebsiteStarterConfig = {
         {
           label: "Title",
           name: "title",
-          widget: "string",
+          widget: WidgetVariant.String,
           required: true
         },
         {
           label: "Content",
           name: "content",
-          widget: "markdown",
+          widget: WidgetVariant.Markdown,
           required: true
         }
       ],
@@ -52,20 +53,20 @@ export const exampleSiteConfig: WebsiteStarterConfig = {
         {
           label: "Title",
           name: "title",
-          widget: "string",
+          widget: WidgetVariant.String,
           required: true
         },
         {
           label: "Description",
           name: "description",
-          widget: "markdown",
+          widget: WidgetVariant.Markdown,
           minimal: true,
           required: true
         },
         {
           label: "File",
           name: "file",
-          widget: "file",
+          widget: WidgetVariant.File,
           required: true
         }
       ],
@@ -79,13 +80,13 @@ export const exampleSiteConfig: WebsiteStarterConfig = {
         {
           label: "Course Title",
           name: "title",
-          widget: "text",
+          widget: WidgetVariant.Text,
           required: true
         },
         {
           label: "Course Description",
           name: "description",
-          widget: "markdown",
+          widget: WidgetVariant.Markdown,
           help:
             "A description of the course that will be shown on the course site home page."
         },
@@ -97,13 +98,19 @@ export const exampleSiteConfig: WebsiteStarterConfig = {
           multiple: true,
           name: "tags",
           options: ["Design", "UX", "Dev"],
-          widget: "select"
+          widget: WidgetVariant.Select
         },
         {
           label: "Align Content",
           name: "align",
-          widget: "select",
+          widget: WidgetVariant.Select,
           options: ["left", "center", "right"]
+        },
+        {
+          label: "Featured course",
+          name: "featured",
+          widget: WidgetVariant.Boolean,
+          default: false
         }
       ],
       file: "data/metadata.json",

--- a/static/js/pages/MarkdownEditorTestPage.tsx
+++ b/static/js/pages/MarkdownEditorTestPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react"
 import { TabContent, TabPane, Nav, NavItem, NavLink } from "reactstrap"
 
-import { MarkdownEditor } from "../components/widgets/MarkdownEditor"
+import MarkdownEditor from "../components/widgets/MarkdownEditor"
 
 import { TEST_MARKDOWN } from "../test_constants"
 

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -1,9 +1,18 @@
 import { ROLE_ADMIN, ROLE_EDITOR, ROLE_GLOBAL, ROLE_OWNER } from "../constants"
 
+export enum WidgetVariant {
+  Markdown = "markdown",
+  File = "file",
+  Boolean = "boolean",
+  Text = "text",
+  String = "string",
+  Select = "select"
+}
+
 export interface ConfigField {
   name: string
   label: string
-  widget: string
+  widget: WidgetVariant
   minimal?: boolean
   help?: string
   required?: boolean

--- a/static/js/util/factories/websites.ts
+++ b/static/js/util/factories/websites.ts
@@ -13,6 +13,8 @@ import {
 
 import {
   ConfigItem,
+  ConfigField,
+  WidgetVariant,
   Website,
   WebsiteCollaborator,
   WebsiteContent,
@@ -23,17 +25,30 @@ import {
 
 const incr = incrementer()
 
+export const makeWebsiteConfigField = (
+  props: Record<string, any> = {}
+): ConfigField => {
+  const label = props.label ?? casual.word
+
+  return {
+    label,
+    name:   label.toLowerCase(),
+    widget: props.widget,
+    ...props
+  }
+}
+
 export const makeWebsiteConfigItem = (name: string): ConfigItem => ({
   fields: [
     {
       label:  "Title",
       name:   "title",
-      widget: "string"
+      widget: WidgetVariant.String
     },
     {
       label:  "Content",
       name:   "content",
-      widget: "markdown"
+      widget: WidgetVariant.Markdown
     }
   ],
   folder:   casual.word,

--- a/websites/config_schema/site-config-schema.yml
+++ b/websites/config_schema/site-config-schema.yml
@@ -16,7 +16,7 @@ inner_content_item:
     file: str(required=False)
 ---
 field:
-    widget: enum('string', 'text', 'markdown', 'file', 'select')
+    widget: enum('string', 'text', 'markdown', 'file', 'select', 'boolean')
     label: str()
     name: str()
     minimal: bool(required=False)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #145 

#### What's this PR do?

This adds a new widget type for setting a Boolean value in the site config. I made a few other changes to parts of the code that I touched when implementing it too:

- I created a new `enum` type called `WidgetVariant` that captures the different possible widgets. The enum will be transformed into string constants at compile time by typescript.
- I slightly refactored how props get from the `ConfigField` down to the `SiteContentField`, creating a `widgetExtraProps` function in `lib/site_content.ts` which switches on the `WidgetVariant` and grab the extra props we want out of the `ConfigField` object for each type.

Anyhow, I think these changes increase clarity a little bit :)

#### How should this be manually tested?

You can use the `override_site_configs` management command to add a Boolean field to the site config (I checked in a change to add one to the `localdev/starters/site-config-override.yml` file). Then check out the metadata config section and make sure you can edit the boolean field.

#### Screenshots (if appropriate)

![Screenshot from 2021-04-01 12-38-43](https://user-images.githubusercontent.com/6207644/113326068-36d59600-92e7-11eb-9b2e-e4fb9eec8a13.png)
