### PR TITLE
add relation widget filtering

### DIFF
--- a/localdev/configs/ocw-course-site-config.yml
+++ b/localdev/configs/ocw-course-site-config.yml
@@ -17,6 +17,17 @@ collections:
         "options": [ "Design", "UX", "Dev" ],
         "widget": "select"
         }
+      - {
+        "label": "PDFs",
+        "name": "pdfs",
+        "widget": "relation",
+        "collection": "resource",
+        "display_field": "title",
+        "multiple": true,
+        "max": 10,
+        "min": 1,
+        "filter": { field: "filetype", filter_type: "equals", value: "PDF"}
+        }
       - name: address
         label: Address
         widget: object
@@ -26,25 +37,6 @@ collections:
           - { label: "City", name: "city", widget: "string", required: true }
           - { label: "State", name: "state", widget: "string", required: true }
           - { label: "Zip Code", name: "zip", widget: "string", required: true }
-      - {
-        "label": "Authors",
-        "name": "authors",
-        "widget": "relation",
-        "collection": "author",
-        "display_field": "title",
-        "multiple": true,
-        "max": 10,
-        "min": 1,
-        "required": false,
-        }
-
-  - name: author
-    label: Author
-    category: Content
-    folder: content
-    fields:
-      - {"label": "Name", "name": "title", "widget": "string", "required": true}
-      - {"label": "Profession", "name": "profession", "widget": "string", "required": false}
 
   - name: resource
     label: Resource
@@ -54,6 +46,13 @@ collections:
       - {"label": "Title", "name": "title", "widget": "string", "required": true}
       - {"label": "Description", "name": "description", "widget": "text"}
       - {"label": "File", "name": "file", "widget": "file"}
+      - {
+        "label": "File Type",
+        "required": true,
+        "name": "filetype",
+        "options": [ "PDF", "Word Doc", "PPT" ],
+        "widget": "select"
+        }
 
   - name: metadata
     label: Metadata

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
     "fmt:check": "LOG_LEVEL= prettier-eslint --list-different --no-semi --ignore $PWD/'static/js/types/*.d.ts' $PWD/'static/js/**/*.ts' $PWD/'static/js/**/*.tsx' $PWD/'static/scss/**/*.scss'",
     "typescript": "rm -rf dist && rm -f .tsbuildinfo && tsc",
     "typecheck": "tsc --noEmit",
