### PR TITLE
check for identifier before accessing it

### DIFF
--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -237,9 +237,10 @@ def import_ocw2hugo_menu(menu_data, website):
         website (Website): The course website
     """
     for i in range(len(menu_data["leftnav"])):
-        menu_data["leftnav"][i]["identifier"] = str(
-            uuid.UUID(menu_data["leftnav"][i]["identifier"])
-        )
+        if "identifier" in menu_data["leftnav"][i]:
+            menu_data["leftnav"][i]["identifier"] = str(
+                uuid.UUID(menu_data["leftnav"][i]["identifier"])
+            )
         if "parent" in menu_data["leftnav"][i]:
             menu_data["leftnav"][i]["parent"] = str(
                 uuid.UUID(menu_data["leftnav"][i]["parent"])

--- a/ocw_import/api_test.py
+++ b/ocw_import/api_test.py
@@ -267,5 +267,6 @@ def test_import_ocw2hugo_menu(settings):
                 "weight": 50,
                 "identifier": "4f5c3926-e4d5-6974-7f16-131a6f692568",
             },
+            {"url": "https://openlearning.mit.edu/", "name": "Open Learning"},
         ]
     }

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/config/_default/menus.yaml
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/config/_default/menus.yaml
@@ -19,3 +19,5 @@ leftnav:
     name: Related Resources
     url: /sections/related-resources
     weight: 50
+  - name: Open Learning
+    url: https://openlearning.mit.edu/


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/472

#### What's this PR do?
This PR addresses a bug with the OCW import code that accesses the `identifier` property of menu items without checking to make sure it exists first.  External menu items don't have an identifier, so now we are checking to make sure it is set before accessing it.

#### How should this be manually tested?
 - Spin up `ocw-studio` locally and configure AWS access to RC or use the RC instance
 - Run `manage.py import_ocw_course_sites --bucket ocw-to-hugo-output-production --filter 7-00`
 - Ensure that all the courses matching the filter are imported successfully without error
