### PR TITLE
use the WidgetVariant constants instead of string literals

### DIFF
--- a/static/js/components/forms/SiteAddContentForm.test.tsx
+++ b/static/js/components/forms/SiteAddContentForm.test.tsx
@@ -70,8 +70,10 @@ describe("SiteAddContentForm", () => {
     componentFromWidget.mockImplementation(() => widget)
 
     const fieldGroups = [
-      configItem.fields.filter(field => field.widget === "markdown"),
-      configItem.fields.filter(field => field.widget !== "markdown")
+      configItem.fields.filter(
+        field => field.widget === WidgetVariant.Markdown
+      ),
+      configItem.fields.filter(field => field.widget !== WidgetVariant.Markdown)
     ]
 
     const form = renderInnerForm({ setFieldValue: setFieldValueStub })
@@ -80,7 +82,9 @@ describe("SiteAddContentForm", () => {
       for (const field of fieldGroup) {
         const fieldWrapper = form.find("SiteContentField").at(idx)
         const setFieldValue =
-          field.widget === "markdown" ? undefined : setFieldValueStub
+          field.widget === WidgetVariant.Markdown ?
+            undefined :
+            setFieldValueStub
         expect(fieldWrapper.find("SiteContentField").prop("field")).toBe(field)
         expect(
           fieldWrapper.find("SiteContentField").prop("setFieldValue")

--- a/static/js/components/forms/SiteAddContentForm.tsx
+++ b/static/js/components/forms/SiteAddContentForm.tsx
@@ -5,7 +5,7 @@ import SiteContentField from "./SiteContentField"
 import { getContentSchema } from "./validation"
 import { newInitialValues } from "../../lib/site_content"
 
-import { ConfigItem } from "../../types/websites"
+import { ConfigItem, WidgetVariant } from "../../types/websites"
 
 interface Props {
   onSubmit: (
@@ -24,8 +24,8 @@ export default function SiteAddContentForm({
   const schema = getContentSchema(configItem)
 
   const fieldsByColumn = [
-    fields.filter(field => field.widget === "markdown"),
-    fields.filter(field => field.widget !== "markdown")
+    fields.filter(field => field.widget === WidgetVariant.Markdown),
+    fields.filter(field => field.widget !== WidgetVariant.Markdown)
   ]
 
   return (

--- a/static/js/components/forms/SiteContentField.test.tsx
+++ b/static/js/components/forms/SiteContentField.test.tsx
@@ -41,7 +41,7 @@ describe("SiteContentField", () => {
       ) {
         expect(props["setFieldValue"]).toBe(setFieldValueStub)
       }
-      if (field.widget === "select") {
+      if (field.widget === WidgetVariant.Select) {
         expect(props["min"]).toBe(field.min)
         expect(props["max"]).toBe(field.max)
         expect(props["multiple"]).toBe(field.multiple)

--- a/static/js/components/forms/SiteEditContentForm.test.tsx
+++ b/static/js/components/forms/SiteEditContentForm.test.tsx
@@ -15,7 +15,7 @@ import { componentFromWidget } from "../../lib/site_content"
 jest.mock("./validation")
 import { getContentSchema } from "./validation"
 
-import { ConfigItem, WebsiteContent } from "../../types/websites"
+import { ConfigItem, WebsiteContent, WidgetVariant } from "../../types/websites"
 
 describe("SiteEditContentForm", () => {
   let sandbox: SinonSandbox,
@@ -67,12 +67,16 @@ describe("SiteEditContentForm", () => {
     for (const field of configItem.fields) {
       const fieldWrapper = form.find("SiteContentField").at(idx)
       const setFieldValue =
-        fieldWrapper.find("SiteContentField").prop("name") === "markdown" ?
+        fieldWrapper.find("SiteContentField").prop("name") ===
+        WidgetVariant.Markdown ?
           undefined :
           setFieldValueStub
       expect(fieldWrapper.find("SiteContentField").prop("field")).toBe(field)
       expect(fieldWrapper.find("SiteContentField").prop("field")).toBe(field)
-      if (fieldWrapper.find("SiteContentField").prop("name") !== "markdown") {
+      if (
+        fieldWrapper.find("SiteContentField").prop("name") !==
+        WidgetVariant.Markdown
+      ) {
         expect(
           fieldWrapper.find("SiteContentField").prop("setFieldValue")
         ).toBe(setFieldValue)

--- a/static/js/components/forms/validation.test.ts
+++ b/static/js/components/forms/validation.test.ts
@@ -43,10 +43,10 @@ describe("form validation util", () => {
 
   //
   ;[
-    ["string", yup.string()],
-    ["text", yup.string()],
-    ["markdown", yup.string()],
-    ["file", yupFileFieldSchema]
+    [WidgetVariant.String, yup.string()],
+    [WidgetVariant.Text, yup.string()],
+    [WidgetVariant.Markdown, yup.string()],
+    [WidgetVariant.File, yupFileFieldSchema]
   ].forEach(([widget, expectedYupField]) => {
     it(`produces the correct validation schema for a required '${widget}' field`, () => {
       configItem = {

--- a/static/js/components/forms/validation.ts
+++ b/static/js/components/forms/validation.ts
@@ -1,7 +1,7 @@
 import * as yup from "yup"
 import { SchemaOf, setLocale } from "yup"
 
-import { ConfigField, ConfigItem } from "../../types/websites"
+import { ConfigField, ConfigItem, WidgetVariant } from "../../types/websites"
 
 // This is added to properly handle file fields, which can have a "null" value
 setLocale({
@@ -12,17 +12,17 @@ setLocale({
 
 export const getFieldSchema = (field: ConfigField): SchemaOf<any> => {
   switch (field.widget) {
-  case "select":
+  case WidgetVariant.Select:
     if (field.multiple) {
       return yup.array()
     } else {
       return yup.string()
     }
-  case "file":
+  case WidgetVariant.File:
     return yup.mixed()
-  case "string":
-  case "text":
-  case "markdown":
+  case WidgetVariant.String:
+  case WidgetVariant.Text:
+  case WidgetVariant.Markdown:
   default:
     return yup.string()
   }
@@ -35,7 +35,7 @@ export const getContentSchema = (configItem: ConfigItem): SchemaOf<any> => {
     yupObjectShape[field.name] = yupField.label(field.label)
     if (field.required) {
       switch (field.widget) {
-      case "file":
+      case WidgetVariant.File:
         yupObjectShape[field.name] = yupObjectShape[field.name]
           .label(field.label)
           .required()

--- a/static/js/lib/site_content.test.ts
+++ b/static/js/lib/site_content.test.ts
@@ -141,16 +141,16 @@ describe("site_content", () => {
 
     it("should use appropriate defaults for different widgets", () => {
       [
-        ["markdown", ""],
-        ["file", ""],
-        ["boolean", false],
-        ["text", ""],
-        ["string", ""],
-        ["select", ""]
+        [WidgetVariant.Markdown, ""],
+        [WidgetVariant.File, ""],
+        [WidgetVariant.Boolean, false],
+        [WidgetVariant.Text, ""],
+        [WidgetVariant.String, ""],
+        [WidgetVariant.Select, ""]
       ].forEach(([widget, expectation]) => {
         const field = makeWebsiteConfigField({
-          widget: widget as WidgetVariant,
-          label:  "Widget"
+          widget,
+          label: "Widget"
         })
         const initialValues = newInitialValues([field])
         expect(initialValues).toStrictEqual({ widget: expectation })

--- a/static/js/lib/site_content.ts
+++ b/static/js/lib/site_content.ts
@@ -18,13 +18,13 @@ export const componentFromWidget = (
   field: ConfigField
 ): string | ComponentType | ElementType => {
   switch (field.widget) {
-  case "markdown":
+  case WidgetVariant.Markdown:
     return MarkdownEditor
-  case "select":
+  case WidgetVariant.Select:
     return SelectField
-  case "file":
+  case WidgetVariant.File:
     return FileUploadField
-  case "boolean":
+  case WidgetVariant.Boolean:
     return BooleanField
   default:
     return "input"
@@ -35,9 +35,9 @@ const SELECT_EXTRA_PROPS = ["options", "multiple", "max", "min"]
 
 export function widgetExtraProps(field: ConfigField): Record<string, any> {
   switch (field.widget) {
-  case "select":
+  case WidgetVariant.Select:
     return pick(SELECT_EXTRA_PROPS, field)
-  case "markdown":
+  case WidgetVariant.Markdown:
     return { minimal: field.minimal ?? false }
   default:
     return {}
@@ -45,7 +45,8 @@ export function widgetExtraProps(field: ConfigField): Record<string, any> {
 }
 
 const isMainContentField = (field: ConfigField) =>
-  field.name === MAIN_PAGE_CONTENT_FIELD && field.widget === "markdown"
+  field.name === MAIN_PAGE_CONTENT_FIELD &&
+  field.widget === WidgetVariant.Markdown
 
 type ValueType = string | File | string[] | null
 
@@ -124,4 +125,4 @@ export const newInitialValues = (fields: ConfigField[]): Record<string, any> =>
   )
 
 const defaultFor = (widget: WidgetVariant): string | boolean =>
-  widget === "boolean" ? false : ""
+  widget === WidgetVariant.Boolean ? false : ""


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

none

#### What's this PR do?

nothing much, I added a `WidgetVariant` enum in #168 which defines the constants that we use for defining which widget a field needs to use when it's been edited. This just updates some code to use the constants declared in that enum rather than string literals.

#### How should this be manually tested?

there shouldn't be any functional changes. would be good to read through the changes and make sure I didn't make a typo!