### PR TITLE
Added management commands for syncing sites to and from backend

### DIFF
--- a/content_sync/admin.py
+++ b/content_sync/admin.py
@@ -1,4 +1,53 @@
 """Content sync admin"""
-# from django.contrib import admin
+from django.contrib import admin
+from mitol.common.admin import TimestampedModelAdmin
 
-# Register your models here.
+from content_sync.models import ContentSyncState
+
+
+class ContentSyncStateAdmin(TimestampedModelAdmin):
+    """ContentSyncState Admin"""
+
+    model = ContentSyncState
+
+    include_created_on_in_list = True
+    search_fields = (
+        "content__text_id",
+        "content__title",
+        "content__website__name",
+        "content__website__title",
+    )
+    list_display = (
+        "get_content_title",
+        "get_content_text_id",
+        "get_website_name",
+    )
+    raw_id_fields = ("content",)
+    ordering = ("-created_on",)
+
+    def get_queryset(self, request):
+        return self.model.objects.get_queryset().select_related("content__website")
+
+    def get_content_title(self, obj):
+        """Returns the related WebsiteContent title"""
+        return obj.content.title
+
+    get_content_title.short_description = "Content Title"
+    get_content_title.admin_order_field = "content__title"
+
+    def get_content_text_id(self, obj):
+        """Returns the related WebsiteContent text ID"""
+        return obj.content.text_id
+
+    get_content_text_id.short_description = "Content Text ID"
+    get_content_text_id.admin_order_field = "content__text_id"
+
+    def get_website_name(self, obj):
+        """Returns the related Website name"""
+        return obj.content.website.name
+
+    get_website_name.short_description = "Website"
+    get_website_name.admin_order_field = "content__website__name"
+
+
+admin.site.register(ContentSyncState, ContentSyncStateAdmin)

--- a/content_sync/apis/github.py
+++ b/content_sync/apis/github.py
@@ -318,14 +318,15 @@ class GithubApiWrapper:
         # Update with the new file data only if the content isn't deleted
         if sync_state.content.deleted is None:
             tree_elements.append(InputGitTreeElement(filepath, "100644", "blob", data))
+        if sync_state.data is None:
+            return tree_elements
         # Remove the old filepath stored in the sync state data
         if (
             # If it has been deleted
             sync_state.content.deleted is not None
             or (
                 # If it doesn't match current path
-                sync_state.data
-                and sync_state.data.get(GIT_DATA_FILEPATH, None)
+                sync_state.data.get(GIT_DATA_FILEPATH, None)
                 and sync_state.data[GIT_DATA_FILEPATH] != filepath
             )
         ):

--- a/content_sync/management/commands/sync_backend_to_db.py
+++ b/content_sync/management/commands/sync_backend_to_db.py
@@ -1,0 +1,27 @@
+"""Syncs a website from a backend (Github, et al) to the database"""
+from django.core.management import BaseCommand
+
+from content_sync.api import get_sync_backend
+from websites.api import fetch_website
+
+
+class Command(BaseCommand):
+    """Syncs a website from a backend (Github, et al) to the database"""
+
+    help = __doc__
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--website",
+            dest="website",
+            help="The uuid, name, or title of the Website that should be synced.",
+            required=True,
+        )
+
+    def handle(self, *args, **options):
+        website = fetch_website(options["website"])
+        backend = get_sync_backend(website)
+        self.stdout.write(
+            f"Syncing content from backend to database for '{website.title}'..."
+        )
+        backend.sync_all_content_to_db()

--- a/content_sync/management/commands/sync_website_to_backend.py
+++ b/content_sync/management/commands/sync_website_to_backend.py
@@ -1,0 +1,45 @@
+"""Syncs a Website and all of its contents to a backend (Github, et al)"""
+from django.core.management import BaseCommand
+
+from content_sync.api import get_sync_backend
+from content_sync.models import ContentSyncState
+from websites.api import fetch_website
+
+
+class Command(BaseCommand):
+    """Syncs a Website and all of its contents to a backend (Github, et al)"""
+
+    help = __doc__
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--website",
+            dest="website",
+            help="The uuid, name, or title of the Website that should be synced.",
+            required=True,
+        )
+        parser.add_argument(
+            "--force-create",
+            dest="force_create",
+            action="store_true",
+            help=(
+                "If this flag is added, this command will attempt to create the website in the backend regardless "
+                "of whether or not our db records say that it has been synced before."
+            ),
+        )
+
+    def handle(self, *args, **options):
+        website = fetch_website(options["website"])
+        backend = get_sync_backend(website)
+        should_create = options["force_create"]
+        if not should_create:
+            should_create = not ContentSyncState.objects.filter(
+                content__website=website
+            ).exists()
+        if should_create:
+            self.stdout.write(f"Creating website in backend for '{website.title}'...")
+            backend.create_website_in_backend()
+        self.stdout.write(
+            f"Updating website content in backend for '{website.title}'..."
+        )
+        backend.sync_all_content_to_backend()

