### PR TITLE
Handle filepath changes when syncing with github

### DIFF
--- a/content_sync/api_test.py
+++ b/content_sync/api_test.py
@@ -38,10 +38,13 @@ def test_upsert_content_sync_state_update(settings):
     """ Verify that upsert_content_sync_state updates a ContentSyncState record for the content """
     settings.CONTENT_SYNC_BACKEND = "content_sync.backends.SampleBackend"
     content = WebsiteContentFactory.create(markdown="abc")
-
     abc_checksum = content.calculate_checksum()
 
-    content.content_sync_state.mark_synced()
+    sync_state = content.content_sync_state
+    sync_state.current_checksum = abc_checksum
+    sync_state.synced_checksum = abc_checksum
+    sync_state.save()
+
     content.markdown = "def"
 
     def_checksum = content.calculate_checksum()

--- a/content_sync/apis/github_test.py
+++ b/content_sync/apis/github_test.py
@@ -193,6 +193,9 @@ def test_upsert_content_files(mocker, mock_api_wrapper):
         id__in=mock_api_wrapper.website.websitecontent_set.values_list("id", flat=True)
     ):
         assert content.content_sync_state.is_synced is True
+        assert (
+            content.content_sync_state.current_checksum == content.calculate_checksum()
+        )
 
 
 @pytest.mark.parametrize(

--- a/content_sync/apis/github_test.py
+++ b/content_sync/apis/github_test.py
@@ -4,9 +4,10 @@ from base64 import b64decode, b64encode
 
 import pytest
 import yaml
+from django.conf import settings
 from github import GithubException
 
-from content_sync.apis.github import GithubApiWrapper
+from content_sync.apis.github import GIT_DATA_FILEPATH, GithubApiWrapper
 from main import features
 from users.factories import UserFactory
 from websites.factories import WebsiteContentFactory, WebsiteFactory
@@ -61,12 +62,12 @@ def test_create_repo(mock_api_wrapper, kwargs):
     )
 
 
-def test_create_repo_slow_api(mocker, mock_api_wrapper):
+def test_create_repo_slow_api(mocker, mock_api_wrapper, mock_branches):
     """ Test that the create_repo function will be retried if it fails initially"""
     mock_api_wrapper.org.create_repo.side_effect = [
         GithubException(status=404, data={}),
         GithubException(status=429, data={}),
-        mocker.Mock(),
+        mocker.Mock(get_branches=mocker.Mock(return_value=mock_branches[0:1])),
     ]
     new_repo = mock_api_wrapper.create_repo()
     assert mock_api_wrapper.org.create_repo.call_count == 3
@@ -165,11 +166,16 @@ def test_upsert_content_file_no_path(mock_api_wrapper, filepath):
 
 def test_upsert_content_files(mocker, mock_api_wrapper):
     """upsert_content_files should process all files in 1 commit per user"""
+    mock_git_tree_element = mocker.patch("content_sync.apis.github.InputGitTreeElement")
     for content in mock_api_wrapper.website.websitecontent_set.all()[:2]:
         content.updated_by = UserFactory.create()
         content.save()
     mock_repo = mock_api_wrapper.org.get_repo.return_value
     mock_api_wrapper.upsert_content_files()
