### PR TITLE
link to content in other websites

### DIFF
--- a/static/js/components/forms/SiteContentField.tsx
+++ b/static/js/components/forms/SiteContentField.tsx
@@ -22,7 +22,8 @@ export default function SiteContentField({
 
   if (
     field.widget === WidgetVariant.File ||
-    field.widget === WidgetVariant.Boolean
+    field.widget === WidgetVariant.Boolean ||
+    field.widget === WidgetVariant.Relation
   ) {
     extraProps.setFieldValue = setFieldValue
   }

--- a/static/js/components/widgets/RelationField.test.tsx
+++ b/static/js/components/widgets/RelationField.test.tsx
@@ -12,7 +12,7 @@ import {
   makeWebsiteContentDetail,
   makeWebsiteDetail
 } from "../../util/factories/websites"
-import { siteApiContentListingUrl } from "../../lib/urls"
+import { siteApiContentListingUrl, siteApiDetailUrl } from "../../lib/urls"
 import { WEBSITE_CONTENT_PAGE_SIZE } from "../../constants"
 
 import { Website, WebsiteContent } from "../../types/websites"
@@ -20,6 +20,7 @@ import R from "ramda"
 
 describe("RelationField", () => {
   let website: Website,
+    otherWebsite: Website,
     render: TestRenderer,
     helper: IntegrationTestHelper,
     onChange: SinonStub,
@@ -27,6 +28,7 @@ describe("RelationField", () => {
 
   beforeEach(() => {
     website = makeWebsiteDetail()
+    otherWebsite = makeWebsiteDetail()
     helper = new IntegrationTestHelper()
     onChange = helper.sandbox.stub()
     render = helper.configureRenderer(
@@ -47,44 +49,46 @@ describe("RelationField", () => {
       R.times(makeWebsiteContentDetail, WEBSITE_CONTENT_PAGE_SIZE),
       R.times(makeWebsiteContentDetail, WEBSITE_CONTENT_PAGE_SIZE)
     ]
-    helper.handleRequestStub
-      .withArgs(
-        siteApiContentListingUrl
-          .param({ name: website.name })
-          .query({ type: "page", offset: 0, detailed_list: true })
-          .toString(),
-        "GET"
-      )
-      .returns({
-        status: 200,
-        body:   {
-          results:  contentListingItemsPages[0],
-          count:    contentListingItemsPages.flat().length,
-          next:     null,
-          previous: null
-        }
-      })
-    helper.handleRequestStub
-      .withArgs(
-        siteApiContentListingUrl
-          .param({ name: website.name })
-          .query({
-            type:          "page",
-            offset:        WEBSITE_CONTENT_PAGE_SIZE,
-            detailed_list: true
-          })
-          .toString(),
-        "GET"
-      )
-      .returns({
-        status: 200,
-        body:   {
-          results:  contentListingItemsPages[1],
-          count:    contentListingItemsPages.flat().length,
-          next:     null,
-          previous: null
-        }
-      })
+    ;[website, otherWebsite].forEach(website => {
+      helper.handleRequestStub
+        .withArgs(
+          siteApiContentListingUrl
+            .param({ name: website.name })
+            .query({ type: "page", offset: 0, detailed_list: true })
+            .toString(),
+          "GET"
+        )
+        .returns({
+          status: 200,
+          body:   {
+            results:  contentListingItemsPages[0],
+            count:    contentListingItemsPages.flat().length,
+            next:     null,
+            previous: null
+          }
+        })
+      helper.handleRequestStub
+        .withArgs(
+          siteApiContentListingUrl
+            .param({ name: website.name })
+            .query({
+              type:          "page",
+              offset:        WEBSITE_CONTENT_PAGE_SIZE,
+              detailed_list: true
+            })
+            .toString(),
+          "GET"
+        )
+        .returns({
+          status: 200,
+          body:   {
+            results:  contentListingItemsPages[1],
+            count:    contentListingItemsPages.flat().length,
+            next:     null,
+            previous: null
+          }
+        })
+    })
   })
 
   afterEach(() => {
@@ -114,11 +118,6 @@ describe("RelationField", () => {
     expect(wrapper.find("SelectField").prop("value")).toBe("foobar")
   })
 
-  it("should pass the onChange handler down to the SelectField", async () => {
-    const { wrapper } = await render()
-    expect(wrapper.find("SelectField").prop("onChange")).toBe(onChange)
-  })
-
   it("should filter results", async () => {
     contentListingItemsPages[0][0].metadata!.testfield = "testvalue"
     const { wrapper } = await render({
@@ -134,5 +133,37 @@ describe("RelationField", () => {
         value: contentListingItemsPages[0][0].text_id
       }
     ])
+  })
+
+  describe("manually-set website parameter", () => {
+    beforeEach(() => {
+      helper.handleRequestStub
+        .withArgs(
+          siteApiDetailUrl.param({ name: otherWebsite.name }).toString()
+        )
+        .returns({
+          status: 200,
+          body:   otherWebsite
+        })
+    })
+
+    it("should support setting a 'website' parameter, fetching and using that website", async () => {
+      const { wrapper } = await render({
+        website: otherWebsite.name
+      })
+
+      expect(
+        helper.handleRequestStub.calledWith(
+          siteApiDetailUrl.param({ name: otherWebsite.name }).toString()
+        )
+      ).toBeTruthy()
+
+      expect(wrapper.find("SelectField").prop("options")).toEqual(
+        contentListingItemsPages.flat().map(entry => ({
+          label: entry.title,
+          value: entry.text_id
+        }))
+      )
+    })
   })
 })

--- a/static/js/lib/site_content.test.ts
+++ b/static/js/lib/site_content.test.ts
@@ -208,7 +208,7 @@ describe("site_content", () => {
         [WidgetVariant.Text, ""],
         [WidgetVariant.String, ""],
         [WidgetVariant.Select, ""],
-        [WidgetVariant.Relation, ""]
+        [WidgetVariant.Relation, { website: null, content: "" }]
       ].forEach(([widget, expectation]) => {
         const field = makeWebsiteConfigField({
           widget,
@@ -234,7 +234,13 @@ describe("site_content", () => {
         multiple: true,
         label:    "Widget"
       })
-      expect(newInitialValues([field])).toStrictEqual({ widget: [] })
+
+      expect(newInitialValues([field])).toStrictEqual({
+        widget: {
+          website: null,
+          content: []
+        }
+      })
     })
 
     it("should use appropriate default for Object widget", () => {
@@ -434,9 +440,21 @@ describe("site_content", () => {
       ).toEqual(["myobject.mystring", "myobject.myselect"])
     })
 
+    it("should rename fields for a Relation field", () => {
+      const field = makeWebsiteConfigField({
+        widget: WidgetVariant.Relation,
+        label:  "myobject"
+      })
+
+      expect(renameNestedFields([field])[0].name).toEqual("myobject.content")
+    })
+
     it("should leave others alone", () => {
       const fields = Object.values(WidgetVariant)
-        .filter(widget => widget !== WidgetVariant.Object)
+        .filter(
+          widget =>
+            widget !== WidgetVariant.Object && widget !== WidgetVariant.Relation
+        )
         .map(widget => makeWebsiteConfigField({ widget }))
       expect(renameNestedFields(fields)).toEqual(fields)
     })

--- a/static/js/lib/site_content.ts
+++ b/static/js/lib/site_content.ts
@@ -60,7 +60,8 @@ const RELATION_EXTRA_PROPS = [
   "max",
   "min",
   "multiple",
-  "filter"
+  "filter",
+  "website"
 ]
 
 export const DEFAULT_TITLE_FIELD: StringConfigField = {
@@ -229,6 +230,10 @@ const defaultForField = (field: ConfigField): SiteFormValue => {
   case WidgetVariant.Boolean:
     return false
   case WidgetVariant.Relation:
+    return {
+      website: null,
+      content: field.multiple ? [] : ""
+    }
   case WidgetVariant.Select:
     return field.multiple ? [] : ""
   case WidgetVariant.File:
@@ -289,9 +294,10 @@ export const fieldIsVisible = (
  * renamed so they can be passed down to Formik.
  **/
 export const renameNestedFields = (fields: ConfigField[]): ConfigField[] =>
-  fields.map((field: ConfigField) =>
-    field.widget === WidgetVariant.Object ?
-      evolve(
+  fields.map((field: ConfigField) => {
+    switch (field.widget) {
+    case WidgetVariant.Object:
+      return evolve(
         {
           fields: map((nestedField: ConfigField) => ({
             ...nestedField,
@@ -299,9 +305,16 @@ export const renameNestedFields = (fields: ConfigField[]): ConfigField[] =>
           }))
         },
         field
-      ) :
-      field
-  )
+      )
+    case WidgetVariant.Relation:
+      return {
+        ...field,
+        name: `${field.name}.content`
+      }
+    default:
+      return field
+    }
+  })
 
 export const addDefaultFields = (
   configItem: EditableConfigItem

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -92,6 +92,7 @@ export interface RelationConfigField extends ConfigFieldBaseProps {
   min?: number
   max?: number
   filter?: RelationFilter
+  website?: string
 }
 
 /**

--- a/websites/config_schema/site-config-schema.yml
+++ b/websites/config_schema/site-config-schema.yml
@@ -32,6 +32,7 @@ field:
     display_field: str(required=False)
     collection: str(required=False)
     filter: include('relation_filter', required=False)
+    website: str(required=False)
 ---
 field_condition:
     field: str()


### PR DESCRIPTION
#### What are the relevant tickets?

part of #288 

#### What's this PR do?

This PR adds support to the Relation widget for linking to entries in collections within other websites. This is done by setting a 'website' prop on the Relation field, which is the `name` prop on the website in question.

I am wondering if there is a better approach for doing this, as this would mean that the name of the other website has to be known at config-writing time, and changing it would require re-writing the config.

However, doing it this way is fairly simple in the implementation. If we wanted to make it more complicated, i.e. allowing the user to pick which website they want to link to in the UI, we'd need an additional UI setup for doing that. This would make it more flexible though, and allow the user to link to content in any other website of their choosing.

So anyhow, interested in hearing some feedback about this. I am sort of leaning towards wanting to do the more complicated thing, but not sure.

As I understand it btw, the potential use-case for this is for linking from something like an OCW course to material which is contained in a different course (using the same config) or potentially even to content in a totally different site, for instance in ocw-www (once that is managed by ocw-studio I mean).

#### How should this be manually tested?

If you create two websites with the OCW course example config you should be able to then set a `website` prop on to the 'PDF File' relation field of one of them to the site name of the other (via the django admin) and then link to PDF files in the other website.

This all works and is relatively straightforward, but I'm wondering if this is the right thing to do.