### PR TITLE
Website preview button

### DIFF
--- a/static/js/lib/urls.ts
+++ b/static/js/lib/urls.ts
@@ -22,6 +22,8 @@ export const startersApi = api.segment("starters/")
 // WEBSITES API
 export const siteApi = api.segment("websites/")
 export const siteApiDetailUrl = siteApi.segment(":name/")
+export const siteApiActionUrl = siteApiDetailUrl.segment(":action/")
+
 export const siteApiCollaboratorsUrl = siteApiDetailUrl.segment(
   "collaborators/"
 )

--- a/static/js/pages/SitePage.test.tsx
+++ b/static/js/pages/SitePage.test.tsx
@@ -1,3 +1,6 @@
+import { act } from "react-dom/test-utils"
+import sinon from "sinon"
+
 const mockUseRouteMatch = jest.fn()
 
 import SitePage from "./SitePage"
@@ -7,7 +10,10 @@ import IntegrationTestHelper, {
 } from "../util/integration_test_helper"
 import { makeWebsiteDetail } from "../util/factories/websites"
 
-import { siteApiDetailUrl } from "../lib/urls"
+import {
+  siteApiActionUrl,
+  siteApiDetailUrl
+} from "../lib/urls"
 
 import { Website } from "../types/websites"
 
@@ -57,5 +63,35 @@ describe("SitePage", () => {
     const { wrapper } = await render()
     expect(wrapper.find("SiteSidebar").prop("website")).toBe(website)
     expect(wrapper.find("h1.title").text()).toBe(website.title)
+  })
+
+  it("preview button sends the expected request", async () => {
+    const previewStub = helper.handleRequestStub
+      .withArgs(
+        siteApiActionUrl
+          .param({
+            name:   website.name,
+            action: "preview"
+          })
+          .toString()
+      )
+      .returns({
+        status: 200
+      })
+    const { wrapper } = await render()
+    await act(async () => {
+      // @ts-ignore
+      wrapper.find(".btn-preview").prop("onClick")()
+    })
+    sinon.assert.calledOnceWithExactly(
+      previewStub,
+      `/api/websites/${website.name}/preview/`,
+      "POST",
+      {
+        body:        {},
+        headers:     { "X-CSRFTOKEN": "" },
+        credentials: undefined
+      }
+    )
   })
 })

--- a/static/js/pages/SitePage.test.tsx
+++ b/static/js/pages/SitePage.test.tsx
@@ -10,10 +10,7 @@ import IntegrationTestHelper, {
 } from "../util/integration_test_helper"
 import { makeWebsiteDetail } from "../util/factories/websites"
 
-import {
-  siteApiActionUrl,
-  siteApiDetailUrl
-} from "../lib/urls"
+import { siteApiActionUrl, siteApiDetailUrl } from "../lib/urls"
 
 import { Website } from "../types/websites"
 

--- a/static/js/pages/SitePage.tsx
+++ b/static/js/pages/SitePage.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 import { useSelector } from "react-redux"
-import { useRequest } from "redux-query-react"
+import { useMutation, useRequest } from "redux-query-react"
 import { Route, Switch, useRouteMatch } from "react-router-dom"
 
 import SiteSidebar from "../components/SiteSidebar"
@@ -8,7 +8,7 @@ import SiteContentListing from "../components/SiteContentListing"
 import SiteCollaboratorList from "../components/SiteCollaboratorList"
 import Card from "../components/Card"
 
