### PR TITLE
Made 'title' field default for 'folder'-type items

### DIFF
--- a/localdev/configs/ocw-course-site-config.yml
+++ b/localdev/configs/ocw-course-site-config.yml
@@ -5,7 +5,6 @@ collections:
     category: Content
     folder: content
     fields:
-      - {"label": "Title", "name": "title", "widget": "string", "required": true}
       - {"label": "Body", "name": "body", "widget": "markdown"}
       - {
         "label": "Tags",
@@ -43,7 +42,6 @@ collections:
     category: Content
     folder: content
     fields:
-      - {"label": "Title", "name": "title", "widget": "string", "required": true}
       - {"label": "Description", "name": "description", "widget": "text"}
       - {"label": "File", "name": "file", "widget": "file"}
       - {
@@ -62,7 +60,7 @@ collections:
         name: sitemetadata
         label: Site Metadata
         fields:
-          - { "label": "Course Title", "name": "title", "widget": "text", "required": true }
+          - { "label": "Course Title", "name": "title", "widget": "string", "required": true }
           - {
             "label": "Course Description",
             "name": "description",

--- a/localdev/management/commands/populate_local_starters.py
+++ b/localdev/management/commands/populate_local_starters.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
                 path=os.path.join(LOCAL_STARTERS_DIR, dir_name),
                 name=dir_name,
                 source=STARTER_SOURCE_LOCAL,
-                defaults=dict(config=parsed_config),
+                defaults=dict(config=parsed_config, slug=dir_name),
             )
             updated = False
             if (

--- a/static/js/components/forms/SiteContentForm.test.tsx
+++ b/static/js/components/forms/SiteContentForm.test.tsx
@@ -16,14 +16,13 @@ import {
   fieldIsVisible,
   splitFieldsIntoColumns
 } from "../../lib/site_content"
-import { getContentSchema } from "./validation"
 
 import {
   EditableConfigItem,
   WebsiteContent,
   WidgetVariant
 } from "../../types/websites"
-import { ContentFormType } from "../../types/forms"
+import { ContentFormType, FormSchema } from "../../types/forms"
 
 jest.mock("../../lib/site_content")
 jest.mock("./validation")
@@ -33,13 +32,15 @@ describe("SiteContentForm", () => {
     onSubmitStub: SinonStub,
     setFieldValueStub: SinonStub,
     configItem: EditableConfigItem,
-    content: WebsiteContent
+    content: WebsiteContent,
+    mockValidationSchema: FormSchema
 
   beforeEach(() => {
     sandbox = sinon.createSandbox()
     setFieldValueStub = sinon.stub()
     content = makeWebsiteContentDetail()
     configItem = makeEditableConfigItem(content.type)
+    mockValidationSchema = yup.object().shape({})
     // @ts-ignore
     splitFieldsIntoColumns.mockImplementation(() => [])
   })
@@ -48,13 +49,15 @@ describe("SiteContentForm", () => {
     sandbox.restore()
   })
 
-  const renderForm = (formType: ContentFormType) =>
+  const renderForm = (props = {}) =>
     shallow(
       <SiteContentForm
-        configItem={configItem}
+        fields={configItem.fields}
+        schema={mockValidationSchema}
         content={content}
         onSubmit={onSubmitStub}
-        formType={formType}
+        formType={ContentFormType.Add}
+        {...props}
       />
     )
 
@@ -62,7 +65,7 @@ describe("SiteContentForm", () => {
     formType: ContentFormType,
     formikChildProps: { [key: string]: any } = {}
   ) => {
-    const wrapper = renderForm(formType)
+    const wrapper = renderForm({ formType })
     return (
       wrapper
         .find("Formik")
@@ -115,12 +118,9 @@ describe("SiteContentForm", () => {
       })
 
       it("has the correct Formik props", () => {
-        const mockValidationSchema = yup.object().shape({})
-        // @ts-ignore
-        getContentSchema.mockReturnValueOnce(mockValidationSchema)
         // @ts-ignore
         splitFieldsIntoColumns.mockImplementation(() => [])
-        const formik = renderForm(formType).find("Formik")
+        const formik = renderForm({ formType }).find("Formik")
         const validationSchema = formik.prop("validationSchema")
         expect(validationSchema).toStrictEqual(mockValidationSchema)
         expect(formik.prop("enableReinitialize")).toBe(true)

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -8,49 +8,41 @@ import {
   contentInitialValues,
   fieldIsVisible,
   newInitialValues,
-  splitFieldsIntoColumns,
-  renameNestedFields
+  splitFieldsIntoColumns
 } from "../../lib/site_content"
-import { getContentSchema } from "./validation"
 
 import {
-  EditableConfigItem,
   WebsiteContent,
   WidgetVariant,
   ConfigField
 } from "../../types/websites"
-import { ContentFormType, SiteFormValues } from "../../types/forms"
+import { ContentFormType, FormSchema, SiteFormValues } from "../../types/forms"
 
 interface Props {
   onSubmit: (
     values: any,
     formikHelpers: FormikHelpers<any>
   ) => void | Promise<any>
-  configItem: EditableConfigItem
+  fields: ConfigField[]
+  schema: FormSchema
   content: WebsiteContent | null
   formType: ContentFormType
 }
 
 export default function SiteContentForm({
   onSubmit,
-  configItem,
+  fields,
+  schema,
   content,
   formType
 }: Props): JSX.Element {
-  const fields: ConfigField[] = useMemo(
-    () => renameNestedFields(configItem.fields),
-    [configItem]
-  )
-
   const initialValues: SiteFormValues = useMemo(
     () =>
       formType === ContentFormType.Add ?
-        newInitialValues(configItem.fields) :
-        contentInitialValues(content as WebsiteContent, configItem.fields),
-    [configItem, formType, content]
+        newInitialValues(fields) :
+        contentInitialValues(content as WebsiteContent, fields),
+    [fields, formType, content]
   )
-
-  const schema = getContentSchema(configItem)
 
   const fieldsByColumn = splitFieldsIntoColumns(fields)
   const columnClass = fieldsByColumn.length === 2 ? "col-6" : "col-12"

--- a/static/js/lib/site_content.ts
+++ b/static/js/lib/site_content.ts
@@ -1,5 +1,5 @@
 import { ComponentType, ElementType } from "react"
-import { pick, partition, map, evolve } from "ramda"
+import { evolve, map, partition, pick } from "ramda"
 
 import MarkdownEditor from "../components/widgets/MarkdownEditor"
 import FileUploadField from "../components/widgets/FileUploadField"
@@ -14,18 +14,19 @@ import {
 } from "../constants"
 
 import {
+  BaseConfigItem,
   ConfigField,
   EditableConfigItem,
-  TopLevelConfigItem,
   RepeatableConfigItem,
   SingletonConfigItem,
+  StringConfigField,
   WebsiteContent,
   WidgetVariant
 } from "../types/websites"
 import {
-  SiteFormValues,
+  SiteFormPrimitive,
   SiteFormValue,
-  SiteFormPrimitive
+  SiteFormValues
 } from "../types/forms"
 
 export const componentFromWidget = (
@@ -61,6 +62,13 @@ const RELATION_EXTRA_PROPS = [
   "multiple",
   "filter"
 ]
+
+export const DEFAULT_TITLE_FIELD: StringConfigField = {
+  name:     "title",
+  label:    "Title",
+  widget:   WidgetVariant.String,
+  required: true
+}
 
 /**
  * Returns extra props that should be provided to the `Field`
@@ -118,11 +126,11 @@ const emptyValue = (field: ConfigField): SiteFormValue => {
 }
 
 export const isRepeatableCollectionItem = (
-  configItem: TopLevelConfigItem
+  configItem: BaseConfigItem
 ): configItem is RepeatableConfigItem => "folder" in configItem
 
 export const isSingletonCollectionItem = (
-  configItem: EditableConfigItem
+  configItem: BaseConfigItem
 ): configItem is SingletonConfigItem => "file" in configItem
 
 /**
@@ -292,3 +300,17 @@ export const renameNestedFields = (fields: ConfigField[]): ConfigField[] =>
       ) :
       field
   )
+
+export const addDefaultFields = (
+  configItem: EditableConfigItem
+): ConfigField[] => {
+  const fields = configItem.fields
+  if (!isRepeatableCollectionItem(configItem)) {
+    return fields
+  }
+  const titleField = fields.find(field => field.name === "title")
+  if (titleField) {
+    return fields
+  }
+  return [DEFAULT_TITLE_FIELD, ...fields]
+}

--- a/static/js/resources/ocw-course-site-config.json
+++ b/static/js/resources/ocw-course-site-config.json
@@ -4,12 +4,6 @@
       "category": "Content",
       "fields": [
         {
-          "label": "Title",
-          "name": "title",
-          "required": true,
-          "widget": "string"
-        },
-        {
           "label": "Body",
           "name": "body",
           "widget": "markdown"
@@ -86,12 +80,6 @@
       "category": "Content",
       "fields": [
         {
-          "label": "Title",
-          "name": "title",
-          "required": true,
-          "widget": "string"
-        },
-        {
           "label": "Description",
           "name": "description",
           "widget": "text"
@@ -126,7 +114,7 @@
               "label": "Course Title",
               "name": "title",
               "required": true,
-              "widget": "text"
+              "widget": "string"
             },
             {
               "help": "A description of the course that will be shown on the course site home page.",

--- a/static/js/test_util.ts
+++ b/static/js/test_util.ts
@@ -10,7 +10,10 @@ export const defaultFormikChildProps: FormikState<any> = {
   submitCount:  0
 }
 
-export const isIf = (tf: boolean | string): string => (tf ? "is" : "is not")
+export const isIf = (
+  tf: any // eslint-disable-line
+): string => (tf ? "is" : "is not")
 
-export const shouldIf = (tf: boolean | string): string =>
-  tf ? "should" : "should not"
+export const shouldIf = (
+  tf: any // eslint-disable-line
+): string => (tf ? "should" : "should not")

--- a/static/js/types/forms.ts
+++ b/static/js/types/forms.ts
@@ -1,7 +1,11 @@
+import { SchemaOf } from "yup"
+
 export enum ContentFormType {
   Add = "add",
   Edit = "edit"
 }
+
+export type FormSchema = SchemaOf<any>
 
 export type SiteFormPrimitive = string | File | string[] | null | boolean
 

--- a/websites/config_schema/api.py
+++ b/websites/config_schema/api.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from websites.config_schema.validators import (
     CollectionsKeysRule,
     ContentFolderRule,
+    RequiredTitleRule,
     UniqueNamesRule,
 )
 
@@ -22,6 +23,7 @@ ADDED_SCHEMA_RULES = [
     CollectionsKeysRule,
     UniqueNamesRule,
     ContentFolderRule,
+    RequiredTitleRule,
 ]
 
 

--- a/websites/config_schema/api_test.py
+++ b/websites/config_schema/api_test.py
@@ -12,6 +12,12 @@ from websites.config_schema.api import (
 
 SCHEMA_RESOURCES_DIR = "localdev/configs/"
 SCHEMA_CONFIG_FILE = "ocw-course-site-config.yml"
+VALID_TITLE_FIELD = {
+    "name": "title",
+    "label": "Title",
+    "required": True,
+    "widget": "string",
+}
 
 
 @pytest.fixture()
@@ -96,6 +102,24 @@ def test_folders_content_only(parsed_site_config):
     config["collections"][0] = {
         **config["collections"][0],
         "folder": "not-the-content-folder",
+    }
+    with pytest.raises(ValueError):
+        validate_parsed_site_config(config)
+
+
+@pytest.mark.parametrize(
+    "attr,value",
+    [
+        ["required", False],
+        ["widget", "text"],
+    ],
+)
+def test_required_title_rule(parsed_site_config, attr, value):
+    """If a config item includes a "title" field, it should be set to required and have the correct type"""
+    config = parsed_site_config.copy()
+    config["collections"][0] = {
+        **config["collections"][0],
+        "fields": [{**VALID_TITLE_FIELD, attr: value}],
     }
     with pytest.raises(ValueError):
         validate_parsed_site_config(config)

--- a/websites/site_config_api.py
+++ b/websites/site_config_api.py
@@ -36,6 +36,11 @@ class ConfigItem:
         """Helper property to return the 'name' value"""
         return self.item["name"]
 
+    @property
+    def fields(self) -> list:
+        """Helper property to return the 'fields' value"""
+        return self.item.get("fields", [])
+
     def is_folder_item(self) -> bool:
         """Returns True if this config item has a folder target"""
         return "folder" in self.item


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #279 

#### What's this PR do?
Makes the 'title' field a default for "folder"-type config items. If a "title" field is not included in the config item, it will be added in the front end. If a "title" field _is_ included, it will be validated to make sure it is set to required and has the correct widget type

#### How should this be manually tested?
- Edit a content object for a "file"-type config item with no "title" field. You should see no "title" form field.
- Edit a content object for a "folder"-type config item with no "title" field. You should see the "title" field in the form, and is should save/load correctly
- Edit a content object for a "folder"-type config item with a "title" field. You should see the "title" field in the form just like the previous example
- Save a site config with a "folder"-type config item that includes a "title" field with `required: false` or `widget: text` and try to save. You should see a validation error.
