### PR TITLE
add initial resource widget plugin

### DIFF
--- a/static/js/lib/ckeditor/CKEditor.ts
+++ b/static/js/lib/ckeditor/CKEditor.ts
@@ -15,6 +15,7 @@ import ParagraphPlugin from "@ckeditor/ckeditor5-paragraph/src/paragraph"
 
 import Markdown from "./plugins/Markdown"
 import MarkdownMediaEmbed from "./plugins/MarkdownMediaEmbed"
+import SiteContentEmbed from "./plugins/SiteContentEmbed"
 
 export const FullEditorConfig = {
   plugins: [
@@ -32,6 +33,7 @@ export const FullEditorConfig = {
     LinkPlugin,
     ListPlugin,
     ParagraphPlugin,
+    SiteContentEmbed,
     MarkdownMediaEmbed,
     Markdown
   ],

--- a/static/js/lib/ckeditor/plugins/Markdown.test.ts
+++ b/static/js/lib/ckeditor/plugins/Markdown.test.ts
@@ -5,6 +5,8 @@ import { turndownService } from "../turndown"
 
 import { TEST_MARKDOWN, TEST_HTML } from "../../../test_constants"
 
+const getEditor = createTestEditor([Markdown])
+
 describe("Markdown CKEditor plugin", () => {
   it("should have a name", () => {
     expect(Markdown.pluginName).toBe("Markdown")
@@ -12,18 +14,18 @@ describe("Markdown CKEditor plugin", () => {
 
   describe("basic Markdown support", () => {
     it("should set custom rules flag after instantiation", async () => {
-      await createTestEditor([Markdown])
+      await getEditor("")
       // @ts-ignore
       expect(turndownService._customRulesSet).toBeTruthy()
     })
 
     it("should set editor.data.processor", async () => {
-      const editor = await createTestEditor([Markdown])
+      const editor = await getEditor("")
       expect(editor.data.processor).toBeInstanceOf(MarkdownDataProcessor)
     })
 
     it("should provide for bi-directional translation", async () => {
-      const editor = await createTestEditor([Markdown])
+      const editor = await getEditor("")
       markdownTest(editor, TEST_MARKDOWN, TEST_HTML)
     })
   })

--- a/static/js/lib/ckeditor/plugins/MarkdownMediaEmbed.test.ts
+++ b/static/js/lib/ckeditor/plugins/MarkdownMediaEmbed.test.ts
@@ -3,8 +3,7 @@ import Markdown from "./Markdown"
 import { createTestEditor, markdownTest } from "./test_util"
 import { turndownService } from "../turndown"
 
-const getEditor = (initialData = "") =>
-  createTestEditor([MarkdownMediaEmbed, Markdown], initialData)
+const getEditor = createTestEditor([MarkdownMediaEmbed, Markdown])
 
 describe("MarkdownMediaEmbed plugin", () => {
   afterEach(() => {

--- a/static/js/lib/ckeditor/plugins/SiteContentEmbed.test.ts
+++ b/static/js/lib/ckeditor/plugins/SiteContentEmbed.test.ts
@@ -1,0 +1,31 @@
+import SiteContentEmbed from "./SiteContentEmbed"
+import Markdown from "./Markdown"
+import { createTestEditor, markdownTest } from "./test_util"
+import { turndownService } from "../turndown"
+
+const getEditor = createTestEditor([SiteContentEmbed, Markdown])
+
+describe("SiteContentEmbed plugin", () => {
+  afterEach(() => {
+    turndownService.rules.array = turndownService.rules.array.filter(
+      (rule: any) => rule.filter !== "figure"
+    )
+    // @ts-ignore
+    turndownService._customRulesSet = undefined
+  })
+
+  it("should take in and return 'resource' shortcode", async () => {
+    const editor = await getEditor("{{< resource 1234567890 >}}")
+    // @ts-ignore
+    expect(editor.getData()).toBe("{{< resource 1234567890 >}}")
+  })
+
+  it("should serialize to and from markdown", async () => {
+    const editor = await getEditor("")
+    markdownTest(
+      editor,
+      "{{< resource asdfasdfasdfasdf >}}",
+      `<section>asdfasdfasdfasdf</section>`
+    )
+  })
+})

--- a/static/js/lib/ckeditor/plugins/SiteContentEmbed.ts
+++ b/static/js/lib/ckeditor/plugins/SiteContentEmbed.ts
@@ -1,0 +1,122 @@
+import Plugin from "@ckeditor/ckeditor5-core/src/plugin"
+import Turndown from "turndown"
+import Showdown from "showdown"
+import { toWidget } from "@ckeditor/ckeditor5-widget/src/utils"
+import { editor } from "@ckeditor/ckeditor5-core"
+
+import MarkdownSyntaxPlugin from "./MarkdownSyntaxPlugin"
+import { TurndownRule } from "../../../types/ckeditor_markdown"
+
+export const SITE_CONTENT_SHORTCODE_REGEX = /{{< resource (\S+) >}}/g
+
+const SITE_CONTENT_EMBED = "siteContent"
+
+class SiteContentMarkdownSyntax extends MarkdownSyntaxPlugin {
+  constructor(editor: editor.Editor) {
+    super(editor)
+  }
+
+  get showdownExtension() {
+    return function siteContentExtension(): Showdown.ShowdownExtension[] {
+      return [
+        {
+          type:    "lang",
+          regex:   SITE_CONTENT_SHORTCODE_REGEX,
+          replace: (s: string, match: string) => `<section>${match}</section>`
+        }
+      ]
+    }
+  }
+
+  get turndownRule(): TurndownRule {
+    return {
+      name: "siteContent",
+      rule: {
+        filter:      "section",
+        replacement: (content: string, _node: Turndown.Node): string => {
+          return `{{< resource ${content} >}}\n`
+        }
+      }
+    }
+  }
+}
+
+class SiteContentEmbedEditing extends Plugin {
+  constructor(editor: editor.Editor) {
+    super(editor)
+  }
+
+  init() {
+    this._defineSchema()
+    this._defineConverters()
+  }
+
+  _defineSchema() {
+    const schema = this.editor.model.schema
+
+    schema.register(SITE_CONTENT_EMBED, {
+      isObject:       true,
+      allowWhere:     "$block",
+      allowContentOf: "$block"
+    })
+  }
+
+  _defineConverters() {
+    const conversion = this.editor.conversion
+
+    /**
+     * convert HTML string to a view element (i.e. ckeditor
+     * internal state, *not* to a DOM element)
+     */
+    conversion.for("upcast").elementToElement({
+      model: SITE_CONTENT_EMBED,
+      view:  {
+        name: "section"
+      }
+    })
+
+    /**
+     * converts view element to HTML element for data output
+     */
+    conversion.for("dataDowncast").elementToElement({
+      model: SITE_CONTENT_EMBED,
+      view:  {
+        name: "section"
+      }
+    })
+
+    /**
+     * editingDowncast converts a view element to HTML which is actually shown
+     * in the editor for WYSIWYG purposes
+     * (for the youtube embed this is an iframe)
+     */
+    conversion.for("editingDowncast").elementToElement({
+      model: SITE_CONTENT_EMBED,
+      view:  (modelElement: any, { writer: viewWriter }: any) => {
+        // this looks bad but I promise it's fine
+        const resourceID = modelElement._children._nodes[0]._data
+        const div = viewWriter.createContainerElement("div", {
+          class: "resource-embed",
+          text:  resourceID
+        })
+        return toWidget(div, viewWriter, { label: "Resources Embed" })
+      }
+    })
+  }
+}
+
+export default class SiteContentEmbed extends Plugin {
+  static get pluginName(): string {
+    return "SiteContentEmbed"
+  }
+
+  static get requires(): Plugin[] {
+    // this line here is throwing a type error that I don't understand,
+    // since very similar code in MarkdownMediaEmbed.ts is fine
+    //
+    // Anyhow, since I have not diagnosed it and since things seem to
+    // be running fine I'm going to just ignore for now.
+    // @ts-ignore
+    return [SiteContentEmbedEditing, SiteContentMarkdownSyntax]
+  }
+}

--- a/static/js/lib/ckeditor/plugins/test_util.ts
+++ b/static/js/lib/ckeditor/plugins/test_util.ts
@@ -5,8 +5,7 @@ import { MarkdownDataProcessor } from "./Markdown"
 
 class ClassicTestEditor extends ClassicEditorBase {}
 
-export const createTestEditor = async (
-  plugins: any[],
+export const createTestEditor = (plugins: any[]) => async (
   initialData = ""
 ): Promise<editor.Editor> => {
   const editor = await ClassicTestEditor.create(initialData, {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #452

#### What's this PR do?

This PR adds the first part of the resource embed functionality that we want to add to our CKEditor-based Markdown editor.

Basically, this just defines a new node type in the editor (called a `SiteContentEmbed`) and adds some basic placeholder stuff for serializing this to and from a hugo shortcode (`{{< resource $UUID >}}`) and to a very barebones display in the editor. There is no UI for adding these to the editor yet, and no rich display when they are embedded in the editor. This is just to get some boilerplate out of the way so that subsequent PRs don't have to be as large.

#### How should this be manually tested?

1. edit `TEST_MARKDOWN` in `test_constants.ts` to add `{{< resource 1234102394812304981234 >}}` on its own line somewhere in the file.
2. Check out `/markdown-editor`. If you click over to the 'Full' editor you should see that in the markdown output there is a hugo shortcode `{{< resource`. In the editor that should look like a block w/ just the resource UUID in it. This node should be a block, so you should be able to delete it in the editor, there should be a select outline if you mouse over, etc.

#### Screenshots (if appropriate)

![Screen Shot 2021-08-02 at 10 14 50 AM](https://user-images.githubusercontent.com/6207644/127875657-1527aabd-b789-423d-9452-f04c5e1b0c59.png)
