### PR TITLE
API endpoint for creating/updating starters from github webhooks

### DIFF
--- a/app.json
+++ b/app.json
@@ -71,6 +71,10 @@
       "description": "Google analytics tracking ID",
       "required": false
     },
+    "GITHUB_WEBHOOK_KEY": {
+      "description": "Github secret key sent by webhook requests",
+      "required": false
+    },
     "GIT_API_URL": {
       "description": "Base URL of git API",
       "required": false
@@ -204,6 +208,10 @@
     },
     "OCW_STUDIO_SECURE_SSL_REDIRECT": {
       "description": "Application-level SSL redirect setting.",
+      "required": false
+    },
+    "OCW_STUDIO_SITE_CONFIG_FILE": {
+      "description": "Standard file name for site config files",
       "required": false
     },
     "OCW_STUDIO_SITE_ID": {

--- a/content_sync/api.py
+++ b/content_sync/api.py
@@ -1,5 +1,6 @@
 """ Syncing API """
 import logging
+from typing import List, Optional
 
 from django.conf import settings
 from django.utils.module_loading import import_string
@@ -55,3 +56,11 @@ def preview_website(website: Website):
 def publish_website(website: Website):
     """ Publish the website on the backend"""
     tasks.publish_website_backend.delay(website.name)
+
+
+def sync_github_website_starters(
+    url: str, files: List[str], commit: Optional[str] = None
+):
+    """ Sync website starters from github """
+    if settings.GIT_TOKEN:
+        tasks.sync_github_site_configs.delay(url, files, commit=commit)

--- a/content_sync/api_test.py
+++ b/content_sync/api_test.py
@@ -147,3 +147,17 @@ def test_publish_website(settings, mocker):
     website = WebsiteFactory.create()
     api.publish_website(website)
     mock_task.delay.assert_called_once_with(website.name)
+
+
+@pytest.mark.parametrize("token", ["abc123", None])
+def test_sync_github_website_starters(settings, mocker, token):
+    """ Sync website starters from github """
+    settings.GIT_TOKEN = token
+    mock_task = mocker.patch("content_sync.api.tasks.sync_github_site_configs.delay")
+    args = "https://github.com/testorg/testconfigs", ["site1/studio.yaml"]
+    kwargs = {"commit": "abc123"}
+    api.sync_github_website_starters(*args, **kwargs)
+    if token:
+        mock_task.assert_called_once_with(*args, **kwargs)
+    else:
+        mock_task.assert_not_called()

--- a/content_sync/apis/github.py
+++ b/content_sync/apis/github.py
@@ -89,16 +89,16 @@ def sync_starter_configs(
     repo = org.get_repo(repo_name)
 
     for config_file in config_files:
-        git_file = repo.get_contents(config_file)
-        slug = (
-            git_file.path.split("/")[0]
-            if git_file.path != settings.OCW_STUDIO_SITE_CONFIG_FILE
-            else repo_name
-        )
-        path = "/".join([repo_url, slug])
-        unique_slug = get_valid_new_slug(slug, path)
-        raw_yaml = git_file.decoded_content
         try:
+            git_file = repo.get_contents(config_file)
+            slug = (
+                git_file.path.split("/")[0]
+                if git_file.path != settings.OCW_STUDIO_SITE_CONFIG_FILE
+                else repo_name
+            )
+            path = "/".join([repo_url, slug])
+            unique_slug = get_valid_new_slug(slug, path)
+            raw_yaml = git_file.decoded_content
             validate_raw_site_config(raw_yaml.decode("utf-8"))
             config = yaml.load(raw_yaml, Loader=yaml.Loader)
             starter, created = WebsiteStarter.objects.update_or_create(

--- a/content_sync/apis/github_test.py
+++ b/content_sync/apis/github_test.py
@@ -593,8 +593,7 @@ def test_sync_starter_configs_success_create(mocker, mock_github):
         mocker.Mock(path=config_filenames[1], decoded_content=config_content),
         mocker.Mock(path=config_filenames[2], decoded_content=config_content),
     ]
-    result = sync_starter_configs(git_url, config_filenames)
-    assert result == (config_filenames, [])
+    sync_starter_configs(git_url, config_filenames)
     for filename in config_filenames:
         expected_slug = filename.split("/")[0] if "/" in filename else "ocws-configs"
         assert WebsiteStarter.objects.filter(
@@ -626,8 +625,7 @@ def test_sync_starter_configs_success_update(mocker, mock_github):
         path=file_list[0], decoded_content=config_content
     )
 
-    result = sync_starter_configs(git_url, file_list)
-    assert result == (file_list, [])
+    sync_starter_configs(git_url, file_list)
     assert WebsiteStarter.objects.count() == starter_count
     starter.refresh_from_db()
     assert starter.name == "Site 1"
@@ -645,8 +643,7 @@ def test_sync_starter_configs_success_partial_failure(mocker, mock_github):
             path=config_filenames[1], decoded_content=b"---\nfcollections: []\nfoo: bar"
         ),
     ]
