### PR TITLE
Adjust get_short_id function

### DIFF
--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -159,9 +159,11 @@ def convert_data_to_content(
 
 def get_short_id(metadata):
     """ Get a short_id from the metadata"""
-    course_num = metadata["primary_course_number"]
-    semester, year = metadata["term"].split()
-    short_id = f"{course_num}-{semester}-{year}".lower()
+    course_num = metadata.get("primary_course_number")
+    if not course_num:
+        raise ValueError("Primary course number is missing")
+    term = "-".join(metadata.get("term", "").split())
+    short_id = "-".join(segment for segment in [course_num, term] if segment).lower()
     short_id_exists = Website.objects.filter(short_id=short_id).exists()
     if short_id_exists:
         short_id_prefix = f"{short_id}-"


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #440 

#### What's this PR do?
Adjusts the `get_short_id` function to handle terms with more than 2 words, and also to throw an error if there is no primary course number.

#### How should this be manually tested?
Tests should pass.
The following import should work and the course should have a `short_id=21g.405-january-iap-2011`
```
manage.py import_ocw_course_sites -b ocw-hugo-output-qa --filter 21g-405-germany-today-intensive-study-of-german-language-and-culture-january-iap-2011
```
