### PR TITLE
add 'Object' field type

### DIFF
--- a/localdev/configs/ocw-course-site-config.yml
+++ b/localdev/configs/ocw-course-site-config.yml
@@ -17,6 +17,14 @@ collections:
         "options": [ "Design", "UX", "Dev" ],
         "widget": "select"
         }
+      - name: address
+        label: Address
+        widget: object
+        fields:
+          - { label: "Street Address", name: "street_address", widget: "string", required: true }
+          - { label: "City", name: "city", widget: "string", required: true }
+          - { label: "State", name: "state", widget: "string", required: true }
+          - { label: "Zip Code", name: "zip", widget: "string", required: true }
 
   - name: resource
     label: Resource

--- a/static/js/components/forms/SiteContentForm.test.tsx
+++ b/static/js/components/forms/SiteContentForm.test.tsx
@@ -8,7 +8,8 @@ import SiteContentForm from "./SiteContentForm"
 import { defaultFormikChildProps } from "../../test_util"
 import {
   makeEditableConfigItem,
-  makeWebsiteContentDetail
+  makeWebsiteContentDetail,
+  makeWebsiteConfigField
 } from "../../util/factories/websites"
 import {
   componentFromWidget,
@@ -17,7 +18,11 @@ import {
 } from "../../lib/site_content"
 import { getContentSchema } from "./validation"
 
-import { EditableConfigItem, WebsiteContent } from "../../types/websites"
+import {
+  EditableConfigItem,
+  WebsiteContent,
+  WidgetVariant
+} from "../../types/websites"
 import { ContentFormType } from "../../types/forms"
 
 jest.mock("../../lib/site_content")
@@ -119,6 +124,18 @@ describe("SiteContentForm", () => {
         const validationSchema = formik.prop("validationSchema")
         expect(validationSchema).toStrictEqual(mockValidationSchema)
         expect(formik.prop("enableReinitialize")).toBe(true)
+      })
+
+      it("should pass an 'object' field to the ObjectWidget component", () => {
+        const field = makeWebsiteConfigField({ widget: WidgetVariant.Object })
+        configItem.fields = [field]
+        // @ts-ignore
+        fieldIsVisible.mockImplementation(() => true)
+        // @ts-ignore
+        splitFieldsIntoColumns.mockImplementation(() => [configItem.fields])
+        const wrapper = renderInnerForm(formType)
+        expect(wrapper.find("ObjectField").exists()).toBeTruthy()
+        expect(wrapper.find("ObjectField").prop("field")).toEqual(field)
       })
     })
   })

--- a/static/js/components/forms/validation.test.ts
+++ b/static/js/components/forms/validation.test.ts
@@ -204,4 +204,54 @@ describe("form validation util", () => {
       ).resolves.toBeTruthy()
     })
   })
+
+  describe("Object validation", () => {
+    const makeObjectConfigItem = (props = {}): [ConfigItem, string] => {
+      const configItem = {
+        ...partialConfigItem,
+        fields: [
+          makeWebsiteConfigField({
+            widget: WidgetVariant.Object,
+            ...props,
+            fields: [
+              makeWebsiteConfigField({
+                widget:   WidgetVariant.String,
+                label:    "mystring",
+                required: true
+              }),
+              makeWebsiteConfigField({
+                widget:   WidgetVariant.Boolean,
+                label:    "myboolean",
+                required: true
+              })
+            ]
+          })
+        ]
+      }
+
+      return [configItem, configItem.fields[0].name]
+    }
+
+    it("should validate the sub-fields", async () => {
+      const [configItem, name] = makeObjectConfigItem({ required: true })
+      const schema = getContentSchema(configItem)
+
+      await schema
+        .validate({ [name]: {} }, { abortEarly: false })
+        .catch(err => {
+          expect(err.errors).toEqual([
+            "mystring is a required field",
+            "myboolean is a required field"
+          ])
+        })
+      await expect(
+        schema.isValid({
+          [name]: {
+            mystring:  "hey!",
+            myboolean: false
+          }
+        })
+      ).resolves.toBeTruthy()
+    })
+  })
 })

--- a/static/js/components/forms/validation.ts
+++ b/static/js/components/forms/validation.ts
@@ -54,6 +54,16 @@ export const getFieldSchema = (field: ConfigField): Schema => {
     schema = yup.mixed()
     break
   }
+  case WidgetVariant.Object: {
+    schema = yup
+      .object()
+      .shape(
+        Object.fromEntries(
+            field.fields!.map(field => [field.name, getFieldSchema(field)])
+        )
+      )
+    break
+  }
   case WidgetVariant.String:
   case WidgetVariant.Text:
   case WidgetVariant.Markdown:

