### PR TITLE
Fixed Hugo nav menu format

### DIFF
--- a/content_sync/serializers_test.py
+++ b/content_sync/serializers_test.py
@@ -64,18 +64,7 @@ description: '**This** is the description'
 title: Content Title
 """
 
-EXAMPLE_MENU_DATA = [
-    {"name": "Page 1", "weight": 0, "identifier": EXAMPLE_UUIDS[0]},
-    {
-        "name": "Ext Link",
-        "weight": 10,
-        "identifier": "external-12345",
-        "url": "http://example.com",
-    },
-]
-
-EXAMPLE_MENU_FILE_YAML = f"""menu:
-  mainmenu:
+EXAMPLE_MENU_FILE_YAML = f"""mainmenu:
   - identifier: {EXAMPLE_UUIDS[0]}
     name: Page 1
     weight: 0
@@ -85,6 +74,19 @@ EXAMPLE_MENU_FILE_YAML = f"""menu:
     weight: 10
     url: http://example.com
 """
+
+
+def get_example_menu_data():
+    """Returns example menu data"""
+    return [
+        {"name": "Page 1", "weight": 0, "identifier": EXAMPLE_UUIDS[0]},
+        {
+            "name": "Ext Link",
+            "weight": 10,
+            "identifier": "external-12345",
+            "url": "http://example.com",
+        },
+    ]
 
 
 @pytest.mark.django_db
@@ -179,21 +181,19 @@ def test_hugo_menu_yaml_serialize(omnibus_config):
         dirpath="path/to",
         filename="myfile",
     )
+    example_menu_data = get_example_menu_data()
     content = WebsiteContentFactory.build(
         is_page_content=False,
         type=nav_menu_config_item.name,
-        metadata={"mainmenu": EXAMPLE_MENU_DATA, "otherfield": "othervalue"},
+        metadata={"mainmenu": example_menu_data},
     )
     serialized_data = HugoMenuYamlFileSerializer(omnibus_config).serialize(content)
     parsed_serialized_data = yaml.load(serialized_data, Loader=yaml.Loader)
     assert parsed_serialized_data == {
-        "menu": {
-            "mainmenu": [
-                {**EXAMPLE_MENU_DATA[0], "url": "path/to/myfile.md"},
-                EXAMPLE_MENU_DATA[1],
-            ]
-        },
-        "otherfield": "othervalue",
+        "mainmenu": [
+            {**example_menu_data[0], "url": "path/to/myfile.md"},
+            example_menu_data[1],
+        ],
         "title": content.title,
     }
 
@@ -209,14 +209,10 @@ def test_hugo_menu_yaml_deserialize(omnibus_config):
     website_content = serializer.deserialize(
         website=website,
         filepath=filepath,
-        file_contents=f"{EXAMPLE_MENU_FILE_YAML}otherfield: othervalue",
+        file_contents=EXAMPLE_MENU_FILE_YAML,
     )
     assert website_content.metadata == {
-        "mainmenu": [
-            {**EXAMPLE_MENU_DATA[0], "url": "content/page-1.md"},
-            EXAMPLE_MENU_DATA[1],
-        ],
-        "otherfield": "othervalue",
+        "mainmenu": get_example_menu_data(),
     }
 
 

--- a/localdev/configs/ocw-course-site-config.yml
+++ b/localdev/configs/ocw-course-site-config.yml
@@ -38,7 +38,7 @@ collections:
     label: Menu
     category: Settings
     files:
-      - file: config/menu-sidenav.yml
+      - file: config/_default/menus.yaml
         name: navmenu
         label: Navigation Menu
         fields:

--- a/localdev/configs/omnibus-site-config.yml
+++ b/localdev/configs/omnibus-site-config.yml
@@ -95,7 +95,7 @@ collections:
     label: Menu
     category: Settings
     files:
-      - file: config/menu-sidenav.yml
+      - file: config/_default/menus.yaml
         name: navmenu
         label: Navigation Menu
         fields:

--- a/static/js/resources/ocw-course-site-config.json
+++ b/static/js/resources/ocw-course-site-config.json
@@ -67,7 +67,7 @@
               "widget": "menu"
             }
           ],
-          "file": "config/menu-sidenav.yml",
+          "file": "config/_default/menus.yaml",
           "label": "Navigation Menu",
           "name": "navmenu"
         }

--- a/static/js/resources/omnibus-site-config.json
+++ b/static/js/resources/omnibus-site-config.json
@@ -197,7 +197,7 @@
               "widget": "menu"
             }
           ],
-          "file": "config/menu-sidenav.yml",
+          "file": "config/_default/menus.yaml",
           "label": "Navigation Menu",
           "name": "navmenu"
         }

--- a/websites/config_schema/api.py
+++ b/websites/config_schema/api.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from websites.config_schema.validators import (
     CollectionsKeysRule,
     ContentFolderRule,
+    MenuOnlyRule,
     RequiredTitleRule,
     UniqueNamesRule,
 )
@@ -24,6 +25,7 @@ ADDED_SCHEMA_RULES = [
     UniqueNamesRule,
     ContentFolderRule,
     RequiredTitleRule,
+    MenuOnlyRule,
 ]
 
 

--- a/websites/config_schema/api_test.py
+++ b/websites/config_schema/api_test.py
@@ -126,3 +126,19 @@ def test_required_title_rule(parsed_site_config, attr, value):
     }
     with pytest.raises(ValueError):
         validate_parsed_site_config(config)
+
+
+def test_menu_rule(parsed_site_config):
+    """If a config item includes a "menu" widget field, it should not have any other fields with other widget types"""
+    config = parsed_site_config.copy()
+    menu_field = {"name": "menu1", "label": "Menu 1", "widget": "menu"}
+    # One "menu"-widget field and one non-"menu"-widget field
+    config["collections"][0] = {
+        **config["collections"][0],
+        "fields": config["collections"][0]["fields"] + [menu_field],
+    }
+    with pytest.raises(ValueError):
+        validate_parsed_site_config(config)
+    # Two "menu"-widget fields
+    config["collections"][0]["fields"] = [menu_field, {**menu_field, "name": "menu2"}]
+    validate_parsed_site_config(config)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #416 

#### What's this PR do?
Fixes the Hugo menu format produced when serializing a config item with `menu` widgets

#### How should this be manually tested?
(copied from #364)

**DB TO GITHUB:**
- Add/edit some data for a field with a "menu" widget (see #340) and save it
- Either thru automatic sync or the `sync_website_to_backend` management command, sync the website to Github
- Check the target file in Github

For each "menu" field, all internal links should have an accurate "url" destination

Example:

```yaml
sidemenu:
  - identifier: c5047db5-5d30-481f-878c-4fe79eebeeb1
    name: Page 1
    url: content/page-1.md
    weight: 0
  - identifier: 38223bd4-8eae-4a81-91c2-b36cac529d69
    name: Page 3
    url: content/page-3.md
    weight: 10
```

**GITHUB TO DB:**
- Note the contents of your `WebsiteContent` record, then hard-delete it
- Run the `sync_backend_to_db` command to recreate that record

The `WebsiteContent` record should be recreated with the same data

#### Any background context you want to provide?
https://gohugo.io/getting-started/configuration/#configuration-directory
