### PR TITLE
add website collection list page

### DIFF
--- a/main/urls.py
+++ b/main/urls.py
@@ -35,6 +35,7 @@ urlpatterns = [
     re_path(r"^sites/.*$", restricted_index, name="sites"),
     path("new-site/", restricted_index, name="new-site"),
     path("markdown-editor", restricted_index, name="markdown-editor-test"),
+    re_path(r"^collections/.*$", restricted_index, name="collections"),
     path("logout/", LogoutView.as_view(), name="logout"),
     path("", include("news.urls")),
     path("", include("websites.urls")),

--- a/static/js/lib/urls.test.ts
+++ b/static/js/lib/urls.test.ts
@@ -13,7 +13,12 @@ import {
   siteApiCollaboratorsDetailUrl,
   siteApiContentUrl,
   siteApiContentDetailUrl,
-  siteApiContentListingUrl
+  siteApiContentListingUrl,
+  collectionsApiUrl,
+  collectionsApiDetailUrl,
+  wcItemsApiUrl,
+  wcItemsApiDetailUrl,
+  collectionsBaseUrl
 } from "./urls"
 
 describe("urls", () => {
@@ -70,6 +75,19 @@ describe("urls", () => {
         ).toBe("/sites/site-name/collaborators/1/")
       })
     })
