### PR TITLE
Fixed is_page_content flag regression

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,9 @@ services:
       sleep 3 &&
       python3 manage.py collectstatic --noinput &&
       python3 manage.py migrate --noinput &&
-      uwsgi uwsgi.ini'
+      uwsgi uwsgi.ini --honour-stdin'
+    stdin_open: true
+    tty: true
     ports:
       - "8041:8041"
     environment:

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -215,12 +215,12 @@ class WebsiteContentCreateSerializer(
                 "website_id": self.context["website_pk"],
                 "owner": user,
                 "updated_by": user,
+                **validated_data,
                 **(
                     {"is_page_content": self.context["is_page_content"]}
                     if "is_page_content" in self.context
                     else {}
                 ),
-                **validated_data,
             }
         )
         update_website_backend(instance.website)

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -204,6 +204,7 @@ def test_website_content_create_serializer(mocker, includes_page_content_param):
         "type": CONTENT_TYPE_RESOURCE,
         "markdown": "some markdown",
         "metadata": metadata,
+        "is_page_content": False,
     }
     website = WebsiteFactory.create()
     user = UserFactory.create()


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
No ticket. Noticed this while testing another PR.

#### What's this PR do?
Fixes website content creation behavior so the `is_page_content` flag is set to `True` when appropriate.

#### How should this be manually tested?
Create some content for the Page and Resource types. The newly-created objects should have `is_page_content=True`

#### Any background context you want to provide?
- I also altered the `web` container definition in `docker-compose.yml` to enable pdb breakpoints in that container