### PR TITLE
remove edit links from 'folder' type

### DIFF
--- a/static/js/components/SiteContentListing.test.tsx
+++ b/static/js/components/SiteContentListing.test.tsx
@@ -185,12 +185,9 @@ describe("SiteContentListing", () => {
       for (const item of contentListingItems) {
         const li = wrapper.find("li").at(idx)
         expect(li.text()).toContain(item.title)
-
-        const link = li.find("a")
-        expect(link.text()).toBe("Edit")
         act(() => {
           // @ts-ignore
-          link.prop("onClick")({ preventDefault: helper.sandbox.stub() })
+          li.prop("onClick")({ preventDefault: helper.sandbox.stub() })
         })
         wrapper.update()
         const component = wrapper.find("SiteEditContent")

--- a/static/js/components/SiteContentListing.tsx
+++ b/static/js/components/SiteContentListing.tsx
@@ -33,6 +33,7 @@ interface MatchParams {
   contenttype: string
   name: string
 }
+
 interface ListingComponentParams {
   listing: WebsiteContentListingResponse
   contenttype: string
@@ -40,7 +41,7 @@ interface ListingComponentParams {
   startEdit: (
     uuid: string,
     configItem: EditableConfigItem
-  ) => (event: ReactMouseEvent<HTMLAnchorElement, MouseEvent>) => void
+  ) => (event: ReactMouseEvent<HTMLLIElement, MouseEvent>) => void
 }
 
 export function SingletonContentListing(
@@ -95,12 +96,13 @@ export function RepeatableContentListing(
         </div>
         <ul className="ruled-list">
           {listing.results.map((item: WebsiteContentListItem) => (
-            <li key={item.uuid} className="py-3">
+            <li
+              key={item.uuid}
+              className="py-3 listing-result"
+              onClick={startEdit(item.uuid, configItem)}
+            >
               <div className="d-flex flex-direction-row align-items-center justify-content-between">
                 <span>{item.title}</span>
-                <a className="edit" onClick={startEdit(item.uuid, configItem)}>
-                  Edit
-                </a>
               </div>
             </li>
           ))}
@@ -153,7 +155,7 @@ export default function SiteContentListing(): JSX.Element | null {
     (
       uuid: string,
       configItem: EditableConfigItem,
-      event: ReactMouseEvent<HTMLAnchorElement, MouseEvent>
+      event: ReactMouseEvent<HTMLLIElement, MouseEvent>
     ) => {
       event.preventDefault()
       setEditedItem({ uuid, configItem })

--- a/static/scss/site-page.scss
+++ b/static/scss/site-page.scss
@@ -29,6 +29,10 @@ $menu-spacing: 20px;
 
   .content {
     flex-grow: 1;
+
+    .listing-result {
+      cursor: pointer;
+    }
   }
 
   .ck.ck-content.ck-editor__editable {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #193 

#### What's this PR do?

removes the 'edit' link on the page-content type content (🤔 ) and makes the whole row in the `SiteContentListing` component clickable.

#### How should this be manually tested?

Check out some content in a site, and make sure you can click on it to edit it. There shouldn't be an edit link!

#### Screenshots (if appropriate)

![Screen Shot 2021-04-12 at 10 59 43 AM](https://user-images.githubusercontent.com/6207644/114416444-b16fa280-9b7e-11eb-8bb1-656559794e72.png)
