### PR TITLE
add the get_destination_url helper function and use it for menu urls

### DIFF
--- a/content_sync/serializers.py
+++ b/content_sync/serializers.py
@@ -7,7 +7,7 @@ from typing import Dict, Optional
 import yaml
 from mitol.common.utils import dict_without_keys
 
-from content_sync.utils import get_destination_filepath
+from content_sync.utils import get_destination_url
 from main.utils import (
     get_dirpath_and_filename,
     get_file_extension,
@@ -215,7 +215,7 @@ def _transform_hugo_menu_data(
             # Add/update the 'url' value if this is an internal link
             if menu_item["identifier"] in uuid_content_map:
                 menu_item_content = uuid_content_map[menu_item["identifier"]]
-                updated_menu_item["url"] = get_destination_filepath(
+                updated_menu_item["url"] = get_destination_url(
                     menu_item_content, site_config
                 )
             result_menu_items.append(updated_menu_item)

--- a/content_sync/serializers_test.py
+++ b/content_sync/serializers_test.py
@@ -191,7 +191,7 @@ def test_hugo_menu_yaml_serialize(omnibus_config):
     parsed_serialized_data = yaml.load(serialized_data, Loader=yaml.SafeLoader)
     assert parsed_serialized_data == {
         "mainmenu": [
-            {**example_menu_data[0], "url": "path/to/myfile.md"},
+            {**example_menu_data[0], "url": "path/to/myfile"},
             example_menu_data[1],
         ],
         "title": content.title,

--- a/content_sync/utils.py
+++ b/content_sync/utils.py
@@ -46,7 +46,7 @@ def get_destination_url(
     """
     if content.is_page_content:
         filename = "" if content.filename == "_index" else content.filename
-        prefix = "{}/{}".format(content.website.name, site_config.content_dir)
+        prefix = f"{content.website.name}/{site_config.content_dir}"
         dirpath = (
             content.dirpath.replace(prefix, "", 1)
             if content.dirpath.startswith(prefix)

--- a/content_sync/utils.py
+++ b/content_sync/utils.py
@@ -46,8 +46,12 @@ def get_destination_url(
     """
     if content.is_page_content:
         filename = "" if content.filename == "_index" else content.filename
-        dirpath = content.dirpath.replace(content.website.name, "", 1)
-        dirpath = dirpath.replace("/{}".format(site_config.content_dir), "", 1)
+        prefix = "{}/{}".format(content.website.name, site_config.content_dir)
+        dirpath = (
+            content.dirpath.replace(prefix, "", 1)
+            if content.dirpath.startswith(prefix)
+            else content.dirpath
+        )
         return os.path.join(dirpath, filename)
     log.error(
         "Cannot get destination URL because is_page_content is false (content: %s)",

--- a/content_sync/utils.py
+++ b/content_sync/utils.py
@@ -45,9 +45,10 @@ def get_destination_url(
     Returns the URL a given piece of content is expected to be at
     """
     if content.is_page_content:
-        return os.path.join(
-            content.dirpath.replace(site_config.content_dir, "", 1), content.filename
-        )
+        filename = "" if content.filename == "_index" else content.filename
+        dirpath = content.dirpath.replace(content.website.name, "", 1)
+        dirpath = dirpath.replace("/{}".format(site_config.content_dir), "", 1)
+        return os.path.join(dirpath, filename)
     log.error(
         "Cannot get destination URL because is_page_content is false (content: %s)",
         (content.id, content.text_id),

--- a/content_sync/utils.py
+++ b/content_sync/utils.py
@@ -36,3 +36,20 @@ def get_destination_filepath(
         (content.id, content.text_id),
     )
     return None
+
+
+def get_destination_url(
+    content: WebsiteContent, site_config: SiteConfig
+) -> Optional[str]:
+    """
+    Returns the URL a given piece of content is expected to be at
+    """
+    if content.is_page_content:
+        return os.path.join(
+            content.dirpath.replace(site_config.content_dir, "", 1), content.filename
+        )
+    log.error(
+        "Cannot get destination URL because is_page_content is false (content: %s)",
+        (content.id, content.text_id),
+    )
+    return None

--- a/content_sync/utils_test.py
+++ b/content_sync/utils_test.py
@@ -39,3 +39,23 @@ def test_get_destination_filepath_errors(mocker, has_missing_name, is_bad_config
     )
     patched_log.error.assert_called_once()
     assert return_value is None
+
+
+def test_get_destination_url_errors(mocker):
+    """
+    get_destination_url should log an error if it is called with a a WebsiteContent object without
+    is_page_content set to true
+    """
+    patched_log = mocker.patch("content_sync.utils.log")
+    # From basic-site-config.yml
+    config_item_name = "blog"
+    starter = WebsiteStarterFactory.build()
+    content = WebsiteContentFactory.build(
+        is_page_content=False,
+        type=config_item_name,
+    )
+    return_value = get_destination_filepath(
+        content=content, site_config=SiteConfig(starter.config)
+    )
+    patched_log.error.assert_called_once()
+    assert return_value is None


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/493

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/425 and https://github.com/mitodl/ocw-studio/pull/364 we added backend support for generating a Hugo nav menu configuration.  A file path to a piece of content's markdown was used for the `url` property, when in reality what is expected here is a URL; relative for internal, absolute for external.  This PR adds a helper function called `get_destination_url` that generates the expected relative URL of a piece of content in a rendered site and uses it in the Hugo menu serializer.

#### How should this be manually tested?
 - Spin up `ocw-studio` locally on this branch and make sure you are set up to sync to github.mit.edu
 - Make sure you have a website starter that includes a nav menu widget, like https://github.com/mitodl/ocw-hugo-projects/blob/main/ocw-course/ocw-studio.yaml
 - Create a website using this starter
 - Add some pages or other pieces of content that can be linked to internally
 - Add some menu entries that point to this content you've created
 - Publish your site and inspect `config/_default/menus.yaml`, the URL properties should now not contain the `content/` prefix nor the `.md` file extension