### PR TITLE
add resource embed widget

### DIFF
--- a/localdev/configs/ocw-course-site-config.yml
+++ b/localdev/configs/ocw-course-site-config.yml
@@ -10,6 +10,7 @@ collections:
         name: title
         widget: string
         required: true
+        attach: "resource"
 
       - label: Body
         name: body

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@dnd-kit/core": "^3.1.1",
     "@dnd-kit/sortable": "^4.0.0",
     "@sentry/browser": "^6.10.0",
+    "@testing-library/react-hooks": "^7.0.1",
     "@types/ckeditor__ckeditor5-core": "^11.0.3",
     "@types/enzyme": "^3.10.9",
     "@types/enzyme-adapter-react-16": "^1.0.6",

--- a/static/js/components/widgets/MarkdownEditor.test.tsx
+++ b/static/js/components/widgets/MarkdownEditor.test.tsx
@@ -50,6 +50,11 @@ describe("MarkdownEditor", () => {
     })
   })
 
+  it("should pass attach down ato a ResourceEmbedField", () => {
+    const wrapper = render({ attach: "resource" })
+    expect(wrapper.find("ResourceEmbedField").prop("attach")).toBe("resource")
+  })
+
   //
   ;[
     ["name", "name"],

--- a/static/js/components/widgets/MarkdownEditor.tsx
+++ b/static/js/components/widgets/MarkdownEditor.tsx
@@ -1,12 +1,14 @@
-import React from "react"
+import React, { useCallback, useRef } from "react"
 import { CKEditor } from "@ckeditor/ckeditor5-react"
-
+import { editor } from "@ckeditor/ckeditor5-core"
 import ClassicEditor from "@ckeditor/ckeditor5-editor-classic/src/classiceditor"
 
 import {
   FullEditorConfig,
   MinimalEditorConfig
 } from "../../lib/ckeditor/CKEditor"
+import ResourceEmbedField from "./ResourceEmbedField"
+import { RESOURCE_EMBED_COMMAND } from "../../lib/ckeditor/plugins/ResourceEmbed"
 
 export interface Props {
   value?: string
@@ -14,6 +16,7 @@ export interface Props {
   onChange?: (event: { target: { value: string; name: string } }) => void
   children?: React.ReactNode
   minimal?: boolean
+  attach?: string
 }
 
 /**
@@ -22,19 +25,41 @@ export interface Props {
  * pass minimal: true to get a minimal version.
  */
 export default function MarkdownEditor(props: Props): JSX.Element {
-  const { value, name, onChange, minimal } = props
+  const { attach, value, name, onChange, minimal } = props
+
+  const editor = useRef<editor.Editor>()
+  const setEditorRef = useCallback(editorInstance => {
+    editor.current = editorInstance
+  }, [])
+
+  const addResourceEmbed = useCallback(
+    (id: string) => {
+      if (editor.current) {
+        editor.current.execute(RESOURCE_EMBED_COMMAND, id)
+        // @ts-ignore
+        editor.current.editing.view.focus()
+      }
+    },
+    [editor]
+  )
 
   return (
-    <CKEditor
-      editor={ClassicEditor}
-      config={minimal ? MinimalEditorConfig : FullEditorConfig}
-      data={value ?? ""}
-      onChange={(event: any, editor: any) => {
-        const data = editor.getData()
-        if (onChange) {
-          onChange({ target: { name: name ?? "", value: data } })
-        }
-      }}
-    />
+    <>
+      <CKEditor
+        editor={ClassicEditor}
+        config={minimal ? MinimalEditorConfig : FullEditorConfig}
+        data={value ?? ""}
+        onReady={setEditorRef}
+        onChange={(_event: any, editor: any) => {
+          const data = editor.getData()
+          if (onChange) {
+            onChange({ target: { name: name ?? "", value: data } })
+          }
+        }}
+      />
+      {attach && attach.length !== 0 ? (
+        <ResourceEmbedField insertEmbed={addResourceEmbed} attach={attach} />
+      ) : null}
+    </>
   )
 }

--- a/static/js/components/widgets/ResourceEmbedField.test.tsx
+++ b/static/js/components/widgets/ResourceEmbedField.test.tsx
@@ -1,0 +1,154 @@
+import { siteApiContentListingUrl } from "../../lib/urls"
+import { Website, WebsiteContentListItem } from "../../types/websites"
+import {
+  makeWebsiteContentListItem,
+  makeWebsiteDetail
+} from "../../util/factories/websites"
+import IntegrationTestHelper, {
+  TestRenderer
+} from "../../util/integration_test_helper"
+import ResourceEmbedField from "./ResourceEmbedField"
+import { useWebsite } from "../../context/Website"
+import { useDebouncedState } from "../../hooks/state"
+import { act } from "react-dom/test-utils"
+import { useState } from "react"
+
+jest.mock("../../context/Website")
+jest.mock("../../hooks/state")
+
+describe("ResourceEmbedField", () => {
+  let helper: IntegrationTestHelper,
+    render: TestRenderer,
+    insertEmbedStub: any,
+    apiResponse,
+    website: Website,
+    contentListingItems: WebsiteContentListItem[],
+    setStub
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+
+    insertEmbedStub = helper.sandbox.stub()
+
+    render = helper.configureRenderer(ResourceEmbedField, {
+      insertEmbed: insertEmbedStub,
+      attach:      "resource"
+    })
+
+    website = makeWebsiteDetail()
+    // @ts-ignore
+    useWebsite.mockReturnValue(website)
+
+    setStub = helper.sandbox.stub()
+    // @ts-ignore
+    useDebouncedState.mockReturnValue(["", setStub])
+
+    contentListingItems = [
+      makeWebsiteContentListItem(),
+      makeWebsiteContentListItem()
+    ]
+
+    apiResponse = {
+      results:  contentListingItems,
+      count:    2,
+      next:     null,
+      previous: null
+    }
+
+    helper.handleRequestStub
+      .withArgs(
+        siteApiContentListingUrl
+          .param({
+            name: website.name
+          })
+          .query({ offset: 0, type: "resource" })
+          .toString(),
+        "GET"
+      )
+      .returns({
+        body:   apiResponse,
+        status: 200
+      })
+
+    helper.handleRequestStub
+      .withArgs(
+        siteApiContentListingUrl
+          .param({
+            name: website.name
+          })
+          .query({ offset: 0, type: "resource", search: "newFilter" })
+          .toString(),
+        "GET"
+      )
+      .returns({
+        body:   apiResponse,
+        status: 200
+      })
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should fetch and display resources", async () => {
+    const { wrapper } = await render()
+    expect(
+      wrapper.find(".resource-list .resource").map(el => el.find("h4").text())
+    ).toEqual(contentListingItems.map(item => item.title))
+  })
+
+  it("should call insertEmbed prop with resources", async () => {
+    const { wrapper } = await render()
+
+    wrapper
+      .find(".resource-list .resource")
+      .at(0)
+      .simulate("click")
+    expect(
+      insertEmbedStub.calledWith(contentListingItems[0].text_id)
+    ).toBeTruthy()
+  })
+
+  it("should allow the user to filter resources", async () => {
+    const setStub = helper.sandbox.stub()
+    // @ts-ignore
+    useDebouncedState.mockImplementation((initial, _ms) => {
+      // this is just to un-debounce to make testing easier
+      const [state, setState] = useState(initial)
+
+      return [
+        state,
+        (update: any) => {
+          setStub(update)
+          setState(update)
+        }
+      ]
+    })
+
+    const { wrapper } = await render()
+
+    act(() => {
+      // @ts-ignore
+      wrapper.find(".filter-input").prop("onChange")({
+        // @ts-ignore
+        currentTarget: { value: "newFilter" }
+      })
+    })
+
+    expect(setStub.calledWith("newFilter")).toBeTruthy()
+    expect(helper.handleRequestStub.args.map(xs => xs[0])).toEqual([
+      siteApiContentListingUrl
+        .param({
+          name: website.name
+        })
+        .query({ offset: 0, type: "resource" })
+        .toString(),
+      siteApiContentListingUrl
+        .param({
+          name: website.name
+        })
+        .query({ offset: 0, type: "resource", search: "newFilter" })
+        .toString()
+    ])
+  })
+})

