### PR TITLE
add UI for editing website collection entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "@ckeditor/ckeditor5-theme-lark": "^27.0.0",
     "@ckeditor/ckeditor5-upload": "^27.0.0",
     "@ckeditor/ckeditor5-widget": "^27.0.0",
+    "@dnd-kit/core": "^3.1.1",
+    "@dnd-kit/sortable": "^4.0.0",
     "@sentry/browser": "^5.20.1",
     "@types/ckeditor__ckeditor5-core": "^11.0.3",
     "@types/enzyme": "^3.10.8",

--- a/static/js/components/SortableWebsiteCollectionItem.test.tsx
+++ b/static/js/components/SortableWebsiteCollectionItem.test.tsx
@@ -1,0 +1,23 @@
+import React from "react"
+import { shallow } from "enzyme"
+
+import SortableWebsiteCollectionItem from "./SortableWebsiteCollectionItem"
+import { WebsiteCollectionItem } from "../types/website_collections"
+import { makeWebsiteCollectionItem } from "../util/factories/website_collections"
+
+describe("SortableWebsiteCollectionItem", () => {
+  let item: WebsiteCollectionItem
+
+  const renderItem = () =>
+    shallow(<SortableWebsiteCollectionItem item={item} id={String(item.id)} />)
+
+  beforeEach(() => {
+    item = makeWebsiteCollectionItem()
+  })
+
+  it("should display the title and a drag handle", () => {
+    const wrapper = renderItem()
+    expect(wrapper.find(".material-icons").text()).toBe("drag_indicator")
+    expect(wrapper.find(".title").text()).toBe(item.website_title)
+  })
+})

--- a/static/js/components/SortableWebsiteCollectionItem.tsx
+++ b/static/js/components/SortableWebsiteCollectionItem.tsx
@@ -1,0 +1,44 @@
+import React from "react"
+import { useSortable } from "@dnd-kit/sortable"
+import { CSS } from "@dnd-kit/utilities"
+
+import { WebsiteCollectionItem } from "../types/website_collections"
+
+interface Props {
+  item: WebsiteCollectionItem
+  id: string
+}
+
+export default function SortableWebsiteCollectionItem(
+  props: Props
+): JSX.Element {
+  const { item } = props
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition
+  } = useSortable({
+    id: String(item.id)
+  })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition
+  }
+
+  return (
+    <div
+      className="d-flex my-3"
+      ref={setNodeRef}
+      // @ts-ignore
+      style={style}
+      {...attributes}
+      {...listeners}
+    >
+      <span className="material-icons">drag_indicator</span>
+      <div className="title">{item.website_title}</div>
+    </div>
+  )
+}

--- a/static/js/components/WebsiteCollectionEditor.test.tsx
+++ b/static/js/components/WebsiteCollectionEditor.test.tsx
@@ -12,6 +12,11 @@ import { createModalState } from "../types/modal_state"
 import { makeWebsiteCollection } from "../util/factories/website_collections"
 import { WebsiteCollection } from "../types/website_collections"
 
+import WebsiteCollectionItemsEditor from "./WebsiteCollectionItemsEditor"
+jest.mock("./WebsiteCollectionItemsEditor")
+// @ts-ignore
+WebsiteCollectionItemsEditor.mockImplementation(() => "MockComponent")
+
 describe("WebsiteCollectionEditor", () => {
   let helper: IntegrationTestHelper,
     render: TestRenderer,
@@ -112,7 +117,7 @@ describe("WebsiteCollectionEditor", () => {
         })
     })
 
