### PR TITLE
Fix object field validation

### DIFF
--- a/static/js/components/SiteContentEditor.test.tsx
+++ b/static/js/components/SiteContentEditor.test.tsx
@@ -148,17 +148,8 @@ describe("SiteContent", () => {
     expect(form.prop("fields")).toStrictEqual([
       // Title field should be added by default
       DEFAULT_TITLE_FIELD,
-      // Nested object field should be renamed
-      {
-        ...objectField,
-        fields: [
-          {
-            // @ts-ignore
-            ...objectField.fields[0],
-            name: "myobject.mystring"
-          }
-        ]
-      }
+      // Nested object field should be not renamed
+      objectField
     ])
   })
 

--- a/static/js/components/SiteContentEditor.tsx
+++ b/static/js/components/SiteContentEditor.tsx
@@ -17,8 +17,7 @@ import { getWebsiteContentDetailCursor } from "../selectors/websites"
 import {
   addDefaultFields,
   contentFormValuesToPayload,
-  isSingletonCollectionItem,
-  renameNestedFields
+  isSingletonCollectionItem
 } from "../lib/site_content"
 import { getResponseBodyError, isErrorResponse } from "../lib/util"
 import { getContentSchema } from "./forms/validation"
@@ -50,10 +49,9 @@ export default function SiteContentEditor(props: Props): JSX.Element | null {
     fetchWebsiteContentListing
   } = props
 
-  const fields: ConfigField[] = useMemo(() => {
-    const fields = addDefaultFields(configItem)
-    return renameNestedFields(fields)
-  }, [configItem])
+  const fields: ConfigField[] = useMemo(() => addDefaultFields(configItem), [
+    configItem
+  ])
   const schema = getContentSchema(configItem)
 
   const site = useWebsite()

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -8,6 +8,7 @@ import {
   contentInitialValues,
   fieldIsVisible,
   newInitialValues,
+  renameNestedFields,
   splitFieldsIntoColumns
 } from "../../lib/site_content"
 
@@ -44,7 +45,11 @@ export default function SiteContentForm({
     [fields, formType, content]
   )
 
-  const fieldsByColumn = splitFieldsIntoColumns(fields)
+  const renamedFields: ConfigField[] = useMemo(
+    () => renameNestedFields(fields),
+    [fields]
+  )
+  const fieldsByColumn = splitFieldsIntoColumns(renamedFields)
   const columnClass = fieldsByColumn.length === 2 ? "col-6" : "col-12"
 
   return (


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
Part of #337

#### What's this PR do?
Changes the rename field behavior to be similar to before. object fields will be renamed for the `Field` objects when they render, but not for validation or submission to the API

I wasn't sure if the scope of #337 included showing validation errors when the object field is collapsed, so I left it as is.

#### How should this be manually tested?
 - Create a site with the omnibus starter. Mark one or all of the fields in the address object as required
 - Add a site and click Save without touching any of the address fields. You should see validation error text for the address fields you marked as required. On master the form would be missing validation errors for address fields unless you alter them first.

