### PR TITLE
add ability to remove items from website collections

### DIFF
--- a/static/js/components/SortableWebsiteCollectionItem.test.tsx
+++ b/static/js/components/SortableWebsiteCollectionItem.test.tsx
@@ -6,18 +6,38 @@ import { WebsiteCollectionItem } from "../types/website_collections"
 import { makeWebsiteCollectionItem } from "../util/factories/website_collections"
 
 describe("SortableWebsiteCollectionItem", () => {
-  let item: WebsiteCollectionItem
+  let item: WebsiteCollectionItem, deleteStub: jest.Mock<any, any>
 
   const renderItem = () =>
-    shallow(<SortableWebsiteCollectionItem item={item} id={String(item.id)} />)
+    shallow(
+      <SortableWebsiteCollectionItem
+        deleteItem={deleteStub}
+        item={item}
+        id={String(item.id)}
+      />
+    )
 
   beforeEach(() => {
     item = makeWebsiteCollectionItem()
+    deleteStub = jest.fn()
   })
 
   it("should display the title and a drag handle", () => {
     const wrapper = renderItem()
-    expect(wrapper.find(".material-icons").text()).toBe("drag_indicator")
+    expect(
+      wrapper
+        .find(".material-icons")
+        .at(0)
+        .text()
+    ).toBe("drag_indicator")
     expect(wrapper.find(".title").text()).toBe(item.website_title)
+  })
+
+  it("should include a delete button", () => {
+    const wrapper = renderItem()
+    const deleteButton = wrapper.find(".material-icons").at(1)
+    expect(deleteButton.text()).toBe("remove_circle_outline")
+    deleteButton.simulate("click")
+    expect(deleteStub).toBeCalledWith(item)
   })
 })

--- a/static/js/components/SortableWebsiteCollectionItem.tsx
+++ b/static/js/components/SortableWebsiteCollectionItem.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useCallback } from "react"
 import { useSortable } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
 
@@ -7,12 +7,14 @@ import { WebsiteCollectionItem } from "../types/website_collections"
 interface Props {
   item: WebsiteCollectionItem
   id: string
+  deleteItem: (item: WebsiteCollectionItem) => void
 }
 
 export default function SortableWebsiteCollectionItem(
   props: Props
 ): JSX.Element {
-  const { item } = props
+  const { item, deleteItem } = props
+
   const {
     attributes,
     listeners,
@@ -28,17 +30,27 @@ export default function SortableWebsiteCollectionItem(
     transition
   }
 
+  const deleteItemCB = useCallback(() => {
+    deleteItem(item)
+  }, [deleteItem, item])
+
   return (
     <div
       className="d-flex my-3"
       ref={setNodeRef}
-      // @ts-ignore
+      // @ts-ignore unfortunately unavoidable because of library types :/
       style={style}
       {...attributes}
       {...listeners}
     >
       <span className="material-icons">drag_indicator</span>
       <div className="title">{item.website_title}</div>
+      <span
+        className="material-icons ml-auto gray-button hover"
+        onClick={deleteItemCB}
+      >
+        remove_circle_outline
+      </span>
     </div>
   )
 }

--- a/static/js/components/WebsiteCollectionItemsEditor.test.tsx
+++ b/static/js/components/WebsiteCollectionItemsEditor.test.tsx
@@ -106,4 +106,40 @@ describe("WebsiteCollectionItemsEditor", () => {
       }
     ])
   })
+
+  it("should pass down a delete callback to sortable items", async () => {
+    const { wrapper } = await render()
+    const [item] = items
+
+    helper.handleRequestStub
+      .withArgs(
+        wcItemsApiDetailUrl
+          .param({ collectionId: collection.id, itemId: item.id })
+          .toString()
+      )
+      .returns({
+        status: 204
+      })
+
+    act(() => {
+      // @ts-ignore
+      wrapper
+        .find("SortableWebsiteCollectionItem")
+        .at(0)
+        .prop("deleteItem")(item)
+    })
+
+    expect(helper.handleRequestStub.args[1]).toEqual([
+      wcItemsApiDetailUrl
+        .param({ collectionId: collection.id, itemId: item.id })
+        .toString(),
+      "DELETE",
+      {
+        credentials: undefined,
+        headers:     {
+          "X-CSRFTOKEN": ""
+        }
+      }
+    ])
+  })
 })

