### PR TITLE
Filter out course sites with null metadata

### DIFF
--- a/websites/views.py
+++ b/websites/views.py
@@ -86,6 +86,8 @@ class WebsiteViewSet(
             ordering = "-publish_date"
             queryset = Website.objects.filter(
                 publish_date__lte=now_in_utc(),
+                # Replace this after imported ocw sites have metadata stored in WebsiteContent objects
+                metadata__isnull=False,
             )
         elif is_global_admin(user):
             # Global admins should get a list of all websites, published or not.

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -50,6 +50,7 @@ def websites(course_starter):
     """ Create some websites for tests """
     courses = WebsiteFactory.create_batch(3, published=True, starter=course_starter)
     noncourses = WebsiteFactory.create_batch(2, published=True)
+    WebsiteFactory.create(published=True, starter=course_starter, metadata=None)
     WebsiteFactory.create(unpublished=True, starter=course_starter)
     WebsiteFactory.create(future_publish=True)
     return SimpleNamespace(courses=courses, noncourses=noncourses)


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested


#### What are the relevant tickets?
Temporarily fixes #308 

#### What's this PR do?
For the "new courses" API request, filters out `Website` objects with a null `metadata` field.

#### How should this be manually tested?
Import some OCW courses and create a couple of your own course sites (`WebsiteStarter.slug=course`). 
In django admin, set publish date to now for your new course site.
In an incognito browser, go to `http://localhost:8043/api/websites/?type=course`.  The response should contain only imported ocw sites, not your new site above.
Add some json to the `Website.metadata` field of your new course.  Then refresh the above url, your course should now show up at the top.


#### Any background context you want to provide?
This is a temporary fix until the imported ocw sites have their metadata saved to `WebsiteContent` objects instead.  See the issue for more details.
