### PR TITLE
Do not use git token for reading from the public site config repo

### DIFF
--- a/content_sync/apis/github.py
+++ b/content_sync/apis/github.py
@@ -84,7 +84,7 @@ def sync_starter_configs(
     """
     repo_path = urlparse(repo_url).path.lstrip("/")
     org_name, repo_name = repo_path.split("/", 1)
-    git = Github(login_or_token=settings.GIT_TOKEN)
+    git = Github()
     org = git.get_organization(org_name)
     repo = org.get_repo(repo_name)
 


### PR DESCRIPTION
#### What are the relevant tickets?
N/A

#### What's this PR do?
Does not instantiate the git API with a token from the `content_sync.apis.github.sync_starter_configs` function because it just reads from a public repo.  If the token is set, and is not valid for that organization, a 401 authentication error will be returned from git.

#### How should this be manually tested?
This should work:

```python
from content_sync.apis.github import *
sync_starter_configs(
    "https://github.com/mitodl/ocw-hugo-projects", 
    ["ocw-www/ocw-studio.yaml"], 
    "123729069c5e28c4ff9ae281d3ae2754c42c5549"
)
```
