### PR TITLE
Concourse pipelines, take 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,6 @@ COPY apt.txt /tmp/apt.txt
 RUN apt-get update
 RUN apt-get install -y $(grep -vE "^\s*#" apt.txt  | tr "\n" " ")
 
-# Add concourse-ci fly executable
-RUN curl --silent --location "https://cicd.odl.mit.edu/api/v1/cli?arch=amd64&platform=linux" --output fly
-RUN chmod +x fly
-RUN mv fly /usr/local/bin/fly
-
 # pip
 RUN curl --silent --location https://bootstrap.pypa.io/get-pip.py | python3 -
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,11 @@ COPY apt.txt /tmp/apt.txt
 RUN apt-get update
 RUN apt-get install -y $(grep -vE "^\s*#" apt.txt  | tr "\n" " ")
 
+# Add concourse-ci fly executable
+RUN curl --silent --location "https://cicd.odl.mit.edu/api/v1/cli?arch=amd64&platform=linux" --output fly
+RUN chmod +x fly
+RUN mv fly /usr/local/bin/fly
+
 # pip
 RUN curl --silent --location https://bootstrap.pypa.io/get-pip.py | python3 -
 

--- a/app.json
+++ b/app.json
@@ -280,8 +280,8 @@
       "description": "How long the robots.txt file should be cached",
       "required": false
     },
