### PR TITLE
Add label_singular field for collections

### DIFF
--- a/localdev/configs/basic-site-config.yml
+++ b/localdev/configs/basic-site-config.yml
@@ -2,13 +2,15 @@ content-dir: content
 root-url-path: "sites"
 collections:
   - name: blog
-    label: Blog
+    label: Blogs
+    label_singular: Blog
     category: Content
     folder: content/blog
     fields:
       - {"label": "Title", "name": "title", "widget": "string", "required": true}
   - name: bio
-    label: Bio
+    label: Bios
+    label_singular: Bio
     category: Content
     folder: content/bio
     fields:
@@ -23,7 +25,8 @@ collections:
         fields:
           - {"label": "Title", "name": "title", "widget": "string", "required": true}
   - name: resource
-    label: Resource
+    label: Resources
+    label_singular: Resource
     category: Content
     folder: content/resource
     fields:

--- a/localdev/configs/ocw-course-site-config.yml
+++ b/localdev/configs/ocw-course-site-config.yml
@@ -2,14 +2,16 @@ content-dir: content
 root-url-path: "courses"
 collections:
   - name: page
-    label: Page
+    label: Pages
+    label_singular: Page
     category: Content
     folder: content
     fields:
       - {"label": "Body", "name": "body", "widget": "markdown"}
 
   - name: resource
-    label: Resource
+    label: Resources
+    label_singular: Resource
     category: Content
     folder: content
     fields:

--- a/localdev/configs/omnibus-site-config.yml
+++ b/localdev/configs/omnibus-site-config.yml
@@ -2,7 +2,8 @@ root-url-path: "omnibus"
 content-dir: content
 collections:
   - name: page
-    label: Page
+    label: Pages
+    label_singular: Page
     category: Content
     folder: content
     fields:
@@ -40,7 +41,8 @@ collections:
           - { label: "Zip Code", name: "zip", widget: "string", required: false }
 
   - name: resource
-    label: Resource
+    label: Resources
+    label_singular: Resource
     category: Content
     folder: content
     fields:

--- a/static/js/components/RepeatableContentListing.test.tsx
+++ b/static/js/components/RepeatableContentListing.test.tsx
@@ -133,7 +133,7 @@ describe("RepeatableContentListing", () => {
     const { wrapper } = await render()
     expect(wrapper.find("BasicModal").prop("isVisible")).toBe(false)
     const link = wrapper.find("a.add")
-    expect(link.text()).toBe(`Add ${configItem.label}`)
+    expect(link.text()).toBe(`Add ${configItem.label_singular}`)
     act(() => {
       // @ts-ignore
       link.prop("onClick")({ preventDefault: helper.sandbox.stub() })
@@ -250,6 +250,42 @@ describe("RepeatableContentListing", () => {
           )
         }
       })
+    })
+  })
+
+  //
+  ;[true, false].forEach(isSingular => {
+    it("should use the singular label where appropriate", async () => {
+      let expectedLabel
+      if (!isSingular) {
+        configItem.label_singular = undefined
+        expectedLabel = configItem.label
+      } else {
+        expectedLabel = configItem.label_singular
+      }
+      const { wrapper } = await render()
+      expect(
+        wrapper
+          .find("Card")
+          .find("h3")
+          .text()
+      ).toBe(expectedLabel)
+      expect(
+        wrapper
+          .find("Card")
+          .find(".add")
+          .text()
+      ).toBe(`Add ${expectedLabel}`)
+      act(() => {
+        const event: any = { preventDefault: jest.fn() }
+        const button = wrapper.find("Card").find(".add")
+        // @ts-ignore
+        button.prop("onClick")(event)
+      })
+      wrapper.update()
+      expect(wrapper.find("BasicModal").prop("title")).toBe(
+        `Add ${expectedLabel}`
+      )
     })
   })
 })

--- a/static/js/components/RepeatableContentListing.test.tsx
+++ b/static/js/components/RepeatableContentListing.test.tsx
@@ -269,7 +269,7 @@ describe("RepeatableContentListing", () => {
           .find("Card")
           .find("h3")
           .text()
-      ).toBe(expectedLabel)
+      ).toBe(configItem.label)
       expect(
         wrapper
           .find("Card")

--- a/static/js/components/RepeatableContentListing.tsx
+++ b/static/js/components/RepeatableContentListing.tsx
@@ -78,11 +78,12 @@ export default function RepeatableContentListing(props: {
     })
   }
 
+  const labelSingular = configItem.label_singular ?? configItem.label
   const modalTitle =
     panelState.formType &&
-    `${panelState.formType === ContentFormType.Edit ? "Edit" : "Add"} ${
-      configItem.label
-    }`
+    `${
+      panelState.formType === ContentFormType.Edit ? "Edit" : "Add"
+    } ${labelSingular}`
   const modalClassName = `right ${
     splitFieldsIntoColumns(configItem.fields).length > 1 ? "wide" : ""
   }`
