### PR TITLE
Skip validation if fields are not visible

### DIFF
--- a/static/js/components/SiteContentEditor.tsx
+++ b/static/js/components/SiteContentEditor.tsx
@@ -20,7 +20,6 @@ import {
   isSingletonCollectionItem
 } from "../lib/site_content"
 import { getResponseBodyError, isErrorResponse } from "../lib/util"
-import { getContentSchema } from "./forms/validation"
 
 import {
   ConfigField,
@@ -52,8 +51,6 @@ export default function SiteContentEditor(props: Props): JSX.Element | null {
   const fields: ConfigField[] = useMemo(() => addDefaultFields(configItem), [
     configItem
   ])
-  const schema = getContentSchema(configItem)
-
   const site = useWebsite()
   const [
     { isPending: addIsPending },
@@ -153,7 +150,7 @@ export default function SiteContentEditor(props: Props): JSX.Element | null {
     <SiteContentForm
       onSubmit={onSubmitForm}
       fields={fields}
-      schema={schema}
+      configItem={configItem}
       content={content}
       formType={formType}
     />

--- a/static/js/components/forms/SiteContentForm.test.tsx
+++ b/static/js/components/forms/SiteContentForm.test.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-import * as yup from "yup"
 import sinon, { SinonSandbox, SinonStub } from "sinon"
 import { shallow } from "enzyme"
 
@@ -40,7 +39,6 @@ describe("SiteContentForm", () => {
     setFieldValueStub = sinon.stub()
     content = makeWebsiteContentDetail()
     configItem = makeEditableConfigItem(content.type)
-    mockValidationSchema = yup.object().shape({})
     // @ts-ignore
     splitFieldsIntoColumns.mockImplementation(() => [])
   })
@@ -53,7 +51,7 @@ describe("SiteContentForm", () => {
     shallow(
       <SiteContentForm
         fields={configItem.fields}
-        schema={mockValidationSchema}
+        configItem={configItem}
         content={content}
         onSubmit={onSubmitStub}
         formType={ContentFormType.Add}

--- a/static/js/components/forms/validation.ts
+++ b/static/js/components/forms/validation.ts
@@ -1,7 +1,10 @@
 import * as yup from "yup"
 import { ArraySchema, setLocale } from "yup"
 
-import { isRepeatableCollectionItem } from "../../lib/site_content"
+import {
+  fieldIsVisible,
+  isRepeatableCollectionItem
+} from "../../lib/site_content"
 
 import {
   ConfigField,
@@ -12,6 +15,7 @@ import {
   EditableConfigItem
 } from "../../types/websites"
 import { FormSchema } from "../../types/forms"
+import { FormikValues } from "formik"
 
 // This is added to properly handle file fields, which can have a "null" value
 setLocale({
@@ -110,12 +114,16 @@ export const getFieldSchema = (field: ConfigField): FormSchema => {
  * a Yup validation schema which will validate a form for those fields.
  **/
 export const getContentSchema = (
-  configItem: ConfigItem | EditableConfigItem
+  configItem: ConfigItem | EditableConfigItem,
+  values: FormikValues
 ): FormSchema => {
+  const titleField = configItem.fields.find(field => field.name === "title")
   const yupObjectShape = Object.fromEntries(
-    configItem.fields.map(field => [field.name, getFieldSchema(field)])
+    configItem.fields
+      .filter(field => fieldIsVisible(field, values))
+      .map(field => [field.name, getFieldSchema(field)])
   )
-  if (isRepeatableCollectionItem(configItem) && !("title" in yupObjectShape)) {
+  if (isRepeatableCollectionItem(configItem) && !titleField) {
     yupObjectShape["title"] = defaultTitleFieldSchema
   }
   return yup.object().shape(yupObjectShape)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #337 

#### What's this PR do?
This disables validation for fields which aren't visible in the UI due to being hidden fields or hidden because of a condition filter. 

There are some edge cases that aren't handled:
 - Collapse/expand behavior of `ObjectField` is not affected by this PR. I think it makes sense for validation to still happen for fields which are inside a collapsed `ObjectField` since it matches the behavior of most HTML forms I've seen. However I think we need some way to highlight the validation error outside the `ObjectField` so that there's some indication of a problem when the `ObjectField` is collapsed.
 - It seems like the `condition` filter can only point to top-level fields. Do we have a standard for referencing nested fields like `Formik` does using periods as separators? In any case our code only handles filtering top-level fields at the moment so this validation PR does that too.
 - Similarly, our hidden field code doesn't currently handle conditionally hiding nested fields. In the example schema in #337 the condition filter is a part of the `ObjectField`, not any of the nested fields. The validation is on a nested field which isn't handled by this PR, but this PR removes all validation for the `ObjectField` so all nested fields are included in that.

#### How should this be manually tested?
Copy the schema in the description of #337 into a starter config for a website. Try to add a new Resource. Enter something for the title, choose a file type which is not Image, and upload a small file. Click 'Save'. On master the Save button should not do anything, but on this PR you should be able to create a resource with the new file correctly.