-    "ROOT_WEBSITE_SLUG": {
-      "description": "The WebsiteStarter slug for site(s) at the root domain",
+    "ROOT_WEBSITE_NAME": {
+      "description": "The Website name for the site at the root domain",
       "required": false
     },
     "SECRET_KEY": {

--- a/app.json
+++ b/app.json
@@ -27,6 +27,14 @@
       "description": "AWS Access Key for S3 storage.",
       "required": false
     },
+    "AWS_PREVIEW_BUCKET_NAME": {
+      "description": "S3 preview bucket name.",
+      "required": false
+    },
+    "AWS_PUBLISH_BUCKET_NAME": {
+      "description": "S3 publish bucket name.",
+      "required": false
+    },
     "AWS_QUERYSTRING_AUTH": {
       "description": "Enables querystring auth for S3 urls",
       "required": false
@@ -51,8 +59,28 @@
       "description": "Early executed tasks propagate exceptions",
       "required": false
     },
+    "CONCOURSE_PASSWORD": {
+      "description": "The concourse-ci login password",
+      "required": false
+    },
+    "CONCOURSE_TEAM": {
+      "description": "The concourse-ci team",
+      "required": false
+    },
+    "CONCOURSE_URL": {
+      "description": "The concourse-ci URL",
+      "required": false
+    },
+    "CONCOURSE_USERNAME": {
+      "description": "The concourse-ci login username",
+      "required": false
+    },
     "CONTENT_SYNC_BACKEND": {
       "description": "The backend to sync websites/content with",
+      "required": false
+    },
+    "CONTENT_SYNC_PIPELINE": {
+      "description": "The pipeline to preview/publish websites with",
       "required": false
     },
     "CONTENT_SYNC_RETRIES": {
@@ -101,6 +129,10 @@
     },
     "GIT_DEFAULT_USER_NAME": {
       "description": "The name for the default git committer",
+      "required": false
+    },
+    "GIT_DOMAIN": {
+      "description": "Base URL of github for site repos",
       "required": false
     },
     "GIT_ORGANIZATION": {
@@ -246,6 +278,10 @@
     },
     "ROBOTS_CACHE_TIMEOUT": {
       "description": "How long the robots.txt file should be cached",
+      "required": false
+    },
+    "ROOT_WEBSITE_SLUG": {
+      "description": "The WebsiteStarter slug for site(s) at the root domain",
       "required": false
     },
     "SECRET_KEY": {

--- a/content_sync/apis/github.py
+++ b/content_sync/apis/github.py
@@ -51,6 +51,11 @@ def decode_file_contents(content_file: ContentFile) -> str:
     return str(b64decode(content_file.content), encoding="utf-8")
 
 
+def get_repo_name(website):
+    """Determine a 100-char-limit repo name based on the website name and uuid"""
+    return f"{website.name[:67]}_{website.uuid.hex}"
+
+
 def sync_starter_configs(  # pylint:disable=too-many-locals
     repo_url: str, config_files: List[str], commit: Optional[str] = None
 ):
@@ -124,10 +129,6 @@ class GithubApiWrapper:
         self.site_config = site_config or SiteConfig(self.website.starter.config)
         self.repo = None
 
-    def get_repo_name(self):
-        """Determine a 100-char-limit repo name based on the website name and uuid"""
-        return f"{self.website.name[:67]}_{self.website.uuid.hex}"
-
     @retry_on_failure
     def get_repo(self) -> Repository:
         """
@@ -135,7 +136,7 @@ class GithubApiWrapper:
         """
         if not self.repo:
             try:
-                self.repo = self.org.get_repo(self.get_repo_name())
+                self.repo = self.org.get_repo(get_repo_name(self.website))
             except GithubException as ge:
                 if ge.status == 404:
                     self.repo = self.create_repo()
@@ -150,12 +151,12 @@ class GithubApiWrapper:
         """
         try:
             self.repo = self.org.create_repo(
-                self.get_repo_name(), auto_init=True, **kwargs
+                get_repo_name(self.website), auto_init=True, **kwargs
             )
         except GithubException as ge:
             if ge.status == 422:
                 # It may already exist, try to retrieve it
-                self.repo = self.org.get_repo(self.get_repo_name())
+                self.repo = self.org.get_repo(get_repo_name(self.website))
                 log.debug("Repo already exists: %s", self.website.name)
         if self.repo.default_branch != settings.GIT_BRANCH_MAIN:
             self.rename_branch(self.repo.default_branch, settings.GIT_BRANCH_MAIN)

--- a/content_sync/apis/github_test.py
+++ b/content_sync/apis/github_test.py
@@ -10,6 +10,7 @@ from github import GithubException
 from content_sync.apis.github import (
     GIT_DATA_FILEPATH,
     GithubApiWrapper,
+    get_repo_name,
     sync_starter_configs,
 )
 from main import features
@@ -88,7 +89,7 @@ def test_get_repo(mock_api_wrapper):
     """get_repo should invoke the appropriate PyGithub call"""
     mock_api_wrapper.get_repo()
     mock_api_wrapper.org.get_repo.assert_called_once_with(
-        mock_api_wrapper.get_repo_name()
+        get_repo_name(mock_api_wrapper.website)
     )
 
 
@@ -100,7 +101,7 @@ def test_get_repo_create(mocker, mock_api_wrapper):
     ]
     mock_api_wrapper.get_repo()
     mock_api_wrapper.org.create_repo.assert_called_once_with(
-        mock_api_wrapper.get_repo_name(), auto_init=True
+        get_repo_name(mock_api_wrapper.website), auto_init=True
     )
 
 
@@ -109,7 +110,7 @@ def test_create_repo(mock_api_wrapper, kwargs):
     """create_repo should invoke the appropriate PyGithub call"""
     mock_api_wrapper.create_repo(**kwargs)
     mock_api_wrapper.org.create_repo.assert_called_once_with(
-        mock_api_wrapper.get_repo_name(), auto_init=True, **kwargs
+        get_repo_name(mock_api_wrapper.website), auto_init=True, **kwargs
     )
 
 
@@ -490,7 +491,7 @@ def test_create_repo_new(mocker, mock_api_wrapper, mock_branches):
     )
     new_repo = mock_api_wrapper.create_repo()
     mock_api_wrapper.org.create_repo.assert_called_once_with(
-        mock_api_wrapper.get_repo_name(), auto_init=True
+        get_repo_name(mock_api_wrapper.website), auto_init=True
     )
     for branch in [settings.GIT_BRANCH_PREVIEW, settings.GIT_BRANCH_RELEASE]:
         new_repo.create_git_ref.assert_any_call(f"refs/heads/{branch}", sha=mocker.ANY)

--- a/content_sync/conftest.py
+++ b/content_sync/conftest.py
@@ -1,4 +1,5 @@
 """Test config for content_sync app"""
+import os
 from base64 import b64encode
 from types import SimpleNamespace
 
@@ -32,3 +33,31 @@ def github_content_file(mocker):
         path=path,
         content_str=content_str,
     )
+
+
+@pytest.fixture
+def mock_fly(mocker):
+    """Default fly test setings"""
+    mock_fly_object = mocker.patch(
+        "content_sync.pipelines.concourse.Fly",
+        return_value=mocker.Mock(login=mocker.Mock(), run=mocker.Mock()),
+    )
+    return mock_fly_object
+
+
+@pytest.fixture(autouse=True)
+def required_concourse_settings(settings):
+    """ Other required settings for concourse pipelines """
+    settings.CONCOURSE_URL = "http://localconcourse.edu"
+    settings.CONCOURSE_USERNAME = "test"
+    settings.CONCOURSE_PASSWORD = "pass"
+    settings.CONCOURSE_TEAM = "ocwtest"
+    settings.AWS_PREVIEW_BUCKET_NAME = "preview_bucket"
+    settings.AWS_PUBLISH_BUCKET_NAME = "publish_bucket"
+    settings.AWS_STORAGE_BUCKET_NAME = "storage_bucket"
+    settings.GIT_BRANCH_PREVIEW = "preview"
+    settings.GIT_BRANCH_RELEASE = "release"
+    settings.GIT_DOMAIN = "test.github.edu"
+    settings.GIT_ORGANIZATION = "test_org"
+    settings.GITHUB_WEBHOOK_BRANCH = "release"
+    os.environ["OCW_STUDIO_BASE_URL"] = "http://test.edu"

--- a/content_sync/conftest.py
+++ b/content_sync/conftest.py
@@ -35,16 +35,6 @@ def github_content_file(mocker):
     )
 
 
-@pytest.fixture
-def mock_fly(mocker):
-    """Default fly test setings"""
-    mock_fly_object = mocker.patch(
-        "content_sync.pipelines.concourse.Fly",
-        return_value=mocker.Mock(login=mocker.Mock(), run=mocker.Mock()),
-    )
-    return mock_fly_object
-
-
 @pytest.fixture(autouse=True)
 def required_concourse_settings(settings):
     """ Other required settings for concourse pipelines """

--- a/content_sync/decorators.py
+++ b/content_sync/decorators.py
@@ -47,6 +47,17 @@ def is_sync_enabled(func: Callable) -> Callable:
     return wrapper
 
 
+def is_publish_pipeline_enabled(func: Callable) -> Callable:
+    """ Returns True if the publishing pipeline is enabled """
+
+    def wrapper(*args, **kwargs):
+        if settings.CONTENT_SYNC_PIPELINE:
+            return func(*args, **kwargs)
+        return None
+
+    return wrapper
+
+
 def check_sync_state(func: Callable) -> Callable:
     """
     Decorator that checks if a content_sync_state is synced before running a function,

--- a/content_sync/pipelines/base.py
+++ b/content_sync/pipelines/base.py
@@ -1,0 +1,37 @@
+""" Sync abstract base """
+import abc
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+from websites.models import Website
+
+
+class BaseSyncPipeline(abc.ABC):
+    """ Base class for preview/publish pipelines """
+
+    MANDATORY_SETTINGS = []
+
+    def __init__(self, website: Website):
+        """Make sure all required settings are present"""
+        missing_settings = []
+        for setting_name in self.MANDATORY_SETTINGS:
+            if getattr(settings, setting_name, None) in (
+                None,
+                "",
+            ):
+                missing_settings.append(setting_name)
+        if missing_settings:
+            raise ImproperlyConfigured(
+                "The following settings are missing: {}".format(
+                    ", ".join(missing_settings)
+                )
+            )
+        self.website = website
+
+    @abc.abstractmethod
+    def upsert_website_pipeline(self):  # pragma: no cover
+        """
+        Called to create/update the website pipeline.
+        """
+        ...

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -1,0 +1,100 @@
+""" Concourse-CI preview/publish pipeline generator"""
+import os
+
+from django.conf import settings
+from fly import Fly
+
+from content_sync.apis.github import get_repo_name
+from content_sync.pipelines.base import BaseSyncPipeline
+from websites.site_config_api import SiteConfig
+
+
+class ConcourseGithubPipeline(BaseSyncPipeline):
+    """
+    Concourse-CI publishing pipeline, dependent on a Github backend
+    """
+
+    MANDATORY_SETTINGS = [
+        "AWS_PREVIEW_BUCKET_NAME",
+        "AWS_PUBLISH_BUCKET_NAME",
+        "AWS_STORAGE_BUCKET_NAME",
+        "CONCOURSE_URL",
+        "CONCOURSE_USERNAME",
+        "CONCOURSE_PASSWORD",
+        "GIT_BRANCH_PREVIEW",
+        "GIT_BRANCH_RELEASE",
+        "GIT_DOMAIN",
+        "GIT_ORGANIZATION",
+        "GITHUB_WEBHOOK_BRANCH",
+    ]
+
+    def upsert_website_pipeline(self):
+        """
+        Create or update a concourse pipeline for the given Website
+        """
+        site_config = SiteConfig(self.website.starter.config)
+        site_url = f"{site_config.root_url_path}/{self.website.name}".strip("/")
+        base_url = (
+            "" if self.website.starter.slug == settings.ROOT_WEBSITE_SLUG else site_url
+        )
+        purge_url = "purge_all" if not base_url else f"purge/{site_url}"
+
+        fly = Fly(concourse_url=settings.CONCOURSE_URL)
+        fly.login(
+            username=settings.CONCOURSE_USERNAME,
+            password=settings.CONCOURSE_PASSWORD,
+            team_name=settings.CONCOURSE_TEAM,
+        )
+        for branch in [settings.GIT_BRANCH_PREVIEW, settings.GIT_BRANCH_RELEASE]:
+            if branch == settings.GIT_BRANCH_PREVIEW:
+                version = "draft"
+                destination_bucket = settings.AWS_PREVIEW_BUCKET_NAME
+            else:
+                version = "live"
+                destination_bucket = settings.AWS_PUBLISH_BUCKET_NAME
+
+            fly.run(
+                "set-pipeline",
+                "-p",
+                version,
+                "--team",
+                settings.CONCOURSE_TEAM,
+                "-c",
+                os.path.join(
+                    os.path.dirname(__file__), "definitions/concourse/site-pipeline.yml"
+                ),
+                "--instance-var",
+                f"site={self.website.name}",
+                "-v",
+                f"git-domain={settings.GIT_DOMAIN}",
+                "-v",
+                f"github-org={settings.GIT_ORGANIZATION}",
+                "-v",
+                f"ocw-bucket={destination_bucket}",
+                "-v",
+                f"ocw-hugo-projects-branch={settings.GITHUB_WEBHOOK_BRANCH}",
+                "-v",
+                f"ocw-studio-url={os.environ.get('OCW_STUDIO_BASE_URL')}",
+                "-v",
+                f"ocw-studio-bucket={settings.AWS_STORAGE_BUCKET_NAME}",
+                "-v",
+                f"ocw-site-repo={get_repo_name(self.website)}",
+                "-v",
+                f"ocw-site-repo-branch={branch}",
+                "-v",
+                f"config-slug={self.website.starter.slug}",
+                "-v",
+                f"base-url={base_url}",
+                "-v",
+                f"site-url={site_url}",
+                "-v",
+                f"purge-url={purge_url}",
+                "-n",
+            )
+            fly.run(
+                "unpause-pipeline",
+                "--team",
+                settings.CONCOURSE_TEAM,
+                "-p",
+                f"{version}/site:{self.website.name}",
+            )

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -1,12 +1,71 @@
 """ Concourse-CI preview/publish pipeline generator"""
+import json
+import logging
 import os
+from typing import Dict, Tuple
+from urllib.parse import quote
 
+import requests
+import yaml
+from concoursepy.api import Api as BaseConcourseApi
 from django.conf import settings
-from fly import Fly
+from requests import HTTPError
 
 from content_sync.apis.github import get_repo_name
 from content_sync.pipelines.base import BaseSyncPipeline
 from websites.site_config_api import SiteConfig
+
+
+log = logging.getLogger(__name__)
+
+
+class ConcourseApi(BaseConcourseApi):
+    """
+    Customized version of concoursepy.api.Api
+    """
+
+    def get_with_headers(
+        self, path: str, stream: bool = False, iterator: bool = False
+    ) -> Tuple[Dict, Dict]:
+        """Customized base get method, returning response data and headers"""
+        url = self._make_api_url(path)
+        r = self.requests.get(url, headers=self.headers, stream=stream)
+        if not self._is_response_ok(r) and self.has_username_and_passwd:
+            self.auth()
+            r = self.requests.get(url, headers=self.headers, stream=stream)
+        if r.status_code == requests.codes.ok:
+            if stream:
+                if iterator:
+                    response_data = self.iter_sse_stream(r)
+                else:
+                    response_data = list(self.iter_sse_stream(r))
+            else:
+                response_data = json.loads(r.text)
+            return response_data, r.headers
+        else:
+            r.raise_for_status()
+
+    def put_with_headers(
+        self, path: str, data: Dict = None, headers: Dict = None
+    ) -> bool:
+        """
+        Allow additional headers to be sent with a put request
+        """
+        url = self._make_api_url(path)
+        request_headers = self.headers
+        request_headers.update(headers or {})
+        kwargs = {"headers": request_headers}
+        if data is not None:
+            kwargs["data"] = data
+        r = self.requests.put(url, **kwargs)
+        if not self._is_response_ok(r) and self.has_username_and_passwd:
+            self.auth()
+            r = self.requests.put(url, **kwargs)
+        if r.status_code == requests.codes.ok:
+            return True
+        else:
+            r.raise_for_status()
+        return False
 
 
 class ConcourseGithubPipeline(BaseSyncPipeline):
@@ -28,22 +87,20 @@ class ConcourseGithubPipeline(BaseSyncPipeline):
         "GITHUB_WEBHOOK_BRANCH",
     ]
 
-    def upsert_website_pipeline(self):
+    def upsert_website_pipeline(self):  # pylint:disable=too-many-locals
         """
         Create or update a concourse pipeline for the given Website
         """
         site_config = SiteConfig(self.website.starter.config)
         site_url = f"{site_config.root_url_path}/{self.website.name}".strip("/")
-        base_url = (
-            "" if self.website.starter.slug == settings.ROOT_WEBSITE_SLUG else site_url
-        )
+        base_url = "" if self.website.name == settings.ROOT_WEBSITE_NAME else site_url
         purge_url = "purge_all" if not base_url else f"purge/{site_url}"
 
-        fly = Fly(concourse_url=settings.CONCOURSE_URL)
-        fly.login(
-            username=settings.CONCOURSE_USERNAME,
-            password=settings.CONCOURSE_PASSWORD,
-            team_name=settings.CONCOURSE_TEAM,
+        ci = ConcourseApi(
+            settings.CONCOURSE_URL,
+            settings.CONCOURSE_USERNAME,
+            settings.CONCOURSE_PASSWORD,
+            settings.CONCOURSE_TEAM,
         )
         for branch in [settings.GIT_BRANCH_PREVIEW, settings.GIT_BRANCH_RELEASE]:
             if branch == settings.GIT_BRANCH_PREVIEW:
@@ -52,49 +109,49 @@ class ConcourseGithubPipeline(BaseSyncPipeline):
             else:
                 version = "live"
                 destination_bucket = settings.AWS_PUBLISH_BUCKET_NAME
+            instance_vars = "{" + quote(f'"site": "{self.website.name}"') + "}"
 
-            fly.run(
-                "set-pipeline",
-                "-p",
-                version,
-                "--team",
-                settings.CONCOURSE_TEAM,
-                "-c",
+            with open(
                 os.path.join(
                     os.path.dirname(__file__), "definitions/concourse/site-pipeline.yml"
-                ),
-                "--instance-var",
-                f"site={self.website.name}",
-                "-v",
-                f"git-domain={settings.GIT_DOMAIN}",
-                "-v",
-                f"github-org={settings.GIT_ORGANIZATION}",
-                "-v",
-                f"ocw-bucket={destination_bucket}",
-                "-v",
-                f"ocw-hugo-projects-branch={settings.GITHUB_WEBHOOK_BRANCH}",
-                "-v",
-                f"ocw-studio-url={os.environ.get('OCW_STUDIO_BASE_URL')}",
-                "-v",
-                f"ocw-studio-bucket={settings.AWS_STORAGE_BUCKET_NAME}",
-                "-v",
-                f"ocw-site-repo={get_repo_name(self.website)}",
-                "-v",
-                f"ocw-site-repo-branch={branch}",
-                "-v",
-                f"config-slug={self.website.starter.slug}",
-                "-v",
-                f"base-url={base_url}",
-                "-v",
-                f"site-url={site_url}",
-                "-v",
-                f"purge-url={purge_url}",
-                "-n",
-            )
-            fly.run(
-                "unpause-pipeline",
-                "--team",
-                settings.CONCOURSE_TEAM,
-                "-p",
-                f"{version}/site:{self.website.name}",
-            )
+                )
+            ) as pipeline_config_file:
+                config_str = (
+                    pipeline_config_file.read()
+                    .replace("((git-domain))", settings.GIT_DOMAIN)
+                    .replace("((github-org))", settings.GIT_ORGANIZATION)
+                    .replace("((ocw-bucket))", destination_bucket)
+                    .replace(
+                        "((ocw-hugo-projects-branch))", settings.GITHUB_WEBHOOK_BRANCH
+                    )
+                    .replace("((ocw-studio-url))", settings.SITE_BASE_URL)
+                    .replace("((ocw-studio-bucket))", settings.AWS_STORAGE_BUCKET_NAME)
+                    .replace("((ocw-site-repo))", get_repo_name(self.website))
+                    .replace("((ocw-site-repo-branch))", branch)
+                    .replace("((config-slug))", self.website.starter.slug)
+                    .replace("((base-url))", base_url)
+                    .replace("((site-url))", site_url)
+                    .replace("((purge-url))", purge_url)
+                )
+            config = json.dumps(yaml.load(config_str, Loader=yaml.Loader))
+            log.debug(config)
+            # Try to get the version of the pipeline if it already exists, because it will be
+            # necessary to update an existing pipeline.
+            url_path = f"/api/v1/teams/{settings.CONCOURSE_TEAM}/pipelines/{version}/config?vars={instance_vars}"
+            try:
+                _, headers = ci.get_with_headers(url_path)
+                version_headers = {
+                    "X-Concourse-Config-Version": headers["X-Concourse-Config-Version"]
+                }
+            except HTTPError:
+                version_headers = None
+            success = False
+            attempts = 0
+            # Usually takes 2 tries because the first fails with a 401 :(
+            while attempts < 2 and not success:
+                try:
+                    ci.put_with_headers(url_path, data=config, headers=version_headers)
+                    success = True
+                except:  # pylint:disable=bare-except
+                    attempts += 1
+            ci.put(url_path.replace("/config", "/unpause"))

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -1,11 +1,11 @@
 """ concourse tests """
-import os
+import json
 
 import pytest
 from django.core.exceptions import ImproperlyConfigured
+from requests import HTTPError
 
-from content_sync.apis.github import get_repo_name
-from content_sync.pipelines.concourse import ConcourseGithubPipeline
+from content_sync.pipelines.concourse import ConcourseApi, ConcourseGithubPipeline
 from websites.factories import WebsiteFactory, WebsiteStarterFactory
 
 
@@ -13,110 +13,144 @@ pytestmark = pytest.mark.django_db
 # pylint:disable=redefined-outer-name
 
 
-def test_upsert_website_pipeline_missing_settings(settings, mock_fly):
+@pytest.mark.parametrize("stream", [True, False])
+@pytest.mark.parametrize("iterator", [True, False])
+def test_api_get_with_headers(mocker, stream, iterator):
+    """ ConcourseApi.get_with_headers function should work as expected """
+    mock_text = '[{"test": "output"}]' if iterator else '{"test": "output"}'
+    stream_output = ["yielded"]
+    mocker.patch(
+        "content_sync.pipelines.concourse.BaseConcourseApi.iter_sse_stream",
+        return_value=stream_output,
+    )
+    mocker.patch("content_sync.pipelines.concourse.BaseConcourseApi.auth")
+    mock_response = mocker.Mock(
+        text=mock_text, status_code=200, headers={"X-Test": "header"}
+    )
+    mock_get = mocker.patch(
+        "content_sync.pipelines.concourse.requests.get", return_value=mock_response
+    )
+    url_path = "/api/v1/teams/myteam/pipelines/draft/config?vars={site=mypipeline}"
+    api = ConcourseApi("http://test.edu", "test", "test", "myteam")
+    result, headers = api.get_with_headers(url_path, stream=stream, iterator=iterator)
+    mock_get.assert_called_once_with(
+        f"http://test.edu{url_path}", headers=mocker.ANY, stream=stream
+    )
+    assert headers == mock_response.headers
+    assert result == (stream_output if stream else json.loads(mock_response.text))
+
+
+@pytest.mark.parametrize("headers", [None, {"X-Concourse-Config-Version": 101}])
+@pytest.mark.parametrize("status_code", [200, 401])
+@pytest.mark.parametrize("ok_response", [True, False])
+def test_api_put(mocker, headers, status_code, ok_response):
+    """ ConcourseApi.put_with_headers function should work as expected """
+    mock_auth = mocker.patch("content_sync.pipelines.concourse.BaseConcourseApi.auth")
+    mock_response = mocker.Mock(
+        status_code=status_code, headers={"X-Test": "header_value"}
+    )
+    mocker.patch(
+        "content_sync.pipelines.concourse.BaseConcourseApi._is_response_ok",
+        return_value=ok_response,
+    )
+    mock_put = mocker.patch(
+        "content_sync.pipelines.concourse.requests.put", return_value=mock_response
+    )
+    url_path = "/api/v1/teams/myteam/pipelines/draft/config?vars={site=mypipeline}"
+    api = ConcourseApi("http://test.edu", "test", "test", "myteam")
+    data = {"test": "value"}
+    assert api.put_with_headers(url_path, data=data, headers=headers) is (
+        status_code == 200
+    )
+    mock_put.assert_any_call(
+        f"http://test.edu{url_path}", data=data, headers=mocker.ANY
+    )
+    if headers is not None:
+        _, kwargs = mock_put.call_args_list[-1]
+        key, value = list(headers.items())[0]
+        assert kwargs["headers"][key] == value
+        assert kwargs["data"] == data
+    assert mock_auth.call_count == 1 if ok_response else 2
+
+
+def test_upsert_website_pipeline_missing_settings(settings):
     """An exception should be raised if required settings are missing"""
     settings.AWS_PREVIEW_BUCKET_NAME = None
     website = WebsiteFactory.create()
     with pytest.raises(ImproperlyConfigured):
         ConcourseGithubPipeline(website)
-    mock_fly.login.assert_not_called()
 
 
-def test_upsert_website_pipeline_homepage(settings, mock_fly):
-    """The correct fly calls/args should be made for a draft 'home page' website"""
-    root_slug = "ocw-www"
-    settings.ROOT_WEBSITE_SLUG = root_slug
-    starter = WebsiteStarterFactory.create(slug=root_slug)
-    starter.config["root-url-path"] = ""
-    website = WebsiteFactory.create(starter=starter)
+@pytest.mark.parametrize("version", ["live", "draft"])
+@pytest.mark.parametrize("home_page", [True, False])
+@pytest.mark.parametrize("pipeline_exists", [True, False])
+def test_upsert_website_pipelines(
+    mocker, settings, version, home_page, pipeline_exists
+):  # pylint:disable=too-many-locals
+    """The correct concourse API args should be made for a website"""
+    settings.ROOT_WEBSITE_NAME = "ocw-www-course"
+    starter = WebsiteStarterFactory.create()
+    if home_page:
+        name = settings.ROOT_WEBSITE_NAME
+        starter.config["root-url-path"] = ""
+    else:
+        name = "standard-course"
+        starter = WebsiteStarterFactory.create()
+        starter.config["root-url-path"] = "courses"
+    website = WebsiteFactory.create(starter=starter, name=name)
+
+    instance_vars = "{" + f"%22site%22%3A%20%22{website.name}%22" + "}"
+    url_path = f"/api/v1/teams/{settings.CONCOURSE_TEAM}/pipelines/{version}/config?vars={instance_vars}"
+    mocker.patch("content_sync.pipelines.concourse.BaseConcourseApi.auth")
+    if not pipeline_exists:
+        mock_get = mocker.patch(
+            "content_sync.pipelines.concourse.ConcourseApi.get_with_headers",
+            side_effect=HTTPError(),
+        )
+    else:
+        mock_get = mocker.patch(
+            "content_sync.pipelines.concourse.ConcourseApi.get_with_headers",
+            return_value=({}, {"X-Concourse-Config-Version": "3"}),
+        )
+    mock_put = mocker.patch("content_sync.pipelines.concourse.ConcourseApi.put")
+    mock_put_headers = mocker.patch(
+        "content_sync.pipelines.concourse.ConcourseApi.put_with_headers"
+    )
     pipeline = ConcourseGithubPipeline(website)
     pipeline.upsert_website_pipeline()
-    mock_fly.return_value.login.assert_called_once_with(
-        username=settings.CONCOURSE_USERNAME,
-        password=settings.CONCOURSE_PASSWORD,
-        team_name=settings.CONCOURSE_TEAM,
-    )
-    mock_fly.return_value.run.assert_any_call(
-        "set-pipeline",
-        "-p",
-        "draft",
-        "--team",
-        settings.CONCOURSE_TEAM,
-        "-c",
-        os.path.join(
-            os.path.dirname(__file__), "definitions/concourse/site-pipeline.yml"
-        ),
-        "--instance-var",
-        f"site={website.name}",
-        "-v",
-        f"git-domain={settings.GIT_DOMAIN}",
-        "-v",
-        f"github-org={settings.GIT_ORGANIZATION}",
-        "-v",
-        f"ocw-bucket={settings.AWS_PREVIEW_BUCKET_NAME}",
-        "-v",
-        f"ocw-hugo-projects-branch={settings.GITHUB_WEBHOOK_BRANCH}",
-        "-v",
-        "ocw-studio-url=http://test.edu",
-        "-v",
-        f"ocw-studio-bucket={settings.AWS_STORAGE_BUCKET_NAME}",
-        "-v",
-        f"ocw-site-repo={get_repo_name(website)}",
-        "-v",
-        "ocw-site-repo-branch=preview",
-        "-v",
-        f"config-slug={starter.slug}",
-        "-v",
-        "base-url=",
-        "-v",
-        f"site-url={website.name}",
-        "-v",
-        "purge-url=purge_all",
-        "-n",
-    )
 
-
-def test_upsert_website_pipeline_course(settings, mock_fly):
-    """The correct fly calls/args should be made for a live course website"""
-    website = WebsiteFactory.create()
-    website.starter.config["root-url-path"] = "courses"
-    pipeline = ConcourseGithubPipeline(website)
-    pipeline.upsert_website_pipeline()
-    mock_fly.return_value.run.assert_any_call(
-        "set-pipeline",
-        "-p",
-        "live",
-        "--team",
-        settings.CONCOURSE_TEAM,
-        "-c",
-        os.path.join(
-            os.path.dirname(__file__), "definitions/concourse/site-pipeline.yml"
-        ),
-        "--instance-var",
-        f"site={website.name}",
-        "-v",
-        f"git-domain={settings.GIT_DOMAIN}",
-        "-v",
-        f"github-org={settings.GIT_ORGANIZATION}",
-        "-v",
-        f"ocw-bucket={settings.AWS_PUBLISH_BUCKET_NAME}",
-        "-v",
-        f"ocw-hugo-projects-branch={settings.GITHUB_WEBHOOK_BRANCH}",
-        "-v",
-        "ocw-studio-url=http://test.edu",
-        "-v",
-        f"ocw-studio-bucket={settings.AWS_STORAGE_BUCKET_NAME}",
-        "-v",
-        f"ocw-site-repo={get_repo_name(website)}",
-        "-v",
-        "ocw-site-repo-branch=release",
-        "-v",
-        f"config-slug={website.starter.slug}",
-        "-v",
-        f"base-url=courses/{website.name}",
-        "-v",
-        f"site-url=courses/{website.name}",
-        "-v",
-        f"purge-url=purge/courses/{website.name}",
-        "-n",
+    mock_get.assert_any_call(url_path)
+    mock_put_headers.assert_any_call(
+        url_path,
+        data=mocker.ANY,
+        headers=({"X-Concourse-Config-Version": "3"} if pipeline_exists else None),
     )
+    _, kwargs = mock_put_headers.call_args_list[0]
+
+    config_str = json.dumps(kwargs)
+
+    if home_page:
+        assert (
+            f"s3 sync s3://{settings.AWS_STORAGE_BUCKET_NAME}/{website.name} s3://{settings.AWS_PREVIEW_BUCKET_NAME}/{website.name}"
+            in config_str
+        )
+
+        assert (
+            f"aws s3 sync course-markdown/public s3://{settings.AWS_PREVIEW_BUCKET_NAME}/\\\\n"
+            in config_str
+        )
+
+        assert "purge_all" in config_str
+    else:
+        assert (
+            f"s3 sync s3://{settings.AWS_STORAGE_BUCKET_NAME}/courses/{website.name} s3://{settings.AWS_PREVIEW_BUCKET_NAME}/courses/{website.name}"
+            in config_str
+        )
+
+        assert (
+            f"aws s3 sync course-markdown/public s3://{settings.AWS_PREVIEW_BUCKET_NAME}/courses/{website.name}\\\\n"
+            in config_str
+        )
+
+        assert f"purge/courses/{website.name}" in config_str
+    mock_put.assert_any_call(url_path.replace("config", "unpause"))

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -102,7 +102,7 @@ def test_upsert_website_pipelines(
         starter.config["root-url-path"] = "courses"
     website = WebsiteFactory.create(starter=starter, name=name)
 
-    instance_vars = "{" + f"%22site%22%3A%20%22{website.name}%22" + "}"
+    instance_vars = f"%7B%22site%22%3A%20%22{website.name}%22%7D"
     url_path = f"/api/v1/teams/{settings.CONCOURSE_TEAM}/pipelines/{version}/config?vars={instance_vars}"
     mocker.patch("content_sync.pipelines.concourse.BaseConcourseApi.auth")
     if not pipeline_exists:
@@ -169,6 +169,7 @@ def test_upsert_website_pipelines(
 )
 def test_upsert_website_pipelines_invalid_starter(mocker, source, path):
     """A pipeline should not be upserted for invalid WebsiteStarters"""
+    mocker.patch("content_sync.pipelines.concourse.BaseConcourseApi.auth")
     mock_get = mocker.patch("content_sync.pipelines.concourse.ConcourseApi.get")
     mock_put = mocker.patch("content_sync.pipelines.concourse.ConcourseApi.put")
     mock_put_headers = mocker.patch(

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -1,0 +1,122 @@
+""" concourse tests """
+import os
+
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+
+from content_sync.apis.github import get_repo_name
+from content_sync.pipelines.concourse import ConcourseGithubPipeline
+from websites.factories import WebsiteFactory, WebsiteStarterFactory
+
+
+pytestmark = pytest.mark.django_db
+# pylint:disable=redefined-outer-name
+
+
+def test_upsert_website_pipeline_missing_settings(settings, mock_fly):
+    """An exception should be raised if required settings are missing"""
+    settings.AWS_PREVIEW_BUCKET_NAME = None
+    website = WebsiteFactory.create()
+    with pytest.raises(ImproperlyConfigured):
+        ConcourseGithubPipeline(website)
+    mock_fly.login.assert_not_called()
+
+
+def test_upsert_website_pipeline_homepage(settings, mock_fly):
+    """The correct fly calls/args should be made for a draft 'home page' website"""
+    root_slug = "ocw-www"
+    settings.ROOT_WEBSITE_SLUG = root_slug
+    starter = WebsiteStarterFactory.create(slug=root_slug)
+    starter.config["root-url-path"] = ""
+    website = WebsiteFactory.create(starter=starter)
+    pipeline = ConcourseGithubPipeline(website)
+    pipeline.upsert_website_pipeline()
+    mock_fly.return_value.login.assert_called_once_with(
+        username=settings.CONCOURSE_USERNAME,
+        password=settings.CONCOURSE_PASSWORD,
+        team_name=settings.CONCOURSE_TEAM,
+    )
+    mock_fly.return_value.run.assert_any_call(
+        "set-pipeline",
+        "-p",
+        "draft",
+        "--team",
+        settings.CONCOURSE_TEAM,
+        "-c",
+        os.path.join(
+            os.path.dirname(__file__), "definitions/concourse/site-pipeline.yml"
+        ),
+        "--instance-var",
+        f"site={website.name}",
+        "-v",
+        f"git-domain={settings.GIT_DOMAIN}",
+        "-v",
+        f"github-org={settings.GIT_ORGANIZATION}",
+        "-v",
+        f"ocw-bucket={settings.AWS_PREVIEW_BUCKET_NAME}",
+        "-v",
+        f"ocw-hugo-projects-branch={settings.GITHUB_WEBHOOK_BRANCH}",
+        "-v",
+        "ocw-studio-url=http://test.edu",
+        "-v",
+        f"ocw-studio-bucket={settings.AWS_STORAGE_BUCKET_NAME}",
+        "-v",
+        f"ocw-site-repo={get_repo_name(website)}",
+        "-v",
+        "ocw-site-repo-branch=preview",
+        "-v",
+        f"config-slug={starter.slug}",
+        "-v",
+        "base-url=",
+        "-v",
+        f"site-url={website.name}",
+        "-v",
+        "purge-url=purge_all",
+        "-n",
+    )
+
+
+def test_upsert_website_pipeline_course(settings, mock_fly):
+    """The correct fly calls/args should be made for a live course website"""
+    website = WebsiteFactory.create()
+    website.starter.config["root-url-path"] = "courses"
+    pipeline = ConcourseGithubPipeline(website)
+    pipeline.upsert_website_pipeline()
+    mock_fly.return_value.run.assert_any_call(
+        "set-pipeline",
+        "-p",
+        "live",
+        "--team",
+        settings.CONCOURSE_TEAM,
+        "-c",
+        os.path.join(
+            os.path.dirname(__file__), "definitions/concourse/site-pipeline.yml"
+        ),
+        "--instance-var",
+        f"site={website.name}",
+        "-v",
+        f"git-domain={settings.GIT_DOMAIN}",
+        "-v",
+        f"github-org={settings.GIT_ORGANIZATION}",
+        "-v",
+        f"ocw-bucket={settings.AWS_PUBLISH_BUCKET_NAME}",
+        "-v",
+        f"ocw-hugo-projects-branch={settings.GITHUB_WEBHOOK_BRANCH}",
+        "-v",
+        "ocw-studio-url=http://test.edu",
+        "-v",
+        f"ocw-studio-bucket={settings.AWS_STORAGE_BUCKET_NAME}",
+        "-v",
+        f"ocw-site-repo={get_repo_name(website)}",
+        "-v",
+        "ocw-site-repo-branch=release",
+        "-v",
+        f"config-slug={website.starter.slug}",
+        "-v",
+        f"base-url=courses/{website.name}",
+        "-v",
+        f"site-url=courses/{website.name}",
+        "-v",
+        f"purge-url=purge/courses/{website.name}",
+        "-n",
+    )

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -1,0 +1,86 @@
+---
+resources:
+  - name: ocw-hugo-themes
+    type: s3
+    source:
+      bucket: ol-eng-artifacts
+      regexp: ocw-hugo-themes/release/ocw-hugo-themes-(.*).tgz
+  - name: course-markdown
+    type: git
+    source:
+      uri: git@((git-domain)):((github-org))/((ocw-site-repo)).git
+      branch: ((ocw-site-repo-branch))
+      private_key: ((git-private-key))
+  - name: ocw-hugo-projects
+    type: git
+    source:
+      uri: https://github.com/mitodl/ocw-hugo-projects.git
+      branch: ((ocw-hugo-projects-branch))
+jobs:
+  - name: build-ocw-site
+    serial: true
+    plan:
+      - get: ocw-hugo-themes
+        trigger: true
+      - get: ocw-hugo-projects
+        trigger: true
+      - get: course-markdown
+        trigger: true
+      - task: build-course-task
+        params:
+          OCW_STUDIO_BASE_URL: ((ocw-studio-url))
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source: {repository: mitodl/ocw-course-publisher, tag: latest}
+          inputs:
+            - name: ocw-hugo-themes
+            - name: course-markdown
+            - name: ocw-hugo-projects
+          outputs:
+            - name: course-markdown
+            - name: ocw-hugo-themes
+          run:
+            dir: course-markdown
+            path: sh
+            args:
+            - -exc
+            - |
+              mkdir ../ocw-hugo-themes/theme
+              tar -xvzf ../ocw-hugo-themes/ocw-hugo-themes-*.tgz -C ../ocw-hugo-themes/theme
+              hugo --config ../ocw-hugo-projects/((config-slug))/config.yaml --baseUrl /((base-url)) --themesDir ../ocw-hugo-themes/theme
+      - task: copy-s3-buckets
+        config:
+          inputs:
+            - name: ocw-hugo-themes
+            - name: course-markdown
+          platform: linux
+          image_resource:
+            type: docker-image
+            source: {repository: amazon/aws-cli, tag: latest}
+          run:
+            path: sh
+            args:
+            - -exc
+            - |
+              aws s3 sync course-markdown/public s3://((ocw-bucket))/((base-url))
+              aws s3 sync s3://((ocw-studio-bucket))/((site-url)) s3://((ocw-bucket))/((site-url))
+              if [[ "((base-url))" == "" ]]; then aws s3 sync ocw-hugo-themes/theme/base-theme/dist s3://((ocw-bucket)); fi
+      - task: clear-cdn-cache
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source: {repository: curlimages/curl}
+          run:
+            path: curl
+            args:
+              - -f
+              - -X
+              - POST
+              - -H
+              - 'Fastly-Key: ((fastly.api_token))'
+              - -H
+              - 'Fastly-Soft-Purge: 1'
+              - https://api.fastly.com/service/((fastly.service_id))/((purge-url))

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -14,7 +14,7 @@ resources:
   - name: ocw-hugo-projects
     type: git
     source:
-      uri: https://github.com/mitodl/ocw-hugo-projects.git
+      uri: ((ocw-hugo-projects-uri))
       branch: ((ocw-hugo-projects-branch))
 jobs:
   - name: build-ocw-site

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -93,6 +93,21 @@ def create_website_backend(website_name: str):
         backend.create_website_in_backend()
 
 
+@app.task(acks_late=True)
+def upsert_website_publishing_pipeline(website_name: str):
+    """ Create/update a pipeline for previewing & publishing a website """
+    try:
+        website = Website.objects.get(name=website_name)
+    except Website.DoesNotExist:
+        log.debug(
+            "Attempted to create pipeline for Website that doesn't exist: name=%s",
+            website_name,
+        )
+    else:
+        pipeline = api.get_sync_pipeline(website)
+        pipeline.upsert_website_pipeline()
+
+
 @app.task(acks_late=True, autoretry_for=(BlockingIOError,), retry_backoff=True)
 @single_website_task(10)
 def sync_website_content(website_name: str):

--- a/main/settings.py
+++ b/main/settings.py
@@ -694,9 +694,9 @@ OCW_STUDIO_SITE_CONFIG_FILE = get_string(
     required=False,
 )
 
-ROOT_WEBSITE_SLUG = get_string(
-    name="ROOT_WEBSITE_SLUG",
+ROOT_WEBSITE_NAME = get_string(
+    name="ROOT_WEBSITE_NAME",
     default="ocw-www",
-    description="The WebsiteStarter slug for site(s) at the root domain",
+    description="The Website name for the site at the root domain",
     required=False,
 )

--- a/main/settings.py
+++ b/main/settings.py
@@ -409,6 +409,12 @@ AWS_SECRET_ACCESS_KEY = get_string(
 AWS_STORAGE_BUCKET_NAME = get_string(
     name="AWS_STORAGE_BUCKET_NAME", default=None, description="S3 Bucket name."
 )
+AWS_PREVIEW_BUCKET_NAME = get_string(
+    name="AWS_PREVIEW_BUCKET_NAME", default=None, description="S3 preview bucket name."
+)
+AWS_PUBLISH_BUCKET_NAME = get_string(
+    name="AWS_PUBLISH_BUCKET_NAME", default=None, description="S3 publish bucket name."
+)
 AWS_QUERYSTRING_AUTH = get_bool(
     name="AWS_QUERYSTRING_AUTH",
     default=False,
@@ -581,6 +587,38 @@ CONTENT_SYNC_RETRIES = get_int(
     description="Number of times to retry backend sync attempts",
     required=False,
 )
+CONTENT_SYNC_PIPELINE = get_string(
+    name="CONTENT_SYNC_PIPELINE",
+    default=None,
+    description="The pipeline to preview/publish websites with",
+    required=False,
+)
+
+# Concourse-CI settings
+CONCOURSE_URL = get_string(
+    name="CONCOURSE_URL",
+    default=None,
+    description="The concourse-ci URL",
+    required=False,
+)
+CONCOURSE_USERNAME = get_string(
+    name="CONCOURSE_USERNAME",
+    default=None,
+    description="The concourse-ci login username",
+    required=False,
+)
+CONCOURSE_PASSWORD = get_string(
+    name="CONCOURSE_PASSWORD",
+    default=None,
+    description="The concourse-ci login password",
+    required=False,
+)
+CONCOURSE_TEAM = get_string(
+    name="CONCOURSE_TEAM",
+    default="ocw",
+    description="The concourse-ci team",
+    required=False,
+)
 
 # Git backend settings
 GIT_TOKEN = get_string(
@@ -631,6 +669,12 @@ GIT_API_URL = get_string(
     description="Base URL of git API",
     required=False,
 )
+GIT_DOMAIN = get_string(
+    name="GIT_DOMAIN",
+    default="www.github.com",
+    description="Base URL of github for site repos",
+    required=False,
+)
 GITHUB_WEBHOOK_KEY = get_string(
     name="GITHUB_WEBHOOK_KEY",
     default="",
@@ -647,5 +691,12 @@ OCW_STUDIO_SITE_CONFIG_FILE = get_string(
     name="OCW_STUDIO_SITE_CONFIG_FILE",
     default="ocw-studio.yaml",
     description="Standard file name for site config files",
+    required=False,
+)
+
+ROOT_WEBSITE_SLUG = get_string(
+    name="ROOT_WEBSITE_SLUG",
+    default="ocw-www",
+    description="The WebsiteStarter slug for site(s) at the root domain",
     required=False,
 )

--- a/requirements.in
+++ b/requirements.in
@@ -2,6 +2,7 @@ beautifulsoup4
 django
 boto3
 celery
+concoursepy
 dj-database-url
 django-guardian
 django-hijack
@@ -20,7 +21,6 @@ ipython
 newrelic
 psycopg2
 pygithub==1.55
-python-fly
 redis
 requests
 sentry-sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,8 @@ cffi==1.14.2
     #   pynacl
 chardet==3.0.4
     # via requests
+concoursepy==0.0.20
+    # via -r requirements.in
 cryptography==3.3.2
     # via
     #   pyopenssl
@@ -201,8 +203,6 @@ python-dateutil==2.8.1
     # via
     #   botocore
     #   faker
-python-fly==0.0.2
-    # via -r requirements.in
 python3-openid==3.2.0
     # via social-auth-core
 python3-saml==1.10.1
@@ -224,11 +224,11 @@ redis==3.5.3
 requests==2.24.0
     # via
     #   -r requirements.in
+    #   concoursepy
     #   django-anymail
     #   mitol-django-common
     #   premailer
     #   pygithub
-    #   python-fly
     #   requests-oauthlib
     #   social-auth-core
 requests-oauthlib==1.3.0
@@ -261,6 +261,8 @@ soupsieve==2.1
     # via beautifulsoup4
 sqlparse==0.3.1
     # via django
+sseclient-py==1.7
+    # via concoursepy
 text-unidecode==1.3
     # via faker
 toml==0.10.2

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -6,7 +6,11 @@ from guardian.shortcuts import get_groups_with_perms, get_users_with_perms
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
-from content_sync.api import create_website_backend, update_website_backend
+from content_sync.api import (
+    create_website_backend,
+    create_website_publishing_pipeline,
+    update_website_backend,
+)
 from main.serializers import RequestUserSerializerMixin
 from users.models import User
 from websites import constants
@@ -81,6 +85,7 @@ class WebsiteDetailSerializer(serializers.ModelSerializer, RequestUserSerializer
         with transaction.atomic():
             website = super().create(validated_data)
         create_website_backend(website)
+        create_website_publishing_pipeline(website)
         return website
 
     def update(self, instance, validated_data):

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -172,6 +172,9 @@ def test_website_content_detail_serializer_save(mocker):
     mock_update_website_backend = mocker.patch(
         "websites.serializers.update_website_backend"
     )
+    mock_create_website_pipeline = mocker.patch(
+        "websites.serializers.create_website_publishing_pipeline"
+    )
     content = WebsiteContentFactory.create(type=CONTENT_TYPE_RESOURCE)
     existing_text_id = content.text_id
     new_title = f"{content.title} with some more text"
@@ -204,6 +207,7 @@ def test_website_content_detail_serializer_save(mocker):
     assert content.metadata == metadata
     assert content.updated_by == user
     mock_update_website_backend.assert_called_once_with(content.website)
+    mock_create_website_pipeline.assert_not_called()
 
 
 @pytest.mark.parametrize("add_context_data", [True, False])

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -127,6 +127,9 @@ def test_websites_endpoint_list_create(mocker, drf_client, permission_groups):
     mock_create_website_backend = mocker.patch(
         "websites.serializers.create_website_backend"
     )
+    mock_create_website_pipeline = mocker.patch(
+        "websites.serializers.create_website_publishing_pipeline"
+    )
     starter = WebsiteStarterFactory.create(source=constants.STARTER_SOURCE_GITHUB)
     for [user, has_perm] in [
         [permission_groups.global_admin, True],
@@ -148,6 +151,7 @@ def test_websites_endpoint_list_create(mocker, drf_client, permission_groups):
             website = Website.objects.get(name=f"{user.username}_site")
             assert website.owner == user
             mock_create_website_backend.assert_any_call(website)
+            mock_create_website_pipeline.assert_any_call(website)
 
 
 @pytest.mark.parametrize("method", ["put", "patch", "delete"])
@@ -192,6 +196,9 @@ def test_websites_endpoint_detail_update(mocker, drf_client):
     mock_update_website_backend = mocker.patch(
         "websites.serializers.update_website_backend"
     )
+    mock_create_website_pipeline = mocker.patch(
+        "websites.serializers.create_website_publishing_pipeline"
+    )
     website = WebsiteFactory.create()
     admin_user = UserFactory.create()
     admin_user.groups.add(website.admin_group)
@@ -206,6 +213,7 @@ def test_websites_endpoint_detail_update(mocker, drf_client):
     assert updated_site.title == new_title
     assert updated_site.owner == website.owner
     mock_update_website_backend.assert_called_once_with(website)
+    mock_create_website_pipeline.assert_not_called()
 
 
 def test_websites_endpoint_preview(mocker, drf_client):
@@ -339,8 +347,11 @@ def test_website_endpoint_search(drf_client):
     assert [website["title"] for website in resp.data.get("results")] == ["BEST"]
 
 
-def test_websites_autogenerate_name(drf_client):
+def test_websites_autogenerate_name(mocker, drf_client):
     """ Website POST endpoint should auto-generate a name if one is not supplied """
+    mock_create_website_pipeline = mocker.patch(
+        "websites.serializers.create_website_publishing_pipeline"
+    )
     superuser = UserFactory.create(is_superuser=True)
     drf_client.force_login(superuser)
     starter = WebsiteStarterFactory.create(source=constants.STARTER_SOURCE_GITHUB)
@@ -352,6 +363,7 @@ def test_websites_autogenerate_name(drf_client):
     )
     assert resp.status_code == status.HTTP_201_CREATED
     assert resp.data["name"] == slugified_title
+    mock_create_website_pipeline.assert_called_once()
 
 
 def test_website_starters_list(settings, drf_client, course_starter):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable
  - [x] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
Closes #368
Closes #384

#### What's this PR do?
- Reverts a previous revert
- Creates an abstract and concourse-specific class for creating publishing pipelines
- If a specific pipeline class is set, instantiates it and runs concourse-ci API requests to generate draft/live pipelines for a Website when it is created via the ocw-studio API.

#### How should this be manually tested?
Kind of tricky, but this should work:

- Unpause and run the `ocw/draft/ocw-www-test` pipeline on the RC instance of concourse, which is deliberately misconfigured to clear out nearly everything on the draft S3 bucket.  After a minute or so verify that the draft site url brings up a 'NoSuchKey' error.  Pause the pipeline again.


- Create a `Website` with name "ocw-www" based on the "ocw-www" starter config from github.com/mitodl/ocw-hugo-projects.  The starter should a slug of "ocw-www" and `"root-url-path": ""` in its config.
- Create a `Website` with name "course-mb-1" based on the "ocw-course" starter config from github.com/mitodl/ocw-hugo-projects. The starter should a slug of "ocw-course" and `"root-url-path": "courses"` in its config.

- Set the following env variables to the same as on RC:
```
OCW_STUDIO_BASE_URL
GIT_ORGANIZATION
```

Plus set the following:
```
GIT_DOMAIN=github.mit.edu
ROOT_WEBSITE_NAME=ocw-www
CONTENT_SYNC_PIPELINE=content_sync.pipelines.concourse.ConcourseGithubPipeline
CONCOURSE_URL=<QA instance of concourse>
CONCOURSE_USERNAME=<ask me>
CONCOURSE_PASSWORD=<ask me>
AWS_PREVIEW_BUCKET_NAME=<ask me>
AWS_PUBLISH_BUCKET_NAME=<ask me>
```

To simulate creating a pipeline for the home page:
- Insert this into `content_sync.pipelines.concourse.ConcourseGithubPipeline.upsert_website_pipeline`, on the 1st line:
```python
from uuid import UUID    
self.website.uuid = UUID("eb8b7017-4c71-4752-a91d-be730af76769") # match the site in ocw-studio-rc
```

- Run the following:
```python
from websites.models import *
from content_sync.pipelines.concourse import *
website = Website.objects.get(name="ocw-www")
pipeline = ConcourseGithubPipeline(website)
pipeline.upsert_website_pipeline()
```

- Go to the QA concourse site at ../teams/ocw/pipelines/draft/jobs/build-ocw-site/builds/2?vars.site="ocw-www" and start a new build.  It should complete successfully and you should see a full home page at the draft fastly url.  Click on the testimonials and you should be brought to a working testimonial page with no missing images.



To simulate creating a pipeline for a course:
- Replace the code change above with this:
```python        
self.website.uuid = UUID("917f160c-7eae-48d8-86a6-a041bd2ef0fe"). # match uuid in ocw-studio-rc
```        
- Restart your shell and run the following:
```python
from websites.models import *
from content_sync.pipelines.concourse import *
website = Website.objects.get(name="course-mb-1")
pipeline = ConcourseGithubPipeline(website)
pipeline.upsert_website_pipeline()
```

- Go to the QA concourse site at ..teams/ocw/pipelines/draft/jobs/build-ocw-site/builds/3?vars.site="course-mb-1" and start a new build.  It should complete successfully and you should see content at the following urls on the fastly draft site:
/courses/course-mb-1/superb-owl/
/courses/course-mb-1/527fc14517b14226a30aa8f21e42a0a4_DSC02800a.jpg
