### PR TITLE
fix drawer width issue

### DIFF
--- a/static/js/components/SiteContentEditor.test.tsx
+++ b/static/js/components/SiteContentEditor.test.tsx
@@ -8,7 +8,6 @@ import * as formikFuncs from "formik"
 import SiteContentEditor from "./SiteContentEditor"
 import WebsiteContext from "../context/Website"
 
-import { DEFAULT_TITLE_FIELD } from "../lib/site_content"
 import * as siteContentFuncs from "../lib/site_content"
 import { siteApiContentDetailUrl, siteApiContentUrl } from "../lib/urls"
 import IntegrationTestHelper, {
@@ -17,7 +16,6 @@ import IntegrationTestHelper, {
 import {
   makeRepeatableConfigItem,
   makeSingletonConfigItem,
-  makeWebsiteConfigField,
   makeWebsiteContentDetail,
   makeWebsiteDetail
 } from "../util/factories/websites"
@@ -29,8 +27,7 @@ import {
   EditableConfigItem,
   Website,
   WebsiteContent,
-  WebsiteContentModalState,
-  WidgetVariant
+  WebsiteContentModalState
 } from "../types/websites"
 import { contentDetailKey } from "../query-configs/websites"
 import { createModalState } from "../types/modal_state"
@@ -132,7 +129,7 @@ describe("SiteContent", () => {
     const { wrapper } = await render()
     const form = wrapper.find("SiteContentForm")
     expect(form.exists()).toBe(true)
-    expect(form.prop("fields")).toStrictEqual(configItem.fields)
+    expect(form.prop("configItem")).toStrictEqual(configItem)
   })
 
   describe("validates using the content schema", () => {
@@ -195,32 +192,6 @@ describe("SiteContent", () => {
       )
       sinon.assert.calledOnceWithExactly(yupToFormErrorsStub, error)
     })
-  })
-
-  it("modifies config item fields before passing them on to form component", async () => {
-    const objectField = makeWebsiteConfigField({
-      widget: WidgetVariant.Object,
-      label:  "myobject",
-      fields: [
-        makeWebsiteConfigField({
-          widget: WidgetVariant.String,
-          label:  "mystring"
-        })
-      ]
-    })
-    const { wrapper } = await render({
-      configItem: {
-        ...makeRepeatableConfigItem(),
-        fields: [objectField]
-      }
-    })
-    const form = wrapper.find("SiteContentForm")
-    expect(form.prop("fields")).toStrictEqual([
-      // Title field should be added by default
-      DEFAULT_TITLE_FIELD,
-      // Nested object field should be not renamed
-      objectField
-    ])
   })
 
   //

--- a/static/js/components/SiteContentEditor.tsx
+++ b/static/js/components/SiteContentEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react"
+import React from "react"
 import { useMutation, useRequest } from "redux-query-react"
 import { useSelector } from "react-redux"
 import { FormikHelpers } from "formik"
@@ -15,7 +15,6 @@ import {
 } from "../query-configs/websites"
 import { getWebsiteContentDetailCursor } from "../selectors/websites"
 import {
-  addDefaultFields,
   contentFormValuesToPayload,
   isSingletonCollectionItem,
   needsContentContext
@@ -23,7 +22,6 @@ import {
 import { getResponseBodyError, isErrorResponse } from "../lib/util"
 
 import {
-  ConfigField,
   EditableConfigItem,
   WebsiteContentModalState,
   WebsiteContent
@@ -48,9 +46,6 @@ export default function SiteContentEditor(props: Props): JSX.Element | null {
     editorState
   } = props
 
-  const fields: ConfigField[] = useMemo(() => addDefaultFields(configItem), [
-    configItem
-  ])
   const site = useWebsite()
 
   const [
@@ -79,7 +74,7 @@ export default function SiteContentEditor(props: Props): JSX.Element | null {
     shouldLoadContent && editorState.editing() ?
       websiteContentDetailRequest(
         { name: site.name, textId: editorState.wrapped },
-        needsContentContext(fields)
+        needsContentContext(configItem.fields)
       ) :
       null
   )
@@ -110,7 +105,7 @@ export default function SiteContentEditor(props: Props): JSX.Element | null {
     if (editorState.adding()) {
       values = { type: configItem.name, ...values }
     }
-    const payload = contentFormValuesToPayload(values, fields, site)
+    const payload = contentFormValuesToPayload(values, configItem.fields, site)
 
     // If the content being created is for a singleton config item,
     // use the config item "name" value as the text_id.
@@ -155,7 +150,6 @@ export default function SiteContentEditor(props: Props): JSX.Element | null {
   return (
     <SiteContentForm
       onSubmit={onSubmitForm}
-      fields={fields}
       configItem={configItem}
       content={content}
       editorState={editorState}

--- a/static/js/components/SiteContentListing.tsx
+++ b/static/js/components/SiteContentListing.tsx
@@ -5,7 +5,10 @@ import { useSelector } from "react-redux"
 import RepeatableContentListing from "./RepeatableContentListing"
 import SingletonsContentListing from "./SingletonsContentListing"
 
-import { isRepeatableCollectionItem } from "../lib/site_content"
+import {
+  addDefaultFields,
+  isRepeatableCollectionItem
+} from "../lib/site_content"
 import { getWebsiteDetailCursor } from "../selectors/websites"
 import WebsiteContext from "../context/Website"
 
@@ -31,7 +34,7 @@ export default function SiteContentListing(): JSX.Element | null {
   return (
     <WebsiteContext.Provider value={website}>
       {isRepeatableCollectionItem(configItem) ? (
-        <RepeatableContentListing configItem={configItem} />
+        <RepeatableContentListing configItem={addDefaultFields(configItem)} />
       ) : (
         <SingletonsContentListing configItem={configItem} />
       )}

--- a/static/js/components/forms/SiteContentForm.test.tsx
+++ b/static/js/components/forms/SiteContentForm.test.tsx
@@ -62,7 +62,6 @@ describe("SiteContentForm", () => {
   const renderForm = (props = {}) =>
     shallow(
       <SiteContentForm
-        fields={configItem.fields}
         configItem={configItem}
         content={content}
         onSubmit={onSubmitStub}

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -35,7 +35,6 @@ interface Props {
     values: any,
     formikHelpers: FormikHelpers<any>
   ) => void | Promise<any>
-  fields: ConfigField[]
   configItem: EditableConfigItem
   content: WebsiteContent | null
   editorState: WebsiteContentModalState
@@ -43,7 +42,6 @@ interface Props {
 
 export default function SiteContentForm({
   onSubmit,
-  fields,
   configItem,
   content,
   editorState
@@ -52,15 +50,19 @@ export default function SiteContentForm({
   const initialValues: SiteFormValues = useMemo(
     () =>
       editorState.adding() ?
-        newInitialValues(fields, website) :
-        contentInitialValues(content as WebsiteContent, fields, website),
-    [fields, editorState, content, website]
+        newInitialValues(configItem.fields, website) :
+        contentInitialValues(
+            content as WebsiteContent,
+            configItem.fields,
+            website
+        ),
+    [configItem.fields, editorState, content, website]
   )
   const contentContext = content?.content_context ?? null
 
   const renamedFields: ConfigField[] = useMemo(
-    () => renameNestedFields(fields),
-    [fields]
+    () => renameNestedFields(configItem.fields),
+    [configItem]
   )
   const fieldsByColumn = splitFieldsIntoColumns(renamedFields)
   const columnClass = fieldsByColumn.length === 2 ? "col-6" : "col-12"

--- a/static/js/lib/site_content.test.ts
+++ b/static/js/lib/site_content.test.ts
@@ -551,7 +551,8 @@ describe("site_content", () => {
         const expectedResult = expAddField ?
           [DEFAULT_TITLE_FIELD, randomField] :
           fields
-        expect(addDefaultFields(configItem)).toEqual(expectedResult)
+        // @ts-ignore
+        expect(addDefaultFields(configItem).fields).toEqual(expectedResult)
       })
     })
   })

--- a/static/js/lib/site_content.ts
+++ b/static/js/lib/site_content.ts
@@ -314,18 +314,27 @@ export const renameNestedFields = (fields: ConfigField[]): ConfigField[] =>
     }
   })
 
-export const addDefaultFields = (
+export function addDefaultFields(
+  configItem: RepeatableConfigItem
+): RepeatableConfigItem
+export function addDefaultFields(
+  configItem: SingletonConfigItem
+): SingletonConfigItem
+export function addDefaultFields(
   configItem: EditableConfigItem
-): ConfigField[] => {
+): EditableConfigItem {
   const fields = configItem.fields
   if (!isRepeatableCollectionItem(configItem)) {
-    return fields
+    return configItem
   }
   const titleField = fields.find(field => field.name === "title")
   if (titleField) {
-    return fields
+    return configItem
   }
-  return [DEFAULT_TITLE_FIELD, ...fields]
+  return {
+    ...configItem,
+    fields: [DEFAULT_TITLE_FIELD, ...fields]
+  }
 }
 
 export const needsContentContext = (fields: ConfigField[]): boolean => {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #459

#### What's this PR do?

this PR fixes an issue where the drawer width wasn't always being set correctly, because we weren't being so consistent about where in the component hierarchy we were calling the `addDefaultFields` function on the fields in a collection. To fix it, I basically hoisted that call up to the `SiteContentListing` component, refactoring the function a bit in the process, so that we have one consistent value throughout that part of the component tree.

Read the issue for more details!

#### How should this be manually tested?

Check the repro steps on the issue, make sure you can repro this on the main branch. Then check out my branch here and make sure it fixes it.

#### Screenshots (if appropriate)

the problem:

![Screen Shot 2021-08-03 at 3 43 47 PM](https://user-images.githubusercontent.com/6207644/128086363-0750c880-f795-4ce3-9ed8-adf21bcc2dad.png)

the solution:

![Screen Shot 2021-08-03 at 5 08 33 PM](https://user-images.githubusercontent.com/6207644/128086418-6487037f-1b22-4870-b05e-a75fe4127991.png)
