### PR TITLE
Added optional 'limit' param to OCW course site import

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,9 @@ manage.py import_ocw_course_sites -b <bucket_name> --filter frameworks-of-urban-
 # Import course sites with a data file name that matches a filter
 manage.py import_ocw_course_sites -b <bucket_name> --filter frameworks-of-urban-governance
 
+# Import 30 total course sites
+manage.py import_ocw_course_sites -b <bucket_name> --limit 30
+
 # Import ALL course sites (this will take quite a while)
 manage.py import_ocw_course_sites -b <bucket_name>
 ```

--- a/ocw_import/management/commands/import_ocw_course_sites.py
+++ b/ocw_import/management/commands/import_ocw_course_sites.py
@@ -49,6 +49,14 @@ class Command(BaseCommand):
             default="",
             help="If specified, only import courses that contain this filter text",
         )
+
+        parser.add_argument(
+            "--limit",
+            dest="limit",
+            default=None,
+            type=int,
+            help="If specified, limits the overall number of course sites imported",
+        )
         super().add_arguments(parser)
 
     def handle(self, *args, **options):
@@ -58,6 +66,7 @@ class Command(BaseCommand):
             prefix = prefix.rstrip("/") + "/"
         bucket_name = options["bucket"]
         filter_str = options["filter"]
+        limit = options["limit"]
 
         if options["list"] is True:
             course_paths = list(
@@ -74,6 +83,7 @@ class Command(BaseCommand):
             bucket_name=bucket_name,
             prefix=prefix,
             filter_str=filter_str,
+            limit=limit,
             chunk_size=options["chunks"],
         )
         task.get()

--- a/ocw_import/tasks.py
+++ b/ocw_import/tasks.py
@@ -40,8 +40,8 @@ def import_ocw2hugo_course_paths(paths=None, bucket_name=None, prefix=None):
 
 @app.task(bind=True)
 def import_ocw2hugo_courses(
-    self, bucket_name=None, prefix=None, filter_str=None, chunk_size=100
-):
+    self, bucket_name=None, prefix=None, filter_str=None, limit=None, chunk_size=100
+):  # pylint:disable=too-many-arguments
     """
     Import all ocw2hugo courses & content
 
@@ -49,13 +49,16 @@ def import_ocw2hugo_courses(
         bucket_name (str): S3 bucket name
         prefix (str): (Optional) S3 prefix before start of course_id path
         filter_str (str): (Optional) If specified, only yield course paths containing this string
+        limit (int or None): (Optional) If specified, limits the number of courses imported
         chunk_size (int): Number of courses to process per task
     """
     if not bucket_name:
         raise TypeError("Bucket name must be specified")
-    course_paths = list(
+    course_paths = iter(
         fetch_ocw2hugo_course_paths(bucket_name, prefix=prefix, filter_str=filter_str)
     )
+    if limit is not None:
+        course_paths = (path for i, path in enumerate(course_paths) if i < limit)
     course_tasks = celery.group(
         [
             import_ocw2hugo_course_paths.si(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #143 

#### What's this PR do?
Adds a `limit` param to the task that imports OCW course sites and the associated management command. This restricts the overall number of course sites that will be imported

#### How should this be manually tested?
You can use Django admin and sort `Website`s by ascending name to make this easier to test.

- Run the management command with `--list` to see the course IDs that the command would import: `python manage.py import_ocw_course_sites -b ocw-to-hugo-output-qa --list`
- Delete the `Website` records for the first ~10 course id's in that list (which is sorted in ascending order)
- Run the management command with a limit lower than the number of `Websites` you deleted: `python manage.py import_ocw_course_sites -b ocw-to-hugo-output-qa --limit 5`

After the command finishes, you should see that you as many `Website` records re-imported as your `limit` specified.

#### Any background context you want to provide?
This doesn't make the command cancelable like the issue describes, but it provides a way to limit the number of course sites imported, which solves the core problem
