### PR TITLE
add OCW_IMPORT_STARTER_SLUG setting and update included testing config

### DIFF
--- a/app.json
+++ b/app.json
@@ -214,6 +214,10 @@
       "description": "If false, disables the node_modules cache to fix yarn install",
       "value": "false"
     },
+    "OCW_IMPORT_STARTER_SLUG": {
+      "description": "The slug of the WebsiteStarter to assign to courses imported from ocw-to-hugo",
+      "required": false
+    },
     "OCW_STUDIO_ADMIN_EMAIL": {
       "description": "E-mail to send 500 reports to.",
       "required": false

--- a/localdev/configs/ocw-course-site-config.yml
+++ b/localdev/configs/ocw-course-site-config.yml
@@ -1,31 +1,250 @@
-content-dir: content
-root-url-path: "courses"
+---
+root-url-path: courses
 collections:
-  - name: page
-    label: Pages
-    label_singular: Page
-    category: Content
-    folder: content
+  - category: Content
+    folder: content/pages
+    label: Page
+    name: page
     fields:
-      - {"label": "Body", "name": "body", "widget": "markdown"}
+      - label: Title
+        name: title
+        widget: string
+        required: true
 
-  - name: resource
+      - label: Body
+        name: body
+        widget: markdown
+
+  - category: Content
+    folder: content/resources
     label: Resources
-    label_singular: Resource
-    category: Content
-    folder: content
+    name: resource
     fields:
-      - {"label": "Description", "name": "description", "widget": "text"}
-      - {"label": "File", "name": "file", "widget": "file"}
+      - label: Title
+        name: title
+        required: true
+        widget: string
+      - label: Description
+        name: description
+        widget: markdown
+        minimal: true
+      - label: File Type
+        name: filetype
+        required: true
+        widget: select
+        options:
+          - Image
+          - Video
+          - Document
+          - Other
+      - label: File
+        name: file
+        widget: file
+      - label: "Course Feature Tags"
+        name: "course_feature_tags"
+        widget: select
+        multiple: true
+        options:
+          - 'Activity Assignments'
+          - 'Activity Assignments with Examples'
+          - 'Competition Videos'
+          - 'Course Introduction'
+          - 'Demonstration Audio'
+          - 'Demonstration Videos'
+          - 'Design Assignments'
+          - 'Design Assignments with Examples'
+          - 'Exam Materials'
+          - Exams
+          - 'Exams with Solutions'
+          - 'Image Gallery'
+          - Labs
+          - 'Lecture Audio'
+          - 'Lecture Notes'
+          - 'Lecture Videos'
+          - 'Media Assignments'
+          - 'Media Assignments with Examples'
+          - 'Multiple Assignment Types'
+          - 'Multiple Assignment Types with Solutions'
+          - Music
+          - 'Online Textbook'
+          - 'Other Audio'
+          - 'Other Video'
+          - 'Presentation Assignments'
+          - 'Presentation Assignments with Examples'
+          - 'Problem Sets'
+          - 'Problem Sets with Solutions'
+          - 'Programming Assignments'
+          - 'Programming Assignments with Examples'
+          - Projects
+          - 'Projects with Examples'
+          - Readings
+          - 'Recitation Videos'
+          - 'Simulation Videos'
+          - Simulations
+          - Tools
+          - 'Tutorial Videos'
+          - 'Video Materials'
+          - Videos
+          - 'Workshop Videos'
+          - 'Written Assignments'
+          - 'Written Assignments with Examples'
+      # show the field below only if the type of resource is "image"
+      - label: Image Metadata
+        name: metadata
+        widget: object
+        condition: { field: filetype, equals: Image }
+        fields:
+          - label: ALT text
+            name: image-alt
+            widget: string
+          - label: Caption
+            name: caption
+            widget: string
+          - label: Credit
+            name: credit
+            widget: text
 
-  - name: metadata
+  - category: Settings
+    name: metadata
     label: Metadata
-    category: Settings
     files:
       - file: data/course.json
         name: sitemetadata
         label: Course Metadata
         fields:
+          - label: "Course Title"
+            name: "course_title"
+            widget: "string"
+            required: true
+          - label: "Course Description"
+            name: "course_description"
+            widget: "markdown"
+          - label: "Primary Course Number"
+            name: "primary_course_number"
+            widget: "string"
+            required: true
+          - label: "Extra Course Numbers (comma separated list)"
+            name: "extra_course_numbers"
+            widget: "string"
+          - label: Course Image
+            name: course_image
+            widget: relation
+            collection: resource
+            display_field: title
+            multiple: false
+            filter:
+              field: "filetype"
+              filter_type: "equals"
+              value: "Image"
+          - label: Course Image Thumbnail
+            name: course_image_thumbnail
+            widget: relation
+            collection: resource
+            display_field: title
+            multiple: false
+            filter:
+              field: "filetype"
+              filter_type: "equals"
+              value: "Image"
+          - label: "Department Numbers"
+            min: 1
+            multiple: true
+            name: "department_numbers"
+            options:
+              - '1'
+              - '2'
+              - '3'
+              - '4'
+              - '5'
+              - '6'
+              - '7'
+              - '8'
+              - '9'
+              - '10'
+              - '11'
+              - '12'
+              - '14'
+              - '15'
+              - '16'
+              - '17'
+              - '18'
+              - '20'
+              - 21A
+              - 21G
+              - 21H
+              - 21L
+              - 21M
+              - '22'
+              - '24'
+              - CC
+              - CMS-W
+              - EC
+              - ES
+              - ESD
+              - HST
+              - IDS
+              - MAS
+              - PE
+              - RES
+              - STS
+              - WGS
+            widget: "select"
+          - label: "Level"
+            name: "level"
+            options:
+              - 'Undergraduate'
+              - 'Graduate'
+              - 'Both'
+              - 'Non Credit'
+            widget: "select"
+          - label: "Course Feature Tags"
+            name: "course_feature_tags"
+            widget: select
+            multiple: true
+            options:
+              - 'Activity Assignments'
+              - 'Activity Assignments with Examples'
+              - 'Competition Videos'
+              - 'Course Introduction'
+              - 'Demonstration Audio'
+              - 'Demonstration Videos'
+              - 'Design Assignments'
+              - 'Design Assignments with Examples'
+              - 'Exam Materials'
+              - Exams
+              - 'Exams with Solutions'
+              - 'Image Gallery'
+              - Labs
+              - 'Lecture Audio'
+              - 'Lecture Notes'
+              - 'Lecture Videos'
+              - 'Media Assignments'
+              - 'Media Assignments with Examples'
+              - 'Multiple Assignment Types'
+              - 'Multiple Assignment Types with Solutions'
+              - Music
+              - 'Online Textbook'
+              - 'Other Audio'
+              - 'Other Video'
+              - 'Presentation Assignments'
+              - 'Presentation Assignments with Examples'
+              - 'Problem Sets'
+              - 'Problem Sets with Solutions'
+              - 'Programming Assignments'
+              - 'Programming Assignments with Examples'
+              - Projects
+              - 'Projects with Examples'
+              - Readings
+              - 'Recitation Videos'
+              - 'Simulation Videos'
+              - Simulations
+              - Tools
+              - 'Tutorial Videos'
+              - 'Video Materials'
+              - Videos
+              - 'Workshop Videos'
+              - 'Written Assignments'
+              - 'Written Assignments with Examples'
           - label: Instructors
             name: instructors
             widget: relation
@@ -34,9 +253,9 @@ collections:
             multiple: true
             website: ocw-www
 
-  - name: menu
+  - category: Settings
     label: Menu
-    category: Settings
+    name: menu
     files:
       - file: config/_default/menus.yaml
         name: navmenu
@@ -44,6 +263,6 @@ collections:
         fields:
           - {
             "label": "Menu",
-            "name": "mainmenu",
+            "name": "leftnav",
             "widget": "menu",
           }

--- a/localdev/configs/ocw-course-site-config.yml
+++ b/localdev/configs/ocw-course-site-config.yml
@@ -3,7 +3,7 @@ root-url-path: courses
 collections:
   - category: Content
     folder: content/pages
-    label: Page
+    label: Pages
     name: page
     fields:
       - label: Title

--- a/main/settings.py
+++ b/main/settings.py
@@ -723,6 +723,12 @@ GITHUB_WEBHOOK_BRANCH = get_string(
     description="Github branch to filter webhook requests against",
     required=False,
 )
+OCW_IMPORT_STARTER_SLUG = get_string(
+    name="OCW_IMPORT_STARTER_SLUG",
+    default="course",
+    description="The slug of the WebsiteStarter to assign to courses imported from ocw-to-hugo",
+    required=False,
+)
 OCW_STUDIO_SITE_CONFIG_FILE = get_string(
     name="OCW_STUDIO_SITE_CONFIG_FILE",
     default="ocw-studio.yaml",

--- a/ocw_import/conftest.py
+++ b/ocw_import/conftest.py
@@ -29,11 +29,9 @@ def setup_s3(settings):
 
     # Add data to the fake bucket
     test_bucket = conn.Bucket(name=MOCK_BUCKET_NAME)
-    # print(TEST_OCW2HUGO_FILES)
     for file in TEST_OCW2HUGO_FILES:
         file_key = file.replace("./test_ocw2hugo/", "")
         with open(file, "r") as f:
-            # print(file_key)
             test_bucket.put_object(Key=file_key, Body=f.read())
 
 

--- a/ocw_import/tasks.py
+++ b/ocw_import/tasks.py
@@ -2,11 +2,11 @@
 import logging
 
 import celery
+from django.conf import settings
 from mitol.common.utils.collections import chunks
 
 from main.celery import app
 from ocw_import.api import fetch_ocw2hugo_course_paths, import_ocw2hugo_course
-from websites.constants import COURSE_STARTER_SLUG
 from websites.models import WebsiteStarter
 
 
@@ -26,8 +26,9 @@ def import_ocw2hugo_course_paths(paths=None, bucket_name=None, prefix=None):
     """
     if not paths:
         return
+    print(settings.OCW_IMPORT_STARTER_SLUG)
     course_site_starter_id = (
-        WebsiteStarter.objects.filter(slug=COURSE_STARTER_SLUG)
+        WebsiteStarter.objects.filter(slug=settings.OCW_IMPORT_STARTER_SLUG)
         .values_list("id", flat=True)
         .first()
     )

--- a/ocw_import/tasks.py
+++ b/ocw_import/tasks.py
@@ -26,7 +26,6 @@ def import_ocw2hugo_course_paths(paths=None, bucket_name=None, prefix=None):
     """
     if not paths:
         return
-    print(settings.OCW_IMPORT_STARTER_SLUG)
     course_site_starter_id = (
         WebsiteStarter.objects.filter(slug=settings.OCW_IMPORT_STARTER_SLUG)
         .values_list("id", flat=True)

--- a/ocw_import/tasks_test.py
+++ b/ocw_import/tasks_test.py
@@ -13,9 +13,10 @@ pytestmark = pytest.mark.django_db
 @pytest.mark.parametrize(
     "paths", [["1-050-mechanical-engineering", "3-34-transportation-systems"], [], None]
 )
-def test_import_ocw2hugo_course_paths(mocker, paths, course_starter):
+def test_import_ocw2hugo_course_paths(mocker, paths, course_starter, settings):
     """ mock_import_course should be called from task with correct kwargs """
     mock_import_course = mocker.patch("ocw_import.tasks.import_ocw2hugo_course")
+    settings.OCW_IMPORT_STARTER_SLUG = "course"
     import_ocw2hugo_course_paths.delay(paths, MOCK_BUCKET_NAME, TEST_OCW2HUGO_PREFIX)
     if not paths:
         mock_import_course.assert_not_called()

--- a/static/js/components/SiteSidebar.test.tsx
+++ b/static/js/components/SiteSidebar.test.tsx
@@ -17,6 +17,7 @@ describe("SiteSidebar", () => {
 
   beforeEach(() => {
     website = makeWebsiteDetail()
+    console.log(website.starter?.config?.collections)
     helper = new IntegrationTestHelper()
     render = helper.configureRenderer(SiteSidebar, { website })
   })
@@ -59,9 +60,17 @@ describe("SiteSidebar", () => {
             contentType: "metadata"
           })
           .toString()
+      ],
+      [
+        "Menu",
+        siteContentListingUrl
+          .param({
+            name:        website.name,
+            contentType: "menu"
+          })
+          .toString()
       ]
     ]
-
     expect(links).toEqual(expect.arrayContaining(expected))
   })
 

--- a/static/js/components/SiteSidebar.test.tsx
+++ b/static/js/components/SiteSidebar.test.tsx
@@ -17,7 +17,6 @@ describe("SiteSidebar", () => {
 
   beforeEach(() => {
     website = makeWebsiteDetail()
-    console.log(website.starter?.config?.collections)
     helper = new IntegrationTestHelper()
     render = helper.configureRenderer(SiteSidebar, { website })
   })

--- a/static/js/resources/ocw-course-site-config.json
+++ b/static/js/resources/ocw-course-site-config.json
@@ -16,7 +16,7 @@
         }
       ],
       "folder": "content/pages",
-      "label": "Page",
+      "label": "Pages",
       "name": "page"
     },
     {

--- a/static/js/resources/ocw-course-site-config.json
+++ b/static/js/resources/ocw-course-site-config.json
@@ -4,33 +4,133 @@
       "category": "Content",
       "fields": [
         {
+          "label": "Title",
+          "name": "title",
+          "required": true,
+          "widget": "string"
+        },
+        {
           "label": "Body",
           "name": "body",
           "widget": "markdown"
         }
       ],
-      "folder": "content",
-      "label": "Pages",
-      "label_singular": "Page",
+      "folder": "content/pages",
+      "label": "Page",
       "name": "page"
     },
     {
       "category": "Content",
       "fields": [
         {
+          "label": "Title",
+          "name": "title",
+          "required": true,
+          "widget": "string"
+        },
+        {
           "label": "Description",
+          "minimal": true,
           "name": "description",
-          "widget": "text"
+          "widget": "markdown"
+        },
+        {
+          "label": "File Type",
+          "name": "filetype",
+          "options": [
+            "Image",
+            "Video",
+            "Document",
+            "Other"
+          ],
+          "required": true,
+          "widget": "select"
         },
         {
           "label": "File",
           "name": "file",
           "widget": "file"
+        },
+        {
+          "label": "Course Feature Tags",
+          "multiple": true,
+          "name": "course_feature_tags",
+          "options": [
+            "Activity Assignments",
+            "Activity Assignments with Examples",
+            "Competition Videos",
+            "Course Introduction",
+            "Demonstration Audio",
+            "Demonstration Videos",
+            "Design Assignments",
+            "Design Assignments with Examples",
+            "Exam Materials",
+            "Exams",
+            "Exams with Solutions",
+            "Image Gallery",
+            "Labs",
+            "Lecture Audio",
+            "Lecture Notes",
+            "Lecture Videos",
+            "Media Assignments",
+            "Media Assignments with Examples",
+            "Multiple Assignment Types",
+            "Multiple Assignment Types with Solutions",
+            "Music",
+            "Online Textbook",
+            "Other Audio",
+            "Other Video",
+            "Presentation Assignments",
+            "Presentation Assignments with Examples",
+            "Problem Sets",
+            "Problem Sets with Solutions",
+            "Programming Assignments",
+            "Programming Assignments with Examples",
+            "Projects",
+            "Projects with Examples",
+            "Readings",
+            "Recitation Videos",
+            "Simulation Videos",
+            "Simulations",
+            "Tools",
+            "Tutorial Videos",
+            "Video Materials",
+            "Videos",
+            "Workshop Videos",
+            "Written Assignments",
+            "Written Assignments with Examples"
+          ],
+          "widget": "select"
+        },
+        {
+          "condition": {
+            "equals": "Image",
+            "field": "filetype"
+          },
+          "fields": [
+            {
+              "label": "ALT text",
+              "name": "image-alt",
+              "widget": "string"
+            },
+            {
+              "label": "Caption",
+              "name": "caption",
+              "widget": "string"
+            },
+            {
+              "label": "Credit",
+              "name": "credit",
+              "widget": "text"
+            }
+          ],
+          "label": "Image Metadata",
+          "name": "metadata",
+          "widget": "object"
         }
       ],
-      "folder": "content",
+      "folder": "content/resources",
       "label": "Resources",
-      "label_singular": "Resource",
       "name": "resource"
     },
     {
@@ -38,6 +138,162 @@
       "files": [
         {
           "fields": [
+            {
+              "label": "Course Title",
+              "name": "course_title",
+              "required": true,
+              "widget": "string"
+            },
+            {
+              "label": "Course Description",
+              "name": "course_description",
+              "widget": "markdown"
+            },
+            {
+              "label": "Primary Course Number",
+              "name": "primary_course_number",
+              "required": true,
+              "widget": "string"
+            },
+            {
+              "label": "Extra Course Numbers (comma separated list)",
+              "name": "extra_course_numbers",
+              "widget": "string"
+            },
+            {
+              "collection": "resource",
+              "display_field": "title",
+              "filter": {
+                "field": "filetype",
+                "filter_type": "equals",
+                "value": "Image"
+              },
+              "label": "Course Image",
+              "multiple": false,
+              "name": "course_image",
+              "widget": "relation"
+            },
+            {
+              "collection": "resource",
+              "display_field": "title",
+              "filter": {
+                "field": "filetype",
+                "filter_type": "equals",
+                "value": "Image"
+              },
+              "label": "Course Image Thumbnail",
+              "multiple": false,
+              "name": "course_image_thumbnail",
+              "widget": "relation"
+            },
+            {
+              "label": "Department Numbers",
+              "min": 1,
+              "multiple": true,
+              "name": "department_numbers",
+              "options": [
+                "1",
+                "2",
+                "3",
+                "4",
+                "5",
+                "6",
+                "7",
+                "8",
+                "9",
+                "10",
+                "11",
+                "12",
+                "14",
+                "15",
+                "16",
+                "17",
+                "18",
+                "20",
+                "21A",
+                "21G",
+                "21H",
+                "21L",
+                "21M",
+                "22",
+                "24",
+                "CC",
+                "CMS-W",
+                "EC",
+                "ES",
+                "ESD",
+                "HST",
+                "IDS",
+                "MAS",
+                "PE",
+                "RES",
+                "STS",
+                "WGS"
+              ],
+              "widget": "select"
+            },
+            {
+              "label": "Level",
+              "name": "level",
+              "options": [
+                "Undergraduate",
+                "Graduate",
+                "Both",
+                "Non Credit"
+              ],
+              "widget": "select"
+            },
+            {
+              "label": "Course Feature Tags",
+              "multiple": true,
+              "name": "course_feature_tags",
+              "options": [
+                "Activity Assignments",
+                "Activity Assignments with Examples",
+                "Competition Videos",
+                "Course Introduction",
+                "Demonstration Audio",
+                "Demonstration Videos",
+                "Design Assignments",
+                "Design Assignments with Examples",
+                "Exam Materials",
+                "Exams",
+                "Exams with Solutions",
+                "Image Gallery",
+                "Labs",
+                "Lecture Audio",
+                "Lecture Notes",
+                "Lecture Videos",
+                "Media Assignments",
+                "Media Assignments with Examples",
+                "Multiple Assignment Types",
+                "Multiple Assignment Types with Solutions",
+                "Music",
+                "Online Textbook",
+                "Other Audio",
+                "Other Video",
+                "Presentation Assignments",
+                "Presentation Assignments with Examples",
+                "Problem Sets",
+                "Problem Sets with Solutions",
+                "Programming Assignments",
+                "Programming Assignments with Examples",
+                "Projects",
+                "Projects with Examples",
+                "Readings",
+                "Recitation Videos",
+                "Simulation Videos",
+                "Simulations",
+                "Tools",
+                "Tutorial Videos",
+                "Video Materials",
+                "Videos",
+                "Workshop Videos",
+                "Written Assignments",
+                "Written Assignments with Examples"
+              ],
+              "widget": "select"
+            },
             {
               "collection": "instructor",
               "display_field": "title",
@@ -63,7 +319,7 @@
           "fields": [
             {
               "label": "Menu",
-              "name": "mainmenu",
+              "name": "leftnav",
               "widget": "menu"
             }
           ],
@@ -76,6 +332,5 @@
       "name": "menu"
     }
   ],
-  "content-dir": "content",
   "root-url-path": "courses"
 }


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable
  - [x] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/457

#### What's this PR do?
In RC and production instances of OCW Studio, the starters from `ocw-hugo-projects` are imported via webhook when changes are made in that repo.  These are the starters for OCW sites that we will be using moving forward, and they should be assigned to courses imported by the `import_ocw_course_sites` management command.  This PR adds the `OCW_IMPORT_STARTER_SLUG` setting that will be assigned to imported courses from `ocw-to-hugo` data.  The default value is "course" to match the starter included in this repo for testing.  The example course starter was also updated with all the latest changes.

#### How should this be manually tested?
 - Set `OCW_IMPORT_STARTER_SLUG` in your `.env` file to `ocw-course`
 - Run a local instance of `ocw-studio`
 - Go to Django admin and create a `WebsiteStarter` with a slug of `ocw-course` and paste in the config from `ocw-hugo-projects/ocw-course/ocw-studio.yaml`
 - Run `docker-compose run web python manage.py import_ocw_course_sites --bucket ocw-to-hugo-output-production --filter 15-401`
 - Browse to the created `Website` in Django admin and ensure that the starter assigned to the site is the one you created with the `ocw-course` slug