-    it("should pass values from focused website down to form", async () => {
+    it("should pass values from focused collection down to form", async () => {
       const { wrapper } = await render({
         modalState: createModalState("editing", collection.id)
       })
@@ -122,6 +127,16 @@ describe("WebsiteCollectionEditor", () => {
         title:       collection.title,
         description: collection.description
       })
+    })
+
+    it("should render item editor", async () => {
+      const { wrapper } = await render({
+        modalState: createModalState("editing", collection.id)
+      })
+      const editor = wrapper.find("WebsiteCollectionItemsEditor")
+
+      expect(editor.exists()).toBeTruthy()
+      expect(editor.prop("websiteCollection")).toEqual(collection)
     })
 
     it("should let us edit an existing collection", async () => {

--- a/static/js/components/WebsiteCollectionEditor.tsx
+++ b/static/js/components/WebsiteCollectionEditor.tsx
@@ -15,6 +15,7 @@ import {
 } from "../query-configs/website_collections"
 import { useSelector } from "react-redux"
 import { getWebsiteCollectionDetailCursor } from "../selectors/website_collections"
+import WebsiteCollectionItemsEditor from "./WebsiteCollectionItemsEditor"
 
 interface Props {
   hideModal: () => void
@@ -82,9 +83,14 @@ export default function WebsiteCollectionEditor(props: Props): JSX.Element {
   return fetchPending ? (
     <div>loading</div>
   ) : (
-    <WebsiteCollectionForm
-      initialValues={initialFormValues(websiteCollection)}
-      onSubmit={onSubmit}
-    />
+    <>
+      <WebsiteCollectionForm
+        initialValues={initialFormValues(websiteCollection)}
+        onSubmit={onSubmit}
+      />
+      {modalState.editing() && websiteCollection ? (
+        <WebsiteCollectionItemsEditor websiteCollection={websiteCollection} />
+      ) : null}
+    </>
   )
 }

--- a/static/js/components/WebsiteCollectionItemsEditor.test.tsx
+++ b/static/js/components/WebsiteCollectionItemsEditor.test.tsx
@@ -1,0 +1,109 @@
+import WebsiteCollectionItemsEditor from "./WebsiteCollectionItemsEditor"
+import { times } from "lodash"
+import { DndContext } from "@dnd-kit/core"
+
+import IntegrationTestHelper, {
+  TestRenderer
+} from "../util/integration_test_helper"
+import {
+  WebsiteCollection,
+  WebsiteCollectionItem
+} from "../types/website_collections"
+import {
+  makeWebsiteCollection,
+  makeWebsiteCollectionItem
+} from "../util/factories/website_collections"
+import { wcItemsApiDetailUrl, wcItemsApiUrl } from "../lib/urls"
+import { act } from "react-dom/test-utils"
+
+describe("WebsiteCollectionItemsEditor", () => {
+  let helper: IntegrationTestHelper,
+    render: TestRenderer,
+    collection: WebsiteCollection,
+    items: WebsiteCollectionItem[]
+
+  beforeEach(() => {
+    collection = makeWebsiteCollection()
+    items = times(15).map(() => makeWebsiteCollectionItem(collection))
+    helper = new IntegrationTestHelper()
+    render = helper.configureRenderer(WebsiteCollectionItemsEditor, {
+      websiteCollection: collection
+    })
+
+    helper.handleRequestStub
+      .withArgs(wcItemsApiUrl.param({ collectionId: collection.id }).toString())
+      .returns({
+        body:   items,
+        status: 200
+      })
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should render, show items", async () => {
+    const { wrapper } = await render()
+    expect(
+      wrapper
+        .find("SortableWebsiteCollectionItem")
+        .map(item => item.prop("item"))
+    ).toEqual(items)
+  })
+
+  it("should render the WebsiteCollectionItemForm", async () => {
+    const { wrapper } = await render()
+    expect(wrapper.find("WebsiteCollectionItemForm").exists()).toBeTruthy()
+    expect(
+      wrapper.find("WebsiteCollectionItemForm").prop("websiteCollection")
+    ).toBe(collection)
+  })
+
+  it("should have a SortableContext with items", async () => {
+    const { wrapper } = await render()
+    const context = wrapper.find("SortableContext")
+    expect(context.exists()).toBeTruthy()
+    expect(context.prop("items")).toEqual(items.map(item => String(item.id)))
+  })
+
+  it("should issue properly-formed requests to reordering items", async () => {
+    const { wrapper } = await render()
+
+    const itemToMove = items[6]
+
+    helper.handleRequestStub
+      .withArgs(
+        wcItemsApiDetailUrl
+          .param({ collectionId: collection.id, itemId: items[6].id })
+          .toString()
+      )
+      .returns({
+        status: 200,
+        body:   {
+          id: items[6].id
+        }
+      })
+
+    act(() => {
+      wrapper.find(DndContext)!.prop("onDragEnd")!({
+        active: { id: String(itemToMove.id) },
+        over:   { id: String(items[2].id) }
+      } as any)
+    })
+    expect(helper.handleRequestStub.args[1]).toEqual([
+      wcItemsApiDetailUrl
+        .param({ collectionId: collection.id, itemId: items[6].id })
+        .toString(),
+      "PATCH",
+      {
+        body: {
+          position: 2
+        },
+        credentials: undefined,
+        headers:     {
+          "X-CSRFTOKEN": ""
+        }
+      }
+    ])
+  })
+})

--- a/static/js/components/WebsiteCollectionItemsEditor.tsx
+++ b/static/js/components/WebsiteCollectionItemsEditor.tsx
@@ -1,0 +1,96 @@
+import React, { useCallback } from "react"
+import { useSelector } from "react-redux"
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors
+} from "@dnd-kit/core"
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy
+} from "@dnd-kit/sortable"
+
+import { useMutation, useRequest } from "redux-query-react"
+import { WebsiteCollection } from "../types/website_collections"
+import {
+  editWebsiteCollectionItemMutation,
+  websiteCollectionItemsRequest
+} from "../query-configs/website_collections"
+import { getWebsiteCollectionItemsCursor } from "../selectors/website_collections"
+import WebsiteCollectionItemForm from "./forms/WebsiteCollectionItemForm"
+import SortableWebsiteCollectionItem from "./SortableWebsiteCollectionItem"
+
+interface Props {
+  websiteCollection: WebsiteCollection
+}
+
+export default function WebsiteCollectionItemsEditor(
+  props: Props
+): JSX.Element {
+  const { websiteCollection } = props
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates
+    })
+  )
+
+  useRequest(websiteCollectionItemsRequest(websiteCollection.id))
+
+  const websiteCollectionItemsCursor = useSelector(
+    getWebsiteCollectionItemsCursor
+  )
+
+  const items = websiteCollectionItemsCursor(websiteCollection.id)
+
+  const [, updateWCItemPosition] = useMutation(
+    editWebsiteCollectionItemMutation
+  )
+
+  const handleDragEnd = useCallback(
+    function handleDragEnd(event: any) {
+      const { active, over } = event
+
+      if (active.id !== over.id) {
+        updateWCItemPosition(
+          {
+            position: items.map(item => String(item.id)).indexOf(over.id)
+          },
+          websiteCollection.id,
+          active.id
+        )
+      }
+    },
+    [updateWCItemPosition, websiteCollection, items]
+  )
+
+  return (
+    <div className="collection-item-editor pt-5 pb-3">
+      <h4>Courses in this collection</h4>
+      <WebsiteCollectionItemForm websiteCollection={websiteCollection} />
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext
+          items={items.map(item => String(item.id))}
+          strategy={verticalListSortingStrategy}
+        >
+          {items.map(item => (
+            <SortableWebsiteCollectionItem
+              key={item.id}
+              id={String(item.id)}
+              item={item}
+            />
+          ))}
+        </SortableContext>
+      </DndContext>
+    </div>
+  )
+}

