### PR TITLE
switch site content over to user ModalState

### DIFF
--- a/static/js/components/RepeatableContentListing.test.tsx
+++ b/static/js/components/RepeatableContentListing.test.tsx
@@ -32,6 +32,7 @@ import {
   WebsiteContentListItem
 } from "../types/websites"
 import { WEBSITE_CONTENT_PAGE_SIZE } from "../constants"
+import { createModalState } from "../types/modal_state"
 
 jest.mock("react-router-dom", () => ({
   // @ts-ignore
@@ -144,7 +145,9 @@ describe("RepeatableContentListing", () => {
     wrapper.update()
     const editorModal = wrapper.find("BasicModal")
     const siteContentEditor = editorModal.find("SiteContentEditor")
-    expect(siteContentEditor.prop("textId")).toBeNull()
+    expect(siteContentEditor.prop("editorState")).toEqual(
+      createModalState("adding")
+    )
     expect(editorModal.prop("isVisible")).toBe(true)
 
     act(() => {
@@ -186,7 +189,9 @@ describe("RepeatableContentListing", () => {
       wrapper.update()
       const editorModal = wrapper.find("BasicModal")
       const siteContentEditor = editorModal.find("SiteContentEditor")
-      expect(siteContentEditor.prop("textId")).toBe(item.text_id)
+      expect(siteContentEditor.prop("editorState")).toEqual(
+        createModalState("editing", item.text_id)
+      )
       expect(editorModal.prop("isVisible")).toBe(true)
 
       act(() => {
@@ -199,6 +204,8 @@ describe("RepeatableContentListing", () => {
       idx++
     }
   })
+
+  //
   ;[true, false].forEach(hasPrevLink => {
     [true, false].forEach(hasNextLink => {
       it(`shows the right links when there ${isIf(

--- a/static/js/components/SingletonsContentListing.test.tsx
+++ b/static/js/components/SingletonsContentListing.test.tsx
@@ -25,7 +25,7 @@ import {
   WebsiteContent
 } from "../types/websites"
 import sinon, { SinonStub } from "sinon"
-import { ContentFormType } from "../types/forms"
+import { createModalState } from "../types/modal_state"
 
 jest.mock("react-router-dom", () => ({
   // @ts-ignore
@@ -209,8 +209,7 @@ describe("SingletonsContentListing", () => {
       content:     content,
       loadContent: false,
       configItem:  singletonConfigItems[0],
-      textId:      singletonConfigItems[0].name,
-      formType:    ContentFormType.Edit
+      editorState: createModalState("editing", singletonConfigItems[0].name)
     })
   })
 })

--- a/static/js/components/SingletonsContentListing.tsx
+++ b/static/js/components/SingletonsContentListing.tsx
@@ -7,13 +7,11 @@ import Card from "./Card"
 import { useWebsite } from "../context/Website"
 
 import { websiteContentDetailRequest } from "../query-configs/websites"
-
 import { SingletonsConfigItem } from "../types/websites"
-import { ContentFormType } from "../types/forms"
-
 import { getWebsiteContentDetailCursor } from "../selectors/websites"
 import SiteContentEditor from "./SiteContentEditor"
 import { needsContentContext } from "../lib/site_content"
+import { createModalState } from "../types/modal_state"
 
 export default function SingletonsContentListing(props: {
   configItem: SingletonsConfigItem
@@ -72,9 +70,10 @@ export default function SingletonsContentListing(props: {
                   content={activeTab === i ? content : null}
                   loadContent={false}
                   configItem={fileConfigItem}
-                  textId={fileConfigItem.name}
-                  formType={
-                    content ? ContentFormType.Edit : ContentFormType.Add
+                  editorState={
+                    content ?
+                      createModalState("editing", fileConfigItem.name) :
+                      createModalState("adding")
                   }
                 />
               )}

--- a/static/js/components/WebsiteCollectionEditor.test.tsx
+++ b/static/js/components/WebsiteCollectionEditor.test.tsx
@@ -27,7 +27,7 @@ describe("WebsiteCollectionEditor", () => {
     hideModalStub = helper.sandbox.stub()
     render = helper.configureRenderer(WebsiteCollectionEditor, {
       hideModal:  hideModalStub,
-      modalState: createModalState("closed", null)
+      modalState: createModalState("closed")
     })
   })
 
@@ -45,7 +45,7 @@ describe("WebsiteCollectionEditor", () => {
 
     it("should pass initial values down to the form", async () => {
       const { wrapper } = await render({
-        modalState: createModalState("adding", null)
+        modalState: createModalState("adding")
       })
       expect(
         wrapper.find("WebsiteCollectionForm").prop("initialValues")
@@ -57,7 +57,7 @@ describe("WebsiteCollectionEditor", () => {
 
     it("should close the modal after saving", async () => {
       const { wrapper } = await render({
-        modalState: createModalState("adding", null)
+        modalState: createModalState("adding")
       })
       await act(async () =>
         wrapper.find("WebsiteCollectionForm").prop("onSubmit")!({
@@ -70,7 +70,7 @@ describe("WebsiteCollectionEditor", () => {
 
     it("should allow us to create a new collection", async () => {
       const { wrapper } = await render({
-        modalState: createModalState("adding", null)
+        modalState: createModalState("adding")
       })
       await act(async () =>
         wrapper.find("WebsiteCollectionForm").prop("onSubmit")!({

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -23,9 +23,10 @@ import {
   WebsiteContent,
   WidgetVariant,
   ConfigField,
-  EditableConfigItem
+  EditableConfigItem,
+  WebsiteContentModalState
 } from "../../types/websites"
-import { ContentFormType, SiteFormValues } from "../../types/forms"
+import { SiteFormValues } from "../../types/forms"
 import { getContentSchema } from "./validation"
 import { useWebsite } from "../../context/Website"
 
@@ -37,7 +38,7 @@ interface Props {
   fields: ConfigField[]
   configItem: EditableConfigItem
   content: WebsiteContent | null
-  formType: ContentFormType
+  editorState: WebsiteContentModalState
 }
 
 export default function SiteContentForm({
@@ -45,15 +46,15 @@ export default function SiteContentForm({
   fields,
   configItem,
   content,
-  formType
+  editorState
 }: Props): JSX.Element {
   const website = useWebsite()
   const initialValues: SiteFormValues = useMemo(
     () =>
-      formType === ContentFormType.Add ?
+      editorState.adding() ?
         newInitialValues(fields, website) :
         contentInitialValues(content as WebsiteContent, fields, website),
-    [fields, formType, content, website]
+    [fields, editorState, content, website]
   )
   const contentContext = content?.content_context ?? null
 

--- a/static/js/pages/WebsiteCollectionsPage.test.tsx
+++ b/static/js/pages/WebsiteCollectionsPage.test.tsx
@@ -112,7 +112,7 @@ describe("CollectionsPage", () => {
     wrapper.update()
     expect(wrapper.find("BasicModal").prop("isVisible")).toBeTruthy()
     expect(wrapper.find("WebsiteCollectionEditor").prop("modalState")).toEqual(
-      createModalState("adding", null)
+      createModalState("adding")
     )
     expect(wrapper.find("BasicModal").prop("title")).toBe("Add")
   })
@@ -127,7 +127,7 @@ describe("CollectionsPage", () => {
     })
     wrapper.update()
     expect(wrapper.find("WebsiteCollectionEditor").prop("modalState")).toEqual(
-      createModalState("closed", null)
+      createModalState("closed")
     )
     expect(helper.handleRequestStub.args).toEqual([
       [

--- a/static/js/pages/WebsiteCollectionsPage.tsx
+++ b/static/js/pages/WebsiteCollectionsPage.tsx
@@ -27,7 +27,7 @@ export default function WebsiteCollectionsPage(): JSX.Element {
   const offset = Number(new URLSearchParams(search).get("offset") ?? 0)
 
   const [modalState, setModalState] = useState<WebsiteCollectionModalState>(
-    createModalState("closed", null)
+    createModalState("closed")
   )
 
   const [, refresh] = useRequest(websiteCollectionListRequest(offset))
@@ -42,11 +42,11 @@ export default function WebsiteCollectionsPage(): JSX.Element {
 
   const closeDrawer = useCallback(() => {
     refresh()
-    setModalState(createModalState("closed", null))
+    setModalState(createModalState("closed"))
   }, [setModalState, refresh])
 
   const startAddingCollection = useCallback(() => {
-    setModalState(createModalState("adding", null))
+    setModalState(createModalState("adding"))
   }, [setModalState])
 
   const startEditingCollection = useCallback(

--- a/static/js/types/forms.ts
+++ b/static/js/types/forms.ts
@@ -1,11 +1,6 @@
 import { SchemaOf } from "yup"
 import { FormikHelpers } from "formik"
 
-export enum ContentFormType {
-  Add = "add",
-  Edit = "edit"
-}
-
 export type FormSchema = SchemaOf<any>
 
 /**

--- a/static/js/types/modal_state.ts
+++ b/static/js/types/modal_state.ts
@@ -28,6 +28,14 @@ abstract class ModalStateVariant<T> {
   closed(): this is Closed<T> {
     return this.state === "closed"
   }
+
+  /**
+   * Check whether the modal state is in either of the two possible
+   * open states.
+   */
+  open(): this is Adding<T> | Editing<T> {
+    return this.editing() || this.adding()
+  }
 }
 
 /**
@@ -78,13 +86,10 @@ export type ModalState<T> = Editing<T> | Adding<T> | Closed<T>
  * (these are used by the WebsiteCollection editing/
  * creation UI to represent possible drawer states).
  */
-export function createModalState<T>(state: "adding", wrapped: null): Adding<T>
-export function createModalState<T>(state: "closed", wrapped: null): Closed<T>
+export function createModalState<T>(state: "adding"): Adding<T>
+export function createModalState<T>(state: "closed"): Closed<T>
 export function createModalState<T>(state: "editing", wrapped: T): Editing<T>
-export function createModalState<T>(
-  state: string,
-  wrapped: T | null
-): ModalState<T> {
+export function createModalState<T>(state: string, wrapped?: T): ModalState<T> {
   if (state === "editing") {
     // the overloading gives us some assurance that we can cast
     // wrapped to T here

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -1,5 +1,6 @@
 import { ROLE_ADMIN, ROLE_EDITOR, ROLE_GLOBAL, ROLE_OWNER } from "../constants"
 import { SiteFormValue } from "./forms"
+import { ModalState } from "./modal_state"
 
 /**
  * The different widget variants supported in Site configurations
@@ -245,3 +246,9 @@ export enum LinkType {
   Internal = "internal",
   External = "external"
 }
+
+/**
+ * For the WebsiteContent drawer we need to keep track of a
+ * content ID when we're editing existing content.
+ */
+export type WebsiteContentModalState = ModalState<string>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

none, just a sort of tech debt / doing things the same way in different places PR

#### What's this PR do?

in #378 I added a module called `modal_state` which exports a way to manage the state of a modal. Basically, there are three options, adding, editing, and closed, with some helper functions to create these states. The type `ModalState` is like a Data type in Haskell or an Enum in Rust (think `Option` or `Result` if you've written some Rust before.

Anyhow - this PR is just some code to manage the modal for editing site content in the same way that we manage the modal for editing website collections.

#### How should this be manually tested?

Exercise the whole site content UI and make sure everything works as it should! Metadata editing and whatnot too.