### PR TITLE
add relation field type and widget

### DIFF
--- a/localdev/configs/ocw-course-site-config.yml
+++ b/localdev/configs/ocw-course-site-config.yml
@@ -20,11 +20,31 @@ collections:
       - name: address
         label: Address
         widget: object
+        required: false
         fields:
           - { label: "Street Address", name: "street_address", widget: "string", required: true }
           - { label: "City", name: "city", widget: "string", required: true }
           - { label: "State", name: "state", widget: "string", required: true }
           - { label: "Zip Code", name: "zip", widget: "string", required: true }
+      - {
+        "label": "Authors",
+        "name": "authors",
+        "widget": "relation",
+        "collection": "author",
+        "display_field": "title",
+        "multiple": true,
+        "max": 10,
+        "min": 1,
+        "required": false,
+        }
+
+  - name: author
+    label: Author
+    category: Content
+    folder: content
+    fields:
+      - {"label": "Name", "name": "title", "widget": "string", "required": true}
+      - {"label": "Profession", "name": "profession", "widget": "string", "required": false}
 
   - name: resource
     label: Resource

--- a/static/js/components/RepeatableContentListing.test.tsx
+++ b/static/js/components/RepeatableContentListing.test.tsx
@@ -4,6 +4,7 @@ import React from "react"
 import { act } from "react-dom/test-utils"
 
 import RepeatableContentListing from "./RepeatableContentListing"
