### PR TITLE
Use debounced fetch for website collection course search

### DIFF
--- a/static/js/components/forms/WebsiteCollectionItemForm.tsx
+++ b/static/js/components/forms/WebsiteCollectionItemForm.tsx
@@ -7,6 +7,7 @@ import { WCItemCreateFormFields } from "../../types/forms"
 import { Website } from "../../types/websites"
 import { useMutation } from "redux-query-react"
 import { siteApiListingUrl } from "../../lib/urls"
+import { debouncedFetch } from "../../lib/api/util"
 import { WebsiteListingResponse } from "../../query-configs/websites"
 import { WebsiteCollection } from "../../types/website_collections"
 import { createWebsiteCollectionItemMutation } from "../../query-configs/website_collections"
@@ -32,7 +33,13 @@ export default function WebsiteCollectionItemForm(props: Props): JSX.Element {
       // using plain fetch rather than redux-query here because this
       // use-case doesn't exactly jibe with redux-query: we need to issue
       // a request programmatically on user input.
-      const response = await fetch(url)
+      const response = await debouncedFetch("website-collection", 300, url, {
+        credentials: "include"
+      })
+      if (!response) {
+        // this happens if this fetch was ignored in favor of a later fetch
+        return
+      }
       const json: WebsiteListingResponse = await response.json()
       const { results } = json
       const options = formatOptions(results)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #394 

#### What's this PR do?
Make fetch debounced so that only the latest in a certain period of time is used. A request should only be made every 300 ms or so instead of on every keystroke

#### How should this be manually tested?
Go to `/collections` and edit a collection. Open the network tab. Type some website names in the course search widget. In the network tab you should see requests made only every 300 ms or so. You should also have correct search results when you stop typing.
