### PR TITLE
Pipeline management commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,6 @@ COPY apt.txt /tmp/apt.txt
 RUN apt-get update
 RUN apt-get install -y $(grep -vE "^\s*#" apt.txt  | tr "\n" " ")
 
-# Add concourse-ci fly executable
-RUN curl --silent --location "https://cicd.odl.mit.edu/api/v1/cli?arch=amd64&platform=linux" --output fly
-RUN chmod +x fly
-RUN mv fly /usr/local/bin/fly
-
 # pip
 RUN curl --silent --location https://bootstrap.pypa.io/get-pip.py | python3 -
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,11 @@ COPY apt.txt /tmp/apt.txt
 RUN apt-get update
 RUN apt-get install -y $(grep -vE "^\s*#" apt.txt  | tr "\n" " ")
 
+# Add concourse-ci fly executable
+RUN curl --silent --location "https://cicd.odl.mit.edu/api/v1/cli?arch=amd64&platform=linux" --output fly
+RUN chmod +x fly
+RUN mv fly /usr/local/bin/fly
+
 # pip
 RUN curl --silent --location https://bootstrap.pypa.io/get-pip.py | python3 -
 

--- a/README.md
+++ b/README.md
@@ -197,3 +197,28 @@ You can enable git integration so that website content will be synced with GitHu
     ```
 - If you need to use a custom git domain, add `GIT_API_URL=<your_domain>/api/v3`
 - If you would like git commits to be anonymized, add `FEATURE_GIT_ANONYMOUS_COMMITS=True`
+
+
+# Enabling Concourse-CI integration
+You can enable Concourse-CI integration to create and trigger publishing pipelines.
+- Set up github integration as described above
+- Set up a Concourse-CI instance with a team, username, and password
+- Add the following to your .env file:
+    ``` 
+    CONTENT_SYNC_PIPELINE=content_sync.pipelines.concourse.ConcourseGithubPipeline
+    AWS_PREVIEW_BUCKET_NAME=<S3 bucket for draft content>
+    AWS_PUBLISH_BUCKET_NAME=<S3 bucket for live content>
+    GIT_DOMAIN=<root domain for github repos, ie github.com>
+    ROOT_WEBSITE_NAME=<Website.name for the website that should be the 'home page'> 
+
+    CONCOURSE_URL=<The URL of your Concourse-CI instance>
+    CONCOURSE_TEAM=<Concourse-CI team, defaults to "ocw">
+    CONCOURSE_USERNAME=<Concourse-CI username>
+    CONCOURSE_PASSWORD=<Concourse-CI password>
+    ```
+- Draft and live pipelines should then be created for every new `Website` based on a `WebsiteStarter` with `source=github` and a valid github `path`.
+- There are also several management commands for Concourse-CI pipelines:
+  - `backpopulate_pipelines`: to create/update pipelines for all or some existing `Websites` (filters available)
+  - `trigger_pipelines <version>`: to manually trigger the draft or live pipeline for all or some existing `Websites` (filters available)
+  
+  

--- a/content_sync/management/commands/backpopulate_pipelines.py
+++ b/content_sync/management/commands/backpopulate_pipelines.py
@@ -1,0 +1,70 @@
+""" Backpopulate website pipelines"""
+from django.conf import settings
+from django.core.management import BaseCommand
+from django.db.models import Q
+from mitol.common.utils.datetime import now_in_utc
+
+from content_sync.api import get_sync_pipeline
+from websites.models import Website
+
+
+class Command(BaseCommand):
+    """ Backpopulate website pipelines """
+
+    help = __doc__
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-f",
+            "--filter",
+            dest="filter",
+            default="",
+            help="If specified, only process websites that contain this filter text in their name",
+        )
+        parser.add_argument(
+            "-s",
+            "--starter",
+            dest="starter",
+            default="",
+            help="If specified, only process websites that are based on this starter slug",
+        )
+
+    def handle(self, *args, **options):
+
+        if not settings.CONTENT_SYNC_PIPELINE:
+            self.stderr.write("Pipeline backend is not configured")
+            return
+
+        self.stdout.write("Creating website pipelines")
+        start = now_in_utc()
+
+        filter_str = options["filter"].lower()
+        starter_str = options["starter"]
+        is_verbose = options["verbosity"] > 1
+
+        total_websites = 0
+
+        if filter_str:
+            website_qset = Website.objects.filter(
+                Q(name__icontains=filter_str) | Q(title__icontains=filter_str)
+            )
+        else:
+            website_qset = Website.objects.all()
+
+        if starter_str:
+            website_qset = website_qset.filter(starter__slug=starter_str)
+
+        for website in website_qset.iterator():
+            get_sync_pipeline(website).upsert_website_pipeline()
+            total_websites += 1
+
+            if is_verbose:
+                self.stdout.write(f"{website.name} pipeline created or updated")
+
+        total_seconds = (now_in_utc() - start).total_seconds()
+        self.stdout.write(
+            "Creation of website pipelines finished, took {} seconds".format(
+                total_seconds
+            )
+        )
+        self.stdout.write(f"{total_websites} websites processed")

--- a/content_sync/management/commands/trigger_pipelines.py
+++ b/content_sync/management/commands/trigger_pipelines.py
@@ -1,0 +1,81 @@
+""" Trigger website pipeline builds"""
+from django.conf import settings
+from django.core.management import BaseCommand
+from django.db.models import Q
+from mitol.common.utils.datetime import now_in_utc
+from requests import HTTPError
+
+from content_sync.api import get_sync_pipeline
+from websites.constants import STARTER_SOURCE_GITHUB
+from websites.models import Website
+
+
+class Command(BaseCommand):
+    """ Trigger all draft or live website pipeline builds """
+
+    help = __doc__
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "version",
+            help="The pipeline version to trigger (live or draft)",
+        )
+        parser.add_argument(
+            "-f",
+            "--filter",
+            dest="filter",
+            default="",
+            help="If specified, only trigger website pipelines that contain this filter text in their name",
+        )
+        parser.add_argument(
+            "-s",
+            "--starter",
+            dest="starter",
+            default="",
+            help="If specified, only trigger pipelines for websites that are based on this starter slug",
+        )
+
+    def handle(self, *args, **options):
+
+        if not settings.CONTENT_SYNC_PIPELINE:
+            self.stderr.write("Pipeline backend is not configured")
+            return
+
+        self.stdout.write("Triggering website pipelines")
+        start = now_in_utc()
+
+        filter_str = options["filter"].lower()
+        version = options["version"].lower()
+        starter_str = options["starter"]
+        is_verbose = options["verbosity"] > 1
+
+        total_pipelines = 0
+
+        website_qset = Website.objects.filter(starter__source=STARTER_SOURCE_GITHUB)
+        if filter_str:
+            website_qset = website_qset.filter(
+                Q(name__icontains=filter_str) | Q(title__icontains=filter_str)
+            )
+        if starter_str:
+            website_qset = website_qset.filter(starter__slug=starter_str)
+
+        for website in website_qset.iterator():
+            pipeline = get_sync_pipeline(website)
+            try:
+                pipeline.trigger_pipeline_build(version)
+                total_pipelines += 1
+                if is_verbose:
+                    self.stdout.write(f"{website.name} pipeline triggered")
+            except HTTPError as err:
+                if err.response.status_code == 404:
+                    self.stderr.write(f"No pipeline exists for website {website.name}")
+                else:
+                    self.stderr.write(
+                        f"Error triggering pipeline for website {website.name}: {err}"
+                    )
+
+        total_seconds = (now_in_utc() - start).total_seconds()
+        self.stdout.write(
+            "Website pipeline triggers finished, took {} seconds".format(total_seconds)
+        )
+        self.stdout.write(f"{total_pipelines} pipelines triggered")

--- a/content_sync/pipelines/base.py
+++ b/content_sync/pipelines/base.py
@@ -11,6 +11,8 @@ class BaseSyncPipeline(abc.ABC):
     """ Base class for preview/publish pipelines """
 
     MANDATORY_SETTINGS = []
+    VERSION_LIVE = "live"
+    VERSION_DRAFT = "draft"
 
     def __init__(self, website: Website):
         """Make sure all required settings are present"""
@@ -33,5 +35,12 @@ class BaseSyncPipeline(abc.ABC):
     def upsert_website_pipeline(self):  # pragma: no cover
         """
         Called to create/update the website pipeline.
+        """
+        ...
+
+    @abc.abstractmethod
+    def trigger_pipeline_build(self, version: str):
+        """
+        Called to trigger the website pipeline.
         """
         ...


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #383 

#### What's this PR do?
- Management command for triggering existing website pipelines
- Management command for creating/updating website pipelines

#### How should this be manually tested?
- Set the following env variables to the same as on RC:
  ```
  OCW_STUDIO_BASE_URL
  GIT_ORGANIZATION
  ```  
- Plus set the following:
  ```
  AWS_PREVIEW_BUCKET_NAME=ocw-content-draft-qa
  AWS_PUBLISH_BUCKET_NAME=ocw-content-live-qa
  GIT_DOMAIN=github.mit.edu
  ROOT_WEBSITE_NAME=ocw-www
  CONTENT_SYNC_PIPELINE=content_sync.pipelines.concourse.ConcourseGithubPipeline
  CONCOURSE_URL=<QA instance of concourse>
  CONCOURSE_USERNAME=<ask me>
  CONCOURSE_PASSWORD=<ask me>
  ```  
- Create a website based on a valid github slug (`source="github", path=<valid_url>`)
- Run `manage.py backpopulate_pipelines --filter <website.name>`
- The command should run without errors.
- Go to the RC concourse site and verify that an unpaused pipeline exists for the website.
- Run `manage.py trigger_pipelines --filter <website.name> draft`
- The command should run without errors.
- Go to the RC concourse site and verify that the pipeline is running a build (which will likely fail because it can't find the git repo, that's okay).
- Using the `fly` CLI (which you can download from the concourse site if you don't already have it), delete the pipeline you created to clean things up:
    ```
    fly -t ocw destroy-pipeline -p draft/site:<site_name> --team ocw
    fly -t ocw destroy-pipeline -p live/site:<site_name> --team ocw    
   ```
  