### PR TITLE
split ConfigField type into specific sub-types

### DIFF
--- a/static/js/components/forms/validation.test.ts
+++ b/static/js/components/forms/validation.test.ts
@@ -3,7 +3,14 @@ import { getContentSchema } from "./validation"
 
 import { makeWebsiteConfigField } from "../../util/factories/websites"
 
-import { ConfigItem, WidgetVariant } from "../../types/websites"
+import {
+  ConfigItem,
+  FileConfigField,
+  MarkdownConfigField,
+  StringConfigField,
+  TextConfigField,
+  WidgetVariant
+} from "../../types/websites"
 
 describe("form validation util", () => {
   const yupFileFieldSchema = yup.mixed()
@@ -58,7 +65,11 @@ describe("form validation util", () => {
             ...partialField,
             widget:   widget as WidgetVariant,
             required: true
-          }
+          } as
+            | StringConfigField
+            | TextConfigField
+            | MarkdownConfigField
+            | FileConfigField
         ]
       }
       const schema = getContentSchema(configItem)

--- a/static/js/components/forms/validation.ts
+++ b/static/js/components/forms/validation.ts
@@ -60,7 +60,7 @@ export const getFieldSchema = (field: ConfigField): Schema => {
       .object()
       .shape(
         Object.fromEntries(
-            field.fields!.map(field => [field.name, getFieldSchema(field)])
+          field.fields.map(field => [field.name, getFieldSchema(field)])
         )
       )
     break

--- a/static/js/components/widgets/ObjectField.test.tsx
+++ b/static/js/components/widgets/ObjectField.test.tsx
@@ -4,10 +4,10 @@ import { shallow } from "enzyme"
 import ObjectField from "./ObjectField"
 import { makeWebsiteConfigField } from "../../util/factories/websites"
 
-import { ConfigField, WidgetVariant } from "../../types/websites"
+import { ObjectConfigField, WidgetVariant } from "../../types/websites"
 
 describe("ObjectField", () => {
-  let setFieldValueStub: any, render: any, field: ConfigField
+  let setFieldValueStub: any, render: any, field: ObjectConfigField
 
   beforeEach(() => {
     setFieldValueStub = jest.fn()
@@ -26,7 +26,7 @@ describe("ObjectField", () => {
           label:    "myselect"
         })
       ]
-    })
+    }) as ObjectConfigField
 
     render = (props = {}) =>
       shallow(

--- a/static/js/components/widgets/ObjectField.tsx
+++ b/static/js/components/widgets/ObjectField.tsx
@@ -2,10 +2,10 @@ import React, { useState, useCallback } from "react"
 
 import SiteContentField from "../forms/SiteContentField"
 
-import { ConfigField } from "../../types/websites"
+import { ConfigField, ObjectConfigField } from "../../types/websites"
 
 interface Props {
-  field: ConfigField
+  field: ObjectConfigField
   setFieldValue: (key: string, value: File | null) => void
 }
 

--- a/static/js/components/widgets/RelationField.test.tsx
+++ b/static/js/components/widgets/RelationField.test.tsx
@@ -40,8 +40,6 @@ describe("RelationField", () => {
         display_field: "title",
         name:          "relation_field",
         multiple:      true,
-        max:           10,
-        min:           1,
         onChange
       }
     )
@@ -115,14 +113,5 @@ describe("RelationField", () => {
   it("should pass the onChange handler down to the SelectField", async () => {
     const { wrapper } = await render()
     expect(wrapper.find("SelectField").prop("onChange")).toBe(onChange)
-  })
-
-  it("should pass max and min to SelectField", async () => {
-    const { wrapper } = await render({
-      max: 10,
-      min: 5
-    })
-    expect(wrapper.find("SelectField").prop("max")).toBe(10)
-    expect(wrapper.find("SelectField").prop("min")).toBe(5)
   })
 })

--- a/static/js/components/widgets/RelationField.tsx
+++ b/static/js/components/widgets/RelationField.tsx
@@ -15,8 +15,6 @@ interface Props {
   name: string
   collection: string
   display_field: string // eslint-disable-line camelcase
-  max: number
-  min: number
   multiple: boolean
   onChange: (event: Event) => void
   value: any
@@ -29,9 +27,7 @@ export default function RelationField(props: Props): JSX.Element {
     name,
     multiple,
     onChange,
-    value,
-    max,
-    min
+    value
   } = props
 
   const [offset, setOffset] = useState(0)
@@ -85,8 +81,6 @@ export default function RelationField(props: Props): JSX.Element {
       onChange={onChange}
       options={options}
       multiple={multiple}
-      max={max}
-      min={min}
     />
   )
 }

--- a/static/js/components/widgets/SelectField.tsx
+++ b/static/js/components/widgets/SelectField.tsx
@@ -12,14 +12,12 @@ interface Props {
   value: any
   onChange: (event: Event) => void
   multiple?: boolean
-  min?: number
-  max?: number
   options: Array<string | Option>
 }
 
 export default function SelectField(props: Props): JSX.Element {
   const { value, onChange, name, options } = props
-  const multiple = Boolean(props.multiple)
+  const multiple = props.multiple ?? false
   const selectOptions = options.map((option: any) =>
     is(String, option) ? { label: option, value: option } : option
   )
@@ -61,7 +59,7 @@ export default function SelectField(props: Props): JSX.Element {
   return (
     <Select
       value={selected}
-      isMulti={Boolean(multiple)}
+      isMulti={multiple}
       onChange={changeHandler}
       options={selectOptions}
     />

--- a/static/js/lib/site_content.test.ts
+++ b/static/js/lib/site_content.test.ts
@@ -29,6 +29,7 @@ import { isIf, shouldIf } from "../test_util"
 import {
   ConfigField,
   FieldValueCondition,
+  ObjectConfigField,
   WidgetVariant
 } from "../types/websites"
 
@@ -413,9 +414,10 @@ describe("site_content", () => {
           })
         ]
       })
+
       expect(
-        renameNestedFields([field])[0].fields!.map(
-          (field: ConfigField) => field.name
+        (renameNestedFields([field])[0] as ObjectConfigField).fields.map(
+          field => field.name
         )
       ).toEqual(["myobject.mystring", "myobject.myselect"])
     })

