### PR TITLE
Add website collection editing functionality

### DIFF
--- a/static/js/components/WebsiteCollectionEditor.test.tsx
+++ b/static/js/components/WebsiteCollectionEditor.test.tsx
@@ -1,0 +1,159 @@
+import { act } from "react-dom/test-utils"
+import { SinonStub } from "sinon"
+
+import WebsiteCollectionEditor from "./WebsiteCollectionEditor"
+
+import { collectionsApiDetailUrl, collectionsApiUrl } from "../lib/urls"
+
+import IntegrationTestHelper, {
+  TestRenderer
+} from "../util/integration_test_helper"
+import { createModalState } from "../types/modal_state"
+import { makeWebsiteCollection } from "../util/factories/website_collections"
+import { WebsiteCollection } from "../types/website_collections"
+
+describe("WebsiteCollectionEditor", () => {
+  let helper: IntegrationTestHelper,
+    render: TestRenderer,
+    hideModalStub: SinonStub
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    hideModalStub = helper.sandbox.stub()
+    render = helper.configureRenderer(WebsiteCollectionEditor, {
+      hideModal:  hideModalStub,
+      modalState: createModalState("closed", null)
+    })
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  describe("adding a new website collection", () => {
+    beforeEach(() => {
+      helper.handleRequestStub.withArgs(collectionsApiUrl.toString()).returns({
+        body:   { id: 32 },
+        status: 200
+      })
+    })
+
+    it("should pass initial values down to the form", async () => {
+      const { wrapper } = await render({
+        modalState: createModalState("adding", null)
+      })
+      expect(
+        wrapper.find("WebsiteCollectionForm").prop("initialValues")
+      ).toEqual({
+        title:       "",
+        description: ""
+      })
+    })
+
+    it("should close the modal after saving", async () => {
+      const { wrapper } = await render({
+        modalState: createModalState("adding", null)
+      })
+      await act(async () =>
+        wrapper.find("WebsiteCollectionForm").prop("onSubmit")!({
+          // @ts-ignore
+          title: "wow!"
+        })
+      )
+      expect(hideModalStub.called).toBeTruthy()
+    })
+
+    it("should allow us to create a new collection", async () => {
+      const { wrapper } = await render({
+        modalState: createModalState("adding", null)
+      })
+      await act(async () =>
+        wrapper.find("WebsiteCollectionForm").prop("onSubmit")!({
+          // @ts-ignore
+          title:       "wow!",
+          description: "the best one around, by far"
+        })
+      )
+
+      expect(helper.handleRequestStub.args[0]).toEqual([
+        collectionsApiUrl.toString(),
+        "POST",
+        {
+          body: {
+            title:       "wow!",
+            description: "the best one around, by far"
+          },
+          credentials: undefined,
+          headers:     {
+            "X-CSRFTOKEN": ""
+          }
+        }
+      ])
+    })
+  })
+
+  describe("editing an existing collection", () => {
+    let collection: WebsiteCollection
+
+    beforeEach(() => {
+      collection = makeWebsiteCollection()
+
+      helper.handleRequestStub
+        .withArgs(
+          collectionsApiDetailUrl
+            .param({
+              collectionId: collection.id
+            })
+            .toString()
+        )
+        .returns({
+          body:   collection,
+          status: 200
+        })
+    })
+
+    it("should pass values from focused website down to form", async () => {
+      const { wrapper } = await render({
+        modalState: createModalState("editing", collection.id)
+      })
+      expect(
+        wrapper.find("WebsiteCollectionForm").prop("initialValues")
+      ).toEqual({
+        title:       collection.title,
+        description: collection.description
+      })
+    })
+
+    it("should let us edit an existing collection", async () => {
+      const { wrapper } = await render({
+        modalState: createModalState("editing", collection.id)
+      })
+      await act(async () =>
+        wrapper.find("WebsiteCollectionForm").prop("onSubmit")!({
+          // @ts-ignore
+          title:       "new title",
+          description: "better description!"
+        })
+      )
+      expect(helper.handleRequestStub.args[1]).toEqual([
+        collectionsApiDetailUrl
+          .param({
+            collectionId: collection.id
+          })
+          .toString(),
+        "PATCH",
+        {
+          body: {
+            ...collection,
+            title:       "new title",
+            description: "better description!"
+          },
+          credentials: undefined,
+          headers:     {
+            "X-CSRFTOKEN": ""
+          }
+        }
+      ])
+    })
+  })
+})

--- a/static/js/components/WebsiteCollectionEditor.tsx
+++ b/static/js/components/WebsiteCollectionEditor.tsx
@@ -1,0 +1,90 @@
+import React, { useCallback } from "react"
+
+import WebsiteCollectionForm from "./forms/WebsiteCollectionForm"
+
+import { useMutation, useRequest } from "redux-query-react"
+import { WebsiteCollectionFormFields } from "../types/forms"
+import {
+  WebsiteCollection,
+  WebsiteCollectionModalState
+} from "../types/website_collections"
+import {
+  createWebsiteCollectionMutation,
+  editWebsiteCollectionMutation,
+  websiteCollectionRequest
+} from "../query-configs/website_collections"
+import { useSelector } from "react-redux"
+import { getWebsiteCollectionDetailCursor } from "../selectors/website_collections"
+
+interface Props {
+  hideModal: () => void
+  modalState: WebsiteCollectionModalState
+}
+
+const initialFormValues = (
+  collection: WebsiteCollection | null
+): WebsiteCollectionFormFields =>
+  collection ?
+    { title: collection.title, description: collection.description } :
+    { title: "", description: "" }
+
+export default function WebsiteCollectionEditor(props: Props): JSX.Element {
+  const { hideModal, modalState } = props
+
+  const [
+    ,
+    editWebsiteCollection
+  ] = useMutation((collection: WebsiteCollection) =>
+    editWebsiteCollectionMutation(collection)
+  )
+
+  const [
+    ,
+    createWebsiteCollection
+  ] = useMutation((collection: WebsiteCollectionFormFields) =>
+    createWebsiteCollectionMutation(collection)
+  )
+
+  const websiteCollectionDetailCursor = useSelector(
+    getWebsiteCollectionDetailCursor
+  )
+
+  const websiteCollection = modalState.editing() ?
+    websiteCollectionDetailCursor(modalState.wrapped) :
+    null
+
+  const onSubmit = useCallback(
+    async (collection: WebsiteCollectionFormFields) => {
+      if (modalState.editing()) {
+        await editWebsiteCollection({
+          // this is just to get the .id prop from the website
+          ...(websiteCollection as WebsiteCollection),
+          ...collection
+        })
+      } else {
+        await createWebsiteCollection(collection)
+      }
+      hideModal()
+    },
+    [
+      editWebsiteCollection,
+      modalState,
+      createWebsiteCollection,
+      websiteCollection,
+      hideModal
+    ]
+  )
+
+  const [{ isPending: fetchPending }] = useRequest(
+    modalState.editing() ? websiteCollectionRequest(modalState.wrapped) : null
+  )
+
+  return fetchPending ? (
+    <div>loading</div>
+  ) : (
+    <WebsiteCollectionForm
+      initialValues={initialFormValues(websiteCollection)}
+      onSubmit={onSubmit}
+    />
+  )
+}

