### PR TITLE
fix some console warnings in RelationField tests

### DIFF
--- a/static/js/components/widgets/RelationField.test.tsx
+++ b/static/js/components/widgets/RelationField.test.tsx
@@ -234,8 +234,10 @@ describe("RelationField", () => {
       const select = wrapper.find("SelectField")
       const numbers = ["one", "two", "three"]
       const fakeEvent = { target: { value: numbers, name } }
-      // @ts-ignore
-      select.prop("onChange")(fakeEvent)
+      await act(async () => {
+        // @ts-ignore
+        await select.prop("onChange")(fakeEvent)
+      })
       expect(onChangeStub).toBeCalledWith({
         target: {
           name:  expectedName,


### PR DESCRIPTION
#### Pre-Flight checklist


- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

no ticket, just noticed these and wanted to fix

#### What's this PR do?

adds an `await act(async () => ...` call around an action that was triggering an update and an console warning.

#### How should this be manually tested?

run the tests locally and observe the issue on master:

```
npm run test -- RelationField
```

then the run the tests on this branch and see it's fixed