--- a/static/js/components/widgets/ResourceEmbedField.tsx
+++ b/static/js/components/widgets/ResourceEmbedField.tsx
@@ -1,0 +1,81 @@
+import React, { useState, useCallback, SyntheticEvent } from "react"
+import { useSelector } from "react-redux"
+import { useRequest } from "redux-query-react"
+
+import { useWebsite } from "../../context/Website"
+import {
+  websiteContentListingRequest,
+  WebsiteContentListingResponse
+} from "../../query-configs/websites"
+import { getWebsiteContentListingCursor } from "../../selectors/websites"
+import { ContentListingParams } from "../../types/websites"
+import { useDebouncedState } from "../../hooks/state"
+
+interface Props {
+  insertEmbed: (id: string) => void
+  attach: string
+}
+
+export default function ResourceEmbedField(props: Props): JSX.Element {
+  const { insertEmbed, attach } = props
+
+  // filterInput is to store user input and is updated synchronously
+  // so that the UI stays responsive
+  const [filterInput, setFilterInput] = useState("")
+  // filter, by contrast, is set by the setFilterDebounced function
+  // to cut down on extraneous requests. filter is set as a param in
+  // the listingParams object below, so updating the value causes the
+  // websiteContentListingRequest to be re-run, so we debounce for
+  // less silliness!
+  const [filter, setFilterDebounced] = useDebouncedState("", 300)
+
+  const onChangeFilter = useCallback(
+    (event: SyntheticEvent<HTMLInputElement>) => {
+      const newFilter = event.currentTarget.value
+      setFilterInput(newFilter)
+      setFilterDebounced(newFilter)
+    },
+    [setFilterDebounced]
+  )
+
+  const website = useWebsite()
+  const listingParams: ContentListingParams = {
+    name:   website.name,
+    type:   attach,
+    search: filter,
+    offset: 0
+  }
+
+  useRequest(websiteContentListingRequest(listingParams, false, false))
+
+  const listing: WebsiteContentListingResponse = useSelector(
+    getWebsiteContentListingCursor
+  )(listingParams)
+
+  return (
+    <div className="my-2 resource-embed-widget">
+      <label>Resources</label>
+      <input
+        placeholder="filter"
+        type="text"
+        onChange={onChangeFilter}
+        value={filterInput}
+        className="form-control filter-input"
+      />
+      <div className="resource-list mx-1">
+        {listing.results ?
+          listing.results.map(item => (
+            <div
+              key={item.text_id}
+              className="m-2 d-flex justify-content-between resource"
+              onClick={() => insertEmbed(item.text_id)}
+            >
+              <h4>{item.title}</h4>
+              <span className="material-icons">insert_drive_file</span>
+            </div>
+          )) :
+          null}
+      </div>
+    </div>
+  )
+}

