### PR TITLE
Don't error on minimal site config

### DIFF
--- a/static/js/components/SiteContentListing.test.tsx
+++ b/static/js/components/SiteContentListing.test.tsx
@@ -1,3 +1,5 @@
+import casual from "casual-browserify"
+
 const mockUseRouteMatch = jest.fn()
 
 import React from "react"
@@ -101,6 +103,25 @@ describe("SiteContentListing", () => {
         configItem
       })
     })
+  })
+
+  it(`renders without erroring when rendering a minimal starter config`, async () => {
+    const configItem = {
+      name:     "minimalist",
+      label:    casual.word,
+      category: casual.word
+    }
+    // @ts-ignore
+    website.starter?.config?.collections = [configItem]
+
+    // @ts-ignore
+    const params = { name: website.name, contenttype: configItem.name }
+    mockUseRouteMatch.mockImplementation(() => ({
+      params
+    }))
+    const { wrapper } = await render()
+    expect(wrapper.find(MockSingletons).exists()).toBeFalsy()
+    expect(wrapper.find(MockRepeatable).exists()).toBeFalsy()
   })
 
   it("modifies config item fields before passing them on RepeatableContentListing", async () => {

--- a/static/js/components/SiteContentListing.tsx
+++ b/static/js/components/SiteContentListing.tsx
@@ -7,7 +7,8 @@ import SingletonsContentListing from "./SingletonsContentListing"
 
 import {
   addDefaultFields,
-  isRepeatableCollectionItem
+  isRepeatableCollectionItem,
+  isSingletonCollectionItem
 } from "../lib/site_content"
 import { getWebsiteDetailCursor } from "../selectors/websites"
 import WebsiteContext from "../context/Website"
@@ -35,9 +36,9 @@ export default function SiteContentListing(): JSX.Element | null {
     <WebsiteContext.Provider value={website}>
       {isRepeatableCollectionItem(configItem) ? (
         <RepeatableContentListing configItem={addDefaultFields(configItem)} />
-      ) : (
+      ) : isSingletonCollectionItem(configItem) ? (
         <SingletonsContentListing configItem={configItem} />
-      )}
+      ) : null}
     </WebsiteContext.Provider>
   )
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #434 

#### What's this PR do?
If the content page is neither a repeatable content listing nor a singleton, it will render a null rather than error.

I think it would be better to fix this in the validation somehow to enforce one or the other but I couldn't see how we could easily make yamale do that
