### PR TITLE
Remove text_id parameter, instead use content_context for MenuField

### DIFF
--- a/static/js/components/forms/MenuItemForm.test.tsx
+++ b/static/js/components/forms/MenuItemForm.test.tsx
@@ -4,18 +4,25 @@ import { shallow } from "enzyme"
 import MenuItemForm from "./MenuItemForm"
 import { defaultFormikChildProps } from "../../test_util"
 
-import { LinkType } from "../../types/websites"
+import { LinkType, WebsiteContent } from "../../types/websites"
+import { makeWebsiteContentDetail } from "../../util/factories/websites"
 
 describe("MenuItemForm", () => {
-  let onSubmitStub: any
+  let onSubmitStub: any, contentContext: WebsiteContent[]
 
   beforeEach(() => {
     onSubmitStub = jest.fn()
+    contentContext = [makeWebsiteContentDetail(), makeWebsiteContentDetail()]
   })
 
   const renderForm = (props = {}) =>
     shallow(
-      <MenuItemForm activeItem={null} onSubmit={onSubmitStub} {...props} />
+      <MenuItemForm
+        activeItem={null}
+        onSubmit={onSubmitStub}
+        contentContext={contentContext}
+        {...props}
+      />
     )
 
   const renderInnerForm = (
@@ -167,7 +174,7 @@ describe("MenuItemForm", () => {
     expect(relationField.exists()).toBe(true)
     expect(relationField.prop("value")).toEqual(value)
     expect(relationField.prop("valuesToOmit")).toEqual(existingMenuIds)
-    expect(relationField.prop("contentContext")).toBeNull()
+    expect(relationField.prop("contentContext")).toBe(contentContext)
     expect(relationField.prop("collection")).toEqual(collections)
     const fakeEvent = { target: { value: "abc" } }
     // @ts-ignore

--- a/static/js/components/forms/MenuItemForm.tsx
+++ b/static/js/components/forms/MenuItemForm.tsx
@@ -6,7 +6,7 @@ import { InternalSortableMenuItem } from "../widgets/MenuField"
 import RelationField from "../widgets/RelationField"
 import { FormError } from "./FormError"
 
-import { LinkType } from "../../types/websites"
+import { LinkType, WebsiteContent } from "../../types/websites"
 
 interface Props {
   onSubmit: (
@@ -16,6 +16,7 @@ interface Props {
   activeItem: InternalSortableMenuItem | null
   collections?: string[]
   existingMenuIds?: Set<string>
+  contentContext: WebsiteContent[] | null
 }
 
 export type MenuItemFormValues = {
@@ -59,7 +60,8 @@ export default function MenuItemForm({
   onSubmit,
   activeItem,
   collections,
-  existingMenuIds
+  existingMenuIds,
+  contentContext
 }: Props): JSX.Element {
   const initialValues = useMemo(
     () =>
@@ -141,7 +143,7 @@ export default function MenuItemForm({
                     }}
                     value={values.internalLink}
                     valuesToOmit={existingMenuIds}
-                    contentContext={null}
+                    contentContext={contentContext}
                   />
                   <ErrorMessage name="internalLink" component={FormError} />
                 </>

--- a/static/js/components/widgets/MenuField.test.tsx
+++ b/static/js/components/widgets/MenuField.test.tsx
@@ -3,7 +3,8 @@ import { shallow } from "enzyme"
 import MenuField, { HugoItem, InternalSortableMenuItem } from "./MenuField"
 import { EXTERNAL_LINK_PREFIX } from "../../constants"
 
-import { LinkType } from "../../types/websites"
+import { LinkType, WebsiteContent } from "../../types/websites"
+import { makeWebsiteContentDetail } from "../../util/factories/websites"
 
 const dummyHugoItems: HugoItem[] = [
   {
@@ -65,11 +66,12 @@ const dummyInternalMenuItems: InternalSortableMenuItem[] = [
 ]
 
 describe("MenuField", () => {
-  let render: any, onChangeStub: any
+  let render: any, onChangeStub: any, contentContext: WebsiteContent[]
   const fieldName = "mymenu"
 
   beforeEach(() => {
     onChangeStub = jest.fn()
+    contentContext = [makeWebsiteContentDetail(), makeWebsiteContentDetail()]
 
     render = (props = {}) =>
       shallow(
@@ -77,6 +79,7 @@ describe("MenuField", () => {
           onChange={onChangeStub}
           name={fieldName}
           value={dummyHugoItems}
+          contentContext={contentContext}
           {...props}
         />
       )

--- a/static/js/components/widgets/MenuField.tsx
+++ b/static/js/components/widgets/MenuField.tsx
@@ -7,13 +7,14 @@ import Dialog from "../Dialog"
 import { EXTERNAL_LINK_PREFIX } from "../../constants"
 import { generateHashCode, isExternalLinkId } from "../../lib/util"
 
-import { LinkType } from "../../types/websites"
+import { LinkType, WebsiteContent } from "../../types/websites"
 
 interface MenuFieldProps {
   name: string
   value: HugoItem[]
   onChange: (event: Event) => void
   collections?: string[]
+  contentContext: WebsiteContent[] | null
 }
 
 export type HugoItem = {
@@ -237,7 +238,7 @@ const getItemPath = (
 }
 
 export default function MenuField(props: MenuFieldProps): JSX.Element {
-  const { name, value, onChange, collections } = props
+  const { name, value, onChange, collections, contentContext } = props
 
   const [menuData, setMenuData] = useState<{
     hugoItems: HugoItem[]
@@ -399,6 +400,7 @@ export default function MenuField(props: MenuFieldProps): JSX.Element {
               onSubmit={values => {
                 onSubmitMenuItem({ values, hideModal: modalProps.hideModal })
               }}
+              contentContext={contentContext}
               {...(collections ? { collections: collections } : {})}
             />
           </div>

--- a/websites/views.py
+++ b/websites/views.py
@@ -365,9 +365,6 @@ class WebsiteContentViewSet(
         parent_lookup_website = self.kwargs.get("parent_lookup_website")
         search = self.request.query_params.get("search")
         types = _get_value_list_from_query_params(self.request.query_params, "type")
-        text_ids = _get_value_list_from_query_params(
-            self.request.query_params, "text_id"
-        )
 
         queryset = WebsiteContent.objects.filter(
             website__name=parent_lookup_website
@@ -376,8 +373,6 @@ class WebsiteContentViewSet(
             queryset = queryset.filter(type__in=types)
         if search:
             queryset = queryset.filter(title__icontains=search)
-        if text_ids:
-            queryset = queryset.filter(text_id__in=text_ids)
 
         if "page_content" in self.request.query_params:
             queryset = queryset.filter(

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -451,16 +451,12 @@ def test_website_starters_site_configs_exception(mocker, drf_client):
 
 @pytest.mark.parametrize("detailed_list", [True, False])
 @pytest.mark.parametrize(
-    "filter_type, search, has_text_id, expected_num_results",
+    "filter_type, search, expected_num_results",
     [
-        ["page", "text3", True, 0],
-        ["page", "text3", False, 1],
-        ["page", "", True, 2],
-        ["page", "", False, 5],
-        ["", "text3", True, 0],
-        ["", "text3", False, 1],
-        ["", "", True, 2],
-        ["", "", False, 6],
+        ["page", "text3", 1],
+        ["page", "", 5],
+        ["", "text3", 1],
+        ["", "", 6],
     ],
 )
 def test_websites_content_list(
@@ -468,7 +464,6 @@ def test_websites_content_list(
     filter_type,
     search,
     detailed_list,
-    has_text_id,
     global_admin_user,
     expected_num_results,
 ):
@@ -496,9 +491,6 @@ def test_websites_content_list(
         query_params["type"] = filter_type
     if detailed_list:
         query_params["detailed_list"] = detailed_list
-    if has_text_id:
-        query_params["text_id[0]"] = contents[0].text_id
-        query_params["text_id[1]"] = contents[1].text_id
     if search:
         query_params["search"] = search
 
@@ -515,12 +507,6 @@ def test_websites_content_list(
     assert resp.data["count"] == expected_num_results
     assert len(results) == expected_num_results
 
-    if has_text_id:
-        contents = [
-            content
-            for content in contents
-            if content.text_id in (contents[0].text_id, contents[1].text_id)
-        ]
     if search:
         contents = [content for content in contents if search in content.title.lower()]
     for idx, content in enumerate(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to #402 

#### What's this PR do?
There are a couple optimizations I broke apart from the other work in #402:
 - Previously `content_context` was passed to `RelationField` for most cases but it was `null` for internal links in `MenuField`. We added code in the backend to produce `content_context` for menu fields in #407. This includes that `content_context` value so that the `RelationField` for internal links in `MenuField` can make use of it
 - This means we don't need to make an extra request for content for a given `text_id`. I removed the code related to the `text_id` parameter since it's now unused

#### How should this be manually tested?
Nothing should appear different for the end user. See the manual testing instructions in this PR for testing internal links and other uses of `RelationField`: https://github.com/mitodl/ocw-studio/pull/402
