### PR TITLE
Add preventDefault to menu buttons

### DIFF
--- a/static/js/components/widgets/MenuField.test.tsx
+++ b/static/js/components/widgets/MenuField.test.tsx
@@ -95,8 +95,12 @@ describe("MenuField", () => {
     } else {
       formShowBtn = wrapper.find("button.blue-button")
     }
-    formShowBtn.simulate("click")
+    const preventDefaultStub = jest.fn()
+    formShowBtn.prop("onClick")({ preventDefault: preventDefaultStub })
     wrapper.update()
+    if (menuItem) {
+      expect(preventDefaultStub).toBeCalledTimes(1)
+    }
     const itemFormPanel = wrapper.find("BasicModal")
     expect(itemFormPanel.prop("isVisible")).toBe(true)
     return itemFormPanel.dive().find("MenuItemForm")
@@ -146,8 +150,11 @@ describe("MenuField", () => {
     expect(deleteBtn.exists()).toBe(true)
     expect(deleteBtn.prop("className")).toContain("material-icons")
     expect(deleteBtn.text()).toEqual("delete")
-    deleteBtn.simulate("click")
+    const preventDefaultStub = jest.fn()
+    // @ts-ignore
+    deleteBtn.prop("onClick")({ preventDefault: preventDefaultStub })
     wrapper.update()
+    expect(preventDefaultStub).toBeCalledTimes(1)
     const removeDialog = wrapper.find("Dialog")
     expect(removeDialog.prop("open")).toBe(true)
     removeDialog.prop("onAccept")()

--- a/static/js/components/widgets/MenuField.tsx
+++ b/static/js/components/widgets/MenuField.tsx
@@ -316,13 +316,19 @@ export default function MenuField(props: MenuFieldProps): JSX.Element {
       <span className="flex-grow-0 d-inline-flex">
         <button
           className="material-icons mr-2"
-          onClick={() => startEditMenuItem(item as InternalSortableMenuItem)}
+          onClick={event => {
+            event.preventDefault()
+            startEditMenuItem(item as InternalSortableMenuItem)
+          }}
         >
           settings
         </button>
         <button
           className="material-icons"
-          onClick={() => setItemToRemove(item as InternalSortableMenuItem)}
+          onClick={event => {
+            event.preventDefault()
+            setItemToRemove(item as InternalSortableMenuItem)
+          }}
         >
           delete
         </button>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #426 

#### What's this PR do?
Adds `event.preventDefault()` to a couple buttons so that the click doesn't propagate and the containing form isn't submitted

#### How should this be manually tested?

 - Create or reuse a site with the omnibus starter
 - Click on Menu in the sidebar
 - Click on "Add New" and create an external link. Click Save in the drawer, then click Save again on the menu page
 - Refresh your browser and open your network tab
 - Click on the gear icon next to the link you created.

On master you should see the PATCH request in the network tab, but on this PR you should not. Otherwise there shouldn't be a change, you should be able to edit the menu as before.