### PR TITLE
Async search backend

### DIFF
--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -1,4 +1,6 @@
 """ Serializers for websites """
+import logging
+
 from django.contrib.auth.models import Group
 from django.db import transaction
 from django.db.models import F, Max
@@ -22,7 +24,11 @@ from websites.models import (
     WebsiteStarter,
 )
 from websites.permissions import is_global_admin, is_site_admin
+from websites.site_config_api import SiteConfig
 from websites.utils import permissions_group_name_for_role
+
+
+log = logging.getLogger(__name__)
 
 
 ROLE_ERROR_MESSAGES = {"invalid_choice": "Invalid role", "required": "Role is required"}
@@ -202,6 +208,8 @@ class WebsiteContentDetailSerializer(
 ):
     """Serializes more parts of WebsiteContent, including content or other things which are too big for the list view"""
 
+    content_context = serializers.SerializerMethodField()
+
     def update(self, instance, validated_data):
         """Add updated_by to the data"""
         instance = super().update(
@@ -209,6 +217,45 @@ class WebsiteContentDetailSerializer(
         )
         update_website_backend(instance.website)
         return instance
+
+    def get_content_context(self, instance):
+        """
+        Create mapping of uuid to a display name for any values in the metadata
+        """
+        if not self.context or not self.context.get("content_context"):
+            return None
+
+        text_ids = []
+        website_name = None
+        metadata = instance.metadata or {}
+        site_config = SiteConfig(instance.website.starter.config)
+        for field in site_config.iter_fields():
+            if field.field.get("widget") == "relation":
+                try:
+                    if field.parent_field is None:
+                        value = metadata.get(field.field["name"])
+                    else:
+                        value = metadata.get(field.parent_field["name"], {}).get(
+                            field.field["name"]
+                        )
+
+                    content = value["content"]
+                    website_name = value["website"]
+                    if isinstance(content, str):
+                        text_ids.append(content)
+                    else:
+                        text_ids.extend(content)
+
+                except (AttributeError, KeyError, TypeError):
+                    # Either missing or malformed relation field value
+                    continue
+
+        contents = WebsiteContent.objects.filter(
+            text_id__in=text_ids, website__name=website_name
+        )
+        return WebsiteContentDetailSerializer(
+            contents, many=True, context={"content_context": False}
+        ).data
 
     def to_representation(self, instance):
         """Add the file field name and url to the serializer if a file exists"""
@@ -221,7 +268,7 @@ class WebsiteContentDetailSerializer(
 
     class Meta:
         model = WebsiteContent
-        read_only_fields = ["text_id", "type"]
+        read_only_fields = ["text_id", "type", "content_context"]
         fields = read_only_fields + [
             "title",
             "markdown",

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -169,6 +169,71 @@ def test_website_content_detail_with_file_serializer():
     assert serialized_data["metadata"]["title"] == content.metadata["title"]
 
 
+@pytest.mark.parametrize("content_context", [True, False])
+@pytest.mark.parametrize("multiple", [True, False])
+@pytest.mark.parametrize("invalid_data", [True, False])
+@pytest.mark.parametrize("nested", [True, False])
+def test_website_content_detail_serializer_content_context(
+    content_context, multiple, invalid_data, nested
+):
+    """WebsiteContentDetailSerializer should serialize content_context for relation fields"""
+    referenced = WebsiteContentFactory.create()
+    # This one has the same text_id but a different website so it should not match
+    WebsiteContentFactory.create(text_id=referenced.text_id)
+    pdf_field = {
+        "name": "pdfs",
+        "label": "PDFs",
+        "widget": "relation",
+        "multiple": multiple,
+    }
+    starter = WebsiteStarterFactory.create(
+        config={
+            "collections": [
+                {
+                    "fields": [
+                        {"name": "outer", "fields": [pdf_field]}
+                        if nested
+                        else pdf_field
+                    ]
+                }
+            ]
+        }
+    )
+    pdf_value = {
+        "content": [referenced.text_id] if multiple else referenced.text_id,
+        "website": referenced.website.name,
+    }
+    content = WebsiteContentFactory.create(
+        website__starter=starter,
+        metadata={"pdfs": []}
+        if invalid_data
+        else {"outer": {"pdfs": pdf_value}}
+        if nested
+        else {"pdfs": pdf_value},
+    )
+    serialized_data = WebsiteContentDetailSerializer(
+        instance=content, context={"content_context": content_context}
+    ).data
+    assert serialized_data["text_id"] == str(content.text_id)
+    assert serialized_data["title"] == content.title
+    assert serialized_data["type"] == content.type
+    assert serialized_data["markdown"] == content.markdown
+    assert serialized_data["metadata"] == content.metadata
+    assert serialized_data["content_context"] == (
+        (
+            []
+            if invalid_data
+            else [
+                WebsiteContentDetailSerializer(
+                    instance=referenced, context={"content_context": False}
+                ).data
+            ]
+        )
+        if content_context
+        else None
+    )
+
+
 def test_website_content_detail_serializer_save(mocker):
     """WebsiteContentDetailSerializer should modify only certain fields"""
     mock_update_website_backend = mocker.patch(

--- a/websites/site_config_api.py
+++ b/websites/site_config_api.py
@@ -51,6 +51,14 @@ class ConfigItem:
         return "file" in self.item
 
 
+@dataclass
+class ConfigField:
+    """Utility class for describing an individual site config field"""
+
+    field: dict
+    parent_field: Optional[dict] = None
+
+
 class SiteConfig:
     """Utility class for parsing and introspecting site configs"""
 
@@ -87,6 +95,15 @@ class SiteConfig:
                         parent_item=collection_item,
                         path=f"{path}.files.{j}",
                     )
+
+    def iter_fields(self) -> Iterator[ConfigField]:
+        """Yield all fields in the configuration"""
+        for item in self.iter_items():
+            for field in item.fields:
+                yield ConfigField(field=field, parent_field=None)
+
+                for inner_field in field.get("fields", []):
+                    yield ConfigField(field=inner_field, parent_field=field)
 
     def find_item_by_name(self, name: str) -> Optional[ConfigItem]:
         """Finds a config item in the site config with a matching 'name' value"""


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Part of #392 

#### What's this PR do?
Adds backend parameters, extra context and tests to enable async relation fields in the frontend. There are three additions:
 - `text_id` parameter to allow filtering on text_id. This is useful for relation fields in menus, so that the serialized `WebsiteContent` for a selected menu item can be retrieved, so that we have the information to display the label
 - `content_context` is included in the `WebsiteContent` detailed listing. It should include any serialized `WebsiteContent` for `text_id`s which appear in the relation field value, so that we have this information to display the label on the frontend
 - `search` query parameter is added which does a case insensitive filter on `title`. **Note**: `title` can be overridden by specifying another value for `display_field`, so searches may not necessarily match the text that's displayed on the frontend. I don't know of a way around this issue since we would need to look up the starter config for each `WebsiteConfig` in order to know which field to search on.

#### How should this be manually tested?

Assume you start with some content in a website: 
 - Create a `RelationField` on some page on your site and select a piece of content.
 - Go to this URL: `/api/websites/website-slug-here/content/?detailed_list=true`, replacing your website name in the URL. You should see a new list called `content_context` in the results. 
 - Look for the content you updated with the relation field. It should be a list with one serialized `WebsiteContent` inside it. For other items without a relationfield you should see an empty list. If you have a relation field with many=true then you may see multiple serialized objects in the list.
 - Add `text_id=...` to the query parameters. You should see only the content with that text_id