+    for content in mock_api_wrapper.website.websitecontent_set.all():
+        mock_git_tree_element.assert_any_call(
+            content.content_filepath, "100644", "blob", mocker.ANY
+        )
 
     assert (
         mock_repo.create_git_commit.call_count == 3
@@ -187,6 +193,59 @@ def test_upsert_content_files(mocker, mock_api_wrapper):
         id__in=mock_api_wrapper.website.websitecontent_set.values_list("id", flat=True)
     ):
         assert content.content_sync_state.is_synced is True
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ["markdown", "NEW"],
+        ["metadata", '{"foo": 2}'],
+        ["content_filepath", "content/newpath.md"],
+    ],
+)
+def test_upsert_content_files_modified_only(mocker, mock_api_wrapper, field, value):
+    """upsert_content_files should process only the file with a modified field"""
+    mock_git_tree_element = mocker.patch("content_sync.apis.github.InputGitTreeElement")
+
+    # Make all content appear to be synced
+    for content in mock_api_wrapper.website.websitecontent_set.all():
+        content_sync = content.content_sync_state
+        content_sync.synced_checksum = content_sync.content.calculate_checksum()
+        content_sync.save()
+
+    # Update the field for one WebsiteContent object
+    content = mock_api_wrapper.website.websitecontent_set.first()
+    setattr(content, field, value)
+    content.save()
+
+    mock_api_wrapper.upsert_content_files()
+    mock_git_tree_element.called_once_with(
+        content.content_filepath, "100644", "blob", mocker.ANY
+    )
+
+    content.refresh_from_db()
+    assert content.content_sync_state.is_synced is True
+
+
+def test_upsert_content_files_modified_filepath(mocker, mock_api_wrapper):
+    """upsert_content_files should save git filepath in sync state and remove old paths from git"""
+    mock_git_tree_element = mocker.patch("content_sync.apis.github.InputGitTreeElement")
+    content = mock_api_wrapper.website.websitecontent_set.first()
+    sync_state = content.content_sync_state
+    old_filepath = content.content_filepath
+    mock_api_wrapper.upsert_content_files()
+    sync_state.refresh_from_db()
+    assert sync_state.data[GIT_DATA_FILEPATH] == old_filepath
+
+    content.content_filepath = "my_new_path.md"
+    content.save()
+    mock_api_wrapper.upsert_content_files()
+    mock_git_tree_element.assert_any_call(
+        content.content_filepath, "100644", "blob", mocker.ANY
+    )
+    mock_git_tree_element.assert_any_call(old_filepath, "100644", "blob", sha=None)
+    sync_state.refresh_from_db()
+    assert sync_state.data[GIT_DATA_FILEPATH] == content.content_filepath
 
 
 def test_delete_content_file(mocker, mock_api_wrapper):
@@ -243,7 +302,9 @@ def test_git_user(settings, mock_api_wrapper, is_anonymous):
 )
 def test_format_content_to_file(mock_api_wrapper, markdown, metadata):
     """A WebsiteContent object should be transformed into the expected string"""
