### PR TITLE
Add rule to require one of files or folder in collection schema

### DIFF
--- a/websites/config_schema/validators.py
+++ b/websites/config_schema/validators.py
@@ -45,7 +45,7 @@ class AddedSchemaRule:
 
 
 class CollectionsKeysRule(AddedSchemaRule):
-    """Ensures that collections items only define one of a set of mutually-exclusive keys"""
+    """Ensures that collections items must define one of a set of mutually-exclusive keys for files and folders"""
 
     @staticmethod
     def apply_rule(data):
@@ -61,6 +61,11 @@ class CollectionsKeysRule(AddedSchemaRule):
                     "{}: Only one of the following keys can be specified for a collection item - {}".format(
                         path, ", ".join(exclusive_keys)
                     )
+                ]
+            if len(matching_keys) < 1:
+                path = f"collections.{i}"
+                return [
+                    f"{path}: A collection must have one of the following keys: {', '.join(sorted(exclusive_keys))}"
                 ]
 
 

--- a/websites/config_schema/validators_test.py
+++ b/websites/config_schema/validators_test.py
@@ -1,0 +1,29 @@
+"""Tests for schema validators"""
+import yaml
+
+from websites.config_schema.validators import CollectionsKeysRule
+
+
+def _validate(validation_class, data):
+    """
+    Validate a starter config
+    """
+    if isinstance(data, str):
+        data = yaml.load(data, Loader=yaml.SafeLoader)
+    return validation_class.apply_rule(data)
+
+
+def test_no_file_or_folder():
+    """either file or folder must be present in the schema"""
+    data = """
+    {
+  "collections": [
+    {
+    }
+  ],
+  "root-url-path": "/"
+}
+    """
+    assert _validate(CollectionsKeysRule, data) == [
+        "collections.0: A collection must have one of the following keys: files, folder"
+    ]


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #434 

#### What's this PR do?
Updates a validation rule to require one of `files` or `folder` as a key in `collections`.

#### How should this be manually tested?
Try to add a starter with this config:

    {
      "collections": [
        {
          "category": "Page",
          "fields": [
            {
              "label": "Title",
              "name": "title",
              "required": true,
              "widget": "string"
            }
          ],
          "label": "Page",
          "name": "page"
        }
      ],
      "root-url-path": "/"
    }

On master this should work fine, but on this PR you should see a validation error: "A collection must have one of the following keys: files, folder"