### PR TITLE
Add settings for using X-Forwarded-* headers

### DIFF
--- a/app.json
+++ b/app.json
@@ -268,6 +268,14 @@
     "STATUS_TOKEN": {
       "description": "Token to access the status API.",
       "required": false
+    },
+    "USE_X_FORWARDED_HOST": {
+      "description": "Set HOST header to original domain accessed by user",
+      "required": false
+    },
+    "USE_X_FORWARDED_PORT": {
+      "description": "Use the PORT from original url accessed by user",
+      "required": false
     }
   },
   "keywords": [

--- a/main/settings.py
+++ b/main/settings.py
@@ -88,6 +88,18 @@ SECURE_SSL_REDIRECT = get_bool(
     description="Application-level SSL redirect setting.",
 )
 
+
+USE_X_FORWARDED_HOST = get_bool(
+    name="USE_X_FORWARDED_HOST",
+    default=False,
+    description="Set HOST header to original domain accessed by user",
+)
+USE_X_FORWARDED_PORT = get_bool(
+    name="USE_X_FORWARDED_PORT",
+    default=False,
+    description="Use the PORT from original url accessed by user",
+)
+
 WEBPACK_LOADER = {
     "DEFAULT": {
         "CACHE": not DEBUG,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable
  - [x] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
Fixes https://github.com/mitodl/ocw-studio/issues/187

#### What's this PR do?
Adds `USE_X_FORWARDED_HOST` and `USE_X_FORWARDED_PORT` as configurable settings.

#### How should this be manually tested?
App should run, functionally this is built-in django settings and we'll test in CI/RC