### PR TITLE
add validation for min and max on select field

### DIFF
--- a/localdev/configs/ocw-course-site-config.yml
+++ b/localdev/configs/ocw-course-site-config.yml
@@ -6,6 +6,16 @@ collections:
     fields:
       - {"label": "Title", "name": "title", "widget": "string", "required": true}
       - {"label": "Body", "name": "body", "widget": "markdown"}
+      - {
+        "label": "Tags",
+        "default": [ "Design" ],
+        "max": 2,
+        "min": 1,
+        "multiple": true,
+        "name": "tags",
+        "options": [ "Design", "UX", "Dev" ],
+        "widget": "select"
+        }
 
   - name: resource
     label: Resource

--- a/static/js/components/forms/validation.test.ts
+++ b/static/js/components/forms/validation.test.ts
@@ -1,6 +1,8 @@
 import * as yup from "yup"
 import { getContentSchema } from "./validation"
 
+import { makeWebsiteConfigField } from "../../util/factories/websites"
+
 import { ConfigItem, WidgetVariant } from "../../types/websites"
 
 describe("form validation util", () => {
@@ -109,5 +111,97 @@ describe("form validation util", () => {
         .required()
         .toString()
     )
+  })
+
+  describe("select validation", () => {
+    const makeSelectConfigItem = (props = {}): [ConfigItem, string] => {
+      const configItem = {
+        ...partialConfigItem,
+        fields: [
+          makeWebsiteConfigField({ widget: WidgetVariant.Select, ...props })
+        ]
+      }
+
+      return [configItem, configItem.fields[0].name]
+    }
+
+    it("should validate for a required multiple select field", () => {
+      const [configItem, name] = makeSelectConfigItem({
+        multiple: true,
+        required: true
+      })
+      const schema = getContentSchema(configItem)
+      expect(() =>
+        schema.validateSync({
+          [name]: null
+        })
+      ).toThrow(new yup.ValidationError(`${name} is a required field.`))
+    })
+
+    it("should pass validation for valid multiple select values", async () => {
+      const [configItem, name] = makeSelectConfigItem({ multiple: true })
+      const schema = getContentSchema(configItem)
+      await Promise.all(
+        [[], ["some value"], ["some value", "another value"]].map(
+          async value => {
+            await expect(
+              schema.isValid({
+                [name]: value
+              })
+            ).resolves.toBeTruthy()
+          }
+        )
+      )
+    })
+
+    it("should validate a multiple select field with max and min set", async () => {
+      const [configItem, name] = makeSelectConfigItem({
+        multiple: true,
+        min:      1,
+        max:      2
+      })
+      const schema = getContentSchema(configItem)
+
+      await Promise.all(
+        [
+          [[], false, `${name} must have at least 1 entry.`],
+          [["some value"], true, ""],
+          [["some value", "another value"], true, ""],
+          [
+            ["some value", "another value", "yet another value"],
+            false,
+            `${name} may have at most 2 entries.`
+          ]
+        ].map(async ([value, shouldValidate, message]) => {
+          if (shouldValidate) {
+            await expect(
+              schema.isValid({
+                [name]: value
+              })
+            ).resolves.toBeTruthy()
+          } else {
+            await expect(
+              schema.validate({
+                [name]: value
+              })
+            ).rejects.toThrow(new yup.ValidationError(message as string))
+          }
+        })
+      )
+    })
+
+    it("should validate a required non-multiple select field", async () => {
+      const [configItem, name] = makeSelectConfigItem({ required: true })
+      const schema = getContentSchema(configItem)
+
+      expect(() =>
+        schema.validateSync({
+          [name]: ""
+        })
+      ).toThrow(new yup.ValidationError(`${name} is a required field`))
+      await expect(
+        schema.isValid({ [name]: "selected value" })
+      ).resolves.toBeTruthy()
+    })
   })
 })