+    "typecheck:watch": "tsc --noEmit --watch",
     "build": "webpack --config webpack.config.prod.js --bail"
   },
   "browserslist": [

--- a/static/js/lib/site_content.ts
+++ b/static/js/lib/site_content.ts
@@ -58,7 +58,8 @@ const RELATION_EXTRA_PROPS = [
   "display_field",
   "max",
   "min",
-  "multiple"
+  "multiple",
+  "filter"
 ]
 
 /**

--- a/static/js/query-configs/websites.ts
+++ b/static/js/query-configs/websites.ts
@@ -250,7 +250,7 @@ export const createWebsiteCollaboratorMutation = (
 }
 
 export type WebsiteContentListingResponse = PaginatedResponse<
-  WebsiteContentListItem
+  WebsiteContentListItem | WebsiteContent
 >
 export type WebsiteContentListing = Record<
   string,
@@ -267,11 +267,27 @@ export const contentListingKey = (
 ): string =>
   JSON.stringify([listingParams.name, listingParams.type, listingParams.offset])
 
+/**
+ * Query config for fetching the content items for a website.
+ *
+ * Pass the `requestDetailedList` param if you need to get the detailed view of
+ * all the content items, as opposed to a minimal, summary view of the items
+ * (requestDetailedList == true tells the serializer to use the
+ * WebsiteContentDetailSerializer as opposed to the WebsiteContentSerializer,
+ * the default for this view).
+ **/
 export const websiteContentListingRequest = (
-  listingParams: ContentListingParams
+  listingParams: ContentListingParams,
+  requestDetailedList = false
 ): QueryConfig => {
   const { name, type, offset } = listingParams
-  const url = siteApiContentListingUrl.param({ name }).query({ type, offset })
+  const url = siteApiContentListingUrl
+    .param({ name })
+    .query(
+      requestDetailedList ?
+        { type, offset, detailed_list: true } :
+        { type, offset }
+    )
   return {
     url:       url.toString(),
     transform: (body: WebsiteContentListingResponse) => {
@@ -387,6 +403,7 @@ export type NewWebsiteContentPayload = {
   // eslint-disable-next-line camelcase
   text_id?: string
 }
+
 export const createWebsiteContentMutation = (
   siteName: string,
   payload: NewWebsiteContentPayload

--- a/static/js/resources/ocw-course-site-config.json
+++ b/static/js/resources/ocw-course-site-config.json
@@ -31,6 +31,21 @@
           "widget": "select"
         },
         {
+          "collection": "resource",
+          "display_field": "title",
+          "filter": {
+            "field": "filetype",
+            "filter_type": "equals",
+            "value": "PDF"
+          },
+          "label": "PDFs",
+          "max": 10,
+          "min": 1,
+          "multiple": true,
+          "name": "pdfs",
+          "widget": "relation"
+        },
+        {
           "fields": [
             {
               "label": "Street Address",
@@ -61,42 +76,11 @@
           "name": "address",
           "required": false,
           "widget": "object"
-        },
-        {
-          "collection": "author",
-          "display_field": "title",
-          "label": "Authors",
-          "max": 10,
-          "min": 1,
-          "multiple": true,
-          "name": "authors",
-          "required": false,
-          "widget": "relation"
         }
       ],
       "folder": "content",
       "label": "Page",
       "name": "page"
-    },
-    {
-      "category": "Content",
-      "fields": [
-        {
-          "label": "Name",
-          "name": "title",
-          "required": true,
-          "widget": "string"
-        },
-        {
-          "label": "Profession",
-          "name": "profession",
-          "required": false,
-          "widget": "string"
-        }
-      ],
-      "folder": "content",
-      "label": "Author",
-      "name": "author"
     },
     {
       "category": "Content",
@@ -116,6 +100,17 @@
           "label": "File",
           "name": "file",
           "widget": "file"
+        },
+        {
+          "label": "File Type",
+          "name": "filetype",
+          "options": [
+            "PDF",
+            "Word Doc",
+            "PPT"
+          ],
+          "required": true,
+          "widget": "select"
         }
       ],
       "folder": "content",

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -1,4 +1,5 @@
 import { ROLE_ADMIN, ROLE_EDITOR, ROLE_GLOBAL, ROLE_OWNER } from "../constants"
+import { SiteFormValue } from "./forms"
 
 /**
  * The different widget variants supported in Site configurations
@@ -73,6 +74,16 @@ export interface ObjectConfigField extends ConfigFieldBaseProps {
   collapsed?: boolean
 }
 
+export enum RelationFilterVariant {
+  Equals = "equals"
+}
+
+export interface RelationFilter {
+  field: string
+  filter_type: RelationFilterVariant // eslint-disable-line camelcase
+  value: SiteFormValue
+}
+
 export interface RelationConfigField extends ConfigFieldBaseProps {
   widget: WidgetVariant.Relation
   collection: string
@@ -80,6 +91,7 @@ export interface RelationConfigField extends ConfigFieldBaseProps {
   multiple?: boolean
   min?: number
   max?: number
+  filter?: RelationFilter
 }
 
 /**

--- a/websites/config_schema/site-config-schema.yml
+++ b/websites/config_schema/site-config-schema.yml
@@ -31,7 +31,14 @@ field:
     condition: include('field_condition', required=False)
     display_field: str(required=False)
     collection: str(required=False)
+    filter: include('relation_filter', required=False)
 ---
 field_condition:
     field: str()
     equals: str()
+---
+relation_filter:
+    field: str()
+    filter_type: enum('equals')
+    value: any()
+

--- a/websites/views.py
+++ b/websites/views.py
@@ -292,7 +292,10 @@ class WebsiteContentViewSet(
         return queryset.order_by("-updated_on")
 
     def get_serializer_class(self):
-        if self.action == "list":
+        detailed_list = self.request.query_params.get("detailed_list", False)
+        if self.action == "list" and detailed_list:
+            return WebsiteContentDetailSerializer
+        elif self.action == "list":
             return WebsiteContentSerializer
         elif self.action == "create":
             return WebsiteContentCreateSerializer


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable
  - [x] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?

closes #289 

#### What's this PR do?

This adds optional filtering to the 'relation' widget. This can be used, for instance, to implement a file type restriction.

We will probably want to add more filter types in the future, but for now the only supported type of filter is a basic equality check. See the example course config for an example, but basically the property `filter` on the relation widget can be set to an object like this:

```ts
{
  field: "my-field",
  filter_type: "equals",
  value: "test-value"
}
```

this will filter the options show in the relation field to only those objects which have a value of `"test-value"` in `"my-field"`.

#### How should this be manually tested?

Check out the example config a bit. Ensure that you can only link from the 'page' content type to 'resources' which have the file type set to PDF.