--- a/static/js/components/forms/WebsiteCollectionForm.test.tsx
+++ b/static/js/components/forms/WebsiteCollectionForm.test.tsx
@@ -5,8 +5,8 @@ import { mount } from "enzyme"
 import { ErrorMessage } from "formik"
 
 import { WebsiteCollectionFormSchema } from "./validation"
-import WebsiteCollectionForm, { SubmitFunc } from "./WebsiteCollectionForm"
-import { WebsiteCollectionFormFields } from "../../types/forms"
+import WebsiteCollectionForm from "./WebsiteCollectionForm"
+import { WebsiteCollectionFormFields, SubmitFunc } from "../../types/forms"
 
 describe("WebsiteCollectionForm", () => {
   let sandbox: sinon.SinonSandbox,

--- a/static/js/components/forms/WebsiteCollectionForm.tsx
+++ b/static/js/components/forms/WebsiteCollectionForm.tsx
@@ -1,13 +1,9 @@
 import React from "react"
-import { Form, Formik, Field, FormikHelpers, ErrorMessage } from "formik"
+import { Form, Formik, Field, ErrorMessage } from "formik"
 
 import { FormError } from "./FormError"
-import { WebsiteCollectionFormFields } from "../../types/forms"
+import { WebsiteCollectionFormFields, SubmitFunc } from "../../types/forms"
 import { WebsiteCollectionFormSchema } from "./validation"
-
-export interface SubmitFunc {
-  (values: any, formikHelpers: FormikHelpers<any>): void | Promise<any>
-}
 
 interface Props {
   onSubmit: SubmitFunc

--- a/static/js/components/forms/WebsiteCollectionItemForm.test.tsx
+++ b/static/js/components/forms/WebsiteCollectionItemForm.test.tsx
@@ -1,0 +1,114 @@
+import { act } from "react-dom/test-utils"
+
+import WebsiteCollectionItemForm from "./WebsiteCollectionItemForm"
+import { makeWebsiteListing } from "../../util/factories/websites"
+import { makeWebsiteCollection } from "../../util/factories/website_collections"
+import { Website } from "../../types/websites"
+import { siteApiListingUrl, wcItemsApiUrl } from "../../lib/urls"
+import { WebsiteCollection } from "../../types/website_collections"
+import IntegrationTestHelper, {
+  TestRenderer
+} from "../../util/integration_test_helper"
+
+describe("WebsiteCollectionItemForm", () => {
+  let helper: IntegrationTestHelper,
+    websiteCollection: WebsiteCollection,
+    render: TestRenderer
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    websiteCollection = makeWebsiteCollection()
+    render = helper.configureRenderer(WebsiteCollectionItemForm, {
+      websiteCollection
+    })
+
+    helper.handleRequestStub
+      .withArgs(
+        wcItemsApiUrl.param({ collectionId: websiteCollection.id }).toString()
+      )
+      .returns({ status: 200 })
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should pass initialValues to Formik", async () => {
+    const { wrapper } = await render()
+    expect(wrapper.find("Formik").prop("initialValues")).toEqual({
+      website: undefined
+    })
+  })
+
+  it("should disable the 'add' button initially", async () => {
+    const { wrapper } = await render()
+    expect(wrapper.find("button").prop("disabled")).toBeTruthy()
+  })
+
+  it("onSubmit should issue request then resetForm", async () => {
+    const resetFormStub = helper.sandbox.stub()
+
+    const { wrapper } = await render()
+    act(() => {
+      wrapper
+        .find("Formik")
+        // @ts-ignore
+        .prop("onSubmit")!({ website: "hey!" }, { resetForm: resetFormStub })
+    })
+    expect(helper.handleRequestStub.args[0]).toEqual([
+      wcItemsApiUrl.param({ collectionId: websiteCollection.id }).toString(),
+      "POST",
+      {
+        body:    { website: "hey!" },
+        headers: {
+          "X-CSRFTOKEN": ""
+        },
+        credentials: undefined
+      }
+    ])
+    expect(resetFormStub.called).toBeTruthy()
+  })
+
+  it("should pass placeholder to SelectField", async () => {
+    const { wrapper } = await render()
+    expect(wrapper.find("Field").prop("placeholder")).toBe(
+      "Find a course to add to this collection"
+    )
+  })
+
+  it("should pass loadOptions function down to SelectField", async () => {
+    const cb = helper.sandbox.stub()
+
+    const websites = makeWebsiteListing()
+    const options = websites.map((website: Website) => ({
+      label: website.title,
+      value: website.uuid
+    }))
+
+    // @ts-ignore
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve({ results: websites })
+      })
+    )
+
+    const { wrapper } = await render()
+    await act(async () => {
+      // @ts-ignore
+      await wrapper.find("Field").prop("loadOptions")("searchstring", cb)
+    })
+    wrapper.update()
+
+    expect(cb.args[0][0]).toEqual(options)
+    expect(wrapper.find("SelectField").prop("options")).toEqual(options)
+    expect(
+      // @ts-ignore
+      global.fetch.mock.calls[0]
+    ).toEqual([
+      siteApiListingUrl
+        .query({ offset: 0 })
+        .param({ search: "searchstring" })
+        .toString()
+    ])
+  })
+})