--- a/static/js/lib/site_content.test.ts
+++ b/static/js/lib/site_content.test.ts
@@ -6,7 +6,6 @@ import SelectField from "../components/widgets/SelectField"
 import BooleanField from "../components/widgets/BooleanField"
 
 import {
-  makeConfigField,
   makeWebsiteConfigField,
   makeWebsiteContentDetail,
   makeFileConfigItem
@@ -157,7 +156,7 @@ describe("site_content", () => {
       // @ts-ignore
       const payload = contentInitialValues(content, fields)
       expect(payload).toStrictEqual({
-        tags:                      "",
+        tags:                      [],
         align:                     "",
         featured:                  false,
         file:                      null,
@@ -189,7 +188,7 @@ describe("site_content", () => {
     it("should use appropriate defaults for different widgets", () => {
       [
         [WidgetVariant.Markdown, ""],
-        [WidgetVariant.File, ""],
+        [WidgetVariant.File, null],
         [WidgetVariant.Boolean, false],
         [WidgetVariant.Text, ""],
         [WidgetVariant.String, ""],
@@ -202,6 +201,15 @@ describe("site_content", () => {
         const initialValues = newInitialValues([field])
         expect(initialValues).toStrictEqual({ widget: expectation })
       })
+    })
+
+    it("should use appropriate default for multiple select widget", () => {
+      const field = makeWebsiteConfigField({
+        widget:   WidgetVariant.Select,
+        multiple: true,
+        label:    "Widget"
+      })
+      expect(newInitialValues([field])).toStrictEqual({ widget: [] })
     })
   })
 
@@ -318,7 +326,7 @@ describe("site_content", () => {
             field:  "conditionField",
             equals: "matching value"
           }
-          const field = makeConfigField()
+          const field = makeWebsiteConfigField()
           // @ts-ignore
           field.widget = widget
           if (hasCondition) {

--- a/static/js/lib/site_content.ts
+++ b/static/js/lib/site_content.ts
@@ -160,7 +160,7 @@ export const contentInitialValues = (
     } else if (field.name === "file") {
       values[field.name] = content[field.name] ?? null
     } else {
-      values[field.name] = metadata[field.name] ?? defaultFor(field.widget)
+      values[field.name] = metadata[field.name] ?? defaultFor(field)
     }
   }
   return values
@@ -173,12 +173,22 @@ export const newInitialValues = (fields: ConfigField[]): SiteFormValues =>
   Object.fromEntries(
     fields.map((field: ConfigField) => [
       field.name,
-      field.default ?? defaultFor(field.widget)
+      field.default ?? defaultFor(field)
     ])
   )
 
-const defaultFor = (widget: WidgetVariant): string | boolean =>
-  widget === WidgetVariant.Boolean ? false : ""
+const defaultFor = (field: ConfigField): boolean | string | string[] | null => {
+  switch (field.widget) {
+  case WidgetVariant.Boolean:
+    return false
+  case WidgetVariant.Select:
+    return field.multiple ? [] : ""
+  case WidgetVariant.File:
+    return null
+  default:
+    return ""
+  }
+}
 
 /*
  * Should field data be sent to the server?

--- a/static/js/resources/ocw-course-site-config.json
+++ b/static/js/resources/ocw-course-site-config.json
@@ -13,6 +13,22 @@
           "label": "Body",
           "name": "body",
           "widget": "markdown"
+        },
+        {
+          "default": [
+            "Design"
+          ],
+          "label": "Tags",
+          "max": 2,
+          "min": 1,
+          "multiple": true,
+          "name": "tags",
+          "options": [
+            "Design",
+            "UX",
+            "Dev"
+          ],
+          "widget": "select"
         }
       ],
       "folder": "content",

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -1,5 +1,8 @@
 import { ROLE_ADMIN, ROLE_EDITOR, ROLE_GLOBAL, ROLE_OWNER } from "../constants"
 
+/**
+ * The different widget variants supported in Site configurations
+ **/
 export enum WidgetVariant {
   Markdown = "markdown",
   File = "file",
@@ -15,6 +18,11 @@ export interface FieldValueCondition {
   equals: string
 }
 
+/**
+ * A configuration for a field for site content. This type basically
+ * contains the information needed to render the field in the UI, to edit it,
+ * validate it, etc.
+ **/
 export interface ConfigField {
   name: string
   label: string

--- a/static/js/util/factories/websites.ts
+++ b/static/js/util/factories/websites.ts
@@ -29,6 +29,17 @@ import {
 
 const incr = incrementer()
 
+/**
+ * Factory for ConfigField, useful for testing various functions that switch
+ * on field.widget
+ *
+ * A ConfigField for a specific widget can be created by passing a prop object
+ * with the `widget` key set:
+ *
+ * ```ts
+ * const myConfigField = makeWebsiteConfigField({ widget: WidgetVariant.Select })
+ * ```
+ **/
 export const makeWebsiteConfigField = (
   props: Record<string, any> = {}
 ): ConfigField => {
@@ -37,16 +48,10 @@ export const makeWebsiteConfigField = (
   return {
     label,
     name:   label.toLowerCase(),
-    widget: props.widget,
+    widget: props.widget ?? WidgetVariant.String,
     ...props
   }
 }
-
-export const makeConfigField = (): ConfigField => ({
-  name:   casual.word,
-  label:  casual.text,
-  widget: WidgetVariant.String
-})
 
 const exampleFields = [
   {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #185 

#### What's this PR do?

this adds validation for the min and max property on a `Select` field (this is only enforced when the `multiple` prop is also set). I also added some general testing for the select validation, as there weren't yet any tests for it.

#### How should this be manually tested?

I made a little change to the `localdev/configs/ocw-course-site-config.yml` file, so you should be able to just run the `override_site_config` management command to add a multiple-select 'tag' field to the page content type. Then you can check in the UI that it's correctly enforcing the `min` and `max` (we may want to remove this again from `localdev/configs/ocw-course-site-config.yml` before we merge so it's not too annoying).

#### Screenshots (if appropriate)

![Screen Shot 2021-04-14 at 2 36 49 PM](https://user-images.githubusercontent.com/6207644/114761741-e6baf280-9d2e-11eb-885d-a44cbc58079f.png)
![Screen Shot 2021-04-14 at 2 37 02 PM](https://user-images.githubusercontent.com/6207644/114761742-e6baf280-9d2e-11eb-85bf-e500b9222296.png)
