### PR TITLE
Remove (transaction=true) from @pytest.mark.django_db in a test

### DIFF
--- a/websites/api_test.py
+++ b/websites/api_test.py
@@ -6,7 +6,7 @@ from websites.api import get_valid_new_filename
 from websites.factories import WebsiteContentFactory, WebsiteFactory
 
 
-@pytest.mark.django_db(transaction=True)
+@pytest.mark.django_db
 @pytest.mark.parametrize(
     "existing_filenames,exp_result_filename",
     [


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #284 

#### What's this PR do?
Removes an unnecessary `transaction=true` kwarg being sent to `@pytest.mark.django_db` in a test.

#### How should this be manually tested?
Delete your old test database.  Run `docker-compose run web pytest websites` at least twice, all tests should pass on every run.
