### PR TITLE
Map fullname to name in social auth

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -555,6 +555,7 @@ SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS = [
     urlparse(SITE_BASE_URL).netloc  # pylint: disable=undefined-variable
 ]
 
+SOCIAL_AUTH_USER_FIELD_MAPPING = {"fullname": "name"}
 
 # SAML backend settings
 SOCIAL_AUTH_SAML_LOGIN_URL = get_string(

--- a/requirements.in
+++ b/requirements.in
@@ -12,7 +12,7 @@ django-robots
 django-server-status
 django-storages
 django-webpack-loader
-mitol-django-authentication==1.0.0
+mitol-django-authentication==1.1.0
 mitol-django-common==0.7.0
 drf-extensions
 ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -132,7 +132,7 @@ lxml==4.6.3
     #   premailer
     #   python3-saml
     #   xmlsec
-mitol-django-authentication==1.0.0
+mitol-django-authentication==1.1.0
     # via -r requirements.in
 mitol-django-common==0.7.0
     # via


### PR DESCRIPTION
Blocked by https://github.com/mitodl/ol-django/pull/36

#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #198 

#### What's this PR do?
Maps the` fullname` coming from SAML to `User.name`

#### How should this be manually tested?
Change your user's name in SSOCircle and login, you should see the new value.