-    result = sync_starter_configs(git_url, config_filenames)
-    assert result == ([config_filenames[0]], [{config_filenames[1]: ANY}])
+    sync_starter_configs(git_url, config_filenames)
     mock_log.assert_called_once_with(
         "Invalid site config YAML found in %s", config_filenames[1]
     )

--- a/content_sync/apis/github_test.py
+++ b/content_sync/apis/github_test.py
@@ -1,8 +1,6 @@
 """ Github API tests """
 import hashlib
-import json
 from types import SimpleNamespace
-from unittest.mock import ANY
 
 import factory
 import pytest

--- a/content_sync/apis/github_test.py
+++ b/content_sync/apis/github_test.py
@@ -1,6 +1,8 @@
 """ Github API tests """
 import hashlib
+import json
 from types import SimpleNamespace
+from unittest.mock import ANY
 
 import factory
 import pytest
@@ -11,15 +13,17 @@ from content_sync.apis.github import (
     GIT_DATA_FILEPATH,
     GithubApiWrapper,
     get_destination_filepath,
+    sync_starter_configs,
 )
 from main import features
 from users.factories import UserFactory
+from websites.constants import STARTER_SOURCE_GITHUB
 from websites.factories import (
     WebsiteContentFactory,
     WebsiteFactory,
     WebsiteStarterFactory,
 )
-from websites.models import WebsiteContent
+from websites.models import WebsiteContent, WebsiteStarter
 from websites.site_config_api import ConfigItem, SiteConfig
 
 
@@ -54,6 +58,12 @@ def mock_api_wrapper(settings, mocker, db_data):
     return GithubApiWrapper(
         website=db_data.website, site_config=SiteConfig(db_data.website.starter.config)
     )
+
+
+@pytest.fixture
+def mock_github(mocker):
+    """ Return a mock Github class"""
+    return mocker.patch("content_sync.apis.github.Github")
 
 
 @pytest.fixture
@@ -567,3 +577,78 @@ def test_get_destination_filepath_errors(mocker, has_missing_name, is_bad_config
     )
     patched_log.error.assert_called_once()
     assert return_value is None
+
+
+def test_sync_starter_configs_success_create(mocker, mock_github):
+    """sync_starter_configs should successfully create new WebsiteStarter objects"""
+    config_filenames = ["site-1/ocw-studio.yaml", "site-2/ocw-studio.yaml"]
+    git_url = "https://github.com/testorg/ocws-configs"
+    config_content = b"---\ncollections: []"
+    mock_github.return_value.get_organization.return_value.get_repo.return_value.get_contents.side_effect = [
+        mocker.Mock(path=config_filenames[0], decoded_content=config_content),
+        mocker.Mock(path=config_filenames[1], decoded_content=config_content),
+    ]
+    result = sync_starter_configs(git_url, config_filenames)
+    assert result == (config_filenames, [])
+    for filename in config_filenames:
+        expected_slug = filename.split("/")[0]
+        assert WebsiteStarter.objects.filter(
+            source=STARTER_SOURCE_GITHUB,
+            path="/".join([git_url, expected_slug]),
+            slug=expected_slug,
+            name=expected_slug,
+            config={"collections": []},
+        ).exists()
+
+
+def test_sync_starter_configs_success_update(mocker, mock_github):
+    """sync_starter_configs should successfully update a WebsiteStarter object"""
+    git_url = "https://github.com/testorg/ocws-configs"
+    slug = "site-1"
+    config_content = b"---\ncollections: []"
+    file_list = [f"{slug}/ocw-studio.yaml"]
+
+    starter = WebsiteStarterFactory.create(
+        source=STARTER_SOURCE_GITHUB,
+        path=f"{git_url}/{slug}",
+        slug=slug,
+        name="Site 1",
+        config={"foo": "bar"},
+    )
+    starter_count = WebsiteStarter.objects.count()
+
+    mock_github.return_value.get_organization.return_value.get_repo.return_value.get_contents.return_value = mocker.Mock(
+        path=file_list[0], decoded_content=config_content
+    )
+
+    result = sync_starter_configs(git_url, file_list)
+    assert result == (file_list, [])
+    assert WebsiteStarter.objects.count() == starter_count
+    starter.refresh_from_db()
+    assert starter.name == "Site 1"
+    assert starter.config == {"collections": []}
+
+
+def test_sync_starter_configs_success_partial_failure(mocker, mock_github):
+    """sync_starter_configs should detect & gracefully handle an invalid config"""
+    config_filenames = ["site-1/ocw-studio.yaml", "site-2/ocw-studio.yaml"]
+    git_url = "https://github.com/testorg/ocws-configs"
+
+    mock_github.return_value.get_organization.return_value.get_repo.return_value.get_contents.side_effect = [
+        mocker.Mock(path=config_filenames[0], decoded_content=b"---\ncollections: []"),
+        mocker.Mock(
+            path=config_filenames[1], decoded_content=b"---\nfcollections: []\nfoo: bar"
+        ),
+    ]
+    result = sync_starter_configs(git_url, config_filenames)
+    assert result == ([config_filenames[0]], [{config_filenames[1]: ANY}])
+    assert WebsiteStarter.objects.filter(
+        source=STARTER_SOURCE_GITHUB,
+        path=f"{git_url}/site-1",
+        slug="site-1",
+        name="site-1",
+        config={"collections": []},
+    ).exists()
+    assert not WebsiteStarter.objects.filter(
+        path=f"{git_url}/site-2",
+    ).exists()

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -1,6 +1,7 @@
 """ Content sync tasks """
 import logging
 from time import sleep
+from typing import List, Optional
 
 from django.conf import settings
 from django.db.models import F, Q
@@ -8,6 +9,7 @@ from github.GithubException import RateLimitExceededException
 from mitol.common.utils import now_in_utc, pytz
 
 from content_sync import api
+from content_sync.apis import github
 from content_sync.decorators import single_website_task
 from content_sync.models import ContentSyncState
 from main.celery import app
@@ -125,3 +127,11 @@ def publish_website_backend(website_name: str):
     """
     backend = api.get_sync_backend(Website.objects.get(name=website_name))
     backend.create_backend_release()
+
+
+@app.task(acks_late=True)
+def sync_github_site_configs(url: str, files: List[str], commit: Optional[str] = None):
+    """
+    Sync WebsiteStarter objects from github
+    """
+    github.sync_starter_configs(url, files, commit=commit)

--- a/content_sync/tasks_test.py
+++ b/content_sync/tasks_test.py
@@ -15,6 +15,7 @@ from content_sync.tasks import (
     publish_website_backend,
     sync_all_websites,
     sync_content,
+    sync_github_site_configs,
     sync_website_content,
 )
 from websites.factories import WebsiteContentFactory, WebsiteFactory
@@ -171,3 +172,12 @@ def test_create_backend_publish(api_mock):
     publish_website_backend(website.name)
     api_mock.get_sync_backend.assert_called_once_with(website)
     api_mock.get_sync_backend.return_value.create_backend_release.assert_called_once()
+
+
+def test_sync_github_site_configs(mocker):
+    """ sync_github_site_configs should call apis.github.sync_starter_configs with same args, kwargs"""
+    mock_git = mocker.patch("content_sync.tasks.github")
+    args = "https://github.com/testorg/testconfigs", ["site1/studio.yaml"]
+    kwargs = {"commit": "abc123"}
+    sync_github_site_configs.delay(*args, **kwargs)
+    mock_git.sync_starter_configs.assert_called_once_with(*args, **kwargs)

--- a/main/settings.py
+++ b/main/settings.py
@@ -629,3 +629,15 @@ GIT_API_URL = get_string(
     description="Base URL of git API",
     required=False,
 )
+GITHUB_WEBHOOK_KEY = get_string(
+    name="GITHUB_WEBHOOK_KEY",
+    default="",
+    description="Github secret key sent by webhook requests",
+    required=False,
+)
+OCW_STUDIO_SITE_CONFIG_FILE = get_string(
+    name="OCW_STUDIO_SITE_CONFIG_FILE",
+    default="ocw-studio.yaml",
+    description="Standard file name for site config files",
+    required=False,
+)

--- a/main/utils.py
+++ b/main/utils.py
@@ -1,9 +1,13 @@
 """ocw_studio utilities"""
+import hashlib
+import hmac
 import re
 from enum import Flag, auto
 from pathlib import Path
 from typing import Tuple
 from uuid import uuid4
+
+from django.http import HttpRequest
 
 
 class FeatureFlag(Flag):
@@ -85,3 +89,12 @@ def get_dirpath_and_filename(
         )
         path_parts = path_parts[0 : (len(path_parts) - 1)]
     return ("/".join(path_parts), filename or None)
+
+
+def valid_key(key: str, request: HttpRequest) -> bool:
+    """
+    Determine if the signature sent in a request is valid
+    """
+    digest = hmac.new(key.encode("utf-8"), request.body, hashlib.sha1).hexdigest()
+    sig_parts = request.headers["X-Hub-Signature"].split("=", 1)
+    return hmac.compare_digest(sig_parts[1], digest)

--- a/main/utils_test.py
+++ b/main/utils_test.py
@@ -6,6 +6,7 @@ from main.utils import (
     get_dirpath_and_filename,
     get_file_extension,
     remove_trailing_slashes,
+    valid_key,
 )
 
 
@@ -68,3 +69,15 @@ def test_get_dirpath_and_filename(filepath, expect_extension, exp_result):
 def test_are_equivalent_paths(filepath1, filepath2, exp_result):
     """are_equivalent_paths should return True if the given paths are equivalent"""
     assert are_equivalent_paths(filepath1, filepath2) is exp_result
+
+
+@pytest.mark.parametrize(
+    "key, is_valid", [["unit-test-me", True], ["wrong-key", False]]
+)
+def test_valid_key(mocker, key, is_valid):
+    """ valid_key should return True for a valid key, false otherwise """
+    mock_request = mocker.Mock(
+        body=b'{"foo":"bar"}',
+        headers={"X-Hub-Signature": "sha1=6a4e7673fa9c3afbb2860ae03ac2082958313a9c"},
+    )
+    assert valid_key(key, mock_request) is is_valid

--- a/websites/api_test.py
+++ b/websites/api_test.py
@@ -12,6 +12,7 @@ from websites.factories import (
 )
 from websites.models import Website
 
+
 pytestmark = pytest.mark.django_db
 
 EXAMPLE_UUID_STR = "ae6cfe0b-37a7-4fe6-b194-5b7f1e3c349e"

--- a/websites/views.py
+++ b/websites/views.py
@@ -15,11 +15,7 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
-from content_sync.api import (
-    preview_website,
-    publish_website,
-    update_website_backend,
-)
+from content_sync.api import preview_website, publish_website, update_website_backend
 from content_sync.apis.github import sync_starter_configs
 from main import features
 from main.permissions import ReadonlyPermission

--- a/websites/views.py
+++ b/websites/views.py
@@ -1,6 +1,8 @@
 """ Views for websites """
+import json
 import logging
 
+from django.conf import settings
 from django.contrib.auth.models import Group
 from django.db.models import Case, CharField, OuterRef, Q, Value, When
 from django.utils.functional import cached_property
@@ -13,9 +15,16 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 from rest_framework_extensions.mixins import NestedViewSetMixin
 
-from content_sync.api import preview_website, publish_website, update_website_backend
+from content_sync.api import (
+    preview_website,
+    publish_website,
+    update_website_backend,
+    get_sync_backend,
+)
+from content_sync.apis.github import sync_starter_configs
 from main import features
 from main.permissions import ReadonlyPermission
+from main.utils import valid_key
 from main.views import DefaultPagination
 from users.models import User
 from websites import constants
@@ -169,6 +178,31 @@ class WebsiteStarterViewSet(
             return WebsiteStarterSerializer
         else:
             return WebsiteStarterDetailSerializer
+
+    @action(detail=False, methods=["post"], permission_classes=[])
+    def site_configs(self, request, *args, **kwargs):
+        """Process webhook requests for WebsiteStarter site configs"""
+        data = json.loads(request.body)
+        if data.get("repository"):
+            if not valid_key(settings.GITHUB_WEBHOOK_KEY, request):
+                return Response(status=status.HTTP_403_FORBIDDEN)
+            files = [
+                file
+                for sublist in [
+                    commit["modified"] + commit["added"] for commit in data["commits"]
+                ]
+                for file in sublist
+                if file.endswith(settings.OCW_STUDIO_SITE_CONFIG_FILE)
+            ]
+            try:
+                sync_starter_configs(data["repository"]["html_url"], files)
+                return Response(status=status.HTTP_200_OK)
+            except Exception as exc:  # pylint: disable=broad-except
+                log.exception("Error syncing config files")
+                return Response(status=500, data={"details": str(exc)})
+        else:
+            # Only github webhooks are currently supported
+            return Response(status=status.HTTP_400_BAD_REQUEST)
 
 
 class WebsiteCollaboratorViewSet(

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -33,6 +33,8 @@ from websites.serializers import (
 pytestmark = pytest.mark.django_db
 
 MOCK_GITHUB_DATA = {
+    "before": "abc123",
+    "after": "def456",
     "repository": {
         "html_url": "https:github.com/ocw-org/ocw-configs",
     },
@@ -380,59 +382,31 @@ def test_website_starters_site_configs_invalid_key(drf_client):
     """A 403 response should be returned if the request signature is invalid"""
     drf_client.credentials(HTTP_X_HUB_SIGNATURE="dfdfdf=dkfldkfl")
     resp = drf_client.post(
-        reverse("website_starters_api-site-configs"),
-        data={"repository": {"foo": "bar"}},
+        reverse("website_starters_api-site-configs"), data=MOCK_GITHUB_DATA
     )
     assert resp.status_code == 403
 
 
-def test_website_starters_site_configs_valid(mocker, drf_client):
-    """A 200 response should be returned for valid data"""
+def test_website_starters_site_configs(settings, mocker, drf_client):
+    """A 202 response should be returned for valid data"""
+    settings.GIT_TOKEN = "git-token"
     mocker.patch("websites.views.valid_key", return_value=True)
     valid_config_files = ["site-1/ocw-studio.yaml", "site-2/ocw-studio.yaml"]
-    mock_sync = mocker.patch(
-        "websites.views.sync_starter_configs", return_value=(valid_config_files, [])
-    )
-    resp = drf_client.post(
-        reverse("website_starters_api-site-configs"), data=MOCK_GITHUB_DATA
-    )
-    mock_sync.assert_called_once_with(
-        MOCK_GITHUB_DATA["repository"]["html_url"], valid_config_files
-    )
-    assert resp.status_code == 200
-    assert resp.data == {"success": valid_config_files, "errors": []}
-
-
-def test_website_starters_site_configs_invalid_config(mocker, drf_client):
-    """A 400 response should be returned if any configs were invalid"""
-    mocker.patch("websites.views.valid_key", return_value=True)
-    valid_config_file = "site-1/ocw-studio.yaml"
-    invalid_config_file = "site-2/ocw-studio.yaml"
-    error = "Unexpected element"
-    mock_sync = mocker.patch(
-        "websites.views.sync_starter_configs",
-        return_value=([valid_config_file], [{invalid_config_file: error}]),
-    )
+    mock_sync = mocker.patch("content_sync.api.tasks.sync_github_site_configs.delay")
     resp = drf_client.post(
         reverse("website_starters_api-site-configs"), data=MOCK_GITHUB_DATA
     )
     mock_sync.assert_called_once_with(
         MOCK_GITHUB_DATA["repository"]["html_url"],
-        [valid_config_file, invalid_config_file],
+        valid_config_files,
+        commit=MOCK_GITHUB_DATA["after"],
     )
-    assert resp.status_code == 400
-    assert resp.data == {
-        "success": [valid_config_file],
-        "errors": [{invalid_config_file: error}],
-    }
+    assert resp.status_code == 202
 
 
 def test_website_starters_site_configs_exception(mocker, drf_client):
     """A 500 response should be returned if an unhandled exception is raised"""
-    mocker.patch("websites.views.valid_key", return_value=True)
-    mocker.patch(
-        "websites.views.sync_starter_configs", side_effect=[KeyError("Key not found")]
-    )
+    mocker.patch("websites.views.valid_key", side_effect=[KeyError("Key not found")])
     resp = drf_client.post(
         reverse("website_starters_api-site-configs"), data=MOCK_GITHUB_DATA
     )


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable
  - [x] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
Closes #291 

#### What's this PR do?
- Adds an API endpoint for processing webhook requests from Github to create or update `WebsiteStarter` objects and their site configs.

#### How should this be manually tested?
- Follow the README section on github integration
- Create a new repo to hold site configs
   
- Use ngrok or something similar to setup a publicly accessible tunnel to your local site:
    - `ngrok http 8043`   
- Create a webhook for the repo (`https://github.com/<org>/<repo>/settings/hooks/`):
   - Payload URL: http://<ngrok_domain>/api/starters/site_configs/
   - Content type: application/json
   - Secret: any value (not blank)
   - Events: pushes
- Set `GITHUB_WEBHOOK_KEY=<secret>` in your `.env` file

- Create new files in the repo with these filepaths:
   ocw-site-1/ocw-studio.yaml
   ocw-site-2/ocw-studio.yaml
   ocw-studio.yaml

   and this content:
   ```
   ---
   collections: []
   ```
- Check that 3 new `WebsiteStarter`  configs were created with a config = `{"collections": []}`
