### PR TITLE
use textarea for 'Text' type fields, rather than a normal input tag

### DIFF
--- a/static/js/lib/site_content.test.ts
+++ b/static/js/lib/site_content.test.ts
@@ -166,7 +166,7 @@ describe("site_content", () => {
         [WidgetVariant.String, "input"],
         [WidgetVariant.Boolean, BooleanField],
         [WidgetVariant.Markdown, MarkdownEditor],
-        [WidgetVariant.Text, "input"]
+        [WidgetVariant.Text, "textarea"]
       ].forEach(([widget, expected]) => {
         const field = makeWebsiteConfigField({
           widget: widget as WidgetVariant

--- a/static/js/lib/site_content.ts
+++ b/static/js/lib/site_content.ts
@@ -26,6 +26,8 @@ export const componentFromWidget = (
     return FileUploadField
   case WidgetVariant.Boolean:
     return BooleanField
+  case WidgetVariant.Text:
+    return "textarea"
   default:
     return "input"
   }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #190 

#### What's this PR do?

this just makes fields of type `Text` use a `textarea` instead of a normal input tag.

#### How should this be manually tested?

If you're using the localdev configuration you can check out the `Resource` page and see the difference there - the `title` field using the `String` type while the 'description' field is `Text`.

#### Screenshots (if appropriate)

![Screenshot from 2021-04-07 10-29-25](https://user-images.githubusercontent.com/6207644/113883431-25c7d180-978c-11eb-86e5-2b12d662adfc.png)
![Screenshot from 2021-04-07 10-29-16](https://user-images.githubusercontent.com/6207644/113883435-26606800-978c-11eb-9a48-1134e8ad2c3e.png)
