### PR TITLE
make links in the markdown editor more obvious

### DIFF
--- a/static/scss/ckeditor.scss
+++ b/static/scss/ckeditor.scss
@@ -1,0 +1,10 @@
+.ck-editor {
+  a {
+    color: $studio-blue;
+    text-decoration: underline;
+
+    &:hover {
+      color: $studio-blue;
+    }
+  }
+}

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -10,6 +10,7 @@
 @import "pagination";
 @import "button";
 @import "list";
+@import "ckeditor";
 
 body {
   font-family: "Roboto", sans-serif;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

no ticket, there was a note of this issue somewhere that I just remembered (but I can't find it 🙊 )

#### What's this PR do?

make links more obivously links (in terms of text styling) in the markdown editor.

#### How should this be manually tested?

just check out the editor, and see what you think of the link styling. it should be obvious that something is a link.

#### Screenshots (if appropriate)

![Screen Shot 2021-04-14 at 3 59 17 PM](https://user-images.githubusercontent.com/6207644/114771356-72864c00-9d3a-11eb-835c-2cd628d2fdb9.png)