--- a/websites/api_test.py
+++ b/websites/api_test.py
@@ -1,9 +1,15 @@
 """Tests for websites API functionality"""
+from uuid import UUID
+
 import factory
 import pytest
 
-from websites.api import get_valid_new_filename
+from websites.api import fetch_website, get_valid_new_filename
 from websites.factories import WebsiteContentFactory, WebsiteFactory
+from websites.models import Website
+
+
+EXAMPLE_UUID_STR = "ae6cfe0b-37a7-4fe6-b194-5b7f1e3c349e"
 
 
 @pytest.mark.django_db
@@ -46,3 +52,58 @@ def test_websitecontent_autogen_filename_unique(
         )
         == exp_result_filename
     )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "uuid_str,filter_value",
+    [
+        [
+            "05d329fd-05ca-4770-b8b2-77ad711daca9",
+            "05d329fd-05ca-4770-b8b2-77ad711daca9",
+        ],
+        ["05d329fd-05ca-4770-b8b2-77ad711daca9", "05d329fd05ca4770b8b277ad711daca9"],
+    ],
+)
+def test_fetch_website_by_uuid(uuid_str, filter_value):
+    """fetch_website should find a website based on uuid"""
+    website = WebsiteFactory.create(uuid=UUID(uuid_str, version=4))
+    result_website = fetch_website(filter_value)
+    assert website == result_website
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "website_attrs,filter_value",
+    [
+        [{"title": "my test title"}, "my test title"],
+        [{"name": "my test name"}, "my test name"],
+        [
+            {"title": "05d329fd-05ca-4770-b8b2-77ad711daca9"},
+            "05d329fd-05ca-4770-b8b2-77ad711daca9",
+        ],
+        [
+            {"title": "abcdefg1-2345-6789-abcd-123456789abc"},
+            "abcdefg1-2345-6789-abcd-123456789abc",
+        ],
+    ],
+)
+def test_fetch_website_by_name_title(website_attrs, filter_value):
+    """fetch_website should find a website based on a name or title"""
+    website = WebsiteFactory.create(
+        uuid=UUID(EXAMPLE_UUID_STR, version=4), **website_attrs
+    )
+    result_website = fetch_website(filter_value)
+    assert website == result_website
+
+
+@pytest.mark.django_db
+def test_fetch_website_not_found():
+    """fetch_website should raise if a matching website was not found"""
+    WebsiteFactory.create(
+        uuid=UUID(EXAMPLE_UUID_STR, version=4),
+        title="my title",
+        name="my name",
+    )
+    with pytest.raises(Website.DoesNotExist):
+        fetch_website("bad values")

--- a/websites/management/commands/sync_content_state.py
+++ b/websites/management/commands/sync_content_state.py
@@ -2,6 +2,7 @@
 from django.core.management import BaseCommand
 
 from content_sync.api import upsert_content_sync_state
+from websites.api import fetch_website
 from websites.models import WebsiteContent
 
 
@@ -12,32 +13,26 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            "--website-name",
-            dest="website_name",
-            help="If provided, only update sync state for website contents for the website with that name.",
-        )
-        parser.add_argument(
-            "--website-title",
-            dest="website_title",
-            help="If provided, only update sync state for website contents for the website with that title.",
+            "--website",
+            dest="website",
+            help="If provided, only update sync states for website with a matching uuid, name, or title.",
         )
         parser.add_argument(
             "--content-title",
             dest="content_title",
-            help="If provided, only update sync state for website contents that match the given title.",
+            help="If provided, only update sync states for website contents that match the given title.",
         )
         parser.add_argument(
             "--text-id",
             dest="text_id",
-            help="If provided, only update sync state for website contents with the given text id.",
+            help="If provided, only update sync states for website contents with the given text id.",
         )
 
     def handle(self, *args, **options):
         filter_qset = {}
-        if options["website_name"]:
-            filter_qset["website__name"] = options["website_name"]
-        if options["website_title"]:
-            filter_qset["website__title"] = options["website_title"]
+        if options["website"]:
+            website = fetch_website(options["website"])
+            filter_qset["website"] = website
         if options["content_title"]:
             filter_qset["title__icontains"] = options["content_title"]
         if options["text_id"]:


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #272

#### What's this PR do?
Adds management commands for syncing sites to and from Github

#### How should this be manually tested?
- Run `manage.py sync_website_to_backend --website <your website name, uuid or title>`. Make sure it syncs the given website to Github
- Run `manage.py sync_backend_to_db --website <your website name, uuid or title>`. Make sure it re-syncs the given website on Github to the database. You can test by hard-deleting or editing `WebsiteContent` records and making sure that after the management command, the record exists and reflects the data from Github

#### Any background context you want to provide?
