### PR TITLE
Reduce default chunk size for import_ocw_course_sites

### DIFF
--- a/ocw_import/management/commands/import_ocw_course_sites.py
+++ b/ocw_import/management/commands/import_ocw_course_sites.py
@@ -34,9 +34,9 @@ class Command(BaseCommand):
             "-c",
             "--chunks",
             dest="chunks",
-            default=100,
+            default=10,
             type=int,
-            help="Number of courses to process per celery task (default 100)",
+            help="Number of courses to process per celery task (default 10)",
         )
         parser.add_argument(
             "-l",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #442 

#### What's this PR do?
Reduces default chunk size for `import_ocw_course_sites` from 100 to 10. On RC this completed in 19 minutes so I think that chunk size should be adequate while reducing memory use

#### How should this be manually tested?
Run `./manage.py import_ocw_course_sites` locally, though I'm not sure there's a need to manually test this since it's a trivial change