--- a/static/js/components/WebsiteCollectionItemsEditor.tsx
+++ b/static/js/components/WebsiteCollectionItemsEditor.tsx
@@ -15,8 +15,12 @@ import {
 } from "@dnd-kit/sortable"
 
 import { useMutation, useRequest } from "redux-query-react"
-import { WebsiteCollection } from "../types/website_collections"
 import {
+  WebsiteCollection,
+  WebsiteCollectionItem
+} from "../types/website_collections"
+import {
+  deleteWebsiteCollectionItemMutation,
   editWebsiteCollectionItemMutation,
   websiteCollectionItemsRequest
 } from "../query-configs/website_collections"
@@ -69,6 +73,10 @@ export default function WebsiteCollectionItemsEditor(
     [updateWCItemPosition, websiteCollection, items]
   )
 
+  const [, deleteWCItem] = useMutation((item: WebsiteCollectionItem) =>
+    deleteWebsiteCollectionItemMutation(item, websiteCollection)
+  )
+
   return (
     <div className="collection-item-editor pt-5 pb-3">
       <h4>Courses in this collection</h4>
@@ -87,6 +95,7 @@ export default function WebsiteCollectionItemsEditor(
               key={item.id}
               id={String(item.id)}
               item={item}
+              deleteItem={deleteWCItem}
             />
           ))}
         </SortableContext>

--- a/static/js/query-configs/website_collections.ts
+++ b/static/js/query-configs/website_collections.ts
@@ -1,5 +1,5 @@
 import { QueryConfig } from "redux-query"
-import { findIndex, mergeRight } from "ramda"
+import { evolve, findIndex, mergeRight } from "ramda"
 
 import { PaginatedResponse } from "./utils"
 
@@ -240,6 +240,33 @@ export const editWebsiteCollectionItemMutation = (
   },
   options: {
     method:  "PATCH",
+    headers: {
+      "X-CSRFTOKEN": getCookie("csrftoken") || ""
+    }
+  }
+})
+
+/**
+ * Delete delete delete!!!
+ */
+export const deleteWebsiteCollectionItemMutation = (
+  item: WebsiteCollectionItem,
+  collection: WebsiteCollection
+): QueryConfig => ({
+  url: wcItemsApiDetailUrl
+    .param({
+      collectionId: collection.id,
+      itemId:       item.id
+    })
+    .toString(),
+  optimisticUpdate: {
+    websiteCollectionItems: evolve({
+      [collection.id]: (items: WebsiteCollectionItem[]) =>
+        (items ?? []).filter(x => x.id !== item.id)
+    })
+  },
+  options: {
+    method:  "DELETE",
     headers: {
       "X-CSRFTOKEN": getCookie("csrftoken") || ""
     }

--- a/static/scss/button.scss
+++ b/static/scss/button.scss
@@ -32,3 +32,14 @@
   background-color: white;
   color: $studio-green;
 }
+
+.gray-button {
+  cursor: pointer;
+  color: $studio-gray;
+
+  &.hover {
+    &:hover {
+      color: $studio-black;
+    }
+  }
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #396

#### What's this PR do?

This adds some UI to remove items from a website collection after they've been added. This is basically a little icon on each entry in the UI we already have for reordering the items and whatnot.

#### How should this be manually tested?

Go to a collection and add some items. You should be able to click on the little minus sign to remove them from the collection.

Normally, these little icons should be sort of gray, but they should be black if you hover over them.

#### Screenshots

![Screen Shot 2021-07-30 at 10 32 06 AM](https://user-images.githubusercontent.com/6207644/127668467-95df4bc9-5ae4-4a3d-9ca7-df1f06f4c10e.png)

![Screen Shot 2021-07-30 at 10 33 54 AM](https://user-images.githubusercontent.com/6207644/127668749-ce6e3fd3-0607-4591-bbef-764784287805.png)

