### PR TITLE
Draft/live publish notifications

### DIFF
--- a/app.json
+++ b/app.json
@@ -23,6 +23,10 @@
   ],
   "description": "OCW Studio manages deployments for OCW courses.",
   "env": {
+    "API_BEARER_TOKEN": {
+      "description": "Authorization bearer token for webhook endpoints",
+      "required": false
+    },
     "AWS_ACCESS_KEY_ID": {
       "description": "AWS Access Key for S3 storage.",
       "required": false
@@ -167,6 +171,14 @@
       "description": "This server's host IP",
       "required": false
     },
+    "MAILGUN_KEY": {
+      "description": "The token for authenticating against the Mailgun API",
+      "required": true
+    },
+    "MAILGUN_SENDER_DOMAIN": {
+      "description": "The domain to send mailgun email through",
+      "required": true
+    },
     "MAX_S3_GET_ITERATIONS": {
       "description": "Max retry attempts to get an S3 object",
       "required": false
@@ -185,6 +197,14 @@
     },
     "MIDDLEWARE_FEATURE_FLAG_QS_PREFIX": {
       "description": "Feature flag middleware querystring prefix",
+      "required": false
+    },
+    "MITOL_MAIL_FROM_EMAIL": {
+      "description": "E-mail to use for the from field",
+      "required": false
+    },
+    "MITOL_MAIL_REPLY_TO_ADDRESS": {
+      "description": "E-mail to use for reply-to address of emails",
       "required": false
     },
     "NEW_RELIC_APP_NAME": {
@@ -212,6 +232,10 @@
     },
     "OCW_STUDIO_DB_DISABLE_SS_CURSORS": {
       "description": "Disables Postgres server side cursors",
+      "required": false
+    },
+    "OCW_STUDIO_DRAFT_URL": {
+      "description": "The base url of the preview site",
       "required": false
     },
     "OCW_STUDIO_EMAIL_BACKEND": {
@@ -244,6 +268,10 @@
     },
     "OCW_STUDIO_FROM_EMAIL": {
       "description": "E-mail to use for the from field",
+      "required": false
+    },
+    "OCW_STUDIO_LIVE_URL": {
+      "description": "The base url of the live site",
       "required": false
     },
     "OCW_STUDIO_LOG_HOST": {

--- a/content_sync/conftest.py
+++ b/content_sync/conftest.py
@@ -50,4 +50,5 @@ def required_concourse_settings(settings):
     settings.GIT_DOMAIN = "test.github.edu"
     settings.GIT_ORGANIZATION = "test_org"
     settings.GITHUB_WEBHOOK_BRANCH = "release"
-    os.environ["OCW_STUDIO_BASE_URL"] = "http://test.edu"
+    settings.SITE_BASE_URL = "http://test.edu"
+    settings.API_BEARER_TOKEN = "abc123"

--- a/content_sync/conftest.py
+++ b/content_sync/conftest.py
@@ -1,5 +1,4 @@
 """Test config for content_sync app"""
-import os
 from base64 import b64encode
 from types import SimpleNamespace
 

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -163,6 +163,8 @@ class ConcourseGithubPipeline(BaseSyncPipeline):
                     .replace("((base-url))", base_url)
                     .replace("((site-url))", site_url)
                     .replace("((purge-url))", purge_url)
+                    .replace("((version))", version)
+                    .replace("((api-token))", settings.API_BEARER_TOKEN)
                 )
             config = json.dumps(yaml.load(config_str, Loader=yaml.Loader))
             log.debug(config)
@@ -186,5 +188,5 @@ class ConcourseGithubPipeline(BaseSyncPipeline):
         )
         job_name = pipeline_info["config"]["jobs"][0]["name"]
         self.ci.post(
-            f"/api/v1/teams/{settings.CONCOURSE_TEAM}/pipelines/draft/jobs/{job_name}/builds?vars={self.instance_vars}"
+            f"/api/v1/teams/{settings.CONCOURSE_TEAM}/pipelines/{version}/jobs/{job_name}/builds?vars={self.instance_vars}"
         )

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -162,6 +162,7 @@ class ConcourseGithubPipeline(BaseSyncPipeline):
                     .replace("((config-slug))", self.website.starter.slug)
                     .replace("((base-url))", base_url)
                     .replace("((site-url))", site_url)