--- a/static/js/components/widgets/ObjectField.test.tsx
+++ b/static/js/components/widgets/ObjectField.test.tsx
@@ -1,0 +1,65 @@
+import React from "react"
+import { shallow } from "enzyme"
+
+import ObjectField from "./ObjectField"
+import { makeWebsiteConfigField } from "../../util/factories/websites"
+
+import { ConfigField, WidgetVariant } from "../../types/websites"
+
+describe("ObjectField", () => {
+  let setFieldValueStub: any, render: any, field: ConfigField
+
+  beforeEach(() => {
+    setFieldValueStub = jest.fn()
+
+    field = makeWebsiteConfigField({
+      widget: WidgetVariant.Object,
+      label:  "myobject",
+      fields: [
+        makeWebsiteConfigField({
+          widget: WidgetVariant.String,
+          label:  "mystring"
+        }),
+        makeWebsiteConfigField({
+          widget:   WidgetVariant.Select,
+          multiple: true,
+          label:    "myselect"
+        })
+      ]
+    })
+
+    render = (props = {}) =>
+      shallow(
+        <ObjectField
+          setFieldValue={setFieldValueStub}
+          field={field}
+          {...props}
+        />
+      )
+  })
+
+  it("should should render an Object field, by passing sub-fields to SiteContentField", () => {
+    const wrapper = render()
+    wrapper.find("SiteContentField").map((field: any) => {
+      expect(field.prop("setFieldValue")).toEqual(setFieldValueStub)
+    })
+    expect(
+      wrapper.find("SiteContentField").map((field: any) => field.prop("field"))
+    ).toEqual(field.fields)
+  })
+
+  it("should collapse if it's a collapsed widget", () => {
+    field.collapsed = true
+    const wrapper = render()
+    expect(wrapper.find("SiteContentField").exists()).toBeFalsy()
+  })
+
+  it("should allow expanding / collapsing", () => {
+    const wrapper = render()
+    expect(wrapper.find("SiteContentField").exists()).toBeTruthy()
+    wrapper.find(".object-field-label").simulate("click", new Event("click"))
+    expect(wrapper.find("SiteContentField").exists()).toBeFalsy()
+    wrapper.find(".object-field-label").simulate("click", new Event("click"))
+    expect(wrapper.find("SiteContentField").exists()).toBeTruthy()
+  })
+})

--- a/static/js/components/widgets/ObjectField.tsx
+++ b/static/js/components/widgets/ObjectField.tsx
@@ -1,0 +1,53 @@
+import React, { useState, useCallback } from "react"
+
+import SiteContentField from "../forms/SiteContentField"
+
+import { ConfigField } from "../../types/websites"
+
+interface Props {
+  field: ConfigField
+  setFieldValue: (key: string, value: File | null) => void
+}
+
+/**
+ * A widget which allows the sub-fields defined within an Object field
+ * to be edited.
+ **/
+export default function ObjectField(props: Props): JSX.Element {
+  const { field, setFieldValue } = props
+
+  const [collapsed, setCollapsed] = useState(field.collapsed ?? false)
+  const toggleCollapse = useCallback(
+    e => {
+      e.preventDefault()
+      setCollapsed(!collapsed)
+    },
+    [setCollapsed, collapsed]
+  )
+
+  return (
+    <div className="object-widget">
+      <div
+        className="d-flex justify-content-between align-objects-center object-field-label"
+        onClick={toggleCollapse}
+      >
+        <label htmlFor={field.name}>{field.label}</label>
+        <i className="material-icons">
+          {collapsed ? "expand_more" : "expand_less"}
+        </i>
+      </div>
+      {collapsed ? null : (
+        <div className="object-sub-fields">
+          {field.fields?.map((field: ConfigField) => (
+            <SiteContentField
+              field={field}
+              key={field.name}
+              setFieldValue={setFieldValue}
+            />
+          ))}
+        </div>
+      )}
+      {field.help && <span className="help-text">{field.help}</span>}
+    </div>
+  )
+}

--- a/static/js/components/widgets/SelectField.tsx
+++ b/static/js/components/widgets/SelectField.tsx
@@ -16,6 +16,7 @@ interface Props {
   max?: number
   options: Array<string | Option>
 }
+
 export default function SelectField(props: Props): JSX.Element {
   const { value, onChange, name, options } = props
   const multiple = Boolean(props.multiple)

--- a/static/js/resources/ocw-course-site-config.json
+++ b/static/js/resources/ocw-course-site-config.json
@@ -29,6 +29,37 @@
             "Dev"
           ],
           "widget": "select"
