### PR TITLE
Fix null website error with RelationField

### DIFF
--- a/static/js/components/SiteContentEditor.tsx
+++ b/static/js/components/SiteContentEditor.tsx
@@ -106,7 +106,7 @@ export default function SiteContentEditor(props: Props): JSX.Element | null {
     if (formType === ContentFormType.Add) {
       values = { type: configItem.name, ...values }
     }
-    const payload = contentFormValuesToPayload(values, fields)
+    const payload = contentFormValuesToPayload(values, fields, site)
 
     // If the content being created is for a singleton config item,
     // use the config item "name" value as the text_id.

--- a/static/js/components/forms/MenuItemForm.test.tsx
+++ b/static/js/components/forms/MenuItemForm.test.tsx
@@ -169,7 +169,9 @@ describe("MenuItemForm", () => {
     expect(relationField.prop("valuesToOmit")).toEqual(existingMenuIds)
     expect(relationField.prop("contentContext")).toBeNull()
     expect(relationField.prop("collection")).toEqual(collections)
-    const fakeEvent = { target: { value: "abc" } }
+    const fakeEvent = {
+      target: { value: { content: "abc", website: "ignored" } }
+    }
     // @ts-ignore
     relationField.prop("onChange")(fakeEvent)
     expect(setFieldValueStub).toBeCalledWith("internalLink", "abc")

--- a/static/js/components/forms/MenuItemForm.tsx
+++ b/static/js/components/forms/MenuItemForm.tsx
@@ -137,7 +137,7 @@ export default function MenuItemForm({
                     display_field="title"
                     multiple={false}
                     onChange={event => {
-                      setFieldValue("internalLink", event.target.value)
+                      setFieldValue("internalLink", event.target.value.content)
                     }}
                     value={values.internalLink}
                     valuesToOmit={existingMenuIds}

--- a/static/js/components/forms/SiteContentField.test.tsx
+++ b/static/js/components/forms/SiteContentField.test.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { shallow } from "enzyme"
-import sinon, { SinonSandbox, SinonStub } from "sinon"
+import sinon, { SinonSandbox } from "sinon"
 
 import SiteContentField from "./SiteContentField"
 import { componentFromWidget } from "../../lib/site_content"
@@ -10,13 +10,10 @@ import { WebsiteContent, WidgetVariant } from "../../types/websites"
 import { makeWebsiteContentDetail } from "../../util/factories/websites"
 
 describe("SiteContentField", () => {
-  let sandbox: SinonSandbox,
-    setFieldValueStub: SinonStub,
-    contentContext: WebsiteContent[]
+  let sandbox: SinonSandbox, contentContext: WebsiteContent[]
 
   beforeEach(() => {
     sandbox = sinon.createSandbox()
-    setFieldValueStub = sandbox.stub()
     const content = makeWebsiteContentDetail()
     contentContext = [content]
   })
@@ -28,11 +25,7 @@ describe("SiteContentField", () => {
   it("renders a form group for a config field", () => {
     for (const field of exampleSiteConfigFields) {
       const wrapper = shallow(
-        <SiteContentField
-          field={field}
-          setFieldValue={setFieldValueStub}
-          contentContext={contentContext}
-        />
+        <SiteContentField field={field} contentContext={contentContext} />
       )
 
       expect(wrapper.find("label").text()).toBe(field.label)
@@ -40,10 +33,10 @@ describe("SiteContentField", () => {
       expect(props["as"]).toBe(componentFromWidget(field))
       expect(props["name"]).toBe(field.name)
       if (
-        field.widget === WidgetVariant.File ||
-        field.widget === WidgetVariant.Boolean
+        field.widget === WidgetVariant.Menu ||
+        field.widget === WidgetVariant.Relation
       ) {
-        expect(props["setFieldValue"]).toBe(setFieldValueStub)
+        expect(props["contentContext"]).toBe(contentContext)
       }
       if (field.widget === WidgetVariant.Select) {
         expect(props["min"]).toBe(field.min)

--- a/static/js/components/forms/SiteContentField.tsx
+++ b/static/js/components/forms/SiteContentField.tsx
@@ -8,7 +8,6 @@ import { ConfigField, WebsiteContent } from "../../types/websites"
 
 interface Props {
   field: ConfigField
-  setFieldValue: (key: string, value: File | null) => void
   contentContext: WebsiteContent[] | null
 }
 
@@ -17,14 +16,12 @@ interface Props {
  */
 export default function SiteContentField({
   field,
-  setFieldValue,
   contentContext
 }: Props): JSX.Element {
   const extraProps = widgetExtraProps(field)
   const component = componentFromWidget(field)
 
   if (component && typeof component !== "string") {
-    extraProps.setFieldValue = setFieldValue
     extraProps.contentContext = contentContext
   }
 

--- a/static/js/components/forms/SiteContentForm.test.tsx
+++ b/static/js/components/forms/SiteContentForm.test.tsx
@@ -36,7 +36,6 @@ jest.mock("../../context/Website")
 describe("SiteContentForm", () => {
   let sandbox: SinonSandbox,
     onSubmitStub: SinonStub,
-    setFieldValueStub: SinonStub,
     configItem: EditableConfigItem,
     content: WebsiteContent,
     mockValidationSchema: FormSchema,
@@ -44,7 +43,6 @@ describe("SiteContentForm", () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox()
-    setFieldValueStub = sinon.stub()
     content = makeWebsiteContentDetail()
     content.content_context = times(() => makeWebsiteContentDetail(), 3)
     configItem = makeEditableConfigItem(content.type)
@@ -99,14 +97,11 @@ describe("SiteContentForm", () => {
         // @ts-ignore
         splitFieldsIntoColumns.mockImplementation(() => [configItem.fields])
 
-        const form = renderInnerForm(formType, {
-          setFieldValue: setFieldValueStub
-        })
+        const form = renderInnerForm(formType)
         let idx = 0
         for (const field of configItem.fields) {
           const fieldWrapper = form.find("SiteContentField").at(idx)
           expect(fieldWrapper.prop("field")).toBe(field)
-          expect(fieldWrapper.prop("setFieldValue")).toBe(setFieldValueStub)
           expect(fieldWrapper.prop("contentContext")).toBe(
             content.content_context
           )
@@ -146,13 +141,10 @@ describe("SiteContentForm", () => {
         fieldIsVisible.mockImplementation(() => true)
         // @ts-ignore
         splitFieldsIntoColumns.mockImplementation(() => [configItem.fields])
-        const wrapper = renderInnerForm(formType, {
-          setFieldValue: setFieldValueStub
-        })
+        const wrapper = renderInnerForm(formType)
         const objectWrapper = wrapper.find("ObjectField")
         expect(objectWrapper.exists()).toBeTruthy()
         expect(objectWrapper.prop("field")).toEqual(field)
-        expect(objectWrapper.prop("setFieldValue")).toBe(setFieldValueStub)
         expect(objectWrapper.prop("contentContext")).toBe(
           content.content_context
         )

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -27,6 +27,7 @@ import {
 } from "../../types/websites"
 import { ContentFormType, SiteFormValues } from "../../types/forms"
 import { getContentSchema } from "./validation"
+import { useWebsite } from "../../context/Website"
 
 interface Props {
   onSubmit: (
@@ -46,12 +47,13 @@ export default function SiteContentForm({
   content,
   formType
 }: Props): JSX.Element {
+  const website = useWebsite()
   const initialValues: SiteFormValues = useMemo(
     () =>
       formType === ContentFormType.Add ?
-        newInitialValues(fields) :
-        contentInitialValues(content as WebsiteContent, fields),
-    [fields, formType, content]
+        newInitialValues(fields, website) :
+        contentInitialValues(content as WebsiteContent, fields, website),
+    [fields, formType, content, website]
   )
   const contentContext = content?.content_context ?? null
 

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -81,7 +81,7 @@ export default function SiteContentForm({
       initialValues={initialValues}
       enableReinitialize={true}
     >
-      {({ isSubmitting, status, setFieldValue, values }) => (
+      {({ isSubmitting, status, values }) => (
         <Form className="row">
           {fieldsByColumn.map((columnFields, idx) => (
             <div className={columnClass} key={idx}>
@@ -92,14 +92,12 @@ export default function SiteContentForm({
                     <ObjectField
                       field={field}
                       key={field.name}
-                      setFieldValue={setFieldValue}
                       contentContext={contentContext}
                     />
                   ) : (
                     <SiteContentField
                       field={field}
                       key={field.name}
-                      setFieldValue={setFieldValue}
                       contentContext={contentContext}
                     />
                   )

--- a/static/js/components/widgets/BooleanField.test.tsx
+++ b/static/js/components/widgets/BooleanField.test.tsx
@@ -4,17 +4,17 @@ import { shallow } from "enzyme"
 import BooleanField from "./BooleanField"
 
 describe("BooleanField", () => {
-  let setFieldValueStub: any, render: any
+  let render: any, onChangeStub: any
 
   beforeEach(() => {
-    setFieldValueStub = jest.fn()
+    onChangeStub = jest.fn()
 
     render = (props = {}) =>
       shallow(
         <BooleanField
           name="name"
           value={false}
-          setFieldValue={setFieldValueStub}
+          onChange={onChangeStub}
           {...props}
         />
       )
@@ -44,15 +44,20 @@ describe("BooleanField", () => {
 
   it("clicking on a radio option should call setFieldValue", () => {
     const wrapper = render()
+    const name = "name"
     wrapper
       .find("input")
       .at(0)
-      .simulate("change")
-    expect(setFieldValueStub).toHaveBeenCalledWith("name", true)
+      .simulate("change", { target: { name, value: "true" } })
+    expect(onChangeStub).toHaveBeenCalledWith({
+      target: { name: "name", value: true }
+    })
     wrapper
       .find("input")
       .at(1)
-      .simulate("change")
-    expect(setFieldValueStub).toHaveBeenCalledWith("name", false)
+      .simulate("change", { target: { name, value: "false" } })
+    expect(onChangeStub).toHaveBeenCalledWith({
+      target: { name: "name", value: false }
+    })
   })
 })

--- a/static/js/components/widgets/BooleanField.tsx
+++ b/static/js/components/widgets/BooleanField.tsx
@@ -6,14 +6,23 @@ const radioOptionId = (name: string, bool: boolean): string =>
 interface Props {
   name: string
   value: boolean
-  setFieldValue: (key: string, value: File | boolean | null) => void
+  onChange: (event: any) => void
 }
 
 /**
  * A widget for editing boolean values
  */
 export default function BooleanField(props: Props): JSX.Element {
-  const { name, value, setFieldValue } = props
+  const { name, value, onChange } = props
+
+  const handleChange = (event: any): void => {
+    onChange({
+      target: {
+        name:  event.target.name,
+        value: event.target.value === "true"
+      }
+    })
+  }
 
   return (
     <div>
@@ -23,9 +32,7 @@ export default function BooleanField(props: Props): JSX.Element {
         name={name}
         value="true"
         checked={value === true}
-        onChange={() => {
-          setFieldValue(name, true)
-        }}
+        onChange={handleChange}
       />
       <label className="px-2" htmlFor={radioOptionId(name, true)}>
         True
@@ -36,9 +43,7 @@ export default function BooleanField(props: Props): JSX.Element {
         name={name}
         value="false"
         checked={value === false}
-        onChange={() => {
-          setFieldValue(name, false)
-        }}
+        onChange={handleChange}
       />
       <label className="px-2" htmlFor={radioOptionId(name, false)}>
         False

--- a/static/js/components/widgets/FileUploadField.test.tsx
+++ b/static/js/components/widgets/FileUploadField.test.tsx
@@ -1,16 +1,15 @@
 import React from "react"
 import { shallow } from "enzyme"
-import sinon, { SinonSandbox, SinonStub } from "sinon"
+import sinon, { SinonSandbox } from "sinon"
 
 import FileUploadField from "./FileUploadField"
 
 describe("FileUploadField", () => {
-  let sandbox: SinonSandbox, setFieldValueStub: SinonStub
+  let sandbox: SinonSandbox
   const mockFile = new File([new ArrayBuffer(1)], "fake.txt")
 
   beforeEach(() => {
     sandbox = sinon.createSandbox()
-    setFieldValueStub = sinon.stub()
   })
 
   afterEach(() => {
@@ -18,11 +17,9 @@ describe("FileUploadField", () => {
   })
   ;["file", "name"].forEach(fileFieldName => {
     it(`renders a file upload field w/name=${fileFieldName}, no pre-existing file, with working button`, () => {
+      const onChangeStub = jest.fn()
       const wrapper = shallow(
-        <FileUploadField
-          name={fileFieldName}
-          setFieldValue={setFieldValueStub}
-        />
+        <FileUploadField name={fileFieldName} onChange={onChangeStub} />
       )
       expect(
         wrapper
@@ -46,17 +43,26 @@ describe("FileUploadField", () => {
       wrapper
         .find("input")
         .at(0)
-        .simulate("change", { target: { files: [mockFile] } })
-      expect(setFieldValueStub.calledWith(fileFieldName, mockFile)).toBeTruthy()
+        .simulate("change", {
+          target: { name: fileFieldName, files: [mockFile] }
+        })
+      expect(onChangeStub).toBeCalledWith({
+        target: {
+          name:  fileFieldName,
+          value: mockFile
+        }
+      })
     })
   })
+
+  //
   ;["file", "name"].forEach(fileFieldName => {
     it(`renders a file upload field w/name=${fileFieldName}, with pre-existing file`, () => {
       const currentFile = "oldfile.txt"
       const wrapper = shallow(
         <FileUploadField
           name={fileFieldName}
-          setFieldValue={setFieldValueStub}
+          onChange={jest.fn()}
           value={`https://aws.com/uuid_${currentFile}`}
         />
       )

--- a/static/js/components/widgets/FileUploadField.tsx
+++ b/static/js/components/widgets/FileUploadField.tsx
@@ -4,14 +4,14 @@ import { filenameFromPath } from "../../lib/util"
 export interface Props {
   name?: string
   value?: string | File | null
-  setFieldValue: (key: string, value: File | null) => void
+  onChange: (event: any) => void
 }
 
 /**
  * A component for uploading files
  */
 export default function FileUploadField(props: Props): JSX.Element {
-  const { name, value, setFieldValue } = props
+  const { name, value, onChange } = props
   const fileInputName = name || "file"
   return (
     <div>
@@ -19,10 +19,12 @@ export default function FileUploadField(props: Props): JSX.Element {
         type="file"
         name={fileInputName}
         onChange={event => {
-          setFieldValue(
-            fileInputName,
-            event.target.files ? event.target.files[0] : null
-          )
+          onChange({
+            target: {
+              name:  event.target.name,
+              value: event.target.files ? event.target.files[0] : null
+            }
+          })
         }}
         className="form-control"
       />

--- a/static/js/components/widgets/ObjectField.test.tsx
+++ b/static/js/components/widgets/ObjectField.test.tsx
@@ -14,14 +14,9 @@ import {
 } from "../../types/websites"
 
 describe("ObjectField", () => {
-  let setFieldValueStub: any,
-    render: any,
-    field: ObjectConfigField,
-    contentContext: WebsiteContent[]
+  let render: any, field: ObjectConfigField, contentContext: WebsiteContent[]
 
   beforeEach(() => {
-    setFieldValueStub = jest.fn()
-
     field = makeWebsiteConfigField({
       widget: WidgetVariant.Object,
       label:  "myobject",
@@ -43,19 +38,13 @@ describe("ObjectField", () => {
 
     render = (props = {}) =>
       shallow(
-        <ObjectField
-          setFieldValue={setFieldValueStub}
-          field={field}
-          contentContext={contentContext}
-          {...props}
-        />
+        <ObjectField field={field} contentContext={contentContext} {...props} />
       )
   })
 
   it("should render an Object field, by passing sub-fields to SiteContentField", () => {
     const wrapper = render()
     wrapper.find("SiteContentField").forEach((field: any) => {
-      expect(field.prop("setFieldValue")).toEqual(setFieldValueStub)
       expect(field.prop("contentContext")).toStrictEqual(contentContext)
     })
     expect(

--- a/static/js/components/widgets/ObjectField.tsx
+++ b/static/js/components/widgets/ObjectField.tsx
@@ -10,7 +10,6 @@ import {
 
 interface Props {
   field: ObjectConfigField
-  setFieldValue: (key: string, value: File | null) => void
   contentContext: WebsiteContent[] | null
 }
 
@@ -19,7 +18,7 @@ interface Props {
  * to be edited.
  **/
 export default function ObjectField(props: Props): JSX.Element {
-  const { field, setFieldValue, contentContext } = props
+  const { field, contentContext } = props
 
   const [collapsed, setCollapsed] = useState(field.collapsed ?? false)
   const toggleCollapse = useCallback(
@@ -47,7 +46,6 @@ export default function ObjectField(props: Props): JSX.Element {
             <SiteContentField
               field={field}
               key={field.name}
-              setFieldValue={setFieldValue}
               contentContext={contentContext}
             />
           ))}

--- a/static/js/components/widgets/RelationField.test.tsx
+++ b/static/js/components/widgets/RelationField.test.tsx
@@ -221,38 +221,30 @@ describe("RelationField", () => {
     ])
   })
 
-  it("should accept an onChange prop, which gets passed to the child select component", async () => {
-    const onChangeStub = jest.fn()
-    const fakeEvent = { target: { value: "abc" } }
-    await act(async () => {
+  //
+  ;[
+    ["name", "name"],
+    ["name.content", "name"]
+  ].forEach(([name, expectedName]) => {
+    it(`should accept an onChange prop with name=${name}, which gets modified then passed to the child select component`, async () => {
+      const onChangeStub = jest.fn()
       const { wrapper } = await render({
         onChange: onChangeStub
       })
       const select = wrapper.find("SelectField")
+      const numbers = ["one", "two", "three"]
+      const fakeEvent = { target: { value: numbers, name } }
       // @ts-ignore
       select.prop("onChange")(fakeEvent)
-    })
-    expect(onChangeStub).toBeCalledTimes(1)
-    expect(onChangeStub).toBeCalledWith(fakeEvent)
-  })
-
-  it("should accept a setFieldValue prop, which is called when the select field changes", async () => {
-    const setFieldValueStub = jest.fn()
-    await act(async () => {
-      const { wrapper } = await render({
-        name:          "nested.field",
-        setFieldValue: setFieldValueStub,
-        onChange:      null
+      expect(onChangeStub).toBeCalledWith({
+        target: {
+          name:  expectedName,
+          value: {
+            website: website.name,
+            content: numbers
+          }
+        }
       })
-      const select = wrapper.find("SelectField")
-      const fakeEvent = { target: { value: "abc" } }
-      // @ts-ignore
-      select.prop("onChange")(fakeEvent)
-    })
-    expect(setFieldValueStub).toBeCalledTimes(1)
-    expect(setFieldValueStub).toBeCalledWith("nested", {
-      website: website.name,
-      content: "abc"
     })
   })
 

--- a/static/js/components/widgets/RelationField.tsx
+++ b/static/js/components/widgets/RelationField.tsx
@@ -11,12 +11,10 @@ import {
   RelationFilterVariant,
   WebsiteContent
 } from "../../types/websites"
-import { SiteFormValue } from "../../types/forms"
-import { XOR } from "../../types/util"
 import { siteApiContentListingUrl } from "../../lib/urls"
 import { PaginatedResponse } from "../../query-configs/utils"
 
-type BaseProps = {
+type Props = {
   name: string
   collection?: string | string[]
   display_field: string // eslint-disable-line camelcase
@@ -28,17 +26,6 @@ type BaseProps = {
   contentContext: WebsiteContent[] | null
   onChange: (event: any) => void
 }
-
-/* NOTE: Either setFieldValue or onChange should be passed in, not both.
- * setFieldValue is passed in under normal circumstances when this widget is being used for some field described
- * in the site config.
- * onChange can be passed in when this widget is needed in a different context and the change behavior needs to be
- * customized.
- */
-type NormalWidgetProps = BaseProps & {
-  setFieldValue: (key: string, value: SiteFormValue) => void
-}
-type CustomProps = BaseProps & { onChange: (event: any) => void }
 
 const filterContent = curry((filter: RelationFilter, entry: WebsiteContent) => {
   if (!filter) {
@@ -52,9 +39,7 @@ const filterContent = curry((filter: RelationFilter, entry: WebsiteContent) => {
   return entry
 })
 
-export default function RelationField(
-  props: XOR<NormalWidgetProps, CustomProps>
-): JSX.Element {
+export default function RelationField(props: Props): JSX.Element {
   const {
     collection,
     contentContext,

--- a/static/js/lib/site_content.test.ts
+++ b/static/js/lib/site_content.test.ts
@@ -8,6 +8,7 @@ import RelationField from "../components/widgets/RelationField"
 import MenuField from "../components/widgets/MenuField"
 
 import {
+  makeWebsiteDetail,
   makeWebsiteConfigField,
   makeWebsiteContentDetail,
   makeFileConfigItem,
@@ -39,6 +40,7 @@ import {
   WidgetVariant
 } from "../types/websites"
 
+const OUR_WEBSITE = "our-website"
 describe("site_content", () => {
   const defaultsMapping = {
     [WidgetVariant.Markdown]: "",
@@ -47,7 +49,7 @@ describe("site_content", () => {
     [WidgetVariant.Text]:     "",
     [WidgetVariant.String]:   "",
     [WidgetVariant.Select]:   "",
-    [WidgetVariant.Relation]: { website: null, content: "" },
+    [WidgetVariant.Relation]: { website: OUR_WEBSITE, content: "" },
     [WidgetVariant.Menu]:     [],
     [WidgetVariant.Object]:   {
       ["nested-one"]: "",
@@ -74,7 +76,11 @@ describe("site_content", () => {
           widget: WidgetVariant.Markdown
         }
       ]
-      const payload = contentFormValuesToPayload(values, fields)
+      const payload = contentFormValuesToPayload(
+        values,
+        fields,
+        makeWebsiteDetail()
+      )
       expect(payload).toStrictEqual({
         markdown: "some content",
         title:    "a title"
@@ -147,7 +153,8 @@ describe("site_content", () => {
           tags: []
         },
         // @ts-ignore
-        [descriptionField]
+        [descriptionField],
+        makeWebsiteDetail()
       )
       expect(payload).toStrictEqual({ metadata: { tags: [] } })
     })
@@ -173,7 +180,8 @@ describe("site_content", () => {
             // @ts-ignore
             description: value
           },
-          [field]
+          [field],
+          makeWebsiteDetail()
         )
         expect(Object.values(payload).length).toBe(isPartOfPayload ? 1 : 0)
       })
@@ -191,7 +199,10 @@ describe("site_content", () => {
             makeWebsiteConfigField({ name: "nested-two" })
           ]
         })
-        const payload = contentFormValuesToPayload({}, [field])
+        const payload = contentFormValuesToPayload({}, [field], {
+          ...makeWebsiteDetail(),
+          name: OUR_WEBSITE
+        })
         expect(payload["metadata"]["test-field"]).toStrictEqual(expectedDefault)
       }
     })
@@ -244,7 +255,8 @@ describe("site_content", () => {
             makeWebsiteConfigField({ name: "nested-two" })
           ]
         })
-        const initialValues = newInitialValues([field])
+        const website = { ...makeWebsiteDetail(), name: OUR_WEBSITE }
+        const initialValues = newInitialValues([field], website)
         expect(initialValues).toStrictEqual({ widget: expectation })
       })
     })
@@ -255,7 +267,9 @@ describe("site_content", () => {
         multiple: true,
         label:    "Widget"
       })
-      expect(newInitialValues([field])).toStrictEqual({ widget: [] })
+      expect(newInitialValues([field], makeWebsiteDetail())).toStrictEqual({
+        widget: []
+      })
     })
 
     it("should use appropriate default for multiple relation", () => {
@@ -264,10 +278,11 @@ describe("site_content", () => {
         multiple: true,
         label:    "Widget"
       })
+      const website = makeWebsiteDetail()
 
-      expect(newInitialValues([field])).toStrictEqual({
+      expect(newInitialValues([field], website)).toStrictEqual({
         widget: {
-          website: null,
+          website: website.name,
           content: []
         }
       })
@@ -289,7 +304,7 @@ describe("site_content", () => {
           })
         ]
       })
-      expect(newInitialValues([field])).toStrictEqual({
+      expect(newInitialValues([field], makeWebsiteDetail())).toStrictEqual({
         myobject: {
           myselect: [],
           mystring: ""


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #412 

#### What's this PR do?
 - Sets website to the correct value (which is specified in the config) when creating a new form or adding a field without data on the backend
 - Sets website to the correct value when the relation field is updated

#### How should this be manually tested?
 - Create a new website with the ocw-course starter from [here](https://github.com/mitodl/ocw-hugo-projects/blob/main/ocw-course/ocw-studio.yaml)
 - Go to metadata. You should see a relation field for instructors. (You do *not* need to populate instructors, an empty list is fine here)
- Open your network tab. Add a department number to bypass validation, then click "Save"
- In your network tab you should see a POST to create the metadata:

        {
          "type": "sitemetadata",
          "metadata": {
            "department_numbers": [
              "6"
            ],
            "instructors": {
              "website": "course-7",
              "content": []
            }
          },
          "text_id": "sitemetadata"
        }

The `website` value should be the same as the name of your site. If you run through these steps on master the value will be `null` instead

Internal menu links should also still work with no change of behavior. To verify this:
 - Create a new site using the omnibus starter
 - Create a couple resources
 - Go to "Menu" on the side. Click "Add new"
 - In the side drawer create an internal link. You should see both resources in the dropdown. You should be able to update them, refresh the page and see the changes you made persist.