### PR TITLE
Fix handling of empty values in new content

### DIFF
--- a/static/js/lib/site_content.ts
+++ b/static/js/lib/site_content.ts
@@ -107,25 +107,6 @@ export const splitFieldsIntoColumns = (
 ): ConfigField[][] =>
   partition(isMainContentField, fields).filter(column => column.length > 0)
 
-/**
- * takes a ConfigField and returns an appropriate empty value
- * for that field.
- **/
-const emptyValue = (field: ConfigField): SiteFormValue => {
-  switch (field.widget) {
-  case "select":
-    if (field.multiple) {
-      return []
-    } else {
-      return null
-    }
-  case "file":
-    return null
-  default:
-    return ""
-  }
-}
-
 export const isRepeatableCollectionItem = (
   configItem: BaseConfigItem
 ): configItem is RepeatableConfigItem => "folder" in configItem
@@ -152,10 +133,9 @@ export const contentFormValuesToPayload = (
 
   let hasFileUpload = false
   for (const field of fields) {
-    let value = values[field.name]
-    if (!fieldHasData(field, values)) {
-      value = emptyValue(field)
-    }
+    const value = fieldHasData(field, values) ?
+      values[field.name] :
+      defaultForField(field)
 
     if (value !== undefined) {
       // Our API expects these bits of data as top-level keys in the payload:
@@ -197,7 +177,7 @@ export const contentInitialValues = (
       values[field.name] = content.markdown ?? ""
     } else if (field.name === "title") {
       values[field.name] = content[field.name] ?? ""
-    } else if (field.widget === "file") {
+    } else if (field.widget === WidgetVariant.File) {
       values[field.name] = content[field.name] ?? null
     } else {
       values[field.name] = metadata[field.name] ?? defaultForField(field)


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Fixes #359 

#### What's this PR do?
In the issue there was a problem with showing validation errors when editing and saving a form. I looked into it and we were storing invalid data in the image metadata when we originally created the content. Since the object field was hidden, it was considered an empty field. However we had two different functions for creating default empty data for a widget type and one of those functions was not updated with new widget types like object fields. This removes `emptyValue` and uses `defaultForValue` instead to create empty field values to be sent to the server.

#### How should this be manually tested?
Create or update a starter with this metadata:

    {
      "collections": [
        {
          "category": "Content",
          "fields": [
            {
              "label": "Title",
              "name": "title",
              "required": true,
              "widget": "string"
            },
            {
              "label": "Description",
              "minimal": true,
              "name": "description",
              "widget": "markdown"
            },
            {
              "label": "File Type",
              "name": "filetype",
              "options": [
                "Image",
                "Video",
                "Document",
                "Other"
              ],
              "required": true,
              "widget": "select"
            },
            {
              "label": "File",
              "name": "file",
              "widget": "file"
            },
            {
              "condition": {
                "equals": "Image",
                "field": "filetype"
              },
              "fields": [
                {
                  "label": "Text alternative",
                  "name": "image-alt",
                  "required": true,
                  "widget": "string"
                },
                {
                  "label": "Caption",
                  "name": "caption",
                  "widget": "string"
                },
                {
                  "label": "Credit",
                  "name": "credit",
                  "widget": "text"
                }
              ],
              "label": "Image Metadata",
              "name": "me2tadata",
              "widget": "object"
            }
          ],
          "folder": "content/resources",
          "label": "Resources",
          "name": "resource"
        }
      ],
      "content-dir": "content",
      "root-url-path": "/george/"
    }

 - Create a new website for it. 
 - Create a new resource. Add a title and change file type to "Video", but don't touch any other fields. Click Save and it should save correctly.
 - Click on the title to edit the resource you just created. Change file type from "Video" to "Image". You should see some new fields pop up. Click Save, and you should see a validation error: "Text alternative is a required field"
