### PR TITLE
Use both website name and content textId for lookup

### DIFF
--- a/static/js/components/SingletonsContentListing.test.tsx
+++ b/static/js/components/SingletonsContentListing.test.tsx
@@ -154,6 +154,7 @@ describe("SingletonsContentListing", () => {
         .stub(siteContentFuncs, "needsContentContext")
         .returns(contentContext)
       const tabIndexToSelect = 1
+      const newContent = makeWebsiteContentDetail()
       contentDetailStub = helper.handleRequestStub
         .withArgs(
           siteApiContentDetailUrl
@@ -166,7 +167,7 @@ describe("SingletonsContentListing", () => {
           "GET"
         )
         .returns({
-          body:   content,
+          body:   newContent,
           status: 200
         })
       const { wrapper } = await render()
@@ -178,11 +179,23 @@ describe("SingletonsContentListing", () => {
         // @ts-ignore
         tabLink.prop("onClick")({ preventDefault: helper.sandbox.stub() })
       })
+      wrapper.update()
       sinon.assert.calledOnce(contentDetailStub)
       sinon.assert.calledWith(
         needsContentContextStub,
-        singletonConfigItems[0].fields
+        singletonConfigItems[tabIndexToSelect].fields
       )
+      expect(
+        wrapper
+          .find("SiteContentEditor")
+          .at(tabIndexToSelect)
+          .prop("content")
+      ).toBe(newContent)
+      wrapper.find("SiteContentEditor").forEach((editorWrapper, idx) => {
+        if (idx !== tabIndexToSelect) {
+          expect(editorWrapper.prop("content")).toBeNull()
+        }
+      })
     })
   })
 