-    content = WebsiteContentFactory.create(markdown=markdown, metadata=metadata)
+    content = WebsiteContentFactory.create(
+        markdown=markdown, metadata=metadata, website=mock_api_wrapper.website
+    )
     assert (
         mock_api_wrapper.format_content_to_file(content)
         == f"---\n{yaml.dump(metadata)}\n---\n{markdown}"
@@ -283,3 +344,66 @@ def test_custom_default_url(mocker, settings):
     mock_github = mocker.patch("content_sync.apis.github.Github", autospec=True)
     GithubApiWrapper(WebsiteFactory.create())
     mock_github.assert_called_once_with(login_or_token=settings.GIT_TOKEN)
+
+
+def test_create_repo_new(mocker, mock_api_wrapper, mock_branches):
+    """ Test that the create_repo function completes without errors and calls expected api functions"""
+    mock_api_wrapper.org.create_repo.return_value = mocker.Mock(
+        default_branch=settings.GIT_BRANCH_MAIN,
+        get_branches=mocker.Mock(return_value=mock_branches[0:1]),
+    )
+    new_repo = mock_api_wrapper.create_repo()
+    mock_api_wrapper.org.create_repo.assert_called_once_with(
+        mock_api_wrapper.get_repo_name(), auto_init=True
+    )
+    for branch in [settings.GIT_BRANCH_PREVIEW, settings.GIT_BRANCH_RELEASE]:
+        new_repo.create_git_ref.assert_any_call(f"refs/heads/{branch}", sha=mocker.ANY)
+    with pytest.raises(AssertionError):
+        new_repo.create_git_ref.assert_any_call(
+            f"refs/heads/{settings.GIT_BRANCH_MAIN}", sha=mocker.ANY
+        )
+    assert new_repo == mock_api_wrapper.get_repo()
+
+
+def test_create_repo_again(mocker, mock_api_wrapper):
+    """ Test that the create_repo function will try retrieving a repo if api.create_repo fails"""
+    mock_log = mocker.patch("content_sync.apis.github.log.debug")
+    mock_api_wrapper.org.create_repo.side_effect = GithubException(status=422, data={})
+    new_repo = mock_api_wrapper.create_repo()
+    assert new_repo is not None
+    assert mock_api_wrapper.org.get_repo.call_count == 1
+    mock_log.assert_called_once_with(
+        "Repo already exists: %s", mock_api_wrapper.website.name
+    )
+
+
+def test_create_backend_custom_default_branch(
+    settings, mocker, mock_api_wrapper, mock_branches
+):
+    """ Test that the create_backend function creates a custom default branch name """
+    settings.GIT_BRANCH_MAIN = "testing"
+    mock_api_wrapper.org.create_repo.return_value = mocker.Mock(
+        default_branch="main", get_branches=mocker.Mock(return_value=mock_branches[0:1])
+    )
+    new_repo = mock_api_wrapper.create_repo()
+    for branch in ["testing", settings.GIT_BRANCH_PREVIEW, settings.GIT_BRANCH_RELEASE]:
+        new_repo.create_git_ref.assert_any_call(f"refs/heads/{branch}", sha=mocker.ANY)
+
+
+def test_create_backend_two_branches_already_exist(
+    mocker, mock_api_wrapper, mock_branches
+):
+    """ Test that the create_backend function only creates branches that don't exist """
+    mock_api_wrapper.org.create_repo.return_value = mocker.Mock(
+        default_branch=settings.GIT_BRANCH_MAIN,
+        get_branches=mocker.Mock(return_value=mock_branches[0:2]),
+    )
+    new_repo = mock_api_wrapper.create_repo()
+    with pytest.raises(AssertionError):
+        new_repo.create_git_ref.assert_any_call(
+            f"refs/heads/{settings.GIT_BRANCH_PREVIEW}", sha=mocker.ANY
+        )
+    new_repo.create_git_ref.assert_any_call(
+        f"refs/heads/{settings.GIT_BRANCH_RELEASE}", sha=mocker.ANY
+    )
+    assert new_repo == mock_api_wrapper.get_repo()

--- a/content_sync/backends/github.py
+++ b/content_sync/backends/github.py
@@ -2,7 +2,6 @@
 import logging
 
 from django.conf import settings
-from github import GithubException
 from github.Commit import Commit
 from github.ContentFile import ContentFile
 from github.PullRequest import PullRequest
@@ -32,20 +31,7 @@ class GithubBackend(BaseSyncBackend):
         """
         Create a Website git repo with 3 branches.  Requires ~6 API calls.
         """
-        try:
-            repo = self.api.create_repo()
-        except GithubException as ge:
-            if ge.status == 422:
-                # It may already exist, try to retrieve it
-                repo = self.api.get_repo()
-                log.debug("Repo already exists: %s", self.website.name)
-        if repo.default_branch != settings.GIT_BRANCH_MAIN:
-            self.api.rename_branch(repo.default_branch, settings.GIT_BRANCH_MAIN)
-        existing_branches = [branch.name for branch in repo.get_branches()]
-        for branch in [settings.GIT_BRANCH_PREVIEW, settings.GIT_BRANCH_RELEASE]:
-            if branch not in existing_branches:
-                self.api.create_branch(branch, settings.GIT_BRANCH_MAIN)
-        return self.api.get_repo()
+        return self.api.create_repo()
 
     def create_backend_preview(self) -> PullRequest:
         """

--- a/content_sync/backends/github.py
+++ b/content_sync/backends/github.py
@@ -131,7 +131,8 @@ class GithubBackend(BaseSyncBackend):
                 content = self.api.format_file_to_content(file_content)
                 sync_state = content.content_sync_state
                 sync_state.current_checksum = content.calculate_checksum()
-                sync_state.mark_synced()
+                sync_state.synced_checksum = sync_state.current_checksum
+                sync_state.save()
                 if content.id in website_content_ids:
                     website_content_ids.remove(content.id)
 

--- a/content_sync/decorators.py
+++ b/content_sync/decorators.py
@@ -55,10 +55,11 @@ def check_sync_state(func: Callable) -> Callable:
 
     def wrapper(self, sync_state: ContentSyncState):
         if not sync_state.is_synced:
+            content = sync_state.content
             result = func(self, sync_state)
             if result:
-                sync_state.current_commit = sync_state.content.calculate_checksum()
-                sync_state.mark_synced()
+                sync_state.synced_checksum = content.calculate_checksum()
+                sync_state.save()
                 return result
         return None
 

--- a/content_sync/models.py
+++ b/content_sync/models.py
@@ -26,11 +26,6 @@ class ContentSyncState(TimestampedModel):
         """ Returns True if the content is up-to-date """
         return self.current_checksum == self.synced_checksum
 
-    def mark_synced(self):
-        """ Marks the state as synced """
-        self.synced_checksum = self.current_checksum
-        self.save()
-
     def __str__(self):  # pragma: no cover
         """ Returns a string representation of the state """
         return f"Sync State for content: {self.content.title if self.content else None}"

--- a/content_sync/models_test.py
+++ b/content_sync/models_test.py
@@ -2,7 +2,6 @@
 import pytest
 
 from content_sync.models import ContentSyncState
-from websites.factories import WebsiteContentFactory
 
 
 @pytest.mark.parametrize(
@@ -20,16 +19,3 @@ def test_contentsyncstate_is_synced(current_checksum, synced_checksum, expected)
     )
 
     assert sync_state.is_synced is expected
-
-
-@pytest.mark.django_db
-def test_contentsyncstate_mark_synced():
-    """ Verify ContentSyncState.mark_synced() updates the synced_checksum to the current one """
-    content = WebsiteContentFactory.create()
-
-    sync_state = content.content_sync_state
-    sync_state.current_checksum = "abc"
-    sync_state.calculate_checksum = "def"
-    sync_state.mark_synced()
-
-    assert sync_state.current_checksum == sync_state.synced_checksum

--- a/websites/models.py
+++ b/websites/models.py
@@ -122,7 +122,13 @@ class WebsiteContent(TimestampedModel):
     def calculate_checksum(self) -> str:
         """ Returns a calculated checksum of the content """
         return sha256(
-            "\n".join([json.dumps(self.metadata), str(self.markdown)]).encode("utf-8")
+            "\n".join(
+                [
+                    json.dumps(self.metadata),
+                    str(self.markdown),
+                    str(self.content_filepath),  # TO DO: Replace with dynamic filepath
+                ]
+            ).encode("utf-8")
         ).hexdigest()
 
     class Meta:

--- a/websites/models.py
+++ b/websites/models.py
@@ -124,7 +124,7 @@ class WebsiteContent(TimestampedModel):
         return sha256(
             "\n".join(
                 [
-                    json.dumps(self.metadata),
+                    json.dumps(self.metadata, sort_keys=True),
                     str(self.markdown),
                     str(self.content_filepath),  # TO DO: Replace with dynamic filepath
                 ]

--- a/websites/models_test.py
+++ b/websites/models_test.py
@@ -5,11 +5,11 @@ from websites.factories import WebsiteContentFactory
 def test_websitecontent_calculate_checksum():
     """ Verify calculate_checksum() returns a sha256 checksum """
     content = WebsiteContentFactory.build(
-        markdown="content", metadata={"data": "value"}
+        markdown="content", metadata={"data": "value"}, content_filepath="_index.md"
     )
 
     # manually computed checksum in a python shell
     assert (
         content.calculate_checksum()
-        == "236c72d38543a9a7dc4cdd2bb9bf3e305b60598dfc2a8616e0429f9020692bed"
+        == "cfcbebb93fdf56848f32afc3d1bda55868a465547de0e6fb4b8dab05b69ec352"
     )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/233

#### What's this PR do?
- Adds `content.content_filepath` to the fields used in calculating sync state checksums.  This will later be changed to a dynamic file path based on site config.
- Stores the git filepath to the JSON field `ContentSyncState.data` after a commit to git.  If the current filepath and the sync state filepath don't match on the next sync, marks the git filepath for removal.
- Moves some logic (and related tests) out of `GithubBackend.create_website_in_backend` to `GithubApiWrapper.create_repo`

#### How should this be manually tested?
Tests should pass.
In a shell, you can do the following for an existing website:
```python
from websites.models import *
from content_sync.apis.github import GithubApiWrapper

website = Website.objects.get(id=<website_id>)
content = website.websitecontent_set.first()
content.content_filepath = "newfilepath1.md"
content.save()

api = GithubApiWrapper(website)
api.upsert_content_files()
```

Check the repo on github, there should be a "newfilepath1.md" there.

Then:
```python
content.content_filepath = "newfilepath2.md"
content.save()
api.upsert_content_files()
```

Check github again, "newfilepath1.md" should be gone and "newfilepath2.md" should be there instead.



#### Any background context you want to provide?
Eventually the filepath will be determined dynamically from the site_config, and the `WebsiteContent.content_filepath` will be used as an override (and possibly renamed to `filepath_override`).  I think that should probably be in a separate PR.  I can mark this PR as blocked if you'd prefer that change to be done first.

This PR continues to use `WebsiteContent.content_filepath` for now, I tried to make it easier to change later by minimizing referencing it directly by name (ie `filepath = content.content_filepath` and then using `filepath` thereafter).



