### PR TITLE
Write task id to console for import_ocw_course_sites

### DIFF
--- a/ocw_import/management/commands/import_ocw_course_sites.py
+++ b/ocw_import/management/commands/import_ocw_course_sites.py
@@ -36,7 +36,7 @@ class Command(BaseCommand):
             dest="chunks",
             default=100,
             type=int,
-            help="Number of courses to process per celery task (default 250)",
+            help="Number of courses to process per celery task (default 100)",
         )
         parser.add_argument(
             "-l",
@@ -94,6 +94,7 @@ class Command(BaseCommand):
             limit=limit,
             chunk_size=options["chunks"],
         )
+        self.stdout.write(f"Starting task {task}...")
         task.get()
         total_seconds = (now_in_utc() - start).total_seconds()
         self.stdout.write(
@@ -104,6 +105,7 @@ class Command(BaseCommand):
             self.stdout.write("Syncing all unsynced courses to the designated backend")
             start = now_in_utc()
             task = sync_all_websites.delay()
+            self.stdout.write(f"Starting task {task}...")
             task.get()
             total_seconds = (now_in_utc() - start).total_seconds()
             self.stdout.write(


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
Writes out the task id during `import_ocw_course_sites` so that we can check up on the results later on

#### How should this be manually tested?
Run `./manage.py import_ocw_course_sites -b ocw-to-hugo-output-qa --limit 5` locally. After the task completes (about a minute), run this in a Django shell:
    - `from main.celery import *`
    - `app.AsyncResult("task-id-goes-here").status`

You should see a success message
