### PR TITLE
Github webhook branch filter

### DIFF
--- a/app.json
+++ b/app.json
@@ -71,6 +71,10 @@
       "description": "Google analytics tracking ID",
       "required": false
     },
+    "GITHUB_WEBHOOK_BRANCH": {
+      "description": "Github branch to filter webhook requests against",
+      "required": false
+    },
     "GITHUB_WEBHOOK_KEY": {
       "description": "Github secret key sent by webhook requests",
       "required": false

--- a/content_sync/apis/github.py
+++ b/content_sync/apis/github.py
@@ -90,10 +90,13 @@ def sync_starter_configs(
     repo = org.get_repo(repo_name)
 
     settings_branch = settings.GITHUB_WEBHOOK_BRANCH
-    branch = repo.get_branch(settings_branch) if settings_branch else None
-    if commit and branch:
-        if commit != branch.commit.sha:
-            return
+    branch = (
+        repo.get_branch(settings_branch)
+        if settings_branch
+        else repo.get_branch(repo.default_branch)
+    )
+    if commit is not None and commit != branch.commit.sha:
+        return
 
     for config_file in config_files:
         try:

--- a/content_sync/apis/github.py
+++ b/content_sync/apis/github.py
@@ -92,7 +92,7 @@ def sync_starter_configs(
     settings_branch = settings.GITHUB_WEBHOOK_BRANCH
     branch = repo.get_branch(settings_branch) if settings_branch else None
     if commit and branch:
-        if commit != branch.commit:
+        if commit != branch.commit.sha:
             return
 
     for config_file in config_files:

--- a/content_sync/apis/github.py
+++ b/content_sync/apis/github.py
@@ -81,7 +81,7 @@ def sync_starter_configs(
     """
     Create/update WebsiteStarter objects given a repo URL and a list of config files in the repo.
     If a commit was passed in and GITHUB_WEBHOOK_BRANCH is set, these are compared and the change
-    is ignored if it does not match the branch in settings
+    is ignored if it does not match the branch in settings.
     """
     repo_path = urlparse(repo_url).path.lstrip("/")
     org_name, repo_name = repo_path.split("/", 1)

--- a/content_sync/apis/github_test.py
+++ b/content_sync/apis/github_test.py
@@ -1,6 +1,5 @@
 """ Github API tests """
 import hashlib
-from posixpath import relpath
 from types import SimpleNamespace
 
 import factory

--- a/content_sync/apis/github_test.py
+++ b/content_sync/apis/github_test.py
@@ -687,7 +687,10 @@ def test_sync_starter_configs_webhook_branch_hash_mismatch(mocker, mock_github):
 
 
 def test_sync_starter_configs_webhook_branch_hash_match(mocker, mock_github):
-    """A push to a branch other than the default branch without GITHUB_WEBHOOK_BRANCH should not trigger a starter update"""
+    """
+    A push to the branch set in settings.GITHUB_WEBHOOK_BRANCH should trigger
+    getting that branch and then the config files themselves
+    """
     git_url = "https://github.com/testorg/ocws-configs"
     config_filenames = ["site-1/ocw-studio.yaml", "site-2/ocw-studio.yaml"]
     fake_commit = "abc123"

--- a/main/settings.py
+++ b/main/settings.py
@@ -637,6 +637,12 @@ GITHUB_WEBHOOK_KEY = get_string(
     description="Github secret key sent by webhook requests",
     required=False,
 )
+GITHUB_WEBHOOK_BRANCH = get_string(
+    name="GITHUB_WEBHOOK_BRANCH",
+    default="",
+    description="Github branch to filter webhook requests against",
+    required=False,
+)
 OCW_STUDIO_SITE_CONFIG_FILE = get_string(
     name="OCW_STUDIO_SITE_CONFIG_FILE",
     default="ocw-studio.yaml",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/341

#### What's this PR do?
The webhook handler for processing `ocw-studio` configurations in a Github repo is currently indiscriminate about the commits that it responds to.  A commit to any branch will fire off the webhook, and the `WebsiteStarter` object will be updated regardless of whether the commit was to `main` or `release-candidate` or `release`.  This PR adds an env variable / setting called `GITHUB_WEBHOOK_BRANCH` where a branch to respond to can be configured.  This way, only push events to the defined branch will trigger an update of `WebsiteStarter` objects.  

#### How should this be manually tested?
 - Create a test organization within Github if you don't already have one
 - Create a new test repo within that organization
 - Make sure you have `ngrok` installed and set `GITHUB_WEBHOOK_KEY` in your env to a value, also make sure you have a superuser ready to go
 - Spin up `ocw-studio` on this branch and in another terminal create an `ngrok` endpoint using `ngrok https 8043`
 - Take the https `ngrok` URL displayed and put that in as a webhook in your test repo using the key you put into your env earlier
 - Clone https://github.com/mitodl/ocw-hugo-projects and copy the contents of it into your test repo, committing everything to the default branch
 - Open Django admin and browse to `WebsiteStarter` objects, then verify that:
   - You see `WebsiteStarters` for `ocw-course` and `ocw-www`
   - The contents of these configs match your test repo
 - Create a new branch in your test repo and make a change to one of the configs; I just changed one of the labels each time during my testing.  Commit the change to your branch.
 - Check the config in Django admin again and verify that nothing has changed
 - Merge your branch into the default branch and push the merge to your test repo
 - Check the config in Django admin and verify that the config has been updated with your change
 - Spin down your `ocw-studio` instance
 - Create a `release-candidate` branch in your test repo
 - Set `GITHUB_WEBHOOK_BRANCH` to `release-candidate` in your `.env` file
 - Spin `ocw-studio` back up
 - Commit a test change directly to your default branch
 - Check Django admin and verify that your change has not been reflected
 - Merge your change into the `release-candidate` branch and push to Github
 - Check Djnago admin and verify that the config has been updated with your change