--- a/static/js/hooks/state.test.ts
+++ b/static/js/hooks/state.test.ts
@@ -1,0 +1,26 @@
+import { renderHook, act } from "@testing-library/react-hooks"
+
+import { useDebouncedState } from "./state"
+
+describe("State Hooks", () => {
+  describe("useDebouncedState", () => {
+    it("should return the default state", () => {
+      const { result } = renderHook(() =>
+        useDebouncedState("initialState", 300)
+      )
+      expect(result.current[0]).toBe("initialState")
+    })
+
+    it("should set new state when the debounce period is over", () => {
+      const { result } = renderHook(() =>
+        useDebouncedState("initialState", 300)
+      )
+
+      act(() => result.current[1]("newState"))
+      expect(result.current[0]).toBe("initialState")
+
+      act(() => result.current[1].flush())
+      expect(result.current[0]).toBe("newState")
+    })
+  })
+})

--- a/static/js/hooks/state.ts
+++ b/static/js/hooks/state.ts
@@ -1,0 +1,36 @@
+import { useState, useCallback } from "react"
+import { debounce, DebouncedFunc } from "lodash"
+
+/**
+ * A debounced state! It works just like `useState`, but `setState`
+ * calls are debounced by `delay` ms. Usage example:
+ *
+ * ```ts
+ * const [state, setStateDebounced] = useDebouncedState(
+ *   "My Initial Value",   // initial value
+ *   300                   // how long to delay updating state
+ * )
+ * ```
+ *
+ * This uses `_.debounce` under the hood, so updates can be made
+ * immediately by calling the `.flush()` method on `setStateDebounced`
+ * if needed.
+ */
+export function useDebouncedState<T>(
+  initialState: T,
+  delay: number
+): [T, DebouncedFunc<(n: T) => void>] {
+  const [state, setState] = useState<T>(initialState)
+
+  // eslint can't infer the requirements of this function because
+  // it's wrapped in `debounce`, but we can manually verify that
+  // it is dependent on just `setState` and `delay`.
+  //
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const setStateDebounced = useCallback(
+    debounce((nextval: T) => setState(nextval), delay),
+    [setState, delay]
+  )
+
+  return [state, setStateDebounced]
+}