@@ -113,9 +114,9 @@ export default function RepeatableContentListing(props: {
       <div>
         <Card>
           <div className="d-flex flex-direction-row align-items-center justify-content-between pb-3">
-            <h3>{configItem.label}</h3>
+            <h3>{labelSingular}</h3>
             <a className="btn blue-button add" onClick={startAddOrEdit(null)}>
-              Add {configItem.label}
+              Add {labelSingular}
             </a>
           </div>
           <ul className="ruled-list">

--- a/static/js/components/RepeatableContentListing.tsx
+++ b/static/js/components/RepeatableContentListing.tsx
@@ -114,7 +114,7 @@ export default function RepeatableContentListing(props: {
       <div>
         <Card>
           <div className="d-flex flex-direction-row align-items-center justify-content-between pb-3">
-            <h3>{labelSingular}</h3>
+            <h3>{configItem.label}</h3>
             <a className="btn blue-button add" onClick={startAddOrEdit(null)}>
               Add {labelSingular}
             </a>

--- a/static/js/components/SiteSidebar.test.tsx
+++ b/static/js/components/SiteSidebar.test.tsx
@@ -34,7 +34,7 @@ describe("SiteSidebar", () => {
 
     const expected = [
       [
-        "Page",
+        "Pages",
         siteContentListingUrl
           .param({
             name:        website.name,
@@ -43,7 +43,7 @@ describe("SiteSidebar", () => {
           .toString()
       ],
       [
-        "Resource",
+        "Resources",
         siteContentListingUrl
           .param({
             name:        website.name,

--- a/static/js/resources/basic-site-config.json
+++ b/static/js/resources/basic-site-config.json
@@ -11,7 +11,8 @@
         }
       ],
       "folder": "content/blog",
-      "label": "Blog",
+      "label": "Blogs",
+      "label_singular": "Blog",
       "name": "blog"
     },
     {
@@ -25,7 +26,8 @@
         }
       ],
       "folder": "content/bio",
-      "label": "Bio",
+      "label": "Bios",
+      "label_singular": "Bio",
       "name": "bio"
     },
     {
@@ -65,7 +67,8 @@
         }
       ],
       "folder": "content/resource",
-      "label": "Resource",
+      "label": "Resources",
+      "label_singular": "Resource",
       "name": "resource"
     }
   ],

--- a/static/js/resources/ocw-course-site-config.json
+++ b/static/js/resources/ocw-course-site-config.json
@@ -10,7 +10,8 @@
         }
       ],
       "folder": "content",
-      "label": "Page",
+      "label": "Pages",
+      "label_singular": "Page",
       "name": "page"
     },
     {
@@ -28,7 +29,8 @@
         }
       ],
       "folder": "content",
-      "label": "Resource",
+      "label": "Resources",
+      "label_singular": "Resource",
       "name": "resource"
     },
     {

--- a/static/js/resources/omnibus-site-config.json
+++ b/static/js/resources/omnibus-site-config.json
@@ -79,7 +79,8 @@
         }
       ],
       "folder": "content",
-      "label": "Page",
+      "label": "Pages",
+      "label_singular": "Page",
       "name": "page"
     },
     {
@@ -114,7 +115,8 @@
         }
       ],
       "folder": "content",
-      "label": "Resource",
+      "label": "Resources",
+      "label_singular": "Resource",
       "name": "resource"
     },
     {

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -126,6 +126,8 @@ export type ConfigField =
 export interface BaseConfigItem {
   name: string
   label: string
+  // eslint-disable-next-line camelcase
+  label_singular?: string
 }
 
 export type SingletonConfigItem = BaseConfigItem & {
@@ -151,6 +153,8 @@ export type EditableConfigItem = RepeatableConfigItem | SingletonConfigItem
 export interface ConfigItem {
   name: string
   label: string
+  // eslint-disable-next-line
+  label_singular?: string
   category: string
   fields: ConfigField[]
   file?: string

--- a/static/js/util/factories/websites.ts
+++ b/static/js/util/factories/websites.ts
@@ -121,11 +121,12 @@ export const makeEditableConfigItem = (
 export const makeRepeatableConfigItem = (
   name?: string
 ): RepeatableConfigItem => ({
-  fields:   cloneDeep(exampleFields),
-  name:     name || casual.word,
-  label:    casual.word,
-  category: casual.word,
-  folder:   casual.word
+  fields:         cloneDeep(exampleFields),
+  name:           name || casual.word,
+  label:          casual.word,
+  label_singular: casual.word,
+  category:       casual.word,
+  folder:         casual.word
 })
 
 export const makeSingletonConfigItem = (

--- a/websites/config_schema/site-config-schema.yml
+++ b/websites/config_schema/site-config-schema.yml
@@ -5,6 +5,7 @@ collections: list(include('content_item'))
 content_item:
     name: str()
     label: str()
+    label_singular: str(required=False)
     category: str()
     fields: list(include('field'), required=False)
     folder: str(required=False)


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Fixes #324 

#### What's this PR do?
Adds `label_singular` for collections and updates the UI in a few places to use the singular value

#### How should this be manually tested?
Update a starter config to have a plural word (ie "Pages") for `label` and add a singular word (ie "Page") as a new field `label_singular`. View the collection. You should see "Add Page" with the value in `label_singular` in the button on the right side