+        },
+        {
+          "fields": [
+            {
+              "label": "Street Address",
+              "name": "street_address",
+              "required": true,
+              "widget": "string"
+            },
+            {
+              "label": "City",
+              "name": "city",
+              "required": true,
+              "widget": "string"
+            },
+            {
+              "label": "State",
+              "name": "state",
+              "required": true,
+              "widget": "string"
+            },
+            {
+              "label": "Zip Code",
+              "name": "zip",
+              "required": true,
+              "widget": "string"
+            }
+          ],
+          "label": "Address",
+          "name": "address",
+          "widget": "object"
         }
       ],
       "folder": "content",

--- a/static/js/types/forms.ts
+++ b/static/js/types/forms.ts
@@ -3,6 +3,10 @@ export enum ContentFormType {
   Edit = "edit"
 }
 
-export type ValueType = string | File | string[] | null
+export type SiteFormPrimitive = string | File | string[] | null | boolean
 
-export type SiteFormValues = Record<string, ValueType>
+export type SiteFormValue =
+  | SiteFormPrimitive
+  | Record<string, SiteFormPrimitive>
+
+export type SiteFormValues = Record<string, SiteFormValue>

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -10,7 +10,8 @@ export enum WidgetVariant {
   Text = "text",
   String = "string",
   Select = "select",
-  Hidden = "hidden"
+  Hidden = "hidden",
+  Object = "object"
 }
 
 export interface FieldValueCondition {
@@ -36,6 +37,8 @@ export interface ConfigField {
   options?: string[]
   multiple?: boolean
   condition?: FieldValueCondition
+  fields?: ConfigField[]
+  collapsed?: boolean
 }
 
 export interface BaseConfigItem {

--- a/static/scss/forms.scss
+++ b/static/scss/forms.scss
@@ -6,3 +6,19 @@
   font-size: $caption-font-size;
   color: $slate-gray;
 }
+
+.object-widget {
+  .object-field-label {
+    font-size: 20px;
+    cursor: pointer;
+  }
+
+  .object-sub-fields {
+    padding-left: 15px;
+    border-left: 5px solid $studio-gray;
+  }
+
+  i {
+    font-size: 30px;
+  }
+}

--- a/websites/config_schema/site-config-schema.yml
+++ b/websites/config_schema/site-config-schema.yml
@@ -16,7 +16,7 @@ inner_content_item:
     file: str(required=False)
 ---
 field:
-    widget: enum('string', 'text', 'markdown', 'file', 'select', 'boolean', 'hidden')
+    widget: enum('string', 'text', 'markdown', 'file', 'select', 'boolean', 'hidden', 'object')
     label: str()
     name: str()
     minimal: bool(required=False)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Tag @ferdi or @pdpinch for review
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #220 

#### What's this PR do?

this adds a new type of field called 'Object', which basically has nested sub-fields that are saved as an object together. They are also visually grouped together in the UI (see screenshots below).

#### How should this be manually tested?

I added an object field called 'address' to the 'Page' content type in the `ocw-course-site-config.yml`, so you should be able to run the `override_site_config` management command to then see it in the UI. The field is designed to represent a street address, with the typical sub-components thereof. So you should try to edit it! Everything should work like on a normal field, so the validation should be there, you should be able to edit an existing page which doesn't yet have that field saved on it without issues, create a new page, etc.

Also the object fields support being collapsed and expanded, so that should work :)

#### Screenshots (if appropriate)

![Screen Shot 2021-04-26 at 12 54 59 PM](https://user-images.githubusercontent.com/6207644/116121775-f4596c00-a68e-11eb-9a48-b8195a0ee861.png)
![Screen Shot 2021-04-26 at 12 58 00 PM](https://user-images.githubusercontent.com/6207644/116121874-118e3a80-a68f-11eb-9638-880e5a5c304b.png)
![Screen Shot 2021-04-26 at 12 57 06 PM](https://user-images.githubusercontent.com/6207644/116121776-f4f20280-a68e-11eb-83dc-0084fee62329.png)
![Screen Shot 2021-04-26 at 12 56 57 PM](https://user-images.githubusercontent.com/6207644/116121779-f58a9900-a68e-11eb-9ba4-c60e76764b72.png)
![Screen Shot 2021-04-26 at 12 56 11 PM](https://user-images.githubusercontent.com/6207644/116121781-f58a9900-a68e-11eb-87c9-35148063ddd8.png)