### PR TITLE
Remove GIT_TOKEN precondition check in content_sync.api.sync_github_website_starters

### DIFF
--- a/content_sync/api.py
+++ b/content_sync/api.py
@@ -62,5 +62,4 @@ def sync_github_website_starters(
     url: str, files: List[str], commit: Optional[str] = None
 ):
     """ Sync website starters from github """
-    if settings.GIT_TOKEN:
-        tasks.sync_github_site_configs.delay(url, files, commit=commit)
+    tasks.sync_github_site_configs.delay(url, files, commit=commit)

--- a/content_sync/api_test.py
+++ b/content_sync/api_test.py
@@ -149,15 +149,10 @@ def test_publish_website(settings, mocker):
     mock_task.delay.assert_called_once_with(website.name)
 
 
-@pytest.mark.parametrize("token", ["abc123", None])
-def test_sync_github_website_starters(settings, mocker, token):
+def test_sync_github_website_starters(mocker):
     """ Sync website starters from github """
-    settings.GIT_TOKEN = token
     mock_task = mocker.patch("content_sync.api.tasks.sync_github_site_configs.delay")
     args = "https://github.com/testorg/testconfigs", ["site1/studio.yaml"]
     kwargs = {"commit": "abc123"}
     api.sync_github_website_starters(*args, **kwargs)
-    if token:
-        mock_task.assert_called_once_with(*args, **kwargs)
-    else:
-        mock_task.assert_not_called()
+    mock_task.assert_called_once_with(*args, **kwargs)


### PR DESCRIPTION

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #346 

#### What's this PR do?
Removes the precondition that `GIT_TOKEN` be set before running the task, it's not necessary.

#### How should this be manually tested?
You can follow test instructions #297 without `GIT_TOKEN` set and it should work.