--- a/static/js/lib/ckeditor/CKEditor.ts
+++ b/static/js/lib/ckeditor/CKEditor.ts
@@ -15,7 +15,7 @@ import ParagraphPlugin from "@ckeditor/ckeditor5-paragraph/src/paragraph"
 
 import Markdown from "./plugins/Markdown"
 import MarkdownMediaEmbed from "./plugins/MarkdownMediaEmbed"
-import SiteContentEmbed from "./plugins/SiteContentEmbed"
+import ResourceEmbed from "./plugins/ResourceEmbed"
 
 export const FullEditorConfig = {
   plugins: [
@@ -33,7 +33,7 @@ export const FullEditorConfig = {
     LinkPlugin,
     ListPlugin,
     ParagraphPlugin,
-    SiteContentEmbed,
+    ResourceEmbed,
     MarkdownMediaEmbed,
     Markdown
   ],

--- a/static/js/lib/ckeditor/plugins/ResourceEmbed.test.tsx
+++ b/static/js/lib/ckeditor/plugins/ResourceEmbed.test.tsx
@@ -1,11 +1,11 @@
-import SiteContentEmbed from "./SiteContentEmbed"
+import ResourceEmbed from "./ResourceEmbed"
 import Markdown from "./Markdown"
 import { createTestEditor, markdownTest } from "./test_util"
 import { turndownService } from "../turndown"
 
-const getEditor = createTestEditor([SiteContentEmbed, Markdown])
+const getEditor = createTestEditor([ResourceEmbed, Markdown])
 
-describe("SiteContentEmbed plugin", () => {
+describe("ResourceEmbed plugin", () => {
   afterEach(() => {
     turndownService.rules.array = turndownService.rules.array.filter(
       (rule: any) => rule.filter !== "figure"

--- a/static/js/lib/site_content.test.ts
+++ b/static/js/lib/site_content.test.ts
@@ -339,10 +339,12 @@ describe("site_content", () => {
     it("should grab the minimal prop for a markdown widget", () => {
       const field = makeWebsiteConfigField({
         widget:  WidgetVariant.Markdown,
-        minimal: true
+        minimal: true,
+        attach:  "resource"
       })
       expect(widgetExtraProps(field)).toStrictEqual({
-        minimal: true
+        minimal: true,
+        attach:  "resource"
       })
     })
 

--- a/static/js/lib/site_content.ts
+++ b/static/js/lib/site_content.ts
@@ -86,7 +86,10 @@ export function widgetExtraProps(field: ConfigField): Record<string, any> {
   case WidgetVariant.Select:
     return pick(SELECT_EXTRA_PROPS, field)
   case WidgetVariant.Markdown:
-    return { minimal: field.minimal ?? false }
+    return {
+      minimal: field.minimal ?? false,
+      attach:  field.attach ?? undefined
+    }
   case WidgetVariant.Relation:
     return pick(RELATION_EXTRA_PROPS, field)
   case WidgetVariant.Menu:

--- a/static/js/query-configs/websites.ts
+++ b/static/js/query-configs/websites.ts
@@ -267,7 +267,7 @@ export const contentDetailKey = (params: ContentDetailParams): string =>
  *
  * Pass the `requestDetailedList` param if you need to get the detailed view of
  * all the content items, as opposed to a minimal, summary view of the items
- * (requestDetailedList == true tells the serializer to use the
+ * (requestDetailedList == true tells the backend to use the
  * WebsiteContentDetailSerializer as opposed to the WebsiteContentSerializer,
  * the default for this view).
  **/
@@ -276,16 +276,22 @@ export const websiteContentListingRequest = (
   requestDetailedList: boolean,
   requestContentContext: boolean
 ): QueryConfig => {
-  const { name, type, offset, pageContent } = listingParams
-  const url = siteApiContentListingUrl.param({ name }).query({
-    offset,
-    ...(type ? { type: type } : {}),
-    ...(pageContent ? { page_content: pageContent } : {}),
-    ...(requestDetailedList ? { detailed_list: true } : {}),
-    ...(requestContentContext ? { content_context: true } : {})
-  })
+  const { name, type, offset, pageContent, search } = listingParams
+  const url = siteApiContentListingUrl
+    .param({ name })
+    .query(
+      Object.assign(
+        { offset },
+        type && { type: type },
+        pageContent && { page_content: pageContent },
+        requestDetailedList && { detailed_list: true },
+        requestContentContext && { content_context: true },
+        search && { search }
+      )
+    )
+    .toString()
   return {
-    url:       url.toString(),
+    url,
     transform: (body: WebsiteContentListingResponse) => {
       const details = {}
       for (const item of body.results) {

--- a/static/js/resources/ocw-course-site-config.json
+++ b/static/js/resources/ocw-course-site-config.json
@@ -4,6 +4,7 @@
       "category": "Content",
       "fields": [
         {
+          "attach": "resource",
           "label": "Title",
           "name": "title",
           "required": true,

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -40,6 +40,7 @@ interface ConfigFieldBaseProps {
 export interface MarkdownConfigField extends ConfigFieldBaseProps {
   widget: WidgetVariant.Markdown
   minimal?: boolean
+  attach?: string
 }
 
 export interface FileConfigField extends ConfigFieldBaseProps {
@@ -235,6 +236,7 @@ export interface ContentListingParams {
   type?: string | string[]
   pageContent?: boolean
   offset: number
+  search?: string
 }
 
 export interface ContentDetailParams {

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -13,3 +13,4 @@ $studio-background: #f7fafc;
 $studio-black: #030303;
 $studio-text-gray: #b3b3b3;
 $studio-gray: #e4e4e4;
+$form-control-gray: #ced4da;

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -12,6 +12,7 @@
 @import "button";
 @import "list";
 @import "ckeditor";
+@import "resource-embed-widget";
 
 body {
   font-family: "Roboto", sans-serif;

--- a/static/scss/resource-embed-widget.scss
+++ b/static/scss/resource-embed-widget.scss
@@ -1,0 +1,14 @@
+.resource-embed-widget {
+  .resource-list {
+    max-height: 225px;
+    overflow: scroll;
+    border-left: 1px solid $form-control-gray;
+    border-right: 1px solid $form-control-gray;
+    border-bottom: 1px solid $form-control-gray;
+    border-radius: 0 0 0.25rem 0.25rem;
+
+    .resource {
+      cursor: pointer;
+    }
+  }
+}

--- a/websites/config_schema/site-config-schema.yml
+++ b/websites/config_schema/site-config-schema.yml
@@ -36,6 +36,7 @@ field:
     collections: list(str(), required=False)
     filter: include('relation_filter', required=False)
     website: str(required=False)
+    attach: str(required=False)
 ---
 field_condition:
     field: str()

--- a/yarn.lock
+++ b/yarn.lock
@@ -1760,6 +1760,17 @@
   resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
   integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
 
+"@testing-library/react-hooks@^7.0.1":
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-7.0.1.tgz#8429d8bf55bfe82e486bd582dd06457c2464900a"
+  integrity sha512-bpEQ2SHSBSzBmfJ437NmnP+oArQ7aVmmULiAp6Ag2rtyLBLPNFSMmgltUbFGmQOJdPWo4Ub31kpUC5T46zXNwQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@types/react" ">=16.9.0"
+    "@types/react-dom" ">=16.9.0"
+    "@types/react-test-renderer" ">=16.9.0"
+    react-error-boundary "^3.1.0"
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
@@ -1965,7 +1976,7 @@
   dependencies:
     ts-toolbelt "^6.15.1"
 
-"@types/react-dom@*", "@types/react-dom@^17.0.9":
+"@types/react-dom@*", "@types/react-dom@>=16.9.0", "@types/react-dom@^17.0.9":
   version "17.0.9"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.9.tgz#441a981da9d7be117042e1a6fd3dac4b30f55add"
   integrity sha512-wIvGxLfgpVDSAMH5utdL9Ngm5Owu0VsGmldro3ORLXV8CShrL8awVj06NuEXFQ5xyaYfdca7Sgbk/50Ri1GdPg==
@@ -2009,6 +2020,13 @@
     "@types/react-dom" "*"
     "@types/react-transition-group" "*"
 
+"@types/react-test-renderer@>=16.9.0":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz#3120f7d1c157fba9df0118dae20cb0297ee0e06b"
+  integrity sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-transition-group@*":
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.2.tgz#38890fd9db68bf1f2252b99a942998dc7877c5b3"
@@ -2020,6 +2038,15 @@
   version "17.0.15"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.15.tgz#c7533dc38025677e312606502df7656a6ea626d0"
   integrity sha512-uTKHDK9STXFHLaKv6IMnwp52fm0hwU+N89w/p9grdUqcFA6WuqDyPhaWopbNyE1k/VhgzmHl8pu1L4wITtmlLw==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/react@>=16.9.0":
+  version "17.0.16"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.16.tgz#056f40c45645761527baeb7d89d842a6abdf285a"
+  integrity sha512-3kCUiOOlQTwUUvjNFkbBTWMTxdTGybz/PfjCw9JmaRGcEDBQh+nGMg7/E9P2rklhJuYVd25IYLNcvqgSPCPksg==
   dependencies:
     "@types/prop-types" "*"
     "@types/scheduler" "*"
@@ -9268,6 +9295,13 @@ react-dom@^15.7.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
     prop-types "^15.5.10"
+
+react-error-boundary@^3.1.0:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.3.tgz#276bfa05de8ac17b863587c9e0647522c25e2a0b"
+  integrity sha512-A+F9HHy9fvt9t8SNDlonq01prnU8AmkjvGKV4kk8seB9kU3xMEO8J/PQlLVmoOIDODl5U2kufSBs4vrWIqhsAA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-fast-compare@^2.0.1:
   version "2.0.4"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #453

#### What's this PR do?

This adds the first part of the resource embed UI: an interface for selecting resources and inserting them into the Markdown editor.

This does not include display a rich preview of those resources in the editor itself.

#### How should this be manually tested?

I updated `ocw-course-site-config.yml`, so you should be able to run the `override_site_config` management command to get some course sites configured to use this feature.

Then you should create some resource records, and then create a page in the same course. You should see a picker for resources, basically a scrollable list of them and a filter. Typing text into the filter should narrow the results shown (it will make a new request to the backend with the filter input text set to the `search` query param). Clicking on an entry in the list should add a node to the Markdown editor with the resource's `.text_id` property in it.


#### Screenshots (if appropriate)

<img width="872" alt="Screen Shot 2021-08-05 at 6 25 59 PM" src="https://user-images.githubusercontent.com/6207644/128429288-2b1d382b-5a64-4bbd-a292-6be36f8a2ddc.png">

<img width="758" alt="Screen Shot 2021-08-05 at 6 26 38 PM" src="https://user-images.githubusercontent.com/6207644/128429301-939fd46d-7c75-4baa-a1ed-c973a53b5301.png">

<img width="833" alt="Screen Shot 2021-08-05 at 6 27 10 PM" src="https://user-images.githubusercontent.com/6207644/128429324-dbe9198b-6ce7-4e03-9c53-4d50dc5062e2.png">
