### PR TITLE
Add custom format_recipient function, assign to MITOL_MAIL_FORMAT_RECIPIENT_FUNC

### DIFF
--- a/app.json
+++ b/app.json
@@ -199,6 +199,10 @@
       "description": "Feature flag middleware querystring prefix",
       "required": false
     },
+    "MITOL_MAIL_FORMAT_RECIPIENT_FUNC": {
+      "description": "function to format email recipients",
+      "required": false
+    },
     "MITOL_MAIL_FROM_EMAIL": {
       "description": "E-mail to use for the from field",
       "required": false

--- a/main/settings.py
+++ b/main/settings.py
@@ -791,7 +791,11 @@ MITOL_MAIL_ENABLE_EMAIL_DEBUGGER = get_bool(
     description="Enable the mitol-mail email debugger",
     dev_only=True,
 )
-
+MITOL_MAIL_FORMAT_RECIPIENT_FUNC = get_string(
+    name="MITOL_MAIL_FORMAT_RECIPIENT_FUNC",
+    default="users.utils.format_recipient",
+    description="function to format email recipients",
+)
 OCW_STUDIO_DRAFT_URL = get_string(
     name="OCW_STUDIO_DRAFT_URL",
     default=None,

--- a/users/utils.py
+++ b/users/utils.py
@@ -8,4 +8,4 @@ def format_recipient(user: User) -> str:
     """
     Format a user as a recipient for an email
     """
-    return formataddr((user.email, user.email))
+    return formataddr((f"{user.name}", user.email))

--- a/users/utils.py
+++ b/users/utils.py
@@ -1,0 +1,11 @@
+"""Utils for users"""
+from email.utils import formataddr
+
+from users.models import User
+
+
+def format_recipient(user: User):
+    """
+    Format a user as a recipient for an email
+    """
+    return formataddr((user.email, user.email))

--- a/users/utils.py
+++ b/users/utils.py
@@ -4,7 +4,7 @@ from email.utils import formataddr
 from users.models import User
 
 
-def format_recipient(user: User):
+def format_recipient(user: User) -> str:
     """
     Format a user as a recipient for an email
     """

--- a/users/utils_test.py
+++ b/users/utils_test.py
@@ -1,0 +1,8 @@
+"""Tests for user utils"""
+from users.factories import UserFactory
+from users.utils import format_recipient
+
+
+def test_format_recipient():
+    user = UserFactory.build()
+    assert format_recipient(user) == f'"{user.email}" <{user.email}>'

--- a/users/utils_test.py
+++ b/users/utils_test.py
@@ -6,4 +6,4 @@ from users.utils import format_recipient
 def test_format_recipient():
     """format_recipient should return the expected string"""
     user = UserFactory.build()
-    assert format_recipient(user) == f'"{user.email}" <{user.email}>'
+    assert format_recipient(user) == f"{user.name} <{user.email}>"

--- a/users/utils_test.py
+++ b/users/utils_test.py
@@ -4,5 +4,6 @@ from users.utils import format_recipient
 
 
 def test_format_recipient():
+    """format_recipient should return the expected string"""
     user = UserFactory.build()
     assert format_recipient(user) == f'"{user.email}" <{user.email}>'


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Closes #482 

#### What's this PR do?
Adds a new `format_recipient` function for emailing
Adds the `MITOL_MAIL_FORMAT_RECIPIENT_FUNC` setting with a default value of the above function name.

#### How should this be manually tested?
- **Remove** `MITOL_MAIL_RECIPIENT_OVERRIDE` from your .env file
- Set the following in your .env:
  ```
   API_BEARER_TOKEN=<any string>
   MAILGUN_KEY=<same as RC>
   MAILGUN_URL=<same as RC>
   MAILGUN_SENDER_DOMAIN=<same as RC>
  ```
- Make a website with a user that has an email address you can check messages for.
- Send a POST request to `http://localhost:8043/api/websites/<your-course-name>/pipeline_complete/` with an authorization header of `Bearer <settings.API_BEARER_TOKEN>` and this body:
```
{
    "version": "draft",
    "site": "<your-course-name>",
    "success": true
}
```
- You should get an empty 200 response and receive an email shortly


#### Any background context you want to provide?
This was overlooked during testing/development because `MITOL_MAIL_RECIPIENT_OVERRIDE` was always set.
