### PR TITLE
Hide the login button if the user is logged in

### DIFF
--- a/static/js/pages/HomePage.test.tsx
+++ b/static/js/pages/HomePage.test.tsx
@@ -4,10 +4,17 @@ import { shallow } from "enzyme"
 import HomePage from "./HomePage"
 
 describe("HomePage", () => {
-  it("shows a Touchstone login button", () => {
+  it("shows the Touchstone login button if the user is logged out", () => {
+    SETTINGS.user = null
     const wrapper = shallow(<HomePage />)
-    const link = wrapper.find("a")
+    const link = wrapper.find("a[href='/login/saml/?idp=default']")
+    expect(link.exists()).toBeTruthy()
     expect(link.text()).toBe("Login with MIT Touchstone")
-    expect(link.prop("href")).toBe("/login/saml/?idp=default")
+  })
+
+  it("hides the Touchstone login button if the user is logged in", () => {
+    const wrapper = shallow(<HomePage />)
+    const link = wrapper.find("a[href='/login/saml/?idp=default']")
+    expect(link.exists()).toBeFalsy()
   })
 })

--- a/static/js/pages/HomePage.tsx
+++ b/static/js/pages/HomePage.tsx
@@ -3,9 +3,11 @@ import React from "react"
 export default function HomePage(): JSX.Element | null {
   return (
     <div className="d-flex align-items-center justify-content-center home-page">
-      <a href="/login/saml/?idp=default" className="btn green-button">
-        Login with MIT Touchstone
-      </a>
+      {!SETTINGS.user ? (
+        <a href="/login/saml/?idp=default" className="btn green-button">
+          Login with MIT Touchstone
+        </a>
+      ) : null}
     </div>
   )
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #208 

#### What's this PR do?
Hides the login button if the user is logged in

#### How should this be manually tested?
Go to the home page of the site, if you're logged out you should see the "Login with Touchstone" button, if you aren't you shouldn't see it.