### PR TITLE
Use SelectField widget for all select fields site-wide

### DIFF
--- a/static/js/components/forms/SiteCollaboratorForm.test.tsx
+++ b/static/js/components/forms/SiteCollaboratorForm.test.tsx
@@ -12,6 +12,7 @@ import { defaultFormikChildProps } from "../../test_util"
 import { makeWebsiteCollaborator } from "../../util/factories/websites"
 
 import { WebsiteCollaborator } from "../../types/websites"
+import { Option } from "../widgets/SelectField"
 
 describe("SiteCollaboratorForm", () => {
   let sandbox, onSubmitStub: SinonStub, collaborator: WebsiteCollaborator
@@ -61,11 +62,10 @@ describe("SiteCollaboratorForm", () => {
       const field = form
         .find("Field")
         .filterWhere(node => node.prop("name") === "role")
-      const options = field.find("option")
+      const options: Array<Option> = field.prop("options")
       expect(options).toHaveLength(EDITABLE_ROLES.length + 1)
-      expect(options.at(0).prop("value")).toBe("")
       for (let i = 1; i < options.length; i++) {
-        expect(options.at(i).prop("value")).toBe(EDITABLE_ROLES[i - 1])
+        expect(options[i]["value"]).toBe(EDITABLE_ROLES[i - 1])
       }
     })
 
@@ -107,10 +107,10 @@ describe("SiteCollaboratorForm", () => {
       const field = form
         .find("Field")
         .filterWhere(node => node.prop("name") === "role")
-      const options = field.find("option")
+      const options: Array<Option> = field.prop("options")
       expect(options).toHaveLength(EDITABLE_ROLES.length + 1)
       for (let i = 1; i < options.length; i++) {
-        expect(options.at(i).prop("value")).toBe(EDITABLE_ROLES[i - 1])
+        expect(options[i]["value"]).toBe(EDITABLE_ROLES[i - 1])
       }
     })
   })

--- a/static/js/components/forms/SiteCollaboratorForm.tsx
+++ b/static/js/components/forms/SiteCollaboratorForm.tsx
@@ -9,6 +9,7 @@ import {
   WebsiteCollaborator,
   WebsiteCollaboratorFormData
 } from "../../types/websites"
+import SelectField from "../widgets/SelectField"
 
 interface Props {
   collaborator?: WebsiteCollaborator
@@ -72,18 +73,17 @@ export default function SiteCollaboratorForm({
           <div className="form-group">
             <label htmlFor="role">Role*</label>
             <Field
-              component="select"
+              as={SelectField}
               name="role"
               className="form-control"
-              value={values.role}
-            >
-              <option value="">-----</option>
-              {EDITABLE_ROLES.map((role: string, i: number) => (
-                <option key={i} value={role}>
-                  {ROLE_LABELS[role]}
-                </option>
-              ))}
-            </Field>
+              options={[
+                { label: "-----", value: "" },
+                ...EDITABLE_ROLES.map((role: string) => ({
+                  label: ROLE_LABELS[role],
+                  value: role
+                }))
+              ]}
+            />
             <ErrorMessage name="role" component={FormError} />
           </div>
           <div className="form-group d-flex justify-content-end">

--- a/static/js/components/forms/SiteForm.test.tsx
+++ b/static/js/components/forms/SiteForm.test.tsx
@@ -8,6 +8,7 @@ import { makeWebsiteStarter } from "../../util/factories/websites"
 import { defaultFormikChildProps } from "../../test_util"
 
 import { WebsiteStarter } from "../../types/websites"
+import { Option } from "../widgets/SelectField"
 
 describe("SiteForm", () => {
   let sandbox, onSubmitStub: SinonStub, websiteStarters: Array<WebsiteStarter>
@@ -50,11 +51,10 @@ describe("SiteForm", () => {
     const field = form
       .find("Field")
       .filterWhere(node => node.prop("name") === "starter")
-
-    const options = field.find("option")
+    const options: Array<Option | string> = field.prop("options")
     expect(options).toHaveLength(websiteStarters.length)
     for (let i = 0; i < options.length; i++) {
-      expect(options.at(i).prop("value")).toBe(websiteStarters[i].id)
+      expect(options[i]["value"]).toBe(websiteStarters[i].id)
     }
   })
 

--- a/static/js/components/forms/SiteForm.tsx
+++ b/static/js/components/forms/SiteForm.tsx
@@ -5,6 +5,7 @@ import * as yup from "yup"
 import { FormError } from "./FormError"
 
 import { WebsiteStarter } from "../../types/websites"
+import SelectField from "../widgets/SelectField"
 
 export interface SiteFormValues {
   title: string
@@ -36,6 +37,7 @@ export const SiteForm = ({
     title:   "",
     starter: websiteStarters.length > 0 ? websiteStarters[0].id : 0
   }
+
   return (
     <Formik
       onSubmit={onSubmit}
@@ -51,18 +53,19 @@ export const SiteForm = ({
           </div>
           <div className="form-group">
             <label htmlFor="starter">Starter*</label>
-            <Field component="select" name="starter" className="form-control">
-              {websiteStarters.length > 0 ? (
-                websiteStarters.map((starter, i) => (
-                  <option key={i} value={starter.id}>
-                    {starter.name}
-                  </option>
-                ))
-              ) : (
-                // Empty option to prevent build warning/errors
-                <option key={0} value={0} />
-              )}
-            </Field>
+            <Field
+              as={SelectField}
+              name="starter"
+              className="form-control"
+              options={
+                websiteStarters.length > 0 ?
+                  websiteStarters.map(starter => ({
+                    label: starter.name,
+                    value: starter.id
+                  })) :
+                  ["0"]
+              }
+            />
             <ErrorMessage name="starter" component={FormError} />
           </div>
           <div className="form-group d-flex justify-content-end">

--- a/static/js/components/widgets/SelectField.test.tsx
+++ b/static/js/components/widgets/SelectField.test.tsx
@@ -9,7 +9,7 @@ describe("SelectField", () => {
   let sandbox: SinonSandbox,
     onChangeStub: SinonStub,
     name: string,
-    options: string[],
+    options: Array<string | Option>,
     expectedOptions: Option[],
     min: number,
     max: number
@@ -17,10 +17,11 @@ describe("SelectField", () => {
   beforeEach(() => {
     sandbox = sinon.createSandbox()
     onChangeStub = sandbox.stub()
-    options = ["one", "two"]
+    options = ["one", "two", { label: "Three", value: "3" }]
     expectedOptions = [
       { label: "one", value: "one" },
-      { label: "two", value: "two" }
+      { label: "two", value: "two" },
+      { label: "Three", value: "3" }
     ]
     min = 1
     max = 3
@@ -74,15 +75,19 @@ describe("SelectField", () => {
 
   describe("multiple choice", () => {
     it("renders a select widget", () => {
-      const value = ["initial", "values"]
+      const value = ["initial", "values", "3", "4"]
+      const expectedValue = [
+        { label: "initial", value: "initial" },
+        { label: "values", value: "values" },
+        { label: "Three", value: "3" },
+        { label: "4", value: "4" }
+      ]
       const wrapper = render({
         value,
         multiple: true
       })
       const props = wrapper.find(Select).props()
-      expect(props.value).toStrictEqual(
-        value.map(_value => ({ label: _value, value: _value }))
-      )
+      expect(props.value).toStrictEqual(expectedValue)
       expect(props.isMulti).toBeTruthy()
       expect(props.options).toStrictEqual(expectedOptions)
 

--- a/static/js/components/widgets/SelectField.tsx
+++ b/static/js/components/widgets/SelectField.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react"
 import Select from "react-select"
-import { isNil } from "ramda"
+import { is, isNil } from "ramda"
 
 export interface Option {
   label: string
@@ -14,11 +14,14 @@ interface Props {
   multiple?: boolean
   min?: number
   max?: number
-  options: string[]
+  options: Array<string | Option>
 }
 export default function SelectField(props: Props): JSX.Element {
   const { value, onChange, name, options } = props
   const multiple = Boolean(props.multiple)
+  const selectOptions = options.map((option: any) =>
+    is(String, option) ? { label: option, value: option } : option
+  )
 
   const changeHandler = useCallback(
     (newValue: any) => {
@@ -31,15 +34,22 @@ export default function SelectField(props: Props): JSX.Element {
     [name, multiple]
   )
 
+  const getSelectOption = (value: string) => {
+    const selectOption = selectOptions.filter(
+      option => option.value === value
+    )[0]
+    return { label: selectOption ? selectOption.label : value, value: value }
+  }
+
   let selected
   if (multiple) {
     if (!Array.isArray(value)) {
       selected = []
     } else {
-      selected = value.map(option => ({ label: option, value: option }))
+      selected = value.map(option => getSelectOption(option))
     }
   } else {
-    selected = isNil(value) ? null : { label: value, value: value }
+    selected = isNil(value) ? null : getSelectOption(value)
   }
 
   return (
@@ -47,7 +57,7 @@ export default function SelectField(props: Props): JSX.Element {
       value={selected}
       isMulti={Boolean(multiple)}
       onChange={changeHandler}
-      options={options.map(option => ({ label: option, value: option }))}
+      options={selectOptions}
     />
   )
 }

--- a/static/js/components/widgets/SelectField.tsx
+++ b/static/js/components/widgets/SelectField.tsx
@@ -34,11 +34,16 @@ export default function SelectField(props: Props): JSX.Element {
     [name, multiple]
   )
 
+  /**
+   * Get or create a select-field Option with the specified value,
+   * so it will appear as a selected value even if there is no available
+   * select option for it.
+   **/
   const getSelectOption = (value: string) => {
     const selectOption = selectOptions.filter(
       option => option.value === value
     )[0]
-    return { label: selectOption ? selectOption.label : value, value: value }
+    return selectOption || { label: value, value: value }
   }
 
   let selected


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #194

#### What's this PR do?
- Replaces the standard select field with the `SelectField` widget on `SiteForm`, `SiteCollaboratorForm`
- Modifies the `SelectField` widget to handle option elements where the label and value differ.

#### How should this be manually tested?
Try out the following, the select field should work as expected on each form:
- Create a new site
- Create/edit site metadata
- Create/edit a collaborator