+                    .replace("((site-name))", self.website.name)
                     .replace("((purge-url))", purge_url)
                     .replace("((version))", version)
                     .replace("((api-token))", settings.API_BEARER_TOKEN)

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -98,6 +98,7 @@ def test_upsert_website_pipelines(
 ):  # pylint:disable=too-many-locals
     """The correct concourse API args should be made for a website"""
     settings.ROOT_WEBSITE_NAME = "ocw-www-course"
+    settings.API_BEARER_TOKEN = "top-secret-token"
     hugo_projects_path = "https://github.com/org/repo"
     starter = WebsiteStarterFactory.create(
         source=STARTER_SOURCE_GITHUB, path=f"{hugo_projects_path}/site"
@@ -146,6 +147,7 @@ def test_upsert_website_pipelines(
     config_str = json.dumps(kwargs)
 
     assert f"{hugo_projects_path}.git" in config_str
+    assert settings.API_BEARER_TOKEN in config_str
     if home_page:
         assert (
             f"s3 sync s3://{settings.AWS_STORAGE_BUCKET_NAME}/{website.name} s3://{bucket}/{website.name}"
@@ -213,5 +215,5 @@ def test_trigger_pipeline_build(settings, mocker, version):
         f"/api/v1/teams/{settings.CONCOURSE_TEAM}/pipelines/{version}/config?vars={pipeline.instance_vars}"
     )
     mock_post.assert_called_once_with(
-        f"/api/v1/teams/{settings.CONCOURSE_TEAM}/pipelines/draft/jobs/{job_name}/builds?vars={pipeline.instance_vars}"
+        f"/api/v1/teams/{settings.CONCOURSE_TEAM}/pipelines/{version}/jobs/{job_name}/builds?vars={pipeline.instance_vars}"
     )

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -25,13 +25,13 @@ resources:
   - name: ocw-studio-webhook
     type: http-api
     source:
-        uri: ((ocw-studio-url))/api/websites/((site))/pipeline_complete/
+        uri: ((ocw-studio-url))/api/websites/((site-url))/pipeline_complete/
         method: POST
         headers:
             Authorization: "Bearer {bearer_token}"
         json:
             version: ((version))
-            site: ((site))
+            site: ((site-url))
             success: "{succeeded}"
         bearer_token: ((api-token))
 jobs:

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -25,13 +25,13 @@ resources:
   - name: ocw-studio-webhook
     type: http-api
     source:
-        uri: ((ocw-studio-url))/api/websites/((site-url))/pipeline_complete/
+        uri: ((ocw-studio-url))/api/websites/((site-name))/pipeline_complete/
         method: POST
         headers:
             Authorization: "Bearer {bearer_token}"
         json:
             version: ((version))
-            site: ((site-url))
+            site: ((base-url))
             success: "{succeeded}"
         bearer_token: ((api-token))
 jobs:

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -1,4 +1,10 @@
 ---
+resource_types:
+  - name: http-api
+    type: docker-image
+    source:
+      repository: aequitas/http-api-resource
+      tag: latest
 resources:
   - name: ocw-hugo-themes
     type: s3
@@ -16,6 +22,18 @@ resources:
     source:
       uri: ((ocw-hugo-projects-uri))
       branch: ((ocw-hugo-projects-branch))
+  - name: ocw-studio-webhook
+    type: http-api
+    source:
+        uri: ((ocw-studio-url))/api/websites/((site))/pipeline_complete/
+        method: POST
+        headers:
+            Authorization: "Bearer {bearer_token}"
+        json:
+            version: ((version))
+            site: ((site))
+            success: "{succeeded}"
+        bearer_token: ((api-token))
 jobs:
   - name: build-ocw-site
     serial: true
@@ -39,6 +57,7 @@ jobs:
             - name: course-markdown
             - name: ocw-hugo-projects
           outputs:
+            - name: ocw-studio-hook
             - name: course-markdown
             - name: ocw-hugo-themes
           run:
@@ -50,11 +69,18 @@ jobs:
               mkdir ../ocw-hugo-themes/theme
               tar -xvzf ../ocw-hugo-themes/ocw-hugo-themes-*.tgz -C ../ocw-hugo-themes/theme
               hugo --config ../ocw-hugo-projects/((config-slug))/config.yaml --baseUrl /((base-url)) --themesDir ../ocw-hugo-themes/theme
+        on_failure:
+          try:
+            put: ocw-studio-webhook
+            params:
+                succeeded: false
       - task: copy-s3-buckets
         config:
           inputs:
             - name: ocw-hugo-themes
             - name: course-markdown
+          outputs:
+            - name: ocw-studio-webhook
           platform: linux
           image_resource:
             type: docker-image
@@ -67,6 +93,11 @@ jobs:
               aws s3 sync course-markdown/public s3://((ocw-bucket))/((base-url))
               aws s3 sync s3://((ocw-studio-bucket))/((site-url)) s3://((ocw-bucket))/((site-url))
               if [[ "((base-url))" == "" ]]; then aws s3 sync ocw-hugo-themes/theme/base-theme/dist s3://((ocw-bucket)); fi
+        on_failure:
+          try:
+            put: ocw-studio-webhook
+            params:
+                succeeded: false
       - task: clear-cdn-cache
         config:
           platform: linux
@@ -84,3 +115,13 @@ jobs:
               - -H
               - 'Fastly-Soft-Purge: 1'
               - https://api.fastly.com/service/((fastly.service_id))/((purge-url))
+        on_success:
+          try:
+            put: ocw-studio-webhook
+            params:
+                succeeded: true
+        on_failure:
+          try:
+            put: ocw-studio-webhook
+            params:
+                succeeded: false

--- a/main/settings.py
+++ b/main/settings.py
@@ -12,6 +12,7 @@ from mitol.common.envs import (
     get_bool,
     get_features,
     get_int,
+    get_site_name,
     get_string,
     import_settings_modules,
     init_app_settings,
@@ -56,6 +57,8 @@ init_sentry(
 )
 
 init_app_settings(namespace="OCW_STUDIO", site_name="OCW Studio")
+SITE_NAME = get_site_name()
+
 import_settings_modules(
     globals(),
     "mitol.common.settings.base",
@@ -134,6 +137,7 @@ INSTALLED_APPS = (
     "rest_framework",
     "social_django",
     "robots",
+    "anymail",
     # Put our apps after this point
     "main",
     "users",
@@ -142,9 +146,10 @@ INSTALLED_APPS = (
     "news",
     "content_sync",
     "gdrive_sync",
-    # common apps, need to be after ocw-studio apps for template overridding
+    # common apps, need to be after ocw-studio apps for template overriding
     "mitol.common.apps.CommonApp",
     "mitol.authentication.apps.AuthenticationApp",
+    "mitol.mail.apps.MailApp",
 )
 
 if ENVIRONMENT not in {"prod", "production"}:
@@ -186,7 +191,7 @@ ROOT_URLCONF = "main.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [f"{BASE_DIR}/templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
@@ -730,4 +735,64 @@ ROOT_WEBSITE_NAME = get_string(
     default="ocw-www",
     description="The Website name for the site at the root domain",
     required=False,
+)
+
+API_BEARER_TOKEN = get_string(
+    name="API_BEARER_TOKEN",
+    default=None,
+    description="Authorization bearer token for webhook endpoints",
+    required=False,
+)
+
+# mitol-django-mail
+MAILGUN_SENDER_DOMAIN = get_string(
+    name="MAILGUN_SENDER_DOMAIN",
+    default=None,
+    description="The domain to send mailgun email through",
+    required=True,
+)
+MAILGUN_KEY = get_string(
+    name="MAILGUN_KEY",
+    default=None,
+    description="The token for authenticating against the Mailgun API",
+    required=True,
+)
+ANYMAIL = {
+    "MAILGUN_API_KEY": MAILGUN_KEY,
+    "MAILGUN_SENDER_DOMAIN": MAILGUN_SENDER_DOMAIN,
+}
+
+MITOL_MAIL_FROM_EMAIL = get_string(
+    name="MITOL_MAIL_FROM_EMAIL",
+    default="webmaster@localhost",
+    description="E-mail to use for the from field",
+)
+MITOL_MAIL_REPLY_TO_ADDRESS = get_string(
+    name="MITOL_MAIL_REPLY_TO_ADDRESS",
+    default="webmaster@localhost",
+    description="E-mail to use for reply-to address of emails",
+)
+MITOL_MAIL_MESSAGE_CLASSES = []
+MITOL_MAIL_RECIPIENT_OVERRIDE = get_string(
+    name="MITOL_MAIL_RECIPIENT_OVERRIDE",
+    default=None,
+    dev_only=True,
+    description="Override the recipient for outgoing email, development only",
+)
+MITOL_MAIL_ENABLE_EMAIL_DEBUGGER = get_bool(
+    name="MITOL_MAIL_ENABLE_EMAIL_DEBUGGER",
+    default=DEBUG,
+    description="Enable the mitol-mail email debugger",
+    dev_only=True,
+)
+
+OCW_STUDIO_DRAFT_URL = get_string(
+    name="OCW_STUDIO_DRAFT_URL",
+    default=None,
+    description="The base url of the preview site",
+)
+OCW_STUDIO_LIVE_URL = get_string(
+    name="OCW_STUDIO_LIVE_URL",
+    default=None,
+    description="The base url of the live site",
 )

--- a/requirements.in
+++ b/requirements.in
@@ -4,6 +4,7 @@ boto3==1.18.7
 celery
 concoursepy
 dj-database-url
+django-anymail[mailgun]==8.4
 django-guardian
 django-hijack
 django-hijack-admin
@@ -16,6 +17,7 @@ django-storages
 django-webpack-loader
 mitol-django-authentication==1.2.0
 mitol-django-common==1.2.0
+mitol-django-mail==2.2.0
 drf-extensions
 ipython
 newrelic

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ botocore==1.21.8
     # via
     #   boto3
     #   s3transfer
-cachetools==4.2.1
+cachetools==4.2.2
     # via
     #   google-auth
     #   premailer
@@ -51,7 +51,7 @@ cryptography==3.3.2
     #   social-auth-core
 cssselect==1.1.0
     # via premailer
-cssutils==2.2.0
+cssutils==2.3.0
     # via premailer
 decorator==4.4.2
     # via
@@ -79,8 +79,10 @@ django==3.1.12
     #   mitol-django-authentication
     #   mitol-django-common
     #   mitol-django-mail
-django-anymail==8.2
-    # via mitol-django-mail
+django-anymail[mailgun]==8.4
+    # via
+    #   -r requirements.in
+    #   mitol-django-mail
 django-compat==1.0.15
     # via
     #   django-hijack
@@ -117,7 +119,7 @@ elasticsearch==7.8.1
     # via django-server-status
 factory-boy==3.2.0
     # via mitol-django-common
-faker==8.10.1
+faker==8.10.0
     # via factory-boy
 google-api-core==1.31.0
     # via google-api-python-client
@@ -172,10 +174,12 @@ mitol-django-common==1.2.0
     #   mitol-django-authentication
     #   mitol-django-mail
 mitol-django-mail==2.2.0
-    # via mitol-django-authentication
+    # via
+    #   -r requirements.in
+    #   mitol-django-authentication
 newrelic==5.16.1.146
     # via -r requirements.in
-oauthlib==3.1.0
+oauthlib==3.1.1
     # via
     #   requests-oauthlib
     #   social-auth-core
@@ -191,7 +195,7 @@ pickleshare==0.7.5
     # via ipython
 pluggy==0.13.1
     # via pytest
-premailer==3.7.0
+premailer==3.9.0
     # via mitol-django-mail
 prompt-toolkit==3.0.6
     # via ipython

--- a/websites/messages.py
+++ b/websites/messages.py
@@ -1,0 +1,23 @@
+"""Website email messages"""
+from types import SimpleNamespace
+
+from mitol.mail.messages import TemplatedMessage
+
+
+class PreviewOrPublishSuccessMessage(TemplatedMessage):
+    """Email message for publish/preview pipeline success"""
+
+    name = "Website Preview/Publish Pipeline Completed"
+    template_name = "mail/preview_publish_success"
+
+    @staticmethod
+    def get_debug_template_context() -> dict:
+        """Returns the extra context for the email debugger"""
+        return {
+            "site": SimpleNamespace(
+                name="1-1-computer-science-fall-2024",
+                title="Intro to Computer Science",
+                full_url="https://ocwtest.edu/courses/1-1-computer-science-fall-2024",
+            ),
+            "version": "live",
+        }

--- a/websites/models.py
+++ b/websites/models.py
@@ -2,9 +2,11 @@
 import json
 from hashlib import sha256
 from typing import Dict
+from urllib.parse import urljoin
 from uuid import uuid4
 
 import yaml
+from django.conf import settings
 from django.contrib.auth.models import Group
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -82,6 +84,15 @@ class Website(TimestampedModel):
         return Group.objects.filter(
             name=permissions_group_name_for_role(constants.ROLE_EDITOR, self)
         ).first()
+
+    def get_url(self, version="live"):
+        """Get the home page (live or draft) of the website"""
+        base_url = (
+            settings.OCW_STUDIO_LIVE_URL
+            if version == "live"
+            else settings.OCW_STUDIO_DRAFT_URL
+        )
+        return urljoin(base_url, self.name)
 
     class Meta:
         permissions = (

--- a/websites/models.py
+++ b/websites/models.py
@@ -92,7 +92,13 @@ class Website(TimestampedModel):
             if version == "live"
             else settings.OCW_STUDIO_DRAFT_URL
         )
-        return urljoin(base_url, self.name)
+        site_config = SiteConfig(self.starter.config)
+        site_url = (
+            ""
+            if self.name == settings.ROOT_WEBSITE_NAME
+            else f"{site_config.root_url_path}/{self.name}".strip("/")
+        )
+        return urljoin(base_url, site_url)
 
     class Meta:
         permissions = (

--- a/websites/permissions_test.py
+++ b/websites/permissions_test.py
@@ -402,3 +402,23 @@ def test_create_global_groups():
     for permission in constants.PERMISSIONS_EDITOR:
         assert author.has_perm(permission) is False
     assert author.has_perm(constants.PERMISSION_ADD) is True
+
+
+@pytest.mark.parametrize(
+    "token,has_permission",
+    [
+        [None, False],
+        ["Bearer abc123", False],
+        ["Bearer 123abc", True],
+        ["123abc", False],
+    ],
+)
+def test_bearer_token_permission(settings, mocker, token, has_permission):
+    """BearerTokenPermission.has_permission should return expected values"""
+    settings.API_BEARER_TOKEN = "123abc"
+    request = mocker.Mock(headers={"Authorization": token})
+    view = mocker.Mock()
+    assert (
+        permissions.BearerTokenPermission().has_permission(request, view)
+        is has_permission
+    )

--- a/websites/templates/mail/preview_publish_success/body.html
+++ b/websites/templates/mail/preview_publish_success/body.html
@@ -1,0 +1,18 @@
+{% extends "mail/email_base.html" %}
+
+{% block content %}
+<tr>
+  <td style="padding: 20px;">
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+      <tr>
+        <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
+          <p style="margin: 0 0 10px;">Dear {{ user.name }},</p>
+          <p style="margin: 0 0 10px;">
+            The {{ version }} version of your site <a href="{{ site.url }}">{{ site.title }}</a> is now ready to view.
+          </p>
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>
+{% endblock %}

--- a/websites/templates/mail/preview_publish_success/subject.txt
+++ b/websites/templates/mail/preview_publish_success/subject.txt
@@ -1,0 +1,1 @@
+{{ site_name }}: "{{site.title}}" {{ version }} version available for viewing

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -323,7 +323,7 @@ def test_websites_endpoint_pipeline_complete(
             {
                 "site": {
                     "title": website.title,
-                    "url": f"http://test.{version}.edu/{website.name}",
+                    "url": f"http://test.{version}.edu/{website.starter.config['root-url-path']}/{website.name}",
                 },
                 "version": version,
             },


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable
  - [x] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
Closes #370

#### What's this PR do?
- Adds a new webhook API endpoint for receiving requests from concourse-ci
- Modifies the concourse-ci pipeline to send success/error notifications to the endpoint
- Adds the required code to send emails to site owners/admins

#### How should this be manually tested?
- Start ngrok to make your local instance accessible to concourse:
   `./ngrok http 8043`
-   Set the following .env variables:
   ```
   AWS_PREVIEW_BUCKET_NAME=ocw-content-draft-qa
   AWS_PUBLISH_BUCKET_NAME=ocw-content-live-qa   
   OCW_STUDIO_BASE_URL=<ngrok url>
   GIT_ORGANIZATION=ocw-content-rc
   GIT_DOMAIN=github.mit.edu
   CONTENT_SYNC_PIPELINE=content_sync.pipelines.concourse.ConcourseGithubPipeline
   CONCOURSE_URL=https://cicd-qa.odl.mit.edu
   CONCOURSE_USERNAME=<ask me>
   CONCOURSE_PASSWORD=<ask me>
   MAILGUN_KEY=<same as on RC>
   MAILGUN_URL=<same as on RC>
   MAILGUN_SENDER_DOMAIN=<same as on RC>
   MITOL_MAIL_RECIPIENT_OVERRIDE=<your email>
   MITOL_MAIL_FROM_EMAIL="admin@admin.edu"   
   OCW_STUDIO_DRAFT_URL=https://ocw-draft-qa.global.ssl.fastly.net/
   OCW_STUDIO_LIVE_URL=https://ocw-live-qa.global.ssl.fastly.net/   
   API_BEARER_TOKEN=<some_string_value>
   ```
- Rebuild the docker instance (new requirements)
- Create a website with a title of "Course MB 1" (so `name=course-mb-1`), based on a starter with slug "ocw-course".
- Tweak the function `content_sync.pipelines.concourse.ConcourseGithubPipeline.upsert_website_pipeline`, adding this after the 1st line of its code:
```
        from uuid import UUID
        self.website.uuid = UUID("917f160c-7eae-48d8-86a6-a041bd2ef0fe")
        self.website.starter.slug = "ocw-course"
```
- Run the following in a shell:
```
from websites.models import *
from content_sync.pipelines.concourse import *
website = Website.objects.get(name="course-mb-1")
pipeline = ConcourseGithubPipeline(website)
pipeline.upsert_website_pipeline()
```        
- Go to https://cicd-qa.odl.mit.edu/teams/ocw/pipelines/draft/jobs/build-ocw-site/builds/7.1?vars.site=%22course-mb-1%22 and start another run.  It should complete successfully and you should get an email shortly about your "draft" version of the site being ready to view (it may end up in junk mail).

#### Any background context you want to provide?
The placeholder logo in the email will be replaced in a future PR.
UI feedback after pressing the "Preview" or "Publish" button will also be handled in a separate PR.

#### Screenshots (if appropriate)
<img width="522" alt="Screen Shot 2021-07-14 at 12 50 37 PM" src="https://user-images.githubusercontent.com/187676/125663218-2fa72606-626a-4325-b488-42cb9b8928ea.png">

-------------------

<img width="454" alt="Screen Shot 2021-07-14 at 12 51 06 PM" src="https://user-images.githubusercontent.com/187676/125663229-878bd030-a275-4d27-9b4a-86e14b6cc692.png">

-------------------

<img width="892" alt="Screen Shot 2021-07-14 at 1 09 22 PM" src="https://user-images.githubusercontent.com/187676/125663746-c0edaf1f-7de7-4779-9688-e012afa1b93a.png">