--- a/static/js/lib/site_content.ts
+++ b/static/js/lib/site_content.ts
@@ -203,7 +203,7 @@ export const newInitialValues = (fields: ConfigField[]): SiteFormValues =>
     fields.map((field: ConfigField) => [
       field.name,
       field.widget === WidgetVariant.Object ?
-        newInitialValues(field.fields!) :
+        newInitialValues(field.fields) :
         field.default ?? defaultForField(field)
     ])
   )
@@ -224,15 +224,15 @@ const defaultForField = (field: ConfigField): SiteFormValue => {
     return null
   case WidgetVariant.Object:
     return Object.fromEntries(
-        field.fields!.map(field => [
-          field.name,
+      field.fields.map(field => [
+        field.name,
           // the `as` is fully justified here: we don't want to allow
           // doubly-nested fields (for now!) so calling `defaultFor` on a
           // nested field *should* only return SiteFormPrimitive (i.e. boolean,
           // string, etc) and *not* another nested
           // Record<string, SiteFormPrimitive>
           defaultForField(field) as SiteFormPrimitive
-        ])
+      ])
     )
   default:
     return ""
@@ -273,7 +273,7 @@ export const fieldIsVisible = (
  * to rename the `name` property on the `zip_code` field from `"zip_code"` to
  * `"address.zip_code"`.
  *
- * This function takes an `Array<ConfigField[]>` and returns a new
+ * This function takes an `Array<ConfigField>` and returns a new
  * `Array<ConfigField>` where all such nested fields have been appropriately
  * renamed so they can be passed down to Formik.
  **/

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -21,33 +21,82 @@ export interface FieldValueCondition {
 }
 
 /**
+ * A configuration for a field for site content.This is a 'base' interface
+ * which the actual interfaces for each type of field extend.
+ **/
+interface ConfigFieldBaseProps {
+  name: string
+  label: string
+  required?: boolean
+  help?: string
+  default?: any
+  widget: WidgetVariant
+  condition?: FieldValueCondition
+}
+
+export interface MarkdownConfigField extends ConfigFieldBaseProps {
+  widget: WidgetVariant.Markdown
+  minimal?: boolean
+}
+
+export interface FileConfigField extends ConfigFieldBaseProps {
+  widget: WidgetVariant.File
+}
+
+export interface BooleanConfigField extends ConfigFieldBaseProps {
+  widget: WidgetVariant.Boolean
+}
+
+export interface TextConfigField extends ConfigFieldBaseProps {
+  widget: WidgetVariant.Text
+}
+
+export interface StringConfigField extends ConfigFieldBaseProps {
+  widget: WidgetVariant.String
+}
+
+export interface HiddenConfigField extends ConfigFieldBaseProps {
+  widget: WidgetVariant.Hidden
+}
+
+export interface SelectConfigField extends ConfigFieldBaseProps {
+  widget: WidgetVariant.Select
+  options: string[]
+  multiple?: boolean
+  min?: number
+  max?: number
+}
+
+export interface ObjectConfigField extends ConfigFieldBaseProps {
+  widget: WidgetVariant.Object
+  fields: ConfigField[]
+  collapsed?: boolean
+}
+
+export interface RelationConfigField extends ConfigFieldBaseProps {
+  widget: WidgetVariant.Relation
+  collection: string
+  display_field: string // eslint-disable-line camelcase
+  multiple?: boolean
+  min?: number
+  max?: number
+}
+
+/**
  * A configuration for a field for site content. This type basically
  * contains the information needed to render the field in the UI, to edit it,
  * validate it, etc.
- *
- * TODO: this is getting a bit much, can we declare a ConfigFieldBaseProps interface
- * and then declare variants, with their WidgetVariant set properly, that set exactly
- * which props they have? Then ConfigField could be a union of these types - might get
- * better typechecking that having all these optional properties.
  **/
-export interface ConfigField {
-  name: string
-  label: string
-  widget: WidgetVariant
-  minimal?: boolean
-  help?: string
-  required?: boolean
-  default?: any
-  min?: number
-  max?: number
-  options?: string[]
-  multiple?: boolean
-  condition?: FieldValueCondition
-  fields?: ConfigField[]
-  collapsed?: boolean
-  collection?: string
-  display_field?: string // eslint-disable-line camelcase
-}
+export type ConfigField =
+  | MarkdownConfigField
+  | FileConfigField
+  | BooleanConfigField
+  | TextConfigField
+  | StringConfigField
+  | HiddenConfigField
+  | SelectConfigField
+  | ObjectConfigField
+  | RelationConfigField
 
 export interface BaseConfigItem {
   name: string

--- a/static/js/util/factories/websites.ts
+++ b/static/js/util/factories/websites.ts
@@ -53,7 +53,7 @@ export const makeWebsiteConfigField = (
   }
 }
 
-const exampleFields = [
+const exampleFields: ConfigField[] = [
   {
     label:  "Title",
     name:   "title",


### PR DESCRIPTION
#### What are the relevant tickets?

closes #278 

#### What's this PR do?

just a typing change, basically creating a `MarkdownConfigField`, `BooleanConfigField`, etc so we can record in the typesystem when various properties should be present on the configuration for a field.

`ConfigField` is redefined to be a union of all these particular types, and some edits are made to introduce the specific types into the codebase where it's possible to be more specific than `ConfigField` (e.g. we pass `field: ObjectConfigField` into the `ObjectField` component).

#### How should this be manually tested?

Exercise the code related to editing and creating site content (and validation and whatnot) and make sure there are no regressions.