-import { websiteDetailRequest } from "../query-configs/websites"
+import { websiteAction, websiteDetailRequest } from "../query-configs/websites"
 import { getWebsiteDetailCursor } from "../selectors/websites"
 
 interface MatchParams {
@@ -18,6 +18,10 @@ interface MatchParams {
 export default function SitePage(): JSX.Element | null {
   const match = useRouteMatch<MatchParams>()
   const { name } = match.params
+
+  const [websitePreviewQueryState, previewWebsite] = useMutation(() =>
+    websiteAction(name, "preview")
+  )
 
   const [{ isPending }] = useRequest(websiteDetailRequest(name))
   const website = useSelector(getWebsiteDetailCursor)(name)
@@ -30,6 +34,18 @@ export default function SitePage(): JSX.Element | null {
     return <div className="site-page std-page-body container">Loading...</div>
   }
 
+  const onPreview = async () => {
+    if (websitePreviewQueryState.isPending) {
+      return
+    }
+    const response = await previewWebsite()
+    if (!response) {
+      return
+    } else {
+      // TBD
+    }
+  }
+
   return (
     <div className="site-page std-page-body container pt-3">
       <div className="content-container">
@@ -37,7 +53,18 @@ export default function SitePage(): JSX.Element | null {
           <SiteSidebar website={website} />
         </Card>
         <div className="content pl-3">
-          <h1 className="py-5 title">{website.title}</h1>
+          <div className="d-flex flex-row justify-content-between">
+            <h1 className="py-5 title my-auto">{website.title}</h1>
+            <div className="my-auto">
+              <button
+                type="button"
+                onClick={onPreview}
+                className="btn btn-preview btn-outline-success float-right"
+              >
+                Preview
+              </button>
+            </div>
+          </div>
           <Switch>
             <Route path={`${match.path}/collaborators/`}>
               <SiteCollaboratorList />

--- a/static/js/pages/SitePage.tsx
+++ b/static/js/pages/SitePage.tsx
@@ -19,7 +19,7 @@ export default function SitePage(): JSX.Element | null {
   const match = useRouteMatch<MatchParams>()
   const { name } = match.params
 
-  const [websitePreviewQueryState, previewWebsite] = useMutation(() =>
+  const [{ isPending: previewIsPending }, previewWebsite] = useMutation(() =>
     websiteAction(name, "preview")
   )
 
@@ -35,7 +35,7 @@ export default function SitePage(): JSX.Element | null {
   }
 
   const onPreview = async () => {
-    if (websitePreviewQueryState.isPending) {
+    if (previewIsPending) {
       return
     }
     const response = await previewWebsite()
@@ -59,6 +59,7 @@ export default function SitePage(): JSX.Element | null {
               <button
                 type="button"
                 onClick={onPreview}
+                disabled={previewIsPending}
                 className="btn btn-preview green-button-outline"
               >
                 Preview

--- a/static/js/pages/SitePage.tsx
+++ b/static/js/pages/SitePage.tsx
@@ -59,7 +59,7 @@ export default function SitePage(): JSX.Element | null {
               <button
                 type="button"
                 onClick={onPreview}
-                className="btn btn-preview btn-outline-success float-right"
+                className="btn btn-preview green-button-outline"
               >
                 Preview
               </button>

--- a/static/js/query-configs/websites.ts
+++ b/static/js/query-configs/websites.ts
@@ -11,6 +11,7 @@ import {
   siteApiCollaboratorsUrl,
   siteApiListingUrl,
   siteApiDetailUrl,
+  siteApiActionUrl,
   siteApiContentListingUrl,
   siteApiContentDetailUrl,
   siteApiContentUrl
@@ -118,6 +119,17 @@ export const websiteMutation = (payload: NewWebsitePayload): QueryConfig => ({
       ...next
     })
   }
+})
+
+export const websiteAction = (name: string, action: string): QueryConfig => ({
+  url:     siteApiActionUrl.param({ name, action }).toString(),
+  options: {
+    method:  "POST",
+    headers: {
+      "X-CSRFTOKEN": getCookie("csrftoken") || ""
+    }
+  },
+  body: {}
 })
 
 export const websiteStartersRequest = (): QueryConfig => ({

--- a/static/scss/button.scss
+++ b/static/scss/button.scss
@@ -15,19 +15,20 @@
 }
 
 .green-button,
-.green-button-outline:hover {
-  background-color: $studio-green;
-  color: white;
+.green-button-outline {
   font-size: 14px;
   border-radius: 8px;
   padding: 6px 16px;
+}
+
+.green-button,
+.green-button-outline:hover {
+  background-color: $studio-green;
+  color: white;
 }
 
 .green-button-outline {
   border-color: $studio-green;
   background-color: white;
   color: $studio-green;
-  font-size: 14px;
-  border-radius: 8px;
-  padding: 6px 16px;
 }

--- a/static/scss/button.scss
+++ b/static/scss/button.scss
@@ -14,9 +14,19 @@
   padding: 6px 16px;
 }
 
-.green-button {
+.green-button,
+.green-button-outline:hover {
   background-color: $studio-green;
   color: white;
+  font-size: 14px;
+  border-radius: 8px;
+  padding: 6px 16px;
+}
+
+.green-button-outline {
+  border-color: $studio-green;
+  background-color: white;
+  color: $studio-green;
   font-size: 14px;
   border-radius: 8px;
   padding: 6px 16px;


### PR DESCRIPTION
Based on #253 

#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #250 

#### What's this PR do?
Adds a preview button to site pages, that triggers a celery task

#### How should this be manually tested?
- Follow github integration instructions in the README
- Create a website and make some content.  
- You'll need to go into a shell and manually populate/save the `content_filepath` field for that content, so github has a place to put them.
- Click the 'preview' button.  Check the github repo, there should be a recent commit merging the main branch to the preview branch.


#### Screenshots (if appropriate)
<img width="752" alt="Screen Shot 2021-05-06 at 12 48 58 PM" src="https://user-images.githubusercontent.com/187676/117336483-3d1cdc00-ae6a-11eb-8e49-3def9abed0c0.png">


On hover:
<img width="753" alt="Screen Shot 2021-05-06 at 12 49 08 PM" src="https://user-images.githubusercontent.com/187676/117336502-4312bd00-ae6a-11eb-9810-c2e7ebd02a0d.png">