--- a/static/js/components/forms/SiteCollaboratorForm.test.tsx
+++ b/static/js/components/forms/SiteCollaboratorForm.test.tsx
@@ -144,6 +144,7 @@ describe("SiteCollaboratorForm", () => {
     const collaboratorValidation = yup
       .object()
       .shape({ ...roleValidation, ...emailValidation })
+
     it("rejects an empty role", async () => {
       try {
         await expect(
@@ -154,6 +155,7 @@ describe("SiteCollaboratorForm", () => {
         expect(error.errors).toStrictEqual(["Role is a required field"])
       }
     })
+
     it("rejects an empty email", async () => {
       try {
         await expect(
@@ -164,6 +166,7 @@ describe("SiteCollaboratorForm", () => {
         expect(error.errors).toStrictEqual(["Email is a required field"])
       }
     })
+
     it("rejects an invalid email", async () => {
       try {
         await expect(
@@ -176,6 +179,7 @@ describe("SiteCollaboratorForm", () => {
         expect(error.errors).toStrictEqual(["Email must be a valid email"])
       }
     })
+
     it("does not reject a valid role", async () => {
       try {
         await expect(

--- a/static/js/components/forms/WebsiteCollectionForm.test.tsx
+++ b/static/js/components/forms/WebsiteCollectionForm.test.tsx
@@ -1,0 +1,72 @@
+import React from "react"
+import sinon, { SinonStub } from "sinon"
+import { mount } from "enzyme"
+
+import { ErrorMessage } from "formik"
+
+import { WebsiteCollectionFormSchema } from "./validation"
+import WebsiteCollectionForm, { SubmitFunc } from "./WebsiteCollectionForm"
+import { WebsiteCollectionFormFields } from "../../types/forms"
+
+describe("WebsiteCollectionForm", () => {
+  let sandbox: sinon.SinonSandbox,
+    onSubmit: SinonStub<Parameters<SubmitFunc>, ReturnType<SubmitFunc>>,
+    initialValues: WebsiteCollectionFormFields
+
+  const renderWCForm = (props = {}) =>
+    mount(
+      <WebsiteCollectionForm
+        onSubmit={onSubmit}
+        initialValues={initialValues}
+        {...props}
+      />
+    )
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+    onSubmit = sandbox.stub()
+    initialValues = {
+      title:       "",
+      description: ""
+    }
+  })
+
+  it("should pass the onSubmit prop down", () => {
+    const wrapper = renderWCForm()
+    expect(wrapper.find("Formik").prop("onSubmit")).toBe(onSubmit)
+  })
+
+  it("should set the validation", () => {
+    const wrapper = renderWCForm()
+    expect(wrapper.find("Formik").prop("validationSchema")).toBe(
+      WebsiteCollectionFormSchema
+    )
+  })
+
+  it("should set Field classname", () => {
+    const wrapper = renderWCForm()
+    wrapper.find("Field").forEach(field => {
+      expect(field.prop("className")).toBe("form-control")
+    })
+  })
+
+  it("should use initialValues", () => {
+    const wrapper = renderWCForm({
+      initialValues: {
+        title:       "My Title",
+        description: "My Description"
+      }
+    })
+
+    expect(
+      wrapper.find("Field").map(field => field.find("input").prop("value"))
+    ).toEqual(["My Title", "My Description"])
+  })
+
+  it("should have ErrorMessage components", () => {
+    const wrapper = renderWCForm()
+    expect(
+      wrapper.find(ErrorMessage).map(errorMsg => errorMsg.prop("name"))
+    ).toEqual(["title", "description"])
+  })
+})

--- a/static/js/components/forms/WebsiteCollectionForm.tsx
+++ b/static/js/components/forms/WebsiteCollectionForm.tsx
@@ -1,0 +1,57 @@
+import React from "react"
+import { Form, Formik, Field, FormikHelpers, ErrorMessage } from "formik"
+
+import { FormError } from "./FormError"
+import { WebsiteCollectionFormFields } from "../../types/forms"
+import { WebsiteCollectionFormSchema } from "./validation"
+
+export interface SubmitFunc {
+  (values: any, formikHelpers: FormikHelpers<any>): void | Promise<any>
+}
+
+interface Props {
+  onSubmit: SubmitFunc
+  initialValues: WebsiteCollectionFormFields
+}
+
+export default function WebsiteCollectionForm(props: Props): JSX.Element {
+  const { onSubmit, initialValues } = props
+
+  return (
+    <Formik
+      onSubmit={onSubmit}
+      initialValues={initialValues}
+      validationSchema={WebsiteCollectionFormSchema}
+    >
+      {() => (
+        <Form>
+          <div className="form-group">
+            <label htmlFor="title">Title</label>
+            <Field
+              className="form-control"
+              type="string"
+              name="title"
+              placeholder="Title"
+            />
+            <ErrorMessage name="title" component={FormError} />
+          </div>
+          <div className="form-group">
+            <label htmlFor="description">Description</label>
+            <Field
+              className="form-control"
+              type="string"
+              name="description"
+              placeholder="Description"
+            />
+            <ErrorMessage name="description" component={FormError} />
+          </div>
+          <div className="form-group d-flex w-100 justify-content-end">
+            <button type="submit" className="px-5 btn blue-button">
+              Save
+            </button>
+          </div>
+        </Form>
+      )}
+    </Formik>
+  )
+}

--- a/static/js/components/forms/validation.test.ts
+++ b/static/js/components/forms/validation.test.ts
@@ -1,5 +1,5 @@
 import * as yup from "yup"
-import { getContentSchema } from "./validation"
+import { getContentSchema, WebsiteCollectionFormSchema } from "./validation"
 import * as siteContentFuncs from "../../lib/site_content"
 import sinon, { SinonSandbox } from "sinon"
 
@@ -19,451 +19,474 @@ import {
   WidgetVariant
 } from "../../types/websites"
 
-describe("form validation util", () => {
-  const repeatableConfigItem = makeRepeatableConfigItem()
-  const singletonConfigItem = makeSingletonConfigItem()
-  const partialField = {
-    name:  "myfield",
-    label: "My Field"
-  }
-  const defaultFormValues = {
-    title: "My Title"
-  }
-  let configItem: ConfigItem, sandbox: SinonSandbox
-
-  beforeEach(() => {
-    sandbox = sinon.createSandbox()
-  })
-
-  afterEach(() => {
-    sandbox.restore()
-  })
-
-  describe("for 'title' field", () => {
-    const titleField: StringConfigField = {
-      name:     "title",
-      label:    "Title",
-      required: true,
-      widget:   WidgetVariant.String
+describe("form validation utils", () => {
+  describe("website content validation", () => {
+    const repeatableConfigItem = makeRepeatableConfigItem()
+    const singletonConfigItem = makeSingletonConfigItem()
+    const partialField = {
+      name:  "myfield",
+      label: "My Field"
     }
+    const defaultFormValues = {
+      title: "My Title"
+    }
+    let configItem: ConfigItem, sandbox: SinonSandbox
 
-    //
-    ;[
-      [null, true, false, true],
-      [titleField, true, true, true],
-      [null, false, false, false]
-    ].forEach(([field, isRepeatable, fieldIncluded, expAddedTitleField]) => {
-      it(`validates correctly if 'title' field ${isIf(
-        fieldIncluded
-      )} included, config item ${isIf(isRepeatable)} repeatable`, async () => {
-        configItem = {
-          ...(isRepeatable ? repeatableConfigItem : singletonConfigItem),
-          // @ts-ignore
-          fields: field ? [field] : []
-        }
-        const schema = getContentSchema(configItem, {})
-        if (expAddedTitleField) {
-          expect(() => schema.validateSync({})).toThrow(
-            new yup.ValidationError("Title is a required field")
-          )
-          await expect(
-            schema.isValid({ title: "My Title" })
-          ).resolves.toBeTruthy()
-        } else {
-          expect(() => schema.validateSync({})).not.toThrow(
-            new yup.ValidationError("Title is a required field")
-          )
-        }
+    beforeEach(() => {
+      sandbox = sinon.createSandbox()
+    })
+
+    afterEach(() => {
+      sandbox.restore()
+    })
+
+    describe("for 'title' field", () => {
+      const titleField: StringConfigField = {
+        name:     "title",
+        label:    "Title",
+        required: true,
+        widget:   WidgetVariant.String
+      }
+
+      //
+      ;[
+        [null, true, false, true],
+        [titleField, true, true, true],
+        [null, false, false, false]
+      ].forEach(([field, isRepeatable, fieldIncluded, expAddedTitleField]) => {
+        it(`validates correctly if 'title' field ${isIf(
+          fieldIncluded
+        )} included, config item ${isIf(
+          isRepeatable
+        )} repeatable`, async () => {
+          configItem = {
+            ...(isRepeatable ? repeatableConfigItem : singletonConfigItem),
+            // @ts-ignore
+            fields: field ? [field] : []
+          }
+          const schema = getContentSchema(configItem, {})
+          if (expAddedTitleField) {
+            expect(() => schema.validateSync({})).toThrow(
+              new yup.ValidationError("Title is a required field")
+            )
+            await expect(
+              schema.isValid({ title: "My Title" })
+            ).resolves.toBeTruthy()
+          } else {
+            expect(() => schema.validateSync({})).not.toThrow(
+              new yup.ValidationError("Title is a required field")
+            )
+          }
+        })
       })
     })
-  })
 
-  it("should skip validation for fields which aren't visible", () => {
-    configItem = {
-      ...repeatableConfigItem,
-      fields: [
-        {
-          ...partialField,
-          widget:   WidgetVariant.String,
-          required: true
-        }
-      ]
-    }
-    const values = { val: "ues" }
-    let schema = getContentSchema(configItem, values)
-    expect(() =>
-      schema.validateSync({
-        ...defaultFormValues,
-        [partialField.name]: null
-      })
-    ).toThrow(`${partialField.label} is a required field`)
-
-    const fieldIsVisibleStub = sandbox
-      .stub(siteContentFuncs, "fieldIsVisible")
-      .returns(false)
-    schema = getContentSchema(configItem, values)
-    // no exception thrown
-    schema.validateSync({
-      ...defaultFormValues,
-      [partialField.name]: null
-    })
-    sinon.assert.calledWith(fieldIsVisibleStub, configItem.fields[0], values)
-  })
-
-  it("should skip validation for a title field which isn't visible", () => {
-    configItem = {
-      ...repeatableConfigItem,
-      fields: [
-        {
-          ...partialField,
-          name:     "title",
-          widget:   WidgetVariant.String,
-          required: true
-        }
-      ]
-    }
-    let schema = getContentSchema(configItem, {})
-    expect(() =>
-      schema.validateSync({
-        ...defaultFormValues,
-        ["title"]: null
-      })
-    ).toThrow(`${partialField.label} is a required field`)
-
-    sandbox.stub(siteContentFuncs, "fieldIsVisible").returns(false)
-    schema = getContentSchema(configItem, {})
-    // no exception thrown
-    schema.validateSync({
-      ...defaultFormValues,
-      ["title"]: null
-    })
-  })
-
-  //
-  ;[
-    WidgetVariant.String,
-    WidgetVariant.Text,
-    WidgetVariant.Markdown,
-    WidgetVariant.File
-  ].forEach(widget => {
-    it(`produces the correct validation schema for a required '${widget}' field`, () => {
+    it("should skip validation for fields which aren't visible", () => {
       configItem = {
         ...repeatableConfigItem,
         fields: [
           {
             ...partialField,
-            widget:   widget as WidgetVariant,
+            widget:   WidgetVariant.String,
             required: true
-          } as
-            | StringConfigField
-            | TextConfigField
-            | MarkdownConfigField
-            | FileConfigField
+          }
         ]
       }
-      const schema = getContentSchema(configItem, {})
+      const values = { val: "ues" }
+      let schema = getContentSchema(configItem, values)
       expect(() =>
         schema.validateSync({
           ...defaultFormValues,
           [partialField.name]: null
         })
       ).toThrow(`${partialField.label} is a required field`)
-    })
-  })
 
-  it("produces the correct validation schema for multiple fields", () => {
-    configItem = {
-      ...repeatableConfigItem,
-      fields: [
-        {
-          name:     "myfield",
-          label:    "My Field",
-          widget:   WidgetVariant.String,
-          required: true
-        },
-        {
-          name:     "myfield2",
-          label:    "My Second Field",
-          widget:   WidgetVariant.String,
-          required: true
+      const fieldIsVisibleStub = sandbox
+        .stub(siteContentFuncs, "fieldIsVisible")
+        .returns(false)
+      schema = getContentSchema(configItem, values)
+      // no exception thrown
+      schema.validateSync({
+        ...defaultFormValues,
+        [partialField.name]: null
+      })
+      sinon.assert.calledWith(fieldIsVisibleStub, configItem.fields[0], values)
+    })
+
+    it("should skip validation for a title field which isn't visible", () => {
+      configItem = {
+        ...repeatableConfigItem,
+        fields: [
+          {
+            ...partialField,
+            name:     "title",
+            widget:   WidgetVariant.String,
+            required: true
+          }
+        ]
+      }
+      let schema = getContentSchema(configItem, {})
+      expect(() =>
+        schema.validateSync({
+          ...defaultFormValues,
+          ["title"]: null
+        })
+      ).toThrow(`${partialField.label} is a required field`)
+
+      sandbox.stub(siteContentFuncs, "fieldIsVisible").returns(false)
+      schema = getContentSchema(configItem, {})
+      // no exception thrown
+      schema.validateSync({
+        ...defaultFormValues,
+        ["title"]: null
+      })
+    })
+
+    //
+    ;[
+      WidgetVariant.String,
+      WidgetVariant.Text,
+      WidgetVariant.Markdown,
+      WidgetVariant.File
+    ].forEach(widget => {
+      it(`produces the correct validation schema for a required '${widget}' field`, () => {
+        configItem = {
+          ...repeatableConfigItem,
+          fields: [
+            {
+              ...partialField,
+              widget:   widget as WidgetVariant,
+              required: true
+            } as
+              | StringConfigField
+              | TextConfigField
+              | MarkdownConfigField
+              | FileConfigField
+          ]
         }
-      ]
-    }
-    const schema = getContentSchema(configItem, {})
-    for (const field of configItem.fields) {
-      expect(() =>
-        schema.validateSync({
-          ...defaultFormValues,
-          myfield:      "text",
-          myfield2:     "text",
-          [field.name]: null
-        })
-      ).toThrow(`${field.label} is a required field`)
-    }
-  })
-
-  describe("select validation", () => {
-    const makeSelectConfigItem = (props = {}): [ConfigItem, string] => {
-      const configItem = {
-        ...repeatableConfigItem,
-        fields: [
-          makeWebsiteConfigField({ widget: WidgetVariant.Select, ...props })
-        ]
-      }
-
-      return [configItem, configItem.fields[0].name]
-    }
-
-    it("should validate for a required multiple select field", () => {
-      const [configItem, name] = makeSelectConfigItem({
-        multiple: true,
-        required: true
-      })
-      const schema = getContentSchema(configItem, {})
-      expect(() =>
-        schema.validateSync({
-          ...defaultFormValues,
-          [name]: null
-        })
-      ).toThrow(new yup.ValidationError(`${name} is a required field.`))
-    })
-
-    it("should pass validation for valid multiple select values", async () => {
-      const [configItem, name] = makeSelectConfigItem({ multiple: true })
-      const schema = getContentSchema(configItem, {})
-      await Promise.all(
-        [[], ["some value"], ["some value", "another value"]].map(
-          async value => {
-            await expect(
-              schema.isValid({
-                ...defaultFormValues,
-                [name]: value
-              })
-            ).resolves.toBeTruthy()
-          }
-        )
-      )
-    })
-
-    it("should validate a multiple select field with max and min set", async () => {
-      const [configItem, name] = makeSelectConfigItem({
-        multiple: true,
-        min:      1,
-        max:      2
-      })
-      const schema = getContentSchema(configItem, {})
-
-      await Promise.all(
-        [
-          [[], false, `${name} must have at least 1 entry.`],
-          [["some value"], true, ""],
-          [["some value", "another value"], true, ""],
-          [
-            ["some value", "another value", "yet another value"],
-            false,
-            `${name} may have at most 2 entries.`
-          ]
-        ].map(async ([value, shouldValidate, message]) => {
-          if (shouldValidate) {
-            await expect(
-              schema.isValid({
-                ...defaultFormValues,
-                [name]: value
-              })
-            ).resolves.toBeTruthy()
-          } else {
-            await expect(
-              schema.validate({
-                ...defaultFormValues,
-                [name]: value
-              })
-            ).rejects.toThrow(new yup.ValidationError(message as string))
-          }
-        })
-      )
-    })
-
-    it("should validate a required non-multiple select field", async () => {
-      const [configItem, name] = makeSelectConfigItem({ required: true })
-      const schema = getContentSchema(configItem, {})
-
-      expect(() =>
-        schema.validateSync({
-          ...defaultFormValues,
-          [name]: ""
-        })
-      ).toThrow(new yup.ValidationError(`${name} is a required field`))
-      await expect(
-        schema.isValid({ ...defaultFormValues, [name]: "selected value" })
-      ).resolves.toBeTruthy()
-    })
-  })
-
-  describe("relation validation", () => {
-    const makeRelationConfigItem = (props = {}): [ConfigItem, string] => {
-      const configItem = {
-        ...repeatableConfigItem,
-        fields: [
-          makeWebsiteConfigField({ widget: WidgetVariant.Relation, ...props })
-        ]
-      }
-
-      return [configItem, configItem.fields[0].name]
-    }
-
-    it("should validate for a required multiple relation field", () => {
-      const [configItem, name] = makeRelationConfigItem({
-        multiple: true,
-        required: true
-      })
-      const schema = getContentSchema(configItem, {})
-      expect(() =>
-        schema.validateSync({
-          ...defaultFormValues,
-          [name]: {
-            website: "UUUIIIIIIDIDIDIDID",
-            content: null
-          }
-        })
-      ).toThrow(new yup.ValidationError(`${name}.content is a required field.`))
-    })
-
-    it("should pass validation for valid multiple relation values", async () => {
-      const [configItem, name] = makeRelationConfigItem({ multiple: true })
-      const schema = getContentSchema(configItem, {})
-      await Promise.all(
-        [[], ["some value"], ["some value", "another value"]].map(
-          async value => {
-            await expect(
-              schema.isValid({
-                ...defaultFormValues,
-                [name]: {
-                  website: "ASDFASDF",
-                  content: value
-                }
-              })
-            ).resolves.toBeTruthy()
-          }
-        )
-      )
-    })
-
-    it("should validate a multiple relation field with max and min set", async () => {
-      const [configItem, name] = makeRelationConfigItem({
-        multiple: true,
-        min:      1,
-        max:      2
-      })
-      const schema = getContentSchema(configItem, {})
-
-      await Promise.all(
-        [
-          [[], false, `${name} must have at least 1 entry.`],
-          [["some value"], true, ""],
-          [["some value", "another value"], true, ""],
-          [
-            ["some value", "another value", "yet another value"],
-            false,
-            `${name} may have at most 2 entries.`
-          ]
-        ].map(async ([value, shouldValidate, message]) => {
-          if (shouldValidate) {
-            await expect(
-              schema.isValid({
-                ...defaultFormValues,
-                [name]: {
-                  website: "UUID",
-                  content: value
-                }
-              })
-            ).resolves.toBeTruthy()
-          } else {
-            await expect(
-              schema.validate({
-                ...defaultFormValues,
-                [name]: {
-                  website: "UUID",
-                  content: value
-                }
-              })
-            ).rejects.toThrow(new yup.ValidationError(message as string))
-          }
-        })
-      )
-    })
-
-    it("should validate a required non-multiple field", async () => {
-      const [configItem, name] = makeRelationConfigItem({ required: true })
-      const schema = getContentSchema(configItem, {})
-
-      expect(() =>
-        schema.validateSync({
-          ...defaultFormValues,
-          [name]: {
-            website: "UUID",
-            content: null
-          }
-        })
-      ).toThrow(new yup.ValidationError(`${name}.content is a required field.`))
-      await expect(
-        schema.isValid({
-          ...defaultFormValues,
-          [name]: {
-            content: "selected value"
-          }
-        })
-      ).resolves.toBeTruthy()
-    })
-  })
-
-  describe("Object validation", () => {
-    const makeObjectConfigItem = (props = {}): [ConfigItem, string] => {
-      const configItem = {
-        ...repeatableConfigItem,
-        fields: [
-          makeWebsiteConfigField({
-            widget: WidgetVariant.Object,
-            ...props,
-            fields: [
-              makeWebsiteConfigField({
-                widget:   WidgetVariant.String,
-                label:    "mystring",
-                required: true
-              }),
-              makeWebsiteConfigField({
-                widget:   WidgetVariant.Boolean,
-                label:    "myboolean",
-                required: true
-              })
-            ]
+        const schema = getContentSchema(configItem, {})
+        expect(() =>
+          schema.validateSync({
+            ...defaultFormValues,
+            [partialField.name]: null
           })
+        ).toThrow(`${partialField.label} is a required field`)
+      })
+    })
+
+    it("produces the correct validation schema for multiple fields", () => {
+      configItem = {
+        ...repeatableConfigItem,
+        fields: [
+          {
+            name:     "myfield",
+            label:    "My Field",
+            widget:   WidgetVariant.String,
+            required: true
+          },
+          {
+            name:     "myfield2",
+            label:    "My Second Field",
+            widget:   WidgetVariant.String,
+            required: true
+          }
         ]
       }
-
-      return [configItem, configItem.fields[0].name]
-    }
-
-    it("should validate the sub-fields", async () => {
-      const [configItem, name] = makeObjectConfigItem({ required: true })
       const schema = getContentSchema(configItem, {})
+      for (const field of configItem.fields) {
+        expect(() =>
+          schema.validateSync({
+            ...defaultFormValues,
+            myfield:      "text",
+            myfield2:     "text",
+            [field.name]: null
+          })
+        ).toThrow(`${field.label} is a required field`)
+      }
+    })
 
-      await schema
-        .validate({ ...defaultFormValues, [name]: {} }, { abortEarly: false })
-        .catch(err => {
-          expect(err.errors).toEqual([
-            "mystring is a required field",
-            "myboolean is a required field"
-          ])
+    describe("select validation", () => {
+      const makeSelectConfigItem = (props = {}): [ConfigItem, string] => {
+        const configItem = {
+          ...repeatableConfigItem,
+          fields: [
+            makeWebsiteConfigField({ widget: WidgetVariant.Select, ...props })
+          ]
+        }
+
+        return [configItem, configItem.fields[0].name]
+      }
+
+      it("should validate for a required multiple select field", () => {
+        const [configItem, name] = makeSelectConfigItem({
+          multiple: true,
+          required: true
         })
-      await expect(
-        schema.isValid({
-          ...defaultFormValues,
-          [name]: {
-            mystring:  "hey!",
-            myboolean: false
+        const schema = getContentSchema(configItem, {})
+        expect(() =>
+          schema.validateSync({
+            ...defaultFormValues,
+            [name]: null
+          })
+        ).toThrow(new yup.ValidationError(`${name} is a required field.`))
+      })
+
+      it("should pass validation for valid multiple select values", async () => {
+        const [configItem, name] = makeSelectConfigItem({ multiple: true })
+        const schema = getContentSchema(configItem, {})
+        await Promise.all(
+          [[], ["some value"], ["some value", "another value"]].map(
+            async value => {
+              await expect(
+                schema.isValid({
+                  ...defaultFormValues,
+                  [name]: value
+                })
+              ).resolves.toBeTruthy()
+            }
+          )
+        )
+      })
+
+      it("should validate a multiple select field with max and min set", async () => {
+        const [configItem, name] = makeSelectConfigItem({
+          multiple: true,
+          min:      1,
+          max:      2
+        })
+        const schema = getContentSchema(configItem, {})
+
+        await Promise.all(
+          [
+            [[], false, `${name} must have at least 1 entry.`],
+            [["some value"], true, ""],
+            [["some value", "another value"], true, ""],
+            [
+              ["some value", "another value", "yet another value"],
+              false,
+              `${name} may have at most 2 entries.`
+            ]
+          ].map(async ([value, shouldValidate, message]) => {
+            if (shouldValidate) {
+              await expect(
+                schema.isValid({
+                  ...defaultFormValues,
+                  [name]: value
+                })
+              ).resolves.toBeTruthy()
+            } else {
+              await expect(
+                schema.validate({
+                  ...defaultFormValues,
+                  [name]: value
+                })
+              ).rejects.toThrow(new yup.ValidationError(message as string))
+            }
+          })
+        )
+      })
+
+      it("should validate a required non-multiple select field", async () => {
+        const [configItem, name] = makeSelectConfigItem({ required: true })
+        const schema = getContentSchema(configItem, {})
+
+        expect(() =>
+          schema.validateSync({
+            ...defaultFormValues,
+            [name]: ""
+          })
+        ).toThrow(new yup.ValidationError(`${name} is a required field`))
+        await expect(
+          schema.isValid({ ...defaultFormValues, [name]: "selected value" })
+        ).resolves.toBeTruthy()
+      })
+    })
+
+    describe("relation validation", () => {
+      const makeRelationConfigItem = (props = {}): [ConfigItem, string] => {
+        const configItem = {
+          ...repeatableConfigItem,
+          fields: [
+            makeWebsiteConfigField({ widget: WidgetVariant.Relation, ...props })
+          ]
+        }
+
+        return [configItem, configItem.fields[0].name]
+      }
+
+      it("should validate for a required multiple relation field", () => {
+        const [configItem, name] = makeRelationConfigItem({
+          multiple: true,
+          required: true
+        })
+        const schema = getContentSchema(configItem, {})
+        expect(() =>
+          schema.validateSync({
+            ...defaultFormValues,
+            [name]: {
+              website: "UUUIIIIIIDIDIDIDID",
+              content: null
+            }
+          })
+        ).toThrow(
+          new yup.ValidationError(`${name}.content is a required field.`)
+        )
+      })
+
+      it("should pass validation for valid multiple relation values", async () => {
+        const [configItem, name] = makeRelationConfigItem({ multiple: true })
+        const schema = getContentSchema(configItem, {})
+        await Promise.all(
+          [[], ["some value"], ["some value", "another value"]].map(
+            async value => {
+              await expect(
+                schema.isValid({
+                  ...defaultFormValues,
+                  [name]: {
+                    website: "ASDFASDF",
+                    content: value
+                  }
+                })
+              ).resolves.toBeTruthy()
+            }
+          )
+        )
+      })
+
+      it("should validate a multiple relation field with max and min set", async () => {
+        const [configItem, name] = makeRelationConfigItem({
+          multiple: true,
+          min:      1,
+          max:      2
+        })
+        const schema = getContentSchema(configItem, {})
+
+        await Promise.all(
+          [
+            [[], false, `${name} must have at least 1 entry.`],
+            [["some value"], true, ""],
+            [["some value", "another value"], true, ""],
+            [
+              ["some value", "another value", "yet another value"],
+              false,
+              `${name} may have at most 2 entries.`
+            ]
+          ].map(async ([value, shouldValidate, message]) => {
+            if (shouldValidate) {
+              await expect(
+                schema.isValid({
+                  ...defaultFormValues,
+                  [name]: {
+                    website: "UUID",
+                    content: value
+                  }
+                })
+              ).resolves.toBeTruthy()
+            } else {
+              await expect(
+                schema.validate({
+                  ...defaultFormValues,
+                  [name]: {
+                    website: "UUID",
+                    content: value
+                  }
+                })
+              ).rejects.toThrow(new yup.ValidationError(message as string))
+            }
+          })
+        )
+      })
+
+      it("should validate a required non-multiple field", async () => {
+        const [configItem, name] = makeRelationConfigItem({ required: true })
+        const schema = getContentSchema(configItem, {})
+
+        expect(() =>
+          schema.validateSync({
+            ...defaultFormValues,
+            [name]: {
+              website: "UUID",
+              content: null
+            }
+          })
+        ).toThrow(
+          new yup.ValidationError(`${name}.content is a required field.`)
+        )
+        await expect(
+          schema.isValid({
+            ...defaultFormValues,
+            [name]: {
+              content: "selected value"
+            }
+          })
+        ).resolves.toBeTruthy()
+      })
+    })
+
+    describe("Object validation", () => {
+      const makeObjectConfigItem = (props = {}): [ConfigItem, string] => {
+        const configItem = {
+          ...repeatableConfigItem,
+          fields: [
+            makeWebsiteConfigField({
+              widget: WidgetVariant.Object,
+              ...props,
+              fields: [
+                makeWebsiteConfigField({
+                  widget:   WidgetVariant.String,
+                  label:    "mystring",
+                  required: true
+                }),
+                makeWebsiteConfigField({
+                  widget:   WidgetVariant.Boolean,
+                  label:    "myboolean",
+                  required: true
+                })
+              ]
+            })
+          ]
+        }
+
+        return [configItem, configItem.fields[0].name]
+      }
+
+      it("should validate the sub-fields", async () => {
+        const [configItem, name] = makeObjectConfigItem({ required: true })
+        const schema = getContentSchema(configItem, {})
+
+        await schema
+          .validate({ ...defaultFormValues, [name]: {} }, { abortEarly: false })
+          .catch(err => {
+            expect(err.errors).toEqual([
+              "mystring is a required field",
+              "myboolean is a required field"
+            ])
+          })
+        await expect(
+          schema.isValid({
+            ...defaultFormValues,
+            [name]: {
+              mystring:  "hey!",
+              myboolean: false
+            }
+          })
+        ).resolves.toBeTruthy()
+      })
+    })
+  })
+
+  describe("Website collection validation", () => {
+    it("should require a title", async () => {
+      for (const titleVal of [undefined, null, ""]) {
+        await WebsiteCollectionFormSchema.validate({ title: titleVal }).catch(
+          err => {
+            expect(err.errors[0]).toMatch("Title is a required field")
           }
-        })
-      ).resolves.toBeTruthy()
+        )
+      }
+      expect(
+        WebsiteCollectionFormSchema.isValid({ title: "My Title" })
+      ).toBeTruthy()
     })
   })
 })

--- a/static/js/components/forms/validation.ts
+++ b/static/js/components/forms/validation.ts
@@ -130,3 +130,14 @@ export const getContentSchema = (
   }
   return yup.object().shape(yupObjectShape)
 }
+
+/**
+ * Validation for the basic WebsiteCollection form
+ **/
+export const WebsiteCollectionFormSchema = yup.object({
+  title: yup
+    .string()
+    .required()
+    .label("Title"),
+  description: yup.string().label("Description")
+})

--- a/static/js/lib/urls.test.ts
+++ b/static/js/lib/urls.test.ts
@@ -156,19 +156,19 @@ describe("urls", () => {
 
       it("renders a collection detail API url", () => {
         expect(
-          collectionsApiDetailUrl.param({ collection_id: 4 }).toString()
+          collectionsApiDetailUrl.param({ collectionId: 4 }).toString()
         ).toBe("/api/collections/4/")
       })
 
       it("renders collection items list API url", () => {
-        expect(wcItemsApiUrl.param({ collection_id: 4 }).toString()).toBe(
+        expect(wcItemsApiUrl.param({ collectionId: 4 }).toString()).toBe(
           "/api/collections/4/items/"
         )
       })
 
       it("renders collection item detail API url", () => {
         expect(
-          wcItemsApiDetailUrl.param({ collection_id: 4, item_id: 3 }).toString()
+          wcItemsApiDetailUrl.param({ collectionId: 4, item_id: 3 }).toString()
         ).toBe("/api/collections/4/items/3/")
       })
     })

--- a/static/js/lib/urls.ts
+++ b/static/js/lib/urls.ts
@@ -55,7 +55,7 @@ export const collectionsApiUrl = api.segment("collections/")
  * not include its items.
  **/
 export const collectionsApiDetailUrl = collectionsApiUrl.segment(
-  ":collection_id/"
+  ":collectionId/"
 )
 
 /**
@@ -63,7 +63,7 @@ export const collectionsApiDetailUrl = collectionsApiUrl.segment(
  *
  * This looks like:
  *
- * /api/collections/:collection_id/items/
+ * /api/collections/:collectionId/items/
  *
  * It returns the items contained in a WebsiteCollection.
  **/
@@ -75,7 +75,7 @@ export const wcItemsApiUrl = collectionsApiDetailUrl.segment("items/")
  * Detail view for a single WebsiteCollectionItem record.
  * this looks like:
  *
- * /api/collections/:collection_id/items/:item_id/
+ * /api/collections/:collectionId/items/:item_id/
  *
  * It's mainly of use for changing the order of items in the
  * WebsiteCollection by editing the `position` attribute.

--- a/static/js/query-configs/website_collections.ts
+++ b/static/js/query-configs/website_collections.ts
@@ -2,8 +2,10 @@ import { QueryConfig } from "redux-query"
 
 import { PaginatedResponse } from "./utils"
 
-import { collectionsApiUrl } from "../lib/urls"
+import { collectionsApiDetailUrl, collectionsApiUrl } from "../lib/urls"
 import { WebsiteCollection } from "../types/website_collections"
+import { getCookie } from "../lib/api/util"
+import { WebsiteCollectionFormFields } from "../types/forms"
 
 export type WebsiteCollectionDetails = Record<number, WebsiteCollection>
 
@@ -53,6 +55,82 @@ export const websiteCollectionListRequest = (offset = 0): QueryConfig => ({
       prev: WebsiteCollectionDetails,
       next: WebsiteCollectionDetails
     ): WebsiteCollectionDetails => ({
+      ...prev,
+      ...next
+    })
+  }
+})
+
+export const websiteCollectionRequest = (id: number): QueryConfig => ({
+  url: collectionsApiDetailUrl
+    .param({
+      collectionId: id
+    })
+    .toString(),
+  transform: (body: WebsiteCollection) => {
+    return {
+      websiteCollectionDetails: {
+        [body.id]: body
+      }
+    }
+  },
+  update: {
+    websiteCollectionDetails: (
+      prev: WebsiteCollectionDetails,
+      next: WebsiteCollectionDetails
+    ): WebsiteCollectionDetails => ({
+      ...prev,
+      ...next
+    })
+  }
+})
+
+export const editWebsiteCollectionMutation = (
+  collection: WebsiteCollection
+): QueryConfig => ({
+  url: collectionsApiDetailUrl
+    .param({
+      collectionId: collection.id
+    })
+    .toString(),
+  body:    collection,
+  options: {
+    method:  "PATCH",
+    headers: {
+      "X-CSRFTOKEN": getCookie("csrftoken") || ""
+    }
+  },
+  transform: response => ({
+    websiteCollectionDetails: {
+      [collection.id]: response
+    }
+  }),
+  update: {
+    websiteCollectionDetails: (prev, next) => ({
+      ...prev,
+      ...next
+    })
+  }
+})
+
+export const createWebsiteCollectionMutation = (
+  collection: WebsiteCollectionFormFields
+): QueryConfig => ({
+  url:     collectionsApiUrl.toString(),
+  body:    collection,
+  options: {
+    method:  "POST",
+    headers: {
+      "X-CSRFTOKEN": getCookie("csrftoken") || ""
+    }
+  },
+  transform: response => ({
+    websiteCollectionDetails: {
+      [response.id]: response
+    }
+  }),
+  update: {
+    websiteCollectionDetails: (prev, next) => ({
       ...prev,
       ...next
     })

--- a/static/js/types/forms.ts
+++ b/static/js/types/forms.ts
@@ -14,3 +14,11 @@ export type SiteFormValue =
   | Record<string, SiteFormPrimitive>
 
 export type SiteFormValues = Record<string, SiteFormValue>
+
+/**
+ * WebsiteCollectionFormFields
+ **/
+export interface WebsiteCollectionFormFields {
+  title: string
+  description: string
+}

--- a/static/js/types/modal_state.ts
+++ b/static/js/types/modal_state.ts
@@ -1,0 +1,97 @@
+/**
+ * Abstract class which our ModalState variant classes inherit from.
+ *
+ * This lets us set up methods like `.editing`, `.adding`, etc which
+ * we can use on all the subclasses to check which variant we're
+ * dealing with.
+ */
+abstract class ModalStateVariant<T> {
+  state = ""
+
+  /**
+   * Check whether this ModalStateVariant instance is an Editing or not.
+   */
+  editing(): this is Editing<T> {
+    return this.state === "editing"
+  }
+
+  /**
+   * Check whether this ModalStateVariant instance is an Adding or not.
+   */
+  adding(): this is Adding<T> {
+    return this.state === "adding"
+  }
+
+  /**
+   * Check whether this ModalStateVariant instance is a Closed or not.
+   */
+  closed(): this is Closed<T> {
+    return this.state === "closed"
+  }
+}
+
+/**
+ * An Editing state, which provides for wrapping a value
+ * related to the content being edited.
+ */
+class Editing<T> extends ModalStateVariant<T> {
+  state: "editing" = "editing"
+  /**
+   * The value wrapped in the Editing state
+   */
+  wrapped: T
+  constructor(wrapped: T) {
+    super()
+    this.wrapped = wrapped
+  }
+}
+
+/**
+ * Adding state, for when new content is being created.
+ */
+class Adding<T> extends ModalStateVariant<T> {
+  state: "adding" = "adding"
+}
+
+/**
+ * Closed state, for when the drawer is closed and deactivated.
+ */
+class Closed<T> extends ModalStateVariant<T> {
+  state: "closed" = "closed"
+}
+
+/**
+ * Represent the three possible states for the WebsiteCollection
+ * adding / editing drawer.
+ *
+ * Use the `createModalState` helper function to simplify creating
+ * instances of these types.
+ *
+ * Provides support for wrapping a value in the Editing state, which
+ * can be used to store the ID of the object currently being edited
+ * or something along those lines.
+ **/
+export type ModalState<T> = Editing<T> | Adding<T> | Closed<T>
+
+/**
+ * Helper function for creating ModalState objects
+ * (these are used by the WebsiteCollection editing/
+ * creation UI to represent possible drawer states).
+ */
+export function createModalState<T>(state: "adding", wrapped: null): Adding<T>
+export function createModalState<T>(state: "closed", wrapped: null): Closed<T>
+export function createModalState<T>(state: "editing", wrapped: T): Editing<T>
+export function createModalState<T>(
+  state: string,
+  wrapped: T | null
+): ModalState<T> {
+  if (state === "editing") {
+    // the overloading gives us some assurance that we can cast
+    // wrapped to T here
+    return new Editing(wrapped as T)
+  }
+  if (state === "adding") {
+    return new Adding()
+  }
+  return new Closed()
+}

--- a/static/js/types/website_collections.ts
+++ b/static/js/types/website_collections.ts
@@ -1,3 +1,5 @@
+import { ModalState } from "./modal_state"
+
 /**
  * A user-editable collection of Websites
  *
@@ -12,6 +14,16 @@ export interface WebsiteCollection {
   id: number
 }
 
+/**
+ * An entry in a WebsiteCollection
+ **/
 export interface WebsiteCollectionItem {
   position: number
 }
+
+/**
+ * For the WebsiteCollection drawer we need to keep track
+ * of a WebsiteCollection ID, which is set in the drawer
+ * state if we're editing an existing collection.
+ */
+export type WebsiteCollectionModalState = ModalState<number>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #357 

#### What's this PR do?

this adds functionality for editing basic attributes of WebsiteCollection records (i.e. their title, description) and for therefore creating new ones.

This does not yet include editing entries in a collection, that will be covered for #376

#### How should this be manually tested?

Visit the collections list page (`/collections`). If you click 'Add' you should get a drawer where you can create a new collection. Then in the list page if you click on the title for a collection you should open an editing drawer where you can change it's title and whatnot.

#### Screenshots (if appropriate)

<img width="1014" alt="Screen Shot 2021-07-13 at 10 48 06 AM" src="https://user-images.githubusercontent.com/6207644/125473339-eb6307af-e4da-484f-af9b-0e3241bd9720.png">
<img width="594" alt="Screen Shot 2021-07-13 at 10 48 13 AM" src="https://user-images.githubusercontent.com/6207644/125473340-2858f365-ac3c-4f0c-8333-ad1c26ba6e89.png">
<img width="555" alt="Screen Shot 2021-07-13 at 10 48 21 AM" src="https://user-images.githubusercontent.com/6207644/125473343-cbe81632-512e-40cd-ae91-b84c040a951b.png">

