### PR TITLE
Restrict routes not used to login or view home page

### DIFF
--- a/main/urls.py
+++ b/main/urls.py
@@ -20,7 +20,7 @@ from django.contrib import admin
 from django.contrib.auth.views import LogoutView
 from django.urls import path, re_path
 
-from main.views import index
+from main.views import public_index, restricted_index
 
 
 urlpatterns = [
@@ -30,10 +30,11 @@ urlpatterns = [
     path("", include("social_django.urls", namespace="social")),
     url(r"^hijack/", include("hijack.urls", namespace="hijack")),
     # Example view
-    path("", index, name="main-index"),
-    re_path(r"^sites/.*$", index, name="sites"),
-    path("new-site/", index),
-    path("markdown-editor", index, name="markdown-editor-test"),
+    re_path("^$", public_index, name="main-index"),
+    path("login/", public_index, name="login"),
+    re_path(r"^sites/.*$", restricted_index, name="sites"),
+    path("new-site/", restricted_index, name="new-site"),
+    path("markdown-editor", restricted_index, name="markdown-editor-test"),
     path("logout/", LogoutView.as_view(), name="logout"),
     path("", include("news.urls")),
     path("", include("websites.urls")),

--- a/main/views.py
+++ b/main/views.py
@@ -4,15 +4,14 @@ ocw_studio views
 import json
 
 from django.conf import settings
+from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
 from mitol.common.utils.webpack import webpack_public_path
 from rest_framework.pagination import LimitOffsetPagination
 
 
-def index(request, *args, **kwargs):  # pylint: disable=unused-argument
-    """
-    The index view. Display available programs
-    """
+def _index(request):
+    """Render the view for React pages"""
 
     js_settings = {
         "gaTrackingID": settings.GA_TRACKING_ID,
@@ -41,6 +40,21 @@ def index(request, *args, **kwargs):  # pylint: disable=unused-argument
             "js_settings_json": json.dumps(js_settings),
         },
     )
+
+
+def public_index(request, *args, **kwargs):  # pylint: disable=unused-argument
+    """
+    Render a React page. The frontend will render an appropriate UI based on the URL
+    """
+    return _index(request)
+
+
+@login_required
+def restricted_index(request, *args, **kwargs):  # pylint: disable=unused-argument
+    """
+    Render a React page. The frontend will render an appropriate UI based on the URL
+    """
+    return _index(request)
 
 
 class DefaultPagination(LimitOffsetPagination):

--- a/main/views_test.py
+++ b/main/views_test.py
@@ -5,6 +5,7 @@ import json
 
 import pytest
 from django.urls import reverse
+from rest_framework.status import HTTP_200_OK, HTTP_302_FOUND
 
 from users.factories import UserFactory
 
@@ -12,12 +13,6 @@ from users.factories import UserFactory
 pytestmark = [
     pytest.mark.django_db,
 ]
-
-
-def test_index_view(client):
-    """Verify the index view is as expected"""
-    response = client.get(reverse("main-index"))
-    assert response.status_code == 200
 
 
 def test_webpack_url(mocker, settings, client):
@@ -37,9 +32,23 @@ def test_webpack_url(mocker, settings, client):
     assert js_settings["public_path"] == "/static/bundles/"
 
 
-@pytest.mark.parametrize("is_authenticated", [True, False])
-def test_js_settings(settings, client, is_authenticated):
-    """Verify that JS settings render correctly"""
+@pytest.mark.parametrize(
+    "name, is_authenticated, expected_success",
+    [
+        ["main-index", True, True],
+        ["main-index", False, True],
+        ["login", True, True],
+        ["login", False, True],
+        ["sites", True, True],
+        ["sites", False, False],
+        ["new-site", True, True],
+        ["new-site", False, False],
+        ["markdown-editor-test", True, True],
+        ["markdown-editor-test", False, False],
+    ],
+)
+def test_react_page(settings, client, name, is_authenticated, expected_success):
+    """Verify that JS settings render correctly for pages used to render React pages"""
     settings.GA_TRACKING_ID = "fake"
     settings.ENVIRONMENT = "test"
     settings.VERSION = "4.5.6"
@@ -50,20 +59,24 @@ def test_js_settings(settings, client, is_authenticated):
     if is_authenticated:
         client.force_login(user)
 
-    response = client.get(reverse("main-index"))
-
-    js_settings = json.loads(response.context["js_settings_json"])
-    assert js_settings == {
-        "gaTrackingID": "fake",
-        "public_path": "/static/bundles/",
-        "environment": settings.ENVIRONMENT,
-        "sentry_dsn": "",
-        "release_version": settings.VERSION,
-        "user": {
-            "username": user.username,
-            "email": user.email,
-            "name": user.name,
+    response = client.get(reverse(name))
+    if expected_success:
+        assert response.status_code == HTTP_200_OK
+        js_settings = json.loads(response.context["js_settings_json"])
+        assert js_settings == {
+            "gaTrackingID": "fake",
+            "public_path": "/static/bundles/",
+            "environment": settings.ENVIRONMENT,
+            "sentry_dsn": "",
+            "release_version": settings.VERSION,
+            "user": {
+                "username": user.username,
+                "email": user.email,
+                "name": user.name,
+            }
+            if is_authenticated
+            else None,
         }
-        if is_authenticated
-        else None,
-    }
+    else:
+        assert response.status_code == HTTP_302_FOUND
+        assert response.url.startswith("/?next=")


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #130 

#### What's this PR do?
Restricts UI routes to logged in user, except those used to login or visit the home page

#### How should this be manually tested?
As an anonymous user:
 - I don't know who has SAML set up to login, but you should still be able to do that and view the home page.
 - If you go to `/sites/` you should be redirected to `?next=...` which is just the home page at the moment

As a logged in user, the user experience should feel the same as before. You should be able to logout and end up on the home page.