+
+    //
+    ;[
+      [0, "/collections/?offset=0"],
+      [10, "/collections/?offset=10"],
+      [20, "/collections/?offset=20"]
+    ].forEach(([offset, expectedLink]) => {
+      it(`renders a collection URL with offset=${offset}`, () => {
+        expect(collectionsBaseUrl.query({ offset }).toString()).toBe(
+          expectedLink
+        )
+      })
+    })
   })
 
   describe("apis", () => {
@@ -77,6 +95,7 @@ describe("urls", () => {
       it("renders a top-level site API", () => {
         expect(siteApi.toString()).toBe("/api/websites/")
       })
+
       it("renders a URL for site listing", () => {
         expect(siteApiListingUrl.query({ offset: 20 }).toString()).toBe(
           "/api/websites/?limit=10&offset=20"
@@ -127,6 +146,30 @@ describe("urls", () => {
             .query({ offset: 40 })
             .toString()
         ).toBe("/api/websites/the-best-course/content/?limit=10&offset=40")
+      })
+    })
+
+    describe("Collections APIs", () => {
+      it("renders the collections API url", () => {
+        expect(collectionsApiUrl.toString()).toBe("/api/collections/")
+      })
+
+      it("renders a collection detail API url", () => {
+        expect(
+          collectionsApiDetailUrl.param({ collection_id: 4 }).toString()
+        ).toBe("/api/collections/4/")
+      })
+
+      it("renders collection items list API url", () => {
+        expect(wcItemsApiUrl.param({ collection_id: 4 }).toString()).toBe(
+          "/api/collections/4/items/"
+        )
+      })
+
+      it("renders collection item detail API url", () => {
+        expect(
+          wcItemsApiDetailUrl.param({ collection_id: 4, item_id: 3 }).toString()
+        ).toBe("/api/collections/4/items/3/")
       })
     })
   })

--- a/static/js/lib/urls.ts
+++ b/static/js/lib/urls.ts
@@ -14,6 +14,8 @@ export const siteCollaboratorsDetailUrl = siteCollaboratorsUrl.segment(
   ":userId/"
 )
 
+export const collectionsBaseUrl = UrlAssembler().prefix("/collections/")
+
 // API URLS
 const api = UrlAssembler().prefix("/api/")
 
@@ -38,3 +40,48 @@ export const siteApiContentDetailUrl = siteApiContentUrl.segment(":textId/")
 export const siteApiListingUrl = siteApi.query({
   limit: WEBSITES_PAGE_SIZE
 })
+
+// WEBSITE COLLECTIONS API
+
+/**
+ * Listing API URL for WebsiteCollection records
+ **/
+export const collectionsApiUrl = api.segment("collections/")
+
+/**
+ * Detail API URL for WebsiteCollection records
+ *
+ * Returns only a single WebsiteCollection record, but does
+ * not include its items.
+ **/
+export const collectionsApiDetailUrl = collectionsApiUrl.segment(
+  ":collection_id/"
+)
+
+/**
+ * Listing API for WebsiteCollectionItems
+ *
+ * This looks like:
+ *
+ * /api/collections/:collection_id/items/
+ *
+ * It returns the items contained in a WebsiteCollection.
+ **/
+export const wcItemsApiUrl = collectionsApiDetailUrl.segment("items/")
+
+/**
+ * Detail API for WebsiteCollectionItems
+ *
+ * Detail view for a single WebsiteCollectionItem record.
+ * this looks like:
+ *
+ * /api/collections/:collection_id/items/:item_id/
+ *
+ * It's mainly of use for changing the order of items in the
+ * WebsiteCollection by editing the `position` attribute.
+ * Note that if a single `WebsiteCollectionItem` has its position
+ * changed the backend takes care of reconciling all the other items
+ * in the list w/ that position change, so only one request is needed
+ * to change an item's position.
+ **/
+export const wcItemsApiDetailUrl = wcItemsApiUrl.segment(":item_id/")

--- a/static/js/pages/App.tsx
+++ b/static/js/pages/App.tsx
@@ -7,6 +7,7 @@ import SitesDashboard from "./SitesDashboard"
 import Header from "../components/Header"
 import HomePage from "./HomePage"
 import MarkdownEditorTestPage from "./MarkdownEditorTestPage"
+import WebsiteCollectionsPage from "./WebsiteCollectionsPage"
 import useTracker from "../hooks/tracker"
 
 export default function App(): JSX.Element {
@@ -14,7 +15,10 @@ export default function App(): JSX.Element {
 
   return (
     <div className="app">
-      <Route path={["/", "/new-site", "/sites", "/markdown-editor"]} exact>
+      <Route
+        path={["/", "/new-site", "/sites", "/markdown-editor", "/collections"]}
+        exact
+      >
         <Header />
       </Route>
       <div className="page-content">
@@ -23,6 +27,7 @@ export default function App(): JSX.Element {
           <Route exact path="/new-site" component={SiteCreationPage} />
           <Route exact path="/sites" component={SitesDashboard} />
           <Route path="/sites/:name" component={SitePage} />
+          <Route path="/collections" component={WebsiteCollectionsPage} />
           <Route path="/markdown-editor">
             <MarkdownEditorTestPage />
           </Route>

--- a/static/js/pages/SitesDashboard.tsx
+++ b/static/js/pages/SitesDashboard.tsx
@@ -42,7 +42,7 @@ export default function SitesDashboard(
   }
 
   return (
-    <div className="px-4 sites-dashboard">
+    <div className="px-4 dashboard">
       <div className="content">
         <div className="d-flex flex-direction-row align-items-center justify-content-between pb-3">
           <h3>Sites</h3>

--- a/static/js/pages/WebsiteCollectionsPage.test.tsx
+++ b/static/js/pages/WebsiteCollectionsPage.test.tsx
@@ -1,0 +1,87 @@
+import WebsiteCollectionsPage from "./WebsiteCollectionsPage"
+
+import IntegrationTestHelper, {
+  TestRenderer
+} from "../util/integration_test_helper"
+import { WebsiteCollection } from "../types/website_collections"
+import { makeWebsiteCollection } from "../util/factories/website_collections"
+import { collectionsApiUrl, collectionsBaseUrl } from "../lib/urls"
+import { times } from "lodash"
+
+describe("CollectionsPage", () => {
+  let helper: IntegrationTestHelper,
+    render: TestRenderer,
+    collections: WebsiteCollection[]
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    collections = times(20, makeWebsiteCollection)
+
+    // first page
+    helper.handleRequestStub
+      .withArgs(collectionsApiUrl.param({ offset: 0 }).toString(), "GET")
+      .returns({
+        body: {
+          results:  collections.slice(0, 10),
+          next:     "https://example.com",
+          previous: null,
+          count:    20
+        },
+        status: 200
+      })
+
+    // second page
+    helper.handleRequestStub
+      .withArgs(collectionsApiUrl.param({ offset: 10 }).toString(), "GET")
+      .returns({
+        body: {
+          results:  collections.slice(10),
+          next:     null,
+          previous: "https://example.com",
+          count:    20
+        },
+        status: 200
+      })
+
+    render = helper.configureRenderer(WebsiteCollectionsPage)
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should render WebsiteCollection records in a list format", async () => {
+    const { wrapper } = await render()
+    expect(wrapper.find("li").length).toBe(10)
+    expect(wrapper.find("li").map(li => li.find("a").text())).toEqual(
+      collections.slice(0, 10).map(col => col.title)
+    )
+  })
+
+  it("should have pagination controls, allow navigating to the second page of results", async () => {
+    const { wrapper } = await render()
+    expect(
+      wrapper
+        .find(".pagination Link.next")
+        .at(0)
+        .prop("to")
+    ).toBe(collectionsBaseUrl.query({ offset: 10 }).toString())
+  })
+
+  it("should show a second page of results", async () => {
+    helper.browserHistory.push({
+      search: "offset=10"
+    })
+    const { wrapper } = await render()
+    expect(wrapper.find("li").map(li => li.find("a").text())).toEqual(
+      collections.slice(10).map(col => col.title)
+    )
+
+    expect(
+      wrapper
+        .find(".pagination Link.previous")
+        .at(0)
+        .prop("to")
+    ).toBe(collectionsBaseUrl.query({ offset: 0 }).toString())
+  })
+})

--- a/static/js/pages/WebsiteCollectionsPage.tsx
+++ b/static/js/pages/WebsiteCollectionsPage.tsx
@@ -1,0 +1,61 @@
+import React from "react"
+import { useRequest } from "redux-query-react"
+import { useSelector } from "react-redux"
+import { useLocation } from "react-router-dom"
+
+import PaginationControls from "../components/PaginationControls"
+import Card from "../components/Card"
+
+import { WEBSITE_CONTENT_PAGE_SIZE } from "../constants"
+import {
+  websiteCollectionListRequest,
+  WebsiteCollectionListingResponse
+} from "../query-configs/website_collections"
+import { getWebsiteCollectionListingCursor } from "../selectors/website_collections"
+import { WebsiteCollection } from "../types/website_collections"
+import { collectionsBaseUrl } from "../lib/urls"
+
+export default function WebsiteCollectionsPage(): JSX.Element {
+  const { search } = useLocation()
+
+  const offset = Number(new URLSearchParams(search).get("offset") ?? 0)
+
+  useRequest(websiteCollectionListRequest(offset))
+
+  const websiteCollectionsListingCursor = useSelector(
+    getWebsiteCollectionListingCursor
+  )
+
+  const listing: WebsiteCollectionListingResponse = websiteCollectionsListingCursor(
+    offset
+  )
+
+  return (
+    <div className="px-4 dashboard">
+      <div className="content">
+        <div className="d-flex flex-direction-row align-items-center justify-content-between pb-3">
+          <h3>Collections</h3>
+        </div>
+        <Card>
+          <ul className="ruled-list">
+            {listing.results.map((collection: WebsiteCollection) => (
+              <li className="py-3" key={collection.id}>
+                <a>{collection.title}</a>
+                <div className="text-gray">{collection.description}</div>
+              </li>
+            ))}
+          </ul>
+          <PaginationControls
+            listing={listing}
+            previous={collectionsBaseUrl
+              .query({ offset: offset - WEBSITE_CONTENT_PAGE_SIZE })
+              .toString()}
+            next={collectionsBaseUrl
+              .query({ offset: offset + WEBSITE_CONTENT_PAGE_SIZE })
+              .toString()}
+          />
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/static/js/query-configs/utils.ts
+++ b/static/js/query-configs/utils.ts
@@ -2,3 +2,10 @@ import { nthArg } from "ramda"
 
 // replace the previous state with the next state without merging
 export const nextState = nthArg(1)
+
+export interface PaginatedResponse<Item> {
+  count: number | null
+  next: string | null
+  previous: string | null
+  results: Item[]
+}

--- a/static/js/query-configs/website_collections.ts
+++ b/static/js/query-configs/website_collections.ts
@@ -1,0 +1,60 @@
+import { QueryConfig } from "redux-query"
+
+import { PaginatedResponse } from "./utils"
+
+import { collectionsApiUrl } from "../lib/urls"
+import { WebsiteCollection } from "../types/website_collections"
+
+export type WebsiteCollectionDetails = Record<number, WebsiteCollection>
+
+export type WebsiteCollectionListing = Record<number, PaginatedResponse<number>>
+
+export type WebsiteCollectionListingResponse = PaginatedResponse<
+  WebsiteCollection
+>
+
+export const websiteCollectionListRequest = (offset = 0): QueryConfig => ({
+  url:       collectionsApiUrl.query({ offset }).toString(),
+  transform: (body: WebsiteCollectionListingResponse) => {
+    const websiteCollectionDetails: WebsiteCollectionDetails = Object.fromEntries(
+      body.results.map((collection: WebsiteCollection) => [
+        collection.id,
+        collection
+      ])
+    )
+
+    const websiteCollectionListing: WebsiteCollectionListing = {
+      [offset]: {
+        ...body,
+        results: body.results.map(
+          (collection: WebsiteCollection) => collection.id
+        )
+      }
+    }
+
+    return {
+      websiteCollectionDetails,
+      websiteCollectionListing
+    }
+  },
+
+  update: {
+    websiteCollectionListing: (
+      prev: WebsiteCollectionListing,
+      next: WebsiteCollectionListing
+    ) =>
+      prev ?
+        {
+          ...prev,
+          ...next
+        } :
+        next,
+    websiteCollectionDetails: (
+      prev: WebsiteCollectionDetails,
+      next: WebsiteCollectionDetails
+    ): WebsiteCollectionDetails => ({
+      ...prev,
+      ...next
+    })
+  }
+})

--- a/static/js/query-configs/websites.ts
+++ b/static/js/query-configs/websites.ts
@@ -1,7 +1,7 @@
 import { ActionPromiseValue, QueryConfig } from "redux-query"
 import { merge, reject, propEq, compose, evolve, when, assoc, map } from "ramda"
 
-import { nextState } from "./utils"
+import { nextState, PaginatedResponse } from "./utils"
 import { getCookie } from "../lib/api/util"
 import { DEFAULT_POST_OPTIONS } from "../lib/redux_query"
 import {
@@ -27,13 +27,6 @@ import {
   WebsiteContentListItem,
   WebsiteStarter
 } from "../types/websites"
-
-interface PaginatedResponse<Item> {
-  count: number | null
-  next: string | null
-  previous: string | null
-  results: Item[]
-}
 
 export type WebsiteDetails = Record<string, Website>
 
@@ -358,6 +351,7 @@ export type EditWebsiteContentPayload = {
   metadata?: any
   file?: File
 }
+
 export const editWebsiteContentMutation = (
   site: Website,
   textId: string,

--- a/static/js/selectors/website_collections.ts
+++ b/static/js/selectors/website_collections.ts
@@ -1,0 +1,31 @@
+import { createSelector } from "reselect"
+import { memoize } from "lodash"
+
+import { ReduxState } from "../reducers"
+import {
+  WebsiteCollectionDetails,
+  WebsiteCollectionListing,
+  WebsiteCollectionListingResponse
+} from "../query-configs/website_collections"
+
+export const getWebsiteCollectionDetailCursor = createSelector(
+  (state: ReduxState) => state.entities?.websiteCollectionDetails ?? {},
+  (collections: WebsiteCollectionDetails) =>
+    memoize((id: number) => collections[id])
+)
+
+export const getWebsiteCollectionListingCursor = createSelector(
+  (state: ReduxState) => state.entities?.websiteCollectionListing ?? {},
+  getWebsiteCollectionDetailCursor,
+  (listing: WebsiteCollectionListing, websiteContentDetailCursor) =>
+    memoize(
+      (offset: number): WebsiteCollectionListingResponse => {
+        const response = listing[offset] ?? {}
+
+        return {
+          ...response,
+          results: (response?.results ?? []).map(websiteContentDetailCursor)
+        }
+      }
+    )
+)

--- a/static/js/types/website_collections.ts
+++ b/static/js/types/website_collections.ts
@@ -1,0 +1,17 @@
+/**
+ * A user-editable collection of Websites
+ *
+ * This is basically an array implemented using Django
+ * records. We have a WebsiteCollection to store the list
+ * metadata (title, description) and then WebsiteCollectionItem
+ * records associate websites to the list.
+ **/
+export interface WebsiteCollection {
+  title: string
+  description: string
+  id: number
+}
+
+export interface WebsiteCollectionItem {
+  position: number
+}

--- a/static/js/util/factories/website_collections.ts
+++ b/static/js/util/factories/website_collections.ts
@@ -1,0 +1,11 @@
+import { WebsiteCollection } from "../../types/website_collections"
+import casual from "casual-browserify"
+import incrementer from "../incrementer"
+
+const incr = incrementer()
+
+export const makeWebsiteCollection = (): WebsiteCollection => ({
+  id:          incr.next().value,
+  title:       casual.title,
+  description: casual.description
+})

--- a/static/js/util/integration_test_helper.tsx
+++ b/static/js/util/integration_test_helper.tsx
@@ -93,7 +93,7 @@ export default class IntegrationTestHelper {
       const store = configureStore(defaultState ?? perRenderDefaultState)
       beforeRenderActions.forEach(action => store.dispatch(action))
 
-      const wrapper = await mount(
+      const wrapper = mount(
         <Provider store={store}>
           <ReduxQueryProvider queriesSelector={getQueries}>
             <Router history={this.browserHistory}>

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -1,4 +1,4 @@
-.sites-dashboard {
+.dashboard {
   .content {
     flex-grow: 1;
     padding: 15px;

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -4,7 +4,7 @@
 @import "variables";
 @import "home-page";
 @import "site-page";
-@import "sites-dashboard";
+@import "dashboard";
 @import "site-collaborators";
 @import "forms";
 @import "card";
@@ -126,4 +126,8 @@ $modal-sidebar-width-wide: 90%;
 :root {
   --ck-z-default: 10000 !important;
   --ck-z-modal: calc(var(--ck-z-default) + 999);
+}
+
+.text-gray {
+  color: $studio-text-gray;
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #356

#### What's this PR do?

This adds the first part of the website collection frontend, a list page which shows the collections that have been created (no UI for creating or editing yet).

#### How should this be manually tested?

Create some WebsiteCollections via the django admin. Then go to `/collections`, and you should see them appear in the list. If you make more than 10 you should be able to page through them with the standard pagination controls.

#### Screenshots (if appropriate)

![Screen Shot 2021-07-07 at 2 59 40 PM](https://user-images.githubusercontent.com/6207644/124814445-02035b80-df34-11eb-9c4d-13f2e0a19971.png)