### PR TITLE
Update publish_date when published

### DIFF
--- a/websites/views.py
+++ b/websites/views.py
@@ -134,7 +134,10 @@ class WebsiteViewSet(
     def publish(self, request, name=None):
         """Trigger a publish task for the website"""
         try:
-            publish_website(self.get_object())
+            website = self.get_object()
+            publish_website(website)
+            website.publish_date = now_in_utc()
+            website.save()
             return Response(
                 status=200,
                 data={"details": f"Success adding a publish task for {name}"},

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -222,12 +222,15 @@ def test_websites_endpoint_publish(mocker, drf_client):
     """A user with admin permissions should be able to request a website publish"""
     mock_publish_website = mocker.patch("websites.views.publish_website")
     website = WebsiteFactory.create()
+    last_published = website.publish_date
     admin = UserFactory.create()
     admin.groups.add(website.admin_group)
     drf_client.force_login(admin)
     resp = drf_client.post(
         reverse("websites_api-publish", kwargs={"name": website.name})
     )
+    website.refresh_from_db()
+    assert website.publish_date > last_published
     assert resp.status_code == 200
     mock_publish_website.assert_called_once_with(website)
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes #287 

#### What's this PR do?
Updates the `Website.publish_date` field when a website is published.

#### How should this be manually tested?
Follow the README instructions for github integration.
Create a new site with at least 1 page, resource, or metadata.
Go to `../api/websites/<website_name>/publish` and click the POST button
Check the `publish_date` field value for that website, it should be very recent and not null.
