### PR TITLE
Dynamic project git url for concourse pipeline based on starter path

### DIFF
--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ImproperlyConfigured
 
 from content_sync.apis.github import get_repo_name
 from content_sync.pipelines.concourse import ConcourseGithubPipeline
+from websites.constants import STARTER_SOURCE_GITHUB, STARTER_SOURCE_LOCAL
 from websites.factories import WebsiteFactory, WebsiteStarterFactory
 
 
@@ -22,63 +23,82 @@ def test_upsert_website_pipeline_missing_settings(settings, mock_fly):
     mock_fly.login.assert_not_called()
 
 
-def test_upsert_website_pipeline_homepage(settings, mock_fly):
+@pytest.mark.parametrize(
+    "source,path,is_valid",
+    [
+        [STARTER_SOURCE_GITHUB, "https://github.com/testorg/testrepo/ocw-course", True],
+        [STARTER_SOURCE_GITHUB, "badvalue", False],
+        [STARTER_SOURCE_LOCAL, "https://github.com/testorg/testrepo/ocw-course", False],
+    ],
+)
+def test_upsert_website_pipeline_homepage(settings, mock_fly, source, path, is_valid):
     """The correct fly calls/args should be made for a draft 'home page' website"""
     root_slug = "ocw-www"
     settings.ROOT_WEBSITE_SLUG = root_slug
-    starter = WebsiteStarterFactory.create(slug=root_slug)
+    starter = WebsiteStarterFactory.create(source=source, path=path, slug=root_slug)
     starter.config["root-url-path"] = ""
     website = WebsiteFactory.create(starter=starter)
     pipeline = ConcourseGithubPipeline(website)
     pipeline.upsert_website_pipeline()
-    mock_fly.return_value.login.assert_called_once_with(
-        username=settings.CONCOURSE_USERNAME,
-        password=settings.CONCOURSE_PASSWORD,
-        team_name=settings.CONCOURSE_TEAM,
-    )
-    mock_fly.return_value.run.assert_any_call(
-        "set-pipeline",
-        "-p",
-        "draft",
-        "--team",
-        settings.CONCOURSE_TEAM,
-        "-c",
-        os.path.join(
-            os.path.dirname(__file__), "definitions/concourse/site-pipeline.yml"
-        ),
-        "--instance-var",
-        f"site={website.name}",
-        "-v",
-        f"git-domain={settings.GIT_DOMAIN}",
-        "-v",
-        f"github-org={settings.GIT_ORGANIZATION}",
-        "-v",
-        f"ocw-bucket={settings.AWS_PREVIEW_BUCKET_NAME}",
-        "-v",
-        f"ocw-hugo-projects-branch={settings.GITHUB_WEBHOOK_BRANCH}",
-        "-v",
-        "ocw-studio-url=http://test.edu",
-        "-v",
-        f"ocw-studio-bucket={settings.AWS_STORAGE_BUCKET_NAME}",
-        "-v",
-        f"ocw-site-repo={get_repo_name(website)}",
-        "-v",
-        "ocw-site-repo-branch=preview",
-        "-v",
-        f"config-slug={starter.slug}",
-        "-v",
-        "base-url=",
-        "-v",
-        f"site-url={website.name}",
-        "-v",
-        "purge-url=purge_all",
-        "-n",
-    )
+    if not is_valid:
+        mock_fly.return_value.login.assert_not_called()
+        mock_fly.return_value.run.assert_not_called()
+    else:
+        mock_fly.return_value.login.assert_called_once_with(
+            username=settings.CONCOURSE_USERNAME,
+            password=settings.CONCOURSE_PASSWORD,
+            team_name=settings.CONCOURSE_TEAM,
+        )
+        mock_fly.return_value.run.assert_any_call(
+            "set-pipeline",
+            "-p",
+            "draft",
+            "--team",
+            settings.CONCOURSE_TEAM,
+            "-c",
+            os.path.join(
+                os.path.dirname(__file__), "definitions/concourse/site-pipeline.yml"
+            ),
+            "--instance-var",
+            f"site={website.name}",
+            "-v",
+            f"git-domain={settings.GIT_DOMAIN}",
+            "-v",
+            f"github-org={settings.GIT_ORGANIZATION}",
+            "-v",
+            f"ocw-bucket={settings.AWS_PREVIEW_BUCKET_NAME}",
+            "-v",
+            "ocw-hugo-projects-uri=https://github.com/testorg/testrepo.git",
+            "-v",
+            f"ocw-hugo-projects-branch={settings.GITHUB_WEBHOOK_BRANCH}",
+            "-v",
+            "ocw-studio-url=http://test.edu",
+            "-v",
+            f"ocw-studio-bucket={settings.AWS_STORAGE_BUCKET_NAME}",
+            "-v",
+            f"ocw-site-repo={get_repo_name(website)}",
+            "-v",
+            "ocw-site-repo-branch=preview",
+            "-v",
+            f"config-slug={starter.slug}",
+            "-v",
+            "base-url=",
+            "-v",
+            f"site-url={website.name}",
+            "-v",
+            "purge-url=purge_all",
+            "-n",
+        )
 
 
 def test_upsert_website_pipeline_course(settings, mock_fly):
     """The correct fly calls/args should be made for a live course website"""
-    website = WebsiteFactory.create()
+    starter = WebsiteStarterFactory.create(
+        source=STARTER_SOURCE_GITHUB,
+        path="http://test.edu/org/repo",
+        slug="ocw-courses",
+    )
+    website = WebsiteFactory.create(starter=starter)
     website.starter.config["root-url-path"] = "courses"
     pipeline = ConcourseGithubPipeline(website)
     pipeline.upsert_website_pipeline()
@@ -100,6 +120,8 @@ def test_upsert_website_pipeline_course(settings, mock_fly):
         f"github-org={settings.GIT_ORGANIZATION}",
         "-v",
         f"ocw-bucket={settings.AWS_PUBLISH_BUCKET_NAME}",
+        "-v",
+        "ocw-hugo-projects-uri=http://test.edu/org/repo.git",
         "-v",
         f"ocw-hugo-projects-branch={settings.GITHUB_WEBHOOK_BRANCH}",
         "-v",

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -14,7 +14,7 @@ resources:
   - name: ocw-hugo-projects
     type: git
     source:
-      uri: https://github.com/mitodl/ocw-hugo-projects.git
+      uri: ((ocw-hugo-projects-uri))
       branch: ((ocw-hugo-projects-branch))
 jobs:
   - name: build-ocw-site


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #384 

#### What's this PR do?
Parses a sites WebsiteStarter.path value to determine the hugo projects repo to use in a concourse-ci pipeline

#### How should this be manually tested?
- Follow testing instructions for #399, and make sure your local `WebsiteStarter` objects are the same as the ones on RC ("ocw-www" and "ocw-course"): path, slug, config, etc.