+import WebsiteContext from "../context/Website"
 
 import { isIf } from "../test_util"
 import {
@@ -102,9 +103,12 @@ describe("RepeatableContentListing", () => {
       })
 
     render = helper.configureRenderer(
-      RepeatableContentListing,
+      props => (
+        <WebsiteContext.Provider value={website}>
+          <RepeatableContentListing {...props} />
+        </WebsiteContext.Provider>
+      ),
       {
-        website:    website,
         configItem: configItem,
         location:   {
           search: ""

--- a/static/js/components/RepeatableContentListing.tsx
+++ b/static/js/components/RepeatableContentListing.tsx
@@ -11,6 +11,7 @@ import SiteContentEditor from "./SiteContentEditor"
 import PaginationControls from "./PaginationControls"
 import Card from "./Card"
 import BasicModal from "./BasicModal"
+import { useWebsite } from "../context/Website"
 
 import { WEBSITE_CONTENT_PAGE_SIZE } from "../constants"
 import { siteContentListingUrl } from "../lib/urls"
@@ -24,16 +25,16 @@ import { getWebsiteContentListingCursor } from "../selectors/websites"
 import {
   ContentListingParams,
   RepeatableConfigItem,
-  Website,
   WebsiteContentListItem
 } from "../types/websites"
 import { ContentFormType } from "../types/forms"
 
 export default function RepeatableContentListing(props: {
-  website: Website
   configItem: RepeatableConfigItem
 }): JSX.Element | null {
-  const { website, configItem } = props
+  const { configItem } = props
+
+  const website = useWebsite()
 
   const { search } = useLocation()
   const offset = Number(new URLSearchParams(search).get("offset") ?? 0)
@@ -43,6 +44,7 @@ export default function RepeatableContentListing(props: {
     type: configItem.name,
     offset
   }
+
   const [
     { isPending: contentListingPending },
     fetchWebsiteContentListing
@@ -97,7 +99,6 @@ export default function RepeatableContentListing(props: {
           panelState.formType && (
             <div className="m-3">
               <SiteContentEditor
-                site={website}
                 loadContent={true}
                 configItem={configItem}
                 textId={panelState.textId}

--- a/static/js/components/SingletonsContentListing.test.tsx
+++ b/static/js/components/SingletonsContentListing.test.tsx
@@ -4,6 +4,7 @@ import React from "react"
 import { act } from "react-dom/test-utils"
 
 import SingletonsContentListing from "./SingletonsContentListing"
+import WebsiteContext from "../context/Website"
 
 import { siteApiContentDetailUrl } from "../lib/urls"
 import IntegrationTestHelper, {
@@ -72,7 +73,11 @@ describe("SingletonsContentListing", () => {
       [singletonConfigItems[0].name]: content
     }
     render = helper.configureRenderer(
-      SingletonsContentListing,
+      props => (
+        <WebsiteContext.Provider value={website}>
+          <SingletonsContentListing {...props} />
+        </WebsiteContext.Provider>
+      ),
       {
         website:    website,
         configItem: configItem
@@ -174,7 +179,6 @@ describe("SingletonsContentListing", () => {
     const siteContentEditor = tabPane.find("SiteContentEditor")
     expect(siteContentEditor.exists()).toBe(true)
     expect(siteContentEditor.props()).toEqual({
-      site:        website,
       content:     content,
       loadContent: false,
       configItem:  singletonConfigItems[0],

--- a/static/js/components/SingletonsContentListing.tsx
+++ b/static/js/components/SingletonsContentListing.tsx
@@ -4,20 +4,21 @@ import { Nav, NavItem, NavLink, TabContent, TabPane } from "reactstrap"
 import { useRequest } from "redux-query-react"
 
 import Card from "./Card"
+import { useWebsite } from "../context/Website"
 
 import { websiteContentDetailRequest } from "../query-configs/websites"
 
-import { SingletonsConfigItem, Website } from "../types/websites"
+import { SingletonsConfigItem } from "../types/websites"
 import { ContentFormType } from "../types/forms"
 
 import { getWebsiteContentDetailCursor } from "../selectors/websites"
 import SiteContentEditor from "./SiteContentEditor"
 
 export default function SingletonsContentListing(props: {
-  website: Website
   configItem: SingletonsConfigItem
 }): JSX.Element | null {
-  const { website, configItem } = props
+  const { configItem } = props
+  const website = useWebsite()
 
   const [activeTab, setActiveTab] = useState(0)
   const toggle = (tab: number) => {
@@ -60,7 +61,6 @@ export default function SingletonsContentListing(props: {
                 "Loading..."
               ) : (
                 <SiteContentEditor
-                  site={website}
                   content={content}
                   loadContent={false}
                   configItem={fileConfigItem}

--- a/static/js/components/SiteContentEditor.test.tsx
+++ b/static/js/components/SiteContentEditor.test.tsx
@@ -4,6 +4,7 @@ import { act } from "react-dom/test-utils"
 import sinon, { SinonStub } from "sinon"
 
 import SiteContentEditor from "./SiteContentEditor"
+import WebsiteContext from "../context/Website"
 
 import { siteApiContentDetailUrl, siteApiContentUrl } from "../lib/urls"
 import IntegrationTestHelper, {
@@ -72,11 +73,15 @@ describe("SiteContent", () => {
       setStatus:     helper.sandbox.stub()
     }
     render = helper.configureRenderer(
-      // @ts-ignore
-      SiteContentEditor,
+      function(props) {
+        return (
+          <WebsiteContext.Provider value={website as Website}>
+            <SiteContentEditor {...props} />
+          </WebsiteContext.Provider>
+        )
+      },
       {
         history:     { push: historyPushStub },
-        site:        website,
         textId:      content.text_id,
         configItem:  configItem,
         loadContent: true

--- a/static/js/components/SiteContentEditor.tsx
+++ b/static/js/components/SiteContentEditor.tsx
@@ -4,6 +4,7 @@ import { useSelector } from "react-redux"
 import { FormikHelpers } from "formik"
 
 import SiteContentForm from "./forms/SiteContentForm"
+import { useWebsite } from "../context/Website"
 
 import {
   createWebsiteContentMutation,
@@ -19,11 +20,10 @@ import {
 } from "../lib/site_content"
 import { getResponseBodyError, isErrorResponse } from "../lib/util"
 
-import { EditableConfigItem, Website, WebsiteContent } from "../types/websites"
+import { EditableConfigItem, WebsiteContent } from "../types/websites"
 import { ContentFormType, SiteFormValues } from "../types/forms"
 
 interface Props {
-  site: Website
   content?: WebsiteContent
   loadContent: boolean
   textId: string | null
@@ -38,11 +38,12 @@ export default function SiteContentEditor(props: Props): JSX.Element | null {
     hideModal,
     configItem,
     textId,
-    site,
     loadContent,
     formType,
     fetchWebsiteContentListing
   } = props
+
+  const site = useWebsite()
 
   const [
     { isPending: addIsPending },

--- a/static/js/components/SiteContentListing.test.tsx
+++ b/static/js/components/SiteContentListing.test.tsx
@@ -86,8 +86,7 @@ describe("SiteContentListing", () => {
       const listing = wrapper.find(expChildComponent)
       expect(listing.exists()).toBe(true)
       expect(listing.props()).toEqual({
-        website:    website,
-        configItem: configItem
+        configItem
       })
     })
   })

--- a/static/js/components/SiteContentListing.tsx
+++ b/static/js/components/SiteContentListing.tsx
@@ -7,6 +7,7 @@ import SingletonsContentListing from "./SingletonsContentListing"
 
 import { isRepeatableCollectionItem } from "../lib/site_content"
 import { getWebsiteDetailCursor } from "../selectors/websites"
+import WebsiteContext from "../context/Website"
 
 import { TopLevelConfigItem } from "../types/websites"
 
@@ -27,10 +28,13 @@ export default function SiteContentListing(): JSX.Element | null {
     return null
   }
 
-  if (isRepeatableCollectionItem(configItem)) {
-    return (
-      <RepeatableContentListing website={website} configItem={configItem} />
-    )
-  }
-  return <SingletonsContentListing website={website} configItem={configItem} />
+  return (
+    <WebsiteContext.Provider value={website}>
+      {isRepeatableCollectionItem(configItem) ? (
+        <RepeatableContentListing configItem={configItem} />
+      ) : (
+        <SingletonsContentListing configItem={configItem} />
+      )}
+    </WebsiteContext.Provider>
+  )
 }

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -27,7 +27,7 @@ interface Props {
     formikHelpers: FormikHelpers<any>
   ) => void | Promise<any>
   configItem: EditableConfigItem
-  content: WebsiteContent
+  content: WebsiteContent | null
   formType: ContentFormType
 }
 
@@ -46,7 +46,7 @@ export default function SiteContentForm({
     () =>
       formType === ContentFormType.Add ?
         newInitialValues(configItem.fields) :
-        contentInitialValues(content, configItem.fields),
+        contentInitialValues(content as WebsiteContent, configItem.fields),
     [configItem, formType, content]
   )
 

--- a/static/js/components/forms/validation.test.ts
+++ b/static/js/components/forms/validation.test.ts
@@ -113,95 +113,98 @@ describe("form validation util", () => {
     )
   })
 
-  describe("select validation", () => {
-    const makeSelectConfigItem = (props = {}): [ConfigItem, string] => {
-      const configItem = {
-        ...partialConfigItem,
-        fields: [
-          makeWebsiteConfigField({ widget: WidgetVariant.Select, ...props })
-        ]
+  //
+  ;[WidgetVariant.Select, WidgetVariant.Relation].forEach(selectLikeVariant => {
+    describe(`${selectLikeVariant} validation`, () => {
+      const makeSelectLikeConfigItem = (props = {}): [ConfigItem, string] => {
+        const configItem = {
+          ...partialConfigItem,
+          fields: [
+            makeWebsiteConfigField({ widget: selectLikeVariant, ...props })
+          ]
+        }
+
+        return [configItem, configItem.fields[0].name]
       }
 
-      return [configItem, configItem.fields[0].name]
-    }
-
-    it("should validate for a required multiple select field", () => {
-      const [configItem, name] = makeSelectConfigItem({
-        multiple: true,
-        required: true
-      })
-      const schema = getContentSchema(configItem)
-      expect(() =>
-        schema.validateSync({
-          [name]: null
+      it(`should validate for a required multiple ${selectLikeVariant} field`, () => {
+        const [configItem, name] = makeSelectLikeConfigItem({
+          multiple: true,
+          required: true
         })
-      ).toThrow(new yup.ValidationError(`${name} is a required field.`))
-    })
+        const schema = getContentSchema(configItem)
+        expect(() =>
+          schema.validateSync({
+            [name]: null
+          })
+        ).toThrow(new yup.ValidationError(`${name} is a required field.`))
+      })
 
-    it("should pass validation for valid multiple select values", async () => {
-      const [configItem, name] = makeSelectConfigItem({ multiple: true })
-      const schema = getContentSchema(configItem)
-      await Promise.all(
-        [[], ["some value"], ["some value", "another value"]].map(
-          async value => {
-            await expect(
-              schema.isValid({
-                [name]: value
-              })
-            ).resolves.toBeTruthy()
-          }
+      it(`should pass validation for valid multiple ${selectLikeVariant} values`, async () => {
+        const [configItem, name] = makeSelectLikeConfigItem({ multiple: true })
+        const schema = getContentSchema(configItem)
+        await Promise.all(
+          [[], ["some value"], ["some value", "another value"]].map(
+            async value => {
+              await expect(
+                schema.isValid({
+                  [name]: value
+                })
+              ).resolves.toBeTruthy()
+            }
+          )
         )
-      )
-    })
-
-    it("should validate a multiple select field with max and min set", async () => {
-      const [configItem, name] = makeSelectConfigItem({
-        multiple: true,
-        min:      1,
-        max:      2
       })
-      const schema = getContentSchema(configItem)
 
-      await Promise.all(
-        [
-          [[], false, `${name} must have at least 1 entry.`],
-          [["some value"], true, ""],
-          [["some value", "another value"], true, ""],
+      it(`should validate a multiple ${selectLikeVariant} field with max and min set`, async () => {
+        const [configItem, name] = makeSelectLikeConfigItem({
+          multiple: true,
+          min:      1,
+          max:      2
+        })
+        const schema = getContentSchema(configItem)
+
+        await Promise.all(
           [
-            ["some value", "another value", "yet another value"],
-            false,
-            `${name} may have at most 2 entries.`
-          ]
-        ].map(async ([value, shouldValidate, message]) => {
-          if (shouldValidate) {
-            await expect(
-              schema.isValid({
-                [name]: value
-              })
-            ).resolves.toBeTruthy()
-          } else {
-            await expect(
-              schema.validate({
-                [name]: value
-              })
-            ).rejects.toThrow(new yup.ValidationError(message as string))
-          }
-        })
-      )
-    })
+            [[], false, `${name} must have at least 1 entry.`],
+            [["some value"], true, ""],
+            [["some value", "another value"], true, ""],
+            [
+              ["some value", "another value", "yet another value"],
+              false,
+              `${name} may have at most 2 entries.`
+            ]
+          ].map(async ([value, shouldValidate, message]) => {
+            if (shouldValidate) {
+              await expect(
+                schema.isValid({
+                  [name]: value
+                })
+              ).resolves.toBeTruthy()
+            } else {
+              await expect(
+                schema.validate({
+                  [name]: value
+                })
+              ).rejects.toThrow(new yup.ValidationError(message as string))
+            }
+          })
+        )
+      })
 
-    it("should validate a required non-multiple select field", async () => {
-      const [configItem, name] = makeSelectConfigItem({ required: true })
-      const schema = getContentSchema(configItem)
+      it(`should validate a required non-multiple ${selectLikeVariant} field`, async () => {
+        const [configItem, name] = makeSelectLikeConfigItem({ required: true })
+        const schema = getContentSchema(configItem)
 
-      expect(() =>
-        schema.validateSync({
-          [name]: ""
-        })
-      ).toThrow(new yup.ValidationError(`${name} is a required field`))
-      await expect(
-        schema.isValid({ [name]: "selected value" })
-      ).resolves.toBeTruthy()
+        expect(() =>
+          schema.validateSync({
+            [name]: ""
+          })
+        ).toThrow(new yup.ValidationError(`${name} is a required field`))
+        await expect(
+          schema.isValid({ [name]: "selected value" })
+        ).resolves.toBeTruthy()
+      })
     })
   })
 

--- a/static/js/components/forms/validation.ts
+++ b/static/js/components/forms/validation.ts
@@ -26,6 +26,7 @@ export const getFieldSchema = (field: ConfigField): Schema => {
   let schema
 
   switch (field.widget) {
+  case WidgetVariant.Relation:
   case WidgetVariant.Select: {
     if (field.multiple) {
       schema = yup.array()

--- a/static/js/components/widgets/RelationField.test.tsx
+++ b/static/js/components/widgets/RelationField.test.tsx
@@ -1,0 +1,128 @@
+import React from "react"
+import { SinonStub } from "sinon"
+
+import RelationField from "./RelationField"
+import WebsiteContext from "../../context/Website"
+
+import IntegrationTestHelper, {
+  TestRenderer
+} from "../../util/integration_test_helper"
+
+import {
+  makeWebsiteContentListItem,
+  makeWebsiteDetail
+} from "../../util/factories/websites"
+import { siteApiContentListingUrl } from "../../lib/urls"
+import { WEBSITE_CONTENT_PAGE_SIZE } from "../../constants"
+
+import { Website, WebsiteContentListItem } from "../../types/websites"
+import R from "ramda"
+
+describe("RelationField", () => {
+  let website: Website,
+    render: TestRenderer,
+    helper: IntegrationTestHelper,
+    onChange: SinonStub,
+    contentListingItemsPages: WebsiteContentListItem[][]
+
+  beforeEach(() => {
+    website = makeWebsiteDetail()
+    helper = new IntegrationTestHelper()
+    onChange = helper.sandbox.stub()
+    render = helper.configureRenderer(
+      props => (
+        <WebsiteContext.Provider value={website}>
+          <RelationField {...props} />
+        </WebsiteContext.Provider>
+      ),
+      {
+        collection:    "page",
+        display_field: "title",
+        name:          "relation_field",
+        multiple:      true,
+        max:           10,
+        min:           1,
+        onChange
+      }
+    )
+    contentListingItemsPages = [
+      R.times(makeWebsiteContentListItem, WEBSITE_CONTENT_PAGE_SIZE),
+      R.times(makeWebsiteContentListItem, WEBSITE_CONTENT_PAGE_SIZE)
+    ]
+    helper.handleRequestStub
+      .withArgs(
+        siteApiContentListingUrl
+          .param({ name: website.name })
+          .query({ type: "page", offset: 0 })
+          .toString(),
+        "GET"
+      )
+      .returns({
+        status: 200,
+        body:   {
+          results:  contentListingItemsPages[0],
+          count:    contentListingItemsPages.flat().length,
+          next:     null,
+          previous: null
+        }
+      })
+    helper.handleRequestStub
+      .withArgs(
+        siteApiContentListingUrl
+          .param({ name: website.name })
+          .query({ type: "page", offset: WEBSITE_CONTENT_PAGE_SIZE })
+          .toString(),
+        "GET"
+      )
+      .returns({
+        status: 200,
+        body:   {
+          results:  contentListingItemsPages[1],
+          count:    contentListingItemsPages.flat().length,
+          next:     null,
+          previous: null
+        }
+      })
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should render a SelectField with the expected options, hitting the API multiple times as needed", async () => {
+    const { wrapper } = await render()
+    expect(wrapper.find("SelectField").prop("options")).toEqual(
+      contentListingItemsPages.flat().map(item => ({
+        label: item.title,
+        value: item.text_id
+      }))
+    )
+  })
+
+  //
+  ;[true, false].forEach(multiple => {
+    it(`should pass the 'multiple===${multiple}' down to the SelectField`, async () => {
+      const { wrapper } = await render({ multiple })
+      expect(wrapper.find("SelectField").prop("multiple")).toBe(multiple)
+    })
+  })
+
+  it("should pass a value down to the SelectField", async () => {
+    const { wrapper } = await render({ value: "foobar" })
+    expect(wrapper.find("SelectField").prop("value")).toBe("foobar")
+  })
+
+  it("should pass the onChange handler down to the SelectField", async () => {
+    const { wrapper } = await render()
+    expect(wrapper.find("SelectField").prop("onChange")).toBe(onChange)
+  })
+
+  it("should pass max and min to SelectField", async () => {
+    const { wrapper } = await render({
+      max: 10,
+      min: 5
+    })
+    expect(wrapper.find("SelectField").prop("max")).toBe(10)
+    expect(wrapper.find("SelectField").prop("min")).toBe(5)
+  })
+})

--- a/static/js/components/widgets/RelationField.tsx
+++ b/static/js/components/widgets/RelationField.tsx
@@ -1,0 +1,92 @@
+import React, { useState, useEffect } from "react"
+import { useRequest } from "redux-query-react"
+import { useSelector } from "react-redux"
+
+import SelectField from "./SelectField"
+import { useWebsite } from "../../context/Website"
+
+import { websiteContentListingRequest } from "../../query-configs/websites"
+import { WEBSITE_CONTENT_PAGE_SIZE } from "../../constants"
+import { getWebsiteContentListingCursor } from "../../selectors/websites"
+
+import { Option } from "./SelectField"
+
+interface Props {
+  name: string
+  collection: string
+  display_field: string // eslint-disable-line camelcase
+  max: number
+  min: number
+  multiple: boolean
+  onChange: (event: Event) => void
+  value: any
+}
+
+export default function RelationField(props: Props): JSX.Element {
+  const {
+    collection,
+    display_field, // eslint-disable-line camelcase
+    name,
+    multiple,
+    onChange,
+    value,
+    max,
+    min
+  } = props
+
+  const [offset, setOffset] = useState(0)
+  const [options, setOptions] = useState<Option[]>([])
+
+  const website = useWebsite()
+
+  const listingParams = website ?
+    { name: website.name, type: collection, offset } :
+    null
+
+  useRequest(listingParams ? websiteContentListingRequest(listingParams) : null)
+
+  const websiteContentListingCursor = useSelector(
+    getWebsiteContentListingCursor
+  )
+
+  const listing = listingParams ?
+    websiteContentListingCursor(listingParams) :
+    null
+  const count = listing?.count ?? 0
+
+  useEffect(() => {
+    // check if we need to re-run the request
+    //
+    // if count is greater than our current offset plus page size (i.e. the
+    // number of items which will be fetched in the current request) then we
+    // need to bump up offset by WEBSITE_CONTENT_PAGE_SIZE to fetch the next
+    // page.
+    //
+    // this will then change the listingParams object and fire off a new
+    // request.
+    if (count > offset + WEBSITE_CONTENT_PAGE_SIZE) {
+      setOffset(offset => (offset += WEBSITE_CONTENT_PAGE_SIZE))
+    }
+  }, [offset, setOffset, count])
+
+  useEffect(() => {
+    const options = (listing?.results ?? []).map((entry: any) => ({
+      label: entry[display_field],
+      value: entry.text_id
+    }))
+
+    setOptions(oldOptions => [...oldOptions, ...options])
+  }, [listing, setOptions, display_field]) // eslint-disable-line camelcase
+
+  return (
+    <SelectField
+      name={name}
+      value={value}
+      onChange={onChange}
+      options={options}
+      multiple={multiple}
+      max={max}
+      min={min}
+    />
+  )
+}

--- a/static/js/context/Website.ts
+++ b/static/js/context/Website.ts
@@ -1,0 +1,40 @@
+import React, { useContext } from "react"
+
+import { Website } from "../types/websites"
+
+/**
+ * This allows us to set a website context for a whole component
+ * tree, starting, for instance, with our SiteContentListing component.
+ * This makes it then easy to grab the current Website from anywhere in
+ * the component tree.
+ *
+ * The easiest way to use it is with the `useWebsite` hook defined in
+ * this file, like so:
+ *
+ * ```ts
+ * import { useWebsite } from '../context/Website'
+ *
+ * const website = useWebsite()
+ * ```
+ **/
+const WebsiteContext = React.createContext<Website | null>(null)
+export default WebsiteContext
+
+/**
+ * A Utility hook for accessing the website context.
+ *
+ * This ensures that we're only reading from the context in a setting
+ * where the component has an ancestor component setting the value.
+ *
+ * Additionally, this simplifies the typing of the context value, since
+ * we have a nice run-time guard against a null value we can safely type
+ * the return value as `Website`, instead of `Website | null`.
+ **/
+export function useWebsite(): Website {
+  const website = useContext(WebsiteContext)
+  if (website === null) {
+    throw new Error("useTodoContext must be within TodoProvider")
+  }
+
+  return website
+}

--- a/static/js/lib/site_content.test.ts
+++ b/static/js/lib/site_content.test.ts
@@ -4,6 +4,7 @@ import MarkdownEditor from "../components/widgets/MarkdownEditor"
 import FileUploadField from "../components/widgets/FileUploadField"
 import SelectField from "../components/widgets/SelectField"
 import BooleanField from "../components/widgets/BooleanField"
+import RelationField from "../components/widgets/RelationField"
 
 import {
   makeWebsiteConfigField,
@@ -193,7 +194,8 @@ describe("site_content", () => {
         [WidgetVariant.Boolean, false],
         [WidgetVariant.Text, ""],
         [WidgetVariant.String, ""],
-        [WidgetVariant.Select, ""]
+        [WidgetVariant.Select, ""],
+        [WidgetVariant.Relation, ""]
       ].forEach(([widget, expectation]) => {
         const field = makeWebsiteConfigField({
           widget,
@@ -207,6 +209,15 @@ describe("site_content", () => {
     it("should use appropriate default for multiple select widget", () => {
       const field = makeWebsiteConfigField({
         widget:   WidgetVariant.Select,
+        multiple: true,
+        label:    "Widget"
+      })
+      expect(newInitialValues([field])).toStrictEqual({ widget: [] })
+    })
+
+    it("should use appropriate default for multiple relation", () => {
+      const field = makeWebsiteConfigField({
+        widget:   WidgetVariant.Relation,
         multiple: true,
         label:    "Widget"
       })
@@ -247,7 +258,8 @@ describe("site_content", () => {
         [WidgetVariant.Boolean, BooleanField],
         [WidgetVariant.Markdown, MarkdownEditor],
         [WidgetVariant.Text, "textarea"],
-        [WidgetVariant.Hidden, null]
+        [WidgetVariant.Hidden, null],
+        [WidgetVariant.Relation, RelationField]
       ].forEach(([widget, expected]) => {
         const field = makeWebsiteConfigField({
           widget: widget as WidgetVariant
@@ -281,6 +293,24 @@ describe("site_content", () => {
         multiple: true,
         max:      30,
         min:      22
+      })
+    })
+
+    it("should grab relation props for the relation widget", () => {
+      const field = makeWebsiteConfigField({
+        widget:        WidgetVariant.Relation,
+        collection:    "greatcollection",
+        display_field: "the field to display!",
+        max:           30,
+        min:           22,
+        multiple:      true
+      })
+      expect(widgetExtraProps(field)).toStrictEqual({
+        collection:    "greatcollection",
+        display_field: "the field to display!",
+        max:           30,
+        min:           22,
+        multiple:      true
       })
     })
 

--- a/static/js/lib/site_content.ts
+++ b/static/js/lib/site_content.ts
@@ -5,6 +5,7 @@ import MarkdownEditor from "../components/widgets/MarkdownEditor"
 import FileUploadField from "../components/widgets/FileUploadField"
 import SelectField from "../components/widgets/SelectField"
 import BooleanField from "../components/widgets/BooleanField"
+import RelationField from "../components/widgets/RelationField"
 
 import { objectToFormData } from "./util"
 import {
@@ -16,6 +17,8 @@ import {
   ConfigField,
   EditableConfigItem,
   TopLevelConfigItem,
+  RepeatableConfigItem,
+  SingletonConfigItem,
   WebsiteContent,
   WidgetVariant
 } from "../types/websites"
@@ -41,12 +44,22 @@ export const componentFromWidget = (
     return "textarea"
   case WidgetVariant.Hidden:
     return null
+  case WidgetVariant.Relation:
+    return RelationField
   default:
     return "input"
   }
 }
 
 const SELECT_EXTRA_PROPS = ["options", "multiple", "max", "min"]
+
+const RELATION_EXTRA_PROPS = [
+  "collection",
+  "display_field",
+  "max",
+  "min",
+  "multiple"
+]
 
 /**
  * Returns extra props that should be provided to the `Field`
@@ -58,6 +71,8 @@ export function widgetExtraProps(field: ConfigField): Record<string, any> {
     return pick(SELECT_EXTRA_PROPS, field)
   case WidgetVariant.Markdown:
     return { minimal: field.minimal ?? false }
+  case WidgetVariant.Relation:
+    return pick(RELATION_EXTRA_PROPS, field)
   default:
     return {}
   }
@@ -103,11 +118,11 @@ const emptyValue = (field: ConfigField): SiteFormValue => {
 
 export const isRepeatableCollectionItem = (
   configItem: TopLevelConfigItem
-): boolean => "folder" in configItem
+): configItem is RepeatableConfigItem => "folder" in configItem
 
 export const isSingletonCollectionItem = (
   configItem: EditableConfigItem
-): boolean => "file" in configItem
+): configItem is SingletonConfigItem => "file" in configItem
 
 /**
  * Translates page content form values into a payload that our REST API understands.
@@ -202,6 +217,7 @@ const defaultForField = (field: ConfigField): SiteFormValue => {
   switch (field.widget) {
   case WidgetVariant.Boolean:
     return false
+  case WidgetVariant.Relation:
   case WidgetVariant.Select:
     return field.multiple ? [] : ""
   case WidgetVariant.File:

--- a/static/js/query-configs/websites.ts
+++ b/static/js/query-configs/websites.ts
@@ -34,7 +34,8 @@ interface PaginatedResponse<Item> {
   previous: string | null
   results: Item[]
 }
-type WebsiteDetails = Record<string, Website>
+
+export type WebsiteDetails = Record<string, Website>
 
 export const getTransformedWebsiteName = (
   response: ActionPromiseValue<Record<string, WebsiteDetails>>
@@ -251,7 +252,16 @@ export const createWebsiteCollaboratorMutation = (
 export type WebsiteContentListingResponse = PaginatedResponse<
   WebsiteContentListItem
 >
-type WebsiteContentListing = Record<string, string[]> // website name mapped to list of text IDs
+export type WebsiteContentListing = Record<
+  string,
+  {
+    results: string[]
+    count: number | null
+    next: string | null
+    previous: string | null
+  }
+>
+
 export const contentListingKey = (
   listingParams: ContentListingParams
 ): string =>

--- a/static/js/resources/ocw-course-site-config.json
+++ b/static/js/resources/ocw-course-site-config.json
@@ -59,12 +59,44 @@
           ],
           "label": "Address",
           "name": "address",
+          "required": false,
           "widget": "object"
+        },
+        {
+          "collection": "author",
+          "display_field": "title",
+          "label": "Authors",
+          "max": 10,
+          "min": 1,
+          "multiple": true,
+          "name": "authors",
+          "required": false,
+          "widget": "relation"
         }
       ],
       "folder": "content",
       "label": "Page",
       "name": "page"
+    },
+    {
+      "category": "Content",
+      "fields": [
+        {
+          "label": "Name",
+          "name": "title",
+          "required": true,
+          "widget": "string"
+        },
+        {
+          "label": "Profession",
+          "name": "profession",
+          "required": false,
+          "widget": "string"
+        }
+      ],
+      "folder": "content",
+      "label": "Author",
+      "name": "author"
     },
     {
       "category": "Content",

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -11,7 +11,8 @@ export enum WidgetVariant {
   String = "string",
   Select = "select",
   Hidden = "hidden",
-  Object = "object"
+  Object = "object",
+  Relation = "relation"
 }
 
 export interface FieldValueCondition {
@@ -23,6 +24,11 @@ export interface FieldValueCondition {
  * A configuration for a field for site content. This type basically
  * contains the information needed to render the field in the UI, to edit it,
  * validate it, etc.
+ *
+ * TODO: this is getting a bit much, can we declare a ConfigFieldBaseProps interface
+ * and then declare variants, with their WidgetVariant set properly, that set exactly
+ * which props they have? Then ConfigField could be a union of these types - might get
+ * better typechecking that having all these optional properties.
  **/
 export interface ConfigField {
   name: string
@@ -39,6 +45,8 @@ export interface ConfigField {
   condition?: FieldValueCondition
   fields?: ConfigField[]
   collapsed?: boolean
+  collection?: string
+  display_field?: string // eslint-disable-line camelcase
 }
 
 export interface BaseConfigItem {

--- a/websites/config_schema/site-config-schema.yml
+++ b/websites/config_schema/site-config-schema.yml
@@ -16,7 +16,7 @@ inner_content_item:
     file: str(required=False)
 ---
 field:
-    widget: enum('string', 'text', 'markdown', 'file', 'select', 'boolean', 'hidden', 'object')
+    widget: enum('string', 'text', 'markdown', 'file', 'select', 'boolean', 'hidden', 'object', 'relation')
     label: str()
     name: str()
     minimal: bool(required=False)
@@ -29,6 +29,8 @@ field:
     options: list(str(), required=False)
     default: any(required=False)
     condition: include('field_condition', required=False)
+    display_field: str(required=False)
+    collection: str(required=False)
 ---
 field_condition:
     field: str()


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #241 

#### What's this PR do?

This PR adds a new 'relation' field which can capture a relationship between one piece of content and one or more others. It is basically a wrapper around our existing `SelectField` component which hits the APIs for website content in order to get the possible values that can be selected.

#### How should this be manually tested?

the site override yaml file now has a collection called 'authors' and a relation field from 'post' called 'author.' So you should be able to add an author, and then set an author on a post. The validation for the field should work just like a normal select field, including min and max values and whatnot.

If you save it and then re-open it everything should work as you expect.

#### Screenshots (if appropriate)

<img width="816" alt="Screen Shot 2021-05-11 at 12 50 38 PM" src="https://user-images.githubusercontent.com/6207644/117875980-ce2bf280-b270-11eb-9a3e-25c312ef9c9e.png">
<img width="759" alt="Screen Shot 2021-05-11 at 12 50 48 PM" src="https://user-images.githubusercontent.com/6207644/117875984-cec48900-b270-11eb-811a-b436faaabc65.png">
