### PR TITLE
Add uniqBy to remove duplicate options for website collection UI

### DIFF
--- a/static/js/components/forms/WebsiteCollectionItemForm.tsx
+++ b/static/js/components/forms/WebsiteCollectionItemForm.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState } from "react"
 import { Form, Formik, Field, FormikHelpers, FormikProps } from "formik"
+import { uniqBy } from "ramda"
 
 import SelectField, { Option } from "../widgets/SelectField"
 import { WCItemCreateFormFields } from "../../types/forms"
@@ -35,7 +36,9 @@ export default function WebsiteCollectionItemForm(props: Props): JSX.Element {
       const json: WebsiteListingResponse = await response.json()
       const { results } = json
       const options = formatOptions(results)
-      setOptions(current => [...current, ...options])
+      setOptions(current =>
+        uniqBy(option => option.value, [...current, ...options])
+      )
       callback(options)
     },
     [setOptions]


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #400 

#### What's this PR do?
Adds a `uniqBy` to remove duplicate options in the website collection UI. Note that when `loadOptions` is set like it is here, the `SelectField` is implemented to use `options` only a lookup for labels. The options displayed to the user are replaced by `loadOptions` as the user types. Since a selected option may not appear in the results from `loadOptions` we still need that selected option to show up in the `options` list in the props for `SelectField`. This PR only makes sure that that `options` list doesn't have duplicates.

#### How should this be manually tested?
Go to `/collections` and edit a website collection. You should be able to use the course selection dropdown to find courses and add them to the collection.
