### PR TITLE
Add MarkdownEditor tests

### DIFF
--- a/static/js/components/widgets/MarkdownEditor.test.tsx
+++ b/static/js/components/widgets/MarkdownEditor.test.tsx
@@ -30,7 +30,7 @@ describe("MarkdownEditor", () => {
   ;[
     [true, MinimalEditorConfig],
     [false, FullEditorConfig]
-  ].forEach(([minimal, expectedMinimalComponent]) => {
+  ].forEach(([minimal, expectedComponent]) => {
     [
       ["value", "value"],
       [null, ""]
@@ -44,7 +44,7 @@ describe("MarkdownEditor", () => {
         })
         const ckWrapper = wrapper.find("CKEditor")
         expect(ckWrapper.prop("editor")).toBe(ClassicEditor)
-        expect(ckWrapper.prop("config")).toBe(expectedMinimalComponent)
+        expect(ckWrapper.prop("config")).toBe(expectedComponent)
         expect(ckWrapper.prop("data")).toBe(expectedPropValue)
       })
     })

--- a/static/js/components/widgets/MarkdownEditor.test.tsx
+++ b/static/js/components/widgets/MarkdownEditor.test.tsx
@@ -56,7 +56,9 @@ describe("MarkdownEditor", () => {
     [null, ""]
   ].forEach(([name, expectedPropName]) => {
     [true, false].forEach(hasOnChange => {
-      it(`triggers ${hasOnChange ? "with" : "without"} an onChange when name=${String(name)}`, () => {
+      it(`triggers ${
+        hasOnChange ? "with" : "without"
+      } an onChange when name=${String(name)}`, () => {
         const onChangeStub = sandbox.stub()
         const wrapper = render({
           name,

--- a/static/js/components/widgets/MarkdownEditor.test.tsx
+++ b/static/js/components/widgets/MarkdownEditor.test.tsx
@@ -1,0 +1,81 @@
+import React from "react"
+import { shallow } from "enzyme"
+import ClassicEditor from "@ckeditor/ckeditor5-editor-classic/src/classiceditor"
+import sinon, { SinonSandbox } from "sinon"
+
+import MarkdownEditor from "./MarkdownEditor"
+import {
+  FullEditorConfig,
+  MinimalEditorConfig
+} from "../../lib/ckeditor/CKEditor"
+
+jest.mock("@ckeditor/ckeditor5-react", () => ({
+  CKEditor: () => <div />
+}))
+
+const render = (props = {}) => shallow(<MarkdownEditor {...props} />)
+
+describe("MarkdownEditor", () => {
+  let sandbox: SinonSandbox
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  //
+  ;[
+    [true, MinimalEditorConfig],
+    [false, FullEditorConfig]
+  ].forEach(([minimal, expectedMinimalComponent]) => {
+    [
+      ["value", "value"],
+      [null, ""]
+    ].forEach(([value, expectedPropValue]) => {
+      it(`renders the ${
+        minimal ? "minimal " : "full"
+      } MarkdownEditor with value=${String(value)}`, () => {
+        const wrapper = render({
+          minimal,
+          value
+        })
+        const ckWrapper = wrapper.find("CKEditor")
+        expect(ckWrapper.prop("editor")).toBe(ClassicEditor)
+        expect(ckWrapper.prop("config")).toBe(expectedMinimalComponent)
+        expect(ckWrapper.prop("data")).toBe(expectedPropValue)
+      })
+    })
+  })
+
+  //
+  ;[
+    ["name", "name"],
+    [null, ""]
+  ].forEach(([name, expectedPropName]) => {
+    [true, false].forEach(hasOnChange => {
+      it(`triggers ${hasOnChange ? "with" : "without"} an onChange when name=${String(name)}`, () => {
+        const onChangeStub = sandbox.stub()
+        const wrapper = render({
+          name,
+          onChange: hasOnChange ? onChangeStub : null
+        })
+        const ckWrapper = wrapper.find("CKEditor")
+
+        const data = "some data"
+        const editor = { getData: sandbox.stub().returns(data) }
+        // @ts-ignore
+        ckWrapper.prop("onChange")(null, editor)
+        if (hasOnChange) {
+          sinon.assert.calledOnceWithExactly(onChangeStub, {
+            target: { value: data, name: expectedPropName }
+          })
+        } else {
+          expect(onChangeStub.called).toBe(false)
+        }
+      })
+    })
+  })
+})


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested

#### What are the relevant tickets?
Fixes #138 

#### What's this PR do?
Adds a couple tests for `MarkdownEditor`, mocking out ckeditor to avoid complications with it. We already have tests for the other custom components so this should complete the issue.

#### How should this be manually tested?
Tests should pass