--- a/static/js/components/SingletonsContentListing.tsx
+++ b/static/js/components/SingletonsContentListing.tsx
@@ -27,16 +27,19 @@ export default function SingletonsContentListing(props: {
   }
 
   const activeFileConfigItem = configItem.files[activeTab]
+  const contentDetailParams = {
+    name:   website.name,
+    textId: activeFileConfigItem.name
+  }
   const content = useSelector(getWebsiteContentDetailCursor)(
-    activeFileConfigItem.name
+    contentDetailParams
   )
 
   const [{ isPending }] = useRequest(
     content ?
       null :
       websiteContentDetailRequest(
-        website.name,
-        activeFileConfigItem.name,
+        contentDetailParams,
         needsContentContext(activeFileConfigItem.fields)
       )
   )
@@ -66,7 +69,7 @@ export default function SingletonsContentListing(props: {
                 "Loading..."
               ) : (
                 <SiteContentEditor
-                  content={content}
+                  content={activeTab === i ? content : null}
                   loadContent={false}
                   configItem={fileConfigItem}
                   textId={fileConfigItem.name}

--- a/static/js/components/SiteContentEditor.test.tsx
+++ b/static/js/components/SiteContentEditor.test.tsx
@@ -31,6 +31,7 @@ import {
   WebsiteContent,
   WidgetVariant
 } from "../types/websites"
+import { contentDetailKey } from "../query-configs/websites"
 
 jest.mock("./forms/validation")
 
@@ -110,7 +111,10 @@ describe("SiteContent", () => {
             [website.name]: website
           },
           websiteContentDetails: {
-            [content.text_id]: content
+            [contentDetailKey({
+              name:   website.name,
+              textId: content.text_id
+            })]: content
           }
         },
         queries: {}
@@ -228,7 +232,7 @@ describe("SiteContent", () => {
         configItem = makeSingletonConfigItem(configItem.name)
         expAddedPayload = { text_id: configItem.name }
       }
-      const { wrapper } = await render({
+      const { wrapper, store } = await render({
         formType:   ContentFormType.Add,
         textId:     null,
         configItem: configItem,
@@ -264,6 +268,13 @@ describe("SiteContent", () => {
 
       sinon.assert.calledWith(refreshStub)
       sinon.assert.calledWith(hideModalStub)
+      const key = contentDetailKey({
+        textId: content.text_id,
+        name:   website.name
+      })
+      expect(
+        store.getState().entities.websiteContentDetails[key]
+      ).toStrictEqual(content)
     })
   })
 
@@ -279,7 +290,7 @@ describe("SiteContent", () => {
         body:   content,
         status: 200
       })
-    const { wrapper } = await render({
+    const { wrapper, store } = await render({
       formType: ContentFormType.Edit,
       ...successStubs
     })
@@ -313,6 +324,13 @@ describe("SiteContent", () => {
 
     sinon.assert.calledWith(refreshStub)
     sinon.assert.calledWith(hideModalStub)
+    // @ts-ignore
+    expect(store.getState().entities.websiteContentDetails).toStrictEqual({
+      [contentDetailKey({
+        textId: content.text_id,
+        name:   website.name
+      })]: content
+    })
   })
 
   //

--- a/static/js/components/SiteContentEditor.tsx
+++ b/static/js/components/SiteContentEditor.tsx
@@ -30,7 +30,7 @@ import {
 import { ContentFormType, SiteFormValues } from "../types/forms"
 
 interface Props {
-  content?: WebsiteContent
+  content?: WebsiteContent | null
   loadContent: boolean
   textId: string | null
   configItem: EditableConfigItem
@@ -63,7 +63,7 @@ export default function SiteContentEditor(props: Props): JSX.Element | null {
     { isPending: editIsPending },
     editWebsiteContent
   ] = useMutation((payload: EditWebsiteContentPayload | FormData) =>
-    editWebsiteContentMutation(site, textId!, configItem.name, payload)
+    editWebsiteContentMutation({ name: site.name, textId: textId! }, payload)
   )
 
   let isPending = false,
@@ -77,9 +77,8 @@ export default function SiteContentEditor(props: Props): JSX.Element | null {
   const queryTuple = useRequest(
     shouldLoadContent ?
       websiteContentDetailRequest(
-        site.name,
-          textId as string,
-          needsContentContext(fields)
+        { name: site.name, textId: textId as string },
+        needsContentContext(fields)
       ) :
       null
   )
@@ -89,7 +88,10 @@ export default function SiteContentEditor(props: Props): JSX.Element | null {
 
   if (shouldLoadContent) {
     isPending = queryTuple[0].isPending
-    content = websiteContentDetailSelector(textId as string)
+    content = websiteContentDetailSelector({
+      name:   site.name,
+      textId: textId as string
+    })
   }
 
   if (isPending || (formType === ContentFormType.Edit && !content)) {

--- a/static/js/selectors/websites.ts
+++ b/static/js/selectors/websites.ts
@@ -3,6 +3,7 @@ import { memoize } from "lodash"
 import { find, propEq } from "ramda"
 
 import {
+  contentDetailKey,
   contentListingKey,
   WebsiteDetails,
   WebsiteListingResponse,
@@ -14,7 +15,8 @@ import {
   WebsiteStarter,
   WebsiteContentListItem,
   Website,
-  WebsiteContent
+  WebsiteContent,
+  ContentDetailParams
 } from "../types/websites"
 
 export const getWebsiteDetailCursor = createSelector(
@@ -63,7 +65,7 @@ export const getWebsiteCollaboratorDetailCursor = createSelector(
 export const getWebsiteContentDetailCursor = createSelector(
   (state: ReduxState) => state.entities?.websiteContentDetails ?? {},
   (content: Record<string, WebsiteContent>) =>
-    memoize((textId: string) => content[textId])
+    memoize((params: ContentDetailParams) => content[contentDetailKey(params)])
 )
 
 interface WebsiteContentItem {
@@ -81,7 +83,9 @@ export const getWebsiteContentListingCursor = createSelector(
       (listingParams: ContentListingParams): WebsiteContentItem => {
         const response = listing[contentListingKey(listingParams)] ?? {}
         const uuids: string[] = response?.results ?? []
-        const items = uuids.map(websiteContentDetailCursor)
+        const items = uuids.map(uuid =>
+          websiteContentDetailCursor({ name: listingParams.name, textId: uuid })
+        )
 
         return {
           ...response,

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -236,6 +236,11 @@ export interface ContentListingParams {
   offset: number
 }
 
+export interface ContentDetailParams {
+  name: string
+  textId: string
+}
+
 export enum LinkType {
   Internal = "internal",
   External = "external"


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Fixes #429 

#### What's this PR do?
We were using `textId` as the only lookup value for our frontend content detail data. However we also need to include the website name to make it a unique key. This updates the key to 

#### How should this be manually tested?

 - Find or create two courses based on the ocw-course starter. Ideally they should be right next to each other in the site listing
 - Add some content to the metadata for each of the two sites. It doesn't matter what fields you update, it just needs to be distinct for each site. 
 - Go to `/sites` and find the link for the first of the two sites. Click on that link, then click on "Metadata". The metadata fields should look correct.
 - Click the back button repeatedly until you get back to `/sites`. Click on the link for the second site then click on "Metadata". You should see the correct data for the website, which is different from the metadata for the first site.
 - Additionally, go to a page listing page and make sure things still work in general
