### PR TITLE
Handle valuesToOmit when value is a list

### DIFF
--- a/static/js/components/widgets/RelationField.test.tsx
+++ b/static/js/components/widgets/RelationField.test.tsx
@@ -264,8 +264,6 @@ describe("RelationField", () => {
     // @ts-ignore
     wrapper.update()
     // @ts-ignore
-    global.fetch.mockClear()
-    // @ts-ignore
     const loadOptions = wrapper.find("SelectField").prop("loadOptions")
     const searchString1 = "searchstring1",
       searchString2 = "searchstring2"
@@ -309,5 +307,44 @@ describe("RelationField", () => {
       fakeResponse.results.map(asOption),
       fakeResponse.results.map(asOption)
     ])
+  })
+
+  //
+  ;[true, false].forEach(valueIsArray => {
+    it(`should omit items listed by valuesToOmit, except those already selected, when value ${
+      valueIsArray ? "is" : "is not"
+    } an array`, async () => {
+      let wrapper: ReactWrapper, loadOptionsResponse
+      const valuesToOmit = new Set([
+        contentListingItems[0].text_id,
+        contentListingItems[2].text_id,
+        contentListingItems[3].text_id
+      ])
+      const value = valueIsArray ?
+        [contentListingItems[0].text_id, contentListingItems[1].text_id] :
+        contentListingItems[0].text_id
+      const expectedResults = fakeResponse.results.filter(
+        (_: any, idx: number) => idx !== 2 && idx !== 3
+      )
+      const expectedOptions = expectedResults.map(asOption)
+
+      await act(async () => {
+        wrapper = (await render({ valuesToOmit, value })).wrapper
+      })
+      // @ts-ignore
+      wrapper.update()
+      // @ts-ignore
+      const loadOptions = wrapper.find("SelectField").prop("loadOptions")
+
+      // @ts-ignore
+      debouncedFetch.mockResolvedValue({ json: async () => fakeResponse })
+
+      await act(async () => {
+        // @ts-ignore
+        loadOptionsResponse = await loadOptions()
+      })
+
+      expect(loadOptionsResponse).toStrictEqual(expectedOptions)
+    })
   })
 })

--- a/static/js/components/widgets/RelationField.tsx
+++ b/static/js/components/widgets/RelationField.tsx
@@ -114,8 +114,12 @@ export default function RelationField(
       newContentListing = newContentListing.filter(filterContent(filter))
     }
     if (valuesToOmit) {
+      const valueAsSet = Array.isArray(value) ?
+        new Set(value) :
+        new Set([value])
       newContentListing = newContentListing.filter(
-        entry => !valuesToOmit.has(entry.text_id) || value === entry.text_id
+        entry =>
+          !valuesToOmit.has(entry.text_id) || valueAsSet.has(entry.text_id)
       )
     }
     return newContentListing


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested

#### What are the relevant tickets?
Fixes #401 

#### What's this PR do?
Fixes bug where `valuesToOmit` didn't handle `value` when it is a list, which is the case when `multiple` is true.

#### How should this be manually tested?
I don't think there's a way to demonstrate this bug since the only code using `valuesToOmit` is the internal link code and that only uses `value` as a string. I would just make sure the internal link UI still works fine.