--- a/static/js/components/forms/WebsiteCollectionItemForm.tsx
+++ b/static/js/components/forms/WebsiteCollectionItemForm.tsx
@@ -1,0 +1,93 @@
+import React, { useCallback, useState } from "react"
+import { Form, Formik, Field, FormikHelpers, FormikProps } from "formik"
+
+import SelectField, { Option } from "../widgets/SelectField"
+import { WCItemCreateFormFields } from "../../types/forms"
+import { Website } from "../../types/websites"
+import { useMutation } from "redux-query-react"
+import { siteApiListingUrl } from "../../lib/urls"
+import { WebsiteListingResponse } from "../../query-configs/websites"
+import { WebsiteCollection } from "../../types/website_collections"
+import { createWebsiteCollectionItemMutation } from "../../query-configs/website_collections"
+
+interface Props {
+  websiteCollection: WebsiteCollection
+}
+
+const formatOptions = (websites: Website[]) =>
+  websites.map(website => ({ label: website.title, value: website.uuid }))
+
+export default function WebsiteCollectionItemForm(props: Props): JSX.Element {
+  const { websiteCollection } = props
+  const [options, setOptions] = useState<Option[]>([])
+
+  const loadOptions = useCallback(
+    async (inputValue: string, callback: (options: Option[]) => void) => {
+      const url = siteApiListingUrl
+        .query({ offset: 0 })
+        .param({ search: inputValue })
+        .toString()
+
+      // using plain fetch rather than redux-query here because this
+      // use-case doesn't exactly jibe with redux-query: we need to issue
+      // a request programmatically on user input.
+      const response = await fetch(url)
+      const json: WebsiteListingResponse = await response.json()
+      const { results } = json
+      const options = formatOptions(results)
+      setOptions(current => [...current, ...options])
+      callback(options)
+    },
+    [setOptions]
+  )
+
+  const [
+    { isPending: itemCreatePending },
+    createWCItem
+  ] = useMutation((values: WCItemCreateFormFields) =>
+    createWebsiteCollectionItemMutation(values, websiteCollection.id)
+  )
+
+  const onSubmit = useCallback(
+    (
+      values: WCItemCreateFormFields,
+      formikHelpers: FormikHelpers<WCItemCreateFormFields>
+    ) => {
+      const { resetForm } = formikHelpers
+      createWCItem(values)
+      resetForm()
+    },
+    [createWCItem]
+  )
+
+  // we pass `{ website: undefined }` to Formik via `initialValues` because
+  // although `""` is a more correct 'empty' value for our field the react-select
+  // component does not consider `""` to be an empty value. So if we pass
+  // `{ website: "" }` react-select won't consider itself to be 'empty' and then
+  // won't display our placeholder.
+  return (
+    <Formik onSubmit={onSubmit} initialValues={{ website: undefined } as any}>
+      {({ values }: FormikProps<{ website: string | undefined }>) => (
+        <Form>
+          <div className="d-flex">
+            <Field
+              name="website"
+              options={options}
+              className="w-100"
+              as={SelectField}
+              loadOptions={loadOptions}
+              placeholder="Find a course to add to this collection"
+            />
+            <button
+              type="submit"
+              disabled={itemCreatePending || values.website === undefined}
+              className="px-4 ml-3 btn blue-button"
+            >
+              Add
+            </button>
+          </div>
+        </Form>
+      )}
+    </Formik>
+  )
+}

--- a/static/js/components/widgets/SelectField.test.tsx
+++ b/static/js/components/widgets/SelectField.test.tsx
@@ -1,7 +1,8 @@
 import React from "react"
 import sinon, { SinonSandbox, SinonStub } from "sinon"
-import { shallow } from "enzyme"
+import { mount } from "enzyme"
 import Select from "react-select"
+import AsyncSelect from "react-select/async"
 
 import SelectField, { Option } from "./SelectField"
 
@@ -32,7 +33,7 @@ describe("SelectField", () => {
   })
 
   const render = (props: any) =>
-    shallow(
+    mount(
       <SelectField
         onChange={onChangeStub}
         name={name}
@@ -42,6 +43,27 @@ describe("SelectField", () => {
         {...props}
       />
     )
+
+  it("should pass placeholder to Select", () => {
+    const wrapper = render({
+      placeholder: "This place is held!"
+    })
+    expect(wrapper.find("Select").prop("placeholder")).toBe(
+      "This place is held!"
+    )
+  })
+
+  it("should use AsyncSelect if a loadOptions callback is supplied", () => {
+    const loadOptions = sandbox.stub()
+    const wrapper = render({
+      loadOptions
+    })
+
+    const select = wrapper.find(AsyncSelect)
+    expect(select.exists()).toBeTruthy()
+
+    expect(select.prop("loadOptions")).toBe(loadOptions)
+  })
 
   describe("not multiple choice", () => {
     it("renders a select widget", () => {

--- a/static/js/components/widgets/SelectField.tsx
+++ b/static/js/components/widgets/SelectField.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, ChangeEvent } from "react"
 import Select from "react-select"
+import AsyncSelect from "react-select/async"
 import { is, isNil } from "ramda"
 
 export interface Option {
@@ -13,10 +14,12 @@ interface Props {
   onChange: (event: ChangeEvent<HTMLSelectElement>) => void
   multiple?: boolean
   options: Array<string | Option>
+  loadOptions?: (s: string, cb: (options: Option[]) => void) => void
+  placeholder?: string
 }
 
 export default function SelectField(props: Props): JSX.Element {
-  const { value, onChange, name, options } = props
+  const { value, onChange, name, options, loadOptions, placeholder } = props
   const multiple = props.multiple ?? false
   const selectOptions = options.map((option: any) =>
     is(String, option) ? { label: option, value: option } : option
@@ -57,12 +60,24 @@ export default function SelectField(props: Props): JSX.Element {
     selected = isNil(value) ? null : getSelectOption(value)
   }
 
-  return (
-    <Select
+  return loadOptions ? (
+    <AsyncSelect
+      className="w-100"
       value={selected}
       isMulti={multiple}
       onChange={changeHandler}
       options={selectOptions}
+      loadOptions={loadOptions}
+      placeholder={placeholder || null}
+    />
+  ) : (
+    <Select
+      className="w-100"
+      value={selected}
+      isMulti={multiple}
+      onChange={changeHandler}
+      options={selectOptions}
+      placeholder={placeholder || null}
     />
   )
 }

--- a/static/js/lib/urls.test.ts
+++ b/static/js/lib/urls.test.ts
@@ -168,7 +168,7 @@ describe("urls", () => {
 
       it("renders collection item detail API url", () => {
         expect(
-          wcItemsApiDetailUrl.param({ collectionId: 4, item_id: 3 }).toString()
+          wcItemsApiDetailUrl.param({ collectionId: 4, itemId: 3 }).toString()
         ).toBe("/api/collections/4/items/3/")
       })
     })

--- a/static/js/lib/urls.ts
+++ b/static/js/lib/urls.ts
@@ -75,7 +75,7 @@ export const wcItemsApiUrl = collectionsApiDetailUrl.segment("items/")
  * Detail view for a single WebsiteCollectionItem record.
  * this looks like:
  *
- * /api/collections/:collectionId/items/:item_id/
+ * /api/collections/:collectionId/items/:itemId/
  *
  * It's mainly of use for changing the order of items in the
  * WebsiteCollection by editing the `position` attribute.
@@ -84,4 +84,4 @@ export const wcItemsApiUrl = collectionsApiDetailUrl.segment("items/")
  * in the list w/ that position change, so only one request is needed
  * to change an item's position.
  **/
-export const wcItemsApiDetailUrl = wcItemsApiUrl.segment(":item_id/")
+export const wcItemsApiDetailUrl = wcItemsApiUrl.segment(":itemId/")

--- a/static/js/pages/WebsiteCollectionsPage.test.tsx
+++ b/static/js/pages/WebsiteCollectionsPage.test.tsx
@@ -10,6 +10,11 @@ import { times } from "lodash"
 import { createModalState } from "../types/modal_state"
 import { act } from "react-dom/test-utils"
 
+import WebsiteCollectionItemsEditor from "../components/WebsiteCollectionItemsEditor"
+jest.mock("../components/WebsiteCollectionItemsEditor")
+// @ts-ignore
+WebsiteCollectionItemsEditor.mockImplementation(() => "MockComponent")
+
 describe("CollectionsPage", () => {
   let helper: IntegrationTestHelper,
     render: TestRenderer,

--- a/static/js/query-configs/websites.ts
+++ b/static/js/query-configs/websites.ts
@@ -44,7 +44,7 @@ export const getTransformedWebsiteName = (
 
 export type WebsiteListingResponse = PaginatedResponse<Website>
 
-type WebsitesListing = Record<string, string[]> // offset to list of site names
+export type WebsitesListing = Record<string, PaginatedResponse<string>>
 
 export const websiteListingRequest = (offset: number): QueryConfig => ({
   url:       siteApiListingUrl.query({ offset }).toString(),

--- a/static/js/selectors/website_collections.ts
+++ b/static/js/selectors/website_collections.ts
@@ -4,9 +4,11 @@ import { memoize } from "lodash"
 import { ReduxState } from "../reducers"
 import {
   WebsiteCollectionDetails,
+  WebsiteCollectionItemListing,
   WebsiteCollectionListing,
   WebsiteCollectionListingResponse
 } from "../query-configs/website_collections"
+import { WebsiteCollectionItem } from "../types/website_collections"
 
 export const getWebsiteCollectionDetailCursor = createSelector(
   (state: ReduxState) => state.entities?.websiteCollectionDetails ?? {},
@@ -28,4 +30,16 @@ export const getWebsiteCollectionListingCursor = createSelector(
         }
       }
     )
+)
+
+/**
+ * Selector to get a cursor for WebsiteCollectionItems.
+ *
+ * This cursor takes a WebsiteCollection id and returns an array
+ * of WebsiteCollectionItems.
+ */
+export const getWebsiteCollectionItemsCursor = createSelector(
+  (state: ReduxState) => state.entities?.websiteCollectionItems ?? {},
+  (listing: WebsiteCollectionItemListing) =>
+    memoize((id: number): WebsiteCollectionItem[] => listing[id] ?? [])
 )

--- a/static/js/selectors/websites.ts
+++ b/static/js/selectors/websites.ts
@@ -2,9 +2,13 @@ import { createSelector } from "reselect"
 import { memoize } from "lodash"
 import { find, propEq } from "ramda"
 
-import { contentListingKey, WebsiteDetails } from "../query-configs/websites"
+import {
+  contentListingKey,
+  WebsiteDetails,
+  WebsiteListingResponse,
+  WebsitesListing
+} from "../query-configs/websites"
 import { ReduxState } from "../reducers"
-
 import {
   ContentListingParams,
   WebsiteStarter,
@@ -19,20 +23,25 @@ export const getWebsiteDetailCursor = createSelector(
     memoize((name: string): Website => websiteDetails[name])
 )
 
+type DetailCursor = ReturnType<typeof getWebsiteDetailCursor>
+
 export const getWebsiteListingCursor = createSelector(
   (state: ReduxState) => state.entities?.websitesListing ?? {},
   getWebsiteDetailCursor,
-  (listing, websiteDetailCursor) =>
-    memoize((offset: number) => {
-      const response = listing[offset] ?? {}
-      const names = response?.results ?? []
-      const sites = names.map(websiteDetailCursor)
+  (listing: WebsitesListing, websiteDetailCursor: DetailCursor) =>
+    memoize(
+      (offset: number): WebsiteListingResponse => {
+        const response = listing[offset] ?? {}
+        const names = response?.results ?? []
+        // @ts-ignore
+        const sites = names.map(websiteDetailCursor)
 
-      return {
-        ...response,
-        results: sites
+        return {
+          ...response,
+          results: sites
+        }
       }
-    })
+    )
 )
 
 export const startersSelector = (state: ReduxState): Array<WebsiteStarter> =>

--- a/static/js/types/forms.ts
+++ b/static/js/types/forms.ts
@@ -1,4 +1,5 @@
 import { SchemaOf } from "yup"
+import { FormikHelpers } from "formik"
 
 export enum ContentFormType {
   Add = "add",
@@ -7,6 +8,10 @@ export enum ContentFormType {
 
 export type FormSchema = SchemaOf<any>
 
+/**
+ * These are the primitive types which can be present in our site content
+ * forms.
+ */
 export type SiteFormPrimitive = string | File | string[] | null | boolean
 
 export type SiteFormValue =
@@ -21,4 +26,23 @@ export type SiteFormValues = Record<string, SiteFormValue>
 export interface WebsiteCollectionFormFields {
   title: string
   description: string
+}
+
+/**
+ * WebsiteCollectionItem form fields
+ *
+ * We pass the WebsiteCollection id in the API URL param
+ * (/api/collections/:collectionId/items) so we don't need
+ * to include it in the form.
+ */
+export interface WCItemCreateFormFields {
+  website: string
+}
+
+export interface WCItemMoveFormFields {
+  position: number
+}
+
+export interface SubmitFunc {
+  (values: any, formikHelpers: FormikHelpers<any>): void | Promise<any>
 }

--- a/static/js/types/website_collections.ts
+++ b/static/js/types/website_collections.ts
@@ -19,6 +19,10 @@ export interface WebsiteCollection {
  **/
 export interface WebsiteCollectionItem {
   position: number
+  id: number
+  website: string
+  website_title: string // eslint-disable-line camelcase
+  website_collection: number // eslint-disable-line camelcase
 }
 
 /**

--- a/static/js/util/factories/website_collections.ts
+++ b/static/js/util/factories/website_collections.ts
@@ -1,4 +1,7 @@
-import { WebsiteCollection } from "../../types/website_collections"
+import {
+  WebsiteCollection,
+  WebsiteCollectionItem
+} from "../../types/website_collections"
 import casual from "casual-browserify"
 import incrementer from "../incrementer"
 
@@ -8,4 +11,16 @@ export const makeWebsiteCollection = (): WebsiteCollection => ({
   id:          incr.next().value,
   title:       casual.title,
   description: casual.description
+})
+
+const positionIncr = incrementer()
+
+export const makeWebsiteCollectionItem = (
+  collection?: WebsiteCollection
+): WebsiteCollectionItem => ({
+  position:           positionIncr.next().value,
+  id:                 incr.next().value,
+  website:            casual.uuid,
+  website_collection: collection ? collection.id : casual.integer(1),
+  website_title:      casual.title
 })

--- a/static/js/util/factories/websites.ts
+++ b/static/js/util/factories/websites.ts
@@ -179,7 +179,7 @@ export const makeWebsiteDetail = (): Website => ({
 })
 
 export const makeWebsiteListing = (): Website[] =>
-  times(WEBSITES_PAGE_SIZE).map(() => makeWebsiteDetail())
+  times(WEBSITES_PAGE_SIZE).map(makeWebsiteDetail)
 
 export const makeWebsiteCollaborator = (): WebsiteCollaborator => ({
   user_id: incr.next().value,
@@ -196,7 +196,7 @@ export const makePermanentWebsiteCollaborator = (): WebsiteCollaborator => ({
 })
 
 export const makeWebsiteCollaborators = (): WebsiteCollaborator[] =>
-  times(5).map(() => makeWebsiteCollaborator())
+  times(5).map(makeWebsiteCollaborator)
 
 export const makeWebsiteContentListItem = (): WebsiteContentListItem => ({
   text_id: casual.uuid,

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -292,10 +292,16 @@ class WebsiteCollectionSerializer(
 class WebsiteCollectionItemSerializer(serializers.ModelSerializer):
     """Serializer for WebsiteCollectionItems"""
 
+    website_title = serializers.SerializerMethodField(read_only=True)
+
+    def get_website_title(self, obj):
+        """Get the title of the """
+        return obj.website.title
+
     class Meta:
         model = WebsiteCollectionItem
         read_only_fields = ["website_collection", "id"]
-        fields = read_only_fields + ["position", "website"]
+        fields = read_only_fields + ["position", "website", "website_title"]
         extra_kwargs = {"position": {"required": False}}
 
     def create(self, validated_data):

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -292,6 +292,7 @@ def test_website_collection_item_serializer():
     assert serialized_data["website_collection"] == item.website_collection.id
     assert serialized_data["website"] == item.website.uuid
     assert serialized_data["id"] == item.id
+    assert serialized_data["website_title"] == item.website.title
 
 
 def test_website_collection_item_create():

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -328,6 +328,17 @@ def test_websites_endpoint_sorting(drf_client, websites):
         assert resp.data.get("results")[idx]["uuid"] == str(course.uuid)
 
 
+def test_website_endpoint_search(drf_client):
+    """ should limit the queryset based on the search param """
+    superuser = UserFactory.create(is_superuser=True)
+    drf_client.force_login(superuser)
+
+    WebsiteFactory.create(title="BEST")
+    WebsiteFactory.create(title="WORST")
+    resp = drf_client.get(reverse("websites_api-list"), {"search": "BEST"})
+    assert [website["title"] for website in resp.data.get("results")] == ["BEST"]
+
+
 def test_websites_autogenerate_name(drf_client):
     """ Website POST endpoint should auto-generate a name if one is not supplied """
     superuser = UserFactory.create(is_superuser=True)
@@ -1006,6 +1017,6 @@ def test_website_collection_items_get(drf_client):
     )
     assert resp.status_code == status.HTTP_200_OK
     assert (
-        resp.data["results"]
+        resp.data
         == WebsiteCollectionItemSerializer([one, two, three, four], many=True).data
     )

--- a/yarn.lock
+++ b/yarn.lock
@@ -1307,6 +1307,37 @@
     "@ckeditor/ckeditor5-utils" "^27.1.0"
     lodash-es "^4.17.15"
 
+"@dnd-kit/accessibility@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/accessibility/-/accessibility-3.0.0.tgz#b56e3750414fd907b7d6972b3116aa8f96d07fde"
+  integrity sha512-QwaQ1IJHQHMMuAGOOYHQSx7h7vMZPfO97aDts8t5N/MY7n2QTDSnW+kF7uRQ1tVBkr6vJ+BqHWG5dlgGvwVjow==
+  dependencies:
+    tslib "^2.0.0"
+
+"@dnd-kit/core@^3.1.1":
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/core/-/core-3.1.1.tgz#c5ad6665931f5a51e74226220e58ac7514f3faf0"
+  integrity sha512-18YY5+1lTqJbGSg6JBSa/fjAOTUYAysFrQ5Ti8oppEPHFacQbC+owM51y2z2KN0LkDHBfGZKw2sFT7++ttwfpA==
+  dependencies:
+    "@dnd-kit/accessibility" "^3.0.0"
+    "@dnd-kit/utilities" "^2.0.0"
+    tslib "^2.0.0"
+
+"@dnd-kit/sortable@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/sortable/-/sortable-4.0.0.tgz#81dd2b014a16527cf89602dc40060d9ee4dad352"
+  integrity sha512-teYVFy6mQG/u6F6CaGxAkzPfiNJvguFzWfJ/zonYQRxfANHX6QJ6GziMG9KON/Ae9Q2ODJP8vib+guWJrDXeGg==
+  dependencies:
+    "@dnd-kit/utilities" "^2.0.0"
+    tslib "^2.0.0"
+
+"@dnd-kit/utilities@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/utilities/-/utilities-2.0.0.tgz#a8462dff65c6f606ecbe95273c7e263b14a1ab97"
+  integrity sha512-bjs49yMNzMM+BYRsBUhTqhTk6HEvhuY3leFt6Em6NaYGgygaMbtGbbXof/UXBv7rqyyi0OkmBBnrCCcxqS2t/g==
+  dependencies:
+    tslib "^2.0.0"
+
 "@emotion/cache@^11.4.0":
   version "11.4.0"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.4.0.tgz#293fc9d9a7a38b9aad8e9337e5014366c3b09ac0"
@@ -10791,6 +10822,11 @@ tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.0.tgz#803b8cdab3e12ba581a4ca41c8839bbb0dacb09e"
+  integrity sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==
 
 tslib@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

closes #376
closes #397

#### What's this PR do?

This adds UI to the website collection editing interface which allows you to add websites to a website collection and also to re-order existing websites in the collection.

#### How should this be manually tested?

Go to `/collections` and check out a collection you have. There should be a new section in the edit form with a field for picking a website. If you pick one and click 'Add' a request should go off to the backend, and then it should appear in your list. Once you've added a few websites to your list you should be able to re-order them as you please.


#### Screenshots (if appropriate)

<img width="577" alt="Screen Shot 2021-07-15 at 2 59 01 PM" src="https://user-images.githubusercontent.com/6207644/125842621-050c6648-307f-494c-b62c-92a84255af88.png">
<img width="679" alt="Screen Shot 2021-07-15 at 2 59 25 PM" src="https://user-images.githubusercontent.com/6207644/125842623-a2049377-43a1-4999-8800-2e1b61ebf439.png">
<img width="628" alt="Screen Shot 2021-07-15 at 2 59 20 PM" src="https://user-images.githubusercontent.com/6207644/125842625-21857fe7-b9f2-41cb-b161-e3a78558cd3c.png">
<img width="657" alt="Screen Shot 2021-07-15 at 2 59 06 PM" src="https://user-images.githubusercontent.com/6207644/125842627-b7dc3e70-cef9-4eba-8fe0-13dfb938842c.png">
