### PR TITLE
import metadata and config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ webpack-stats.json
 celerybeat-schedule
 
 # Local dev
+.vscode
 /localdev/starters/**
 !/localdev/starters/example-starter
 !/localdev/starters/README.md

--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -175,7 +175,10 @@ def convert_json_to_resource(filepath="", data="", website=None, **kwargs):
 
 def convert_toml_to_resource(filepath="", data="", website=None, **kwargs):
     return save_resource(
-        filepath=filepath, extension="toml", data=str(toml.loads(data)), website=website
+        filepath=filepath,
+        extension="toml",
+        data=json.dumps(toml.loads(data)),
+        website=website,
     )
 
 

--- a/ocw_import/api_test.py
+++ b/ocw_import/api_test.py
@@ -39,7 +39,7 @@ def test_import_ocw2hugo_course(settings):
             json.load(infile), sort_keys=True
         )
     assert WebsiteContent.objects.filter(type=CONTENT_TYPE_PAGE).count() == 6
-    assert WebsiteContent.objects.filter(type=CONTENT_TYPE_RESOURCE).count() == 3
+    assert WebsiteContent.objects.filter(type=CONTENT_TYPE_RESOURCE).count() == 4
 
     home_page = WebsiteContent.objects.get(
         website=website, metadata__layout="course_home"

--- a/ocw_import/tasks_test.py
+++ b/ocw_import/tasks_test.py
@@ -11,7 +11,16 @@ from ocw_import.tasks import import_ocw2hugo_course_paths, import_ocw2hugo_cours
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "paths", [["1-050-mechanical-engineering", "3-34-transportation-systems"], [], None]
+    "paths",
+    [
+        [
+            "1-050-mechanical-engineering",
+            "3-34-transportation-systems",
+            "7-00-covid-19-sars-cov-2-and-the-pandemic",
+        ],
+        [],
+        None,
+    ],
 )
 def test_import_ocw2hugo_course_paths(mocker, paths, course_starter):
     """ mock_import_course should be called from task with correct kwargs """
@@ -32,7 +41,7 @@ def test_import_ocw2hugo_course_paths(mocker, paths, course_starter):
 @mock_s3
 @pytest.mark.parametrize(
     "chunk_size, filter_str, limit, call_count",
-    [[1, None, None, 3], [1, "1-050", None, 1], [2, None, None, 2], [1, None, 1, 1]],
+    [[1, None, None, 4], [1, "1-050", None, 1], [2, None, None, 2], [1, None, 1, 1]],
 )
 def test_import_ocw2hugo_courses(
     settings, mocked_celery, mocker, filter_str, chunk_size, limit, call_count

--- a/requirements.in
+++ b/requirements.in
@@ -25,6 +25,7 @@ requests
 sentry-sdk
 social-auth-core
 social-auth-app-django
+toml
 uwsgi
 pyyaml
 yamale

--- a/requirements.txt
+++ b/requirements.txt
@@ -242,6 +242,8 @@ soupsieve==2.1
     # via beautifulsoup4
 sqlparse==0.3.1
     # via django
+toml==0.10.2
+    # via -r requirements.in
 toolz==0.9.0
     # via mitol-django-mail
 traitlets==4.3.3

--- a/test_hugo2ocw/output/7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020/config/_default/menus.toml
+++ b/test_hugo2ocw/output/7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020/config/_default/menus.toml
@@ -1,0 +1,4 @@
+[[leftnav]]
+	name = "Online Publication"
+	url = "https://biology.mit.edu/undergraduate/current-students/subject-offerings/covid-19-sars-cov-2-and-the-pandemic/"
+	weight = 1000

--- a/test_hugo2ocw/output/7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020/content/_index.md
+++ b/test_hugo2ocw/output/7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020/content/_index.md
@@ -1,0 +1,13 @@
+---
+uid: 30dc860dd5231f0f6577ee871e435fcc
+title: ''
+type: course
+layout: course_home
+course_id: 7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020
+other_versions: []
+---
+During Fall 2020, all MIT students and the general public were welcomed to join Professors Richard Young and Facundo Batista as they discussed the science of the pandemic during this new class. The livestream of the lectures was available to the public, but only registered students were able to ask questions during the Q&A. 
+
+Special guest speakers included: Drs. Anthony Fauci, David Baltimore, James Bradner, Victoria Clark, Kizzmekia Corbett, Britt Glaunsinger, Akiko Iwasaki, Eric Lander, Michael Mina, Michel Nussenzweig, Shiv Pillai, Arlene Sharpe, Skip Virgin, and Bruce Walker.
+
+NOTE: This class ran from September 1, 2020 through December 8, 2020.

--- a/test_hugo2ocw/output/7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020/content/sections/calendar.md
+++ b/test_hugo2ocw/output/7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020/content/sections/calendar.md
@@ -1,0 +1,31 @@
+---
+uid: 2c792bd745905d336e5077b0ae1237e1
+title: Calendar
+course_id: 7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020
+type: course
+layout: course_section
+menu:
+  leftnav:
+    identifier: 2c792bd745905d336e5077b0ae1237e1
+    name: Calendar
+    weight: 20
+---
+
+Note: The guest speakers are among the leading scientists in diverse areas relevant to COVID-19. Some of these scientists are employed by biopharmaceutical companies; the selection of these speakers is not meant as an endorsement of these companies or their products. 
+
+| lec # | TOPIC & DaTE | SPEAKER |
+| --- | --- | --- |
+| 1 |  {{< br >}}{{< br >}} [COVID-19 and the Pandemic](https://www.youtube.com/watch?v=XbIfFY_fJ_s&feature=emb_imp_woyt) {{< br >}}{{< br >}} 9/1/2020 {{< br >}}{{< br >}}  | Dr. Bruce D. Walker of the Ragon Institute of MGH, MIT and Harvard |
+| 2 |  {{< br >}}{{< br >}} [Coronavirus Biology](https://www.youtube.com/watch?v=r2mOU2qOCYs&feature=emb_imp_woyt) {{< br >}}{{< br >}} 9/8/2020 {{< br >}}{{< br >}}  | Dr. Britt Glaunsinger ﻿of the University of California, Berkeley  |
+| 3 |  {{< br >}}{{< br >}} [Virology and Lessons from the AIDS Pandemic](https://www.youtube.com/watch?v=0tfYTx5C4Es&feature=emb_imp_woyt) {{< br >}}{{< br >}} 9/15/2020 {{< br >}}{{< br >}}  | Dr. David Baltimore of Caltech |
+| 4 |  {{< br >}}{{< br >}} [Insights from the COVID-19 Pandemic](https://www.youtube.com/watch?v=J38QN1vnSO0&feature=emb_imp_woyt) {{< br >}}{{< br >}} 9/22/2020 {{< br >}}{{< br >}}  | Dr. Anthony Fauci, Director of the National Institute of Allergy and Infectious Diseases (NIAID) |
+| 5 |  {{< br >}}{{< br >}} [Viral Immunology](https://www.youtube.com/watch?v=2xdOHvADDdI&feature=emb_imp_woyt) {{< br >}}{{< br >}} 9/29/2020 {{< br >}}{{< br >}}  | Dr. Michel Nussenzweig of The Rockefeller University |
+| 6 |  {{< br >}}{{< br >}} [Target Cells and the Innate Response](https://www.youtube.com/watch?v=2mL_cOckhzg&feature=emb_imp_woyt) {{< br >}}{{< br >}} 10/6/2020 {{< br >}}{{< br >}}  | Dr. Shiv Pillai of the Ragon Institute and MGH |
+| 7 |  {{< br >}}{{< br >}} [The Patient](https://www.youtube.com/watch?v=SUMOipm3kAg&feature=emb_imp_woyt) {{< br >}}{{< br >}} 10/20/2020 {{< br >}}{{< br >}}  | Dr. Victoria Clark of Whitehead Institute and MGH |
+| 8 |  {{< br >}}{{< br >}} [Epidemiology](https://www.youtube.com/watch?v=tAHIAd2Cvmo&feature=emb_imp_woyt) {{< br >}}{{< br >}} 10/27/2020 {{< br >}}{{< br >}}  | Dr. Michael Mina of the Harvard T. H. Chan School of Public Health |
+| 9 |  {{< br >}}{{< br >}} [Immunology: T Cells](https://www.youtube.com/watch?v=1FVAFy6qruY&feature=emb_imp_woyt) {{< br >}}{{< br >}} 11/3/2020 {{< br >}}{{< br >}}  | Dr. Arlene Sharpe of Harvard Medical School |
+| 10 |  {{< br >}}{{< br >}} [Vaccines](https://www.youtube.com/watch?v=xpqfdr9FPWM&feature=emb_imp_woyt) {{< br >}}{{< br >}} 11/10/2020 {{< br >}}{{< br >}}  | Dr. Kizzmekia Corbett of the National Institutes of Health |
+| 11 |  {{< br >}}{{< br >}} [Immunology: Antibodies](https://www.youtube.com/watch?v=UXEEonb7MGM&feature=emb_imp_woyt) {{< br >}}{{< br >}} 11/17/2020 {{< br >}}{{< br >}}  | Dr. Akiko Iwasaki of Yale Medical School |
+| 12 |  {{< br >}}{{< br >}} [Small Molecule Therapeutics](https://www.youtube.com/watch?v=2B0BXowfnzo&feature=emb_imp_woyt) {{< br >}}{{< br >}} 11/24/2020 {{< br >}}{{< br >}}  | Dr. James Bradner of the Novartis Institutes for BioMedical Research (NIBR) |
+| 13 |  {{< br >}}{{< br >}} [Therapeutics Discovery](https://www.youtube.com/watch?v=f0110oTQZD8&feature=emb_imp_woyt) {{< br >}}{{< br >}} 12/1/2020 {{< br >}}{{< br >}}  | Dr. Skip Virgin of Vir Biotechnology |
+| 14 |  {{< br >}}{{< br >}} [Rapid Research Response in a Pandemic](https://www.youtube.com/watch?v=HLkuchTScn8&feature=emb_imp_woyt) {{< br >}}{{< br >}} 12/6/2020 {{< br >}}{{< br >}}  | Dr. Eric Lander of the Broad Institute of MIT and Harvard

--- a/test_hugo2ocw/output/7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020/content/sections/onlinecourse.md
+++ b/test_hugo2ocw/output/7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020/content/sections/onlinecourse.md
@@ -1,0 +1,12 @@
+---
+uid: b6c8c090d7079126837f7dda4af627c7
+title: Syllabus
+course_id: 7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020
+type: course
+layout: course_section
+menu:
+  leftnav:
+    identifier: b6c8c090d7079126837f7dda4af627c7
+    name: Syllabus
+    weight: 10
+---

--- a/test_hugo2ocw/output/7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020/data/course.json
+++ b/test_hugo2ocw/output/7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020/data/course.json
@@ -1,0 +1,60 @@
+{
+  "course_id": "7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020",
+  "course_title": "COVID-19, SARS-CoV-2 and the Pandemic",
+  "course_image_url": "https://open-learning-course-data-production.s3.amazonaws.com/7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020/17497d485988c885f44fbbdfce060462_7-00F20.gif",
+  "course_thumbnail_image_url": "https://open-learning-course-data-production.s3.amazonaws.com/7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020/d85ffdac5f559f92bed8a039d66ea340_7-00F20-th.gif",
+  "course_image_alternate_text": "Graphic of world map with COVID image overlay",
+  "course_image_caption_text": "<p>COVID-19 is a worldwide pandemic. (Image courtesy MIT Department of Biology.)</p>",
+  "publishdate": "2020-09-10T15:53:03-04:00",
+  "instructors": [
+    {
+      "instructor": "MIT Department of Biology ",
+      "url": "/search/?q=%22MIT%20Department%20of%20Biology%20%22"
+    }
+  ],
+  "departments": [
+    {
+      "department": "Biology",
+      "url": "/search/?d=Biology"
+    }
+  ],
+  "course_features": [],
+  "topics": [
+    {
+      "topic": "Science",
+      "subtopics": [
+        {
+          "subtopic": "Biology",
+          "specialities": [
+            {
+              "speciality": "Cell Biology",
+              "url": "/search/?t=Cell%20Biology"
+            },
+            {
+              "speciality": "Microbiology",
+              "url": "/search/?t=Microbiology"
+            },
+            {
+              "speciality": "Molecular Biology",
+              "url": "/search/?t=Molecular%20Biology"
+            },
+            {
+              "speciality": "Virology",
+              "url": "/search/?t=Virology"
+            }
+          ],
+          "url": "/search/?t=Biology"
+        }
+      ],
+      "url": "/search/?t=Science"
+    }
+  ],
+  "course_numbers": [
+    "7.00"
+  ],
+  "term": "Fall 2020",
+  "level": {
+    "level": "Undergraduate",
+    "url": "/search/?l=Undergraduate"
+  }
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/281

#### What's this PR do?
Previously, the `ocw_import/api.py` functions used to import `ocw-to-hugo` data into `ocw-studio` were only set up to import `.md` files from the course data.  In order to publish content compatible with `ocw-hugo-themes`'s `course` theme, we need to output some other metadata files such as the `course.json` data template and any `menus.toml` config files.  This PR refactors the import code a bit and adds support for importing any `.json` or `.toml` files as resources as `WebsiteContent` objects.

#### How should this be manually tested?
 - Read the readme and ensure you are set up to pull course data from S3
 - Ensure your docker containers are properly built
 - Run `docker-compose run web ./manage.py import_ocw_course_sites -b ocw-to-hugo-output-qa --limit 30`
 - Go to Django admin (or a shell) and verify that each course `Website` has a `course.json` `WebsiteContent` object created
 - Run `docker-compose run web ./manage.py import_ocw_course_sites -b ocw-to-hugo-output-qa --filter 7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020`
 - Go to Django admin (or a shell) and verify that the `7-00-covid-19-sars-cov-2-and-the-pandemic-fall-2020` course has a `menus.toml` file imported
