### PR TITLE
Content -> Body

### DIFF
--- a/localdev/starters/site-config-override.yml
+++ b/localdev/starters/site-config-override.yml
@@ -6,7 +6,7 @@ course:
       folder: content
       fields:
         - {"label": "Title", "name": "title", "widget": "string", "required": true}
-        - {"label": "Content", "name": "content", "widget": "markdown", "required": true}
+        - {"label": "Body", "name": "body", "widget": "markdown", "required": true}
 
     - name: resource
       label: Resource

--- a/static/js/components/SiteAddContent.test.tsx
+++ b/static/js/components/SiteAddContent.test.tsx
@@ -101,8 +101,8 @@ describe("SiteAddContent", () => {
 
     const onSubmit = wrapper.find("SiteAddContentForm").prop("onSubmit")
     const values = {
-      title:   "A title",
-      content: "some markdown here"
+      title: "A title",
+      body:  "some markdown here"
     }
     await act(async () => {
       // @ts-ignore
@@ -116,7 +116,7 @@ describe("SiteAddContent", () => {
         body: {
           type:     configItem.name,
           title:    values.title,
-          markdown: values.content
+          markdown: values.body
         },
         headers:     { "X-CSRFTOKEN": "" },
         credentials: undefined

--- a/static/js/components/forms/SiteAddContentForm.test.tsx
+++ b/static/js/components/forms/SiteAddContentForm.test.tsx
@@ -30,8 +30,8 @@ describe("SiteAddContentForm", () => {
           widget: WidgetVariant.String
         },
         {
-          label:  "Content",
-          name:   "content",
+          label:  "Body",
+          name:   "body",
           widget: WidgetVariant.Markdown
         }
       ],

--- a/static/js/constants.ts
+++ b/static/js/constants.ts
@@ -22,7 +22,7 @@ export const WEBSITE_CONTENT_PAGE_SIZE = 10
  * This represents the "reserved" name for the field that captures the markdown content for the body of a page.
  * In Hugo terms, this is everything below the front matter in a ".md" file.
  */
-export const MAIN_PAGE_CONTENT_FIELD = "content"
+export const MAIN_PAGE_CONTENT_FIELD = "body"
 export const MAIN_PAGE_CONTENT_DB_FIELD = "markdown"
 
 /* eslint-disable quote-props, key-spacing */
@@ -37,8 +37,8 @@ export const exampleSiteConfig: WebsiteStarterConfig = {
           required: true
         },
         {
-          label: "Content",
-          name: "content",
+          label: "Body",
+          name: "body",
           widget: WidgetVariant.Markdown,
           required: true
         }

--- a/static/js/lib/site_content.test.ts
+++ b/static/js/lib/site_content.test.ts
@@ -24,8 +24,8 @@ describe("site_content", () => {
   describe("contentFormValuesToPayload", () => {
     it("changes the name of a 'content' field if it uses the markdown widget", () => {
       const values = {
-        title:   "a title",
-        content: "some content"
+        title: "a title",
+        body:  "some content"
       }
       const fields: ConfigField[] = [
         {
@@ -34,7 +34,7 @@ describe("site_content", () => {
           widget: WidgetVariant.String
         },
         {
-          label:  "Content",
+          label:  "Body",
           name:   MAIN_PAGE_CONTENT_FIELD,
           widget: WidgetVariant.Markdown
         }

--- a/static/js/util/factories/websites.ts
+++ b/static/js/util/factories/websites.ts
@@ -46,8 +46,8 @@ export const makeWebsiteConfigItem = (name: string): ConfigItem => ({
       widget: WidgetVariant.String
     },
     {
-      label:  "Content",
-      name:   "content",
+      label:  "Body",
+      name:   "body",
       widget: WidgetVariant.Markdown
     }
   ],

--- a/websites/config_schema/resources/valid-config.yml
+++ b/websites/config_schema/resources/valid-config.yml
@@ -5,7 +5,7 @@ collections:
     folder: content
     fields:
       - {"label": "Title", "name": "title", "widget": "string"}
-      - {"label": "Content", "name": "content", "widget": "markdown"}
+      - {"label": "Body", "name": "body", "widget": "markdown"}
 
   - name: resource
     label: Resource


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #157 

#### What's this PR do?
Updates main widget field name from "content" to "body"

#### How should this be manually tested?
Run `./manage.py override_site_configs` and edit a page in a site. You should see a "Body" label where it used to be "Content" but you should not see any other changes. Functionality should generally work like before.
