### PR TITLE
Hide hidden fields inside object fields

### DIFF
--- a/static/js/components/forms/SiteContentForm.test.tsx
+++ b/static/js/components/forms/SiteContentForm.test.tsx
@@ -138,20 +138,22 @@ describe("SiteContentForm", () => {
         expect(formik.prop("enableReinitialize")).toBe(true)
       })
 
-      it("should pass an 'object' field to the ObjectWidget component", () => {
+      it("should pass an 'object' field to the ObjectField component", () => {
         const field = makeWebsiteConfigField({ widget: WidgetVariant.Object })
         configItem.fields = [field]
         // @ts-ignore
         fieldIsVisible.mockImplementation(() => true)
         // @ts-ignore
         splitFieldsIntoColumns.mockImplementation(() => [configItem.fields])
-        const wrapper = renderInnerForm(editorState)
+        const values = { some: "values" }
+        const wrapper = renderInnerForm(editorState, { values })
         const objectWrapper = wrapper.find("ObjectField")
         expect(objectWrapper.exists()).toBeTruthy()
         expect(objectWrapper.prop("field")).toEqual(field)
         expect(objectWrapper.prop("contentContext")).toBe(
           content.content_context
         )
+        expect(objectWrapper.prop("values")).toStrictEqual(values)
       })
 
       it("creates initialValues", () => {

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -96,6 +96,7 @@ export default function SiteContentForm({
                       field={field}
                       key={field.name}
                       contentContext={contentContext}
+                      values={values}
                     />
                   ) : (
                     <SiteContentField

--- a/static/js/components/forms/validation.test.ts
+++ b/static/js/components/forms/validation.test.ts
@@ -540,6 +540,29 @@ describe("form validation utils", () => {
           })
         ).resolves.toBeTruthy()
       })
+
+      it("should skip validation on sub-fields which don't have data to send", async () => {
+        const [configItem, name] = makeObjectConfigItem({ required: true })
+        const fieldIsVisibleStub = sandbox
+          .stub(siteContentFuncs, "fieldIsVisible")
+          .returns(false)
+        const values = {}
+        const schema = getContentSchema(configItem, values)
+
+        await expect(
+          schema.isValid({
+            ...defaultFormValues,
+            [name]: {
+              mystring: null
+            }
+          })
+        ).resolves.toBeTruthy()
+        sinon.assert.calledWith(
+          fieldIsVisibleStub,
+          configItem.fields[0],
+          values
+        )
+      })
     })
   })
 

--- a/static/js/components/forms/validation.ts
+++ b/static/js/components/forms/validation.ts
@@ -15,8 +15,7 @@ import {
   SelectConfigField,
   WidgetVariant
 } from "../../types/websites"
-import { FormSchema } from "../../types/forms"
-import { FormikValues } from "formik"
+import { FormSchema, SiteFormValues } from "../../types/forms"
 
 // This is added to properly handle file fields, which can have a "null" value
 setLocale({
@@ -56,7 +55,10 @@ const minMax = (
  * WidgetVariant, but also looks at some other props like `min`, `max`,
  * `required`, and `label`.
  **/
-export const getFieldSchema = (field: ConfigField): FormSchema => {
+export const getFieldSchema = (
+  field: ConfigField,
+  values: SiteFormValues
+): FormSchema => {
   let schema
 
   switch (field.widget) {
@@ -89,7 +91,9 @@ export const getFieldSchema = (field: ConfigField): FormSchema => {
       .object()
       .shape(
         Object.fromEntries(
-          field.fields.map(field => [field.name, getFieldSchema(field)])
+          field.fields
+            .filter(field => fieldIsVisible(field, values))
+            .map(field => [field.name, getFieldSchema(field, values)])
         )
       )
     break
@@ -122,13 +126,13 @@ export const getFieldSchema = (field: ConfigField): FormSchema => {
  **/
 export const getContentSchema = (
   configItem: ConfigItem | EditableConfigItem,
-  values: FormikValues
+  values: SiteFormValues
 ): FormSchema => {
   const titleField = configItem.fields.find(field => field.name === "title")
   const yupObjectShape = Object.fromEntries(
     configItem.fields
       .filter(field => fieldIsVisible(field, values))
-      .map(field => [field.name, getFieldSchema(field)])
+      .map(field => [field.name, getFieldSchema(field, values)])
   )
   if (isRepeatableCollectionItem(configItem) && !titleField) {
     yupObjectShape["title"] = defaultTitleFieldSchema

--- a/static/js/components/widgets/ObjectField.test.tsx
+++ b/static/js/components/widgets/ObjectField.test.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { shallow } from "enzyme"
 
+import * as siteContent from "../../lib/site_content"
 import ObjectField from "./ObjectField"
 import {
   makeWebsiteConfigField,
@@ -12,9 +13,15 @@ import {
   WebsiteContent,
   WidgetVariant
 } from "../../types/websites"
+import { SiteFormValues } from "../../types/forms"
+
+jest.mock("../../lib/site_content")
 
 describe("ObjectField", () => {
-  let render: any, field: ObjectConfigField, contentContext: WebsiteContent[]
+  let render: any,
+    field: ObjectConfigField,
+    contentContext: WebsiteContent[],
+    values: SiteFormValues
 
   beforeEach(() => {
     field = makeWebsiteConfigField({
@@ -33,12 +40,21 @@ describe("ObjectField", () => {
       ]
     }) as ObjectConfigField
 
+    // @ts-ignore
+    siteContent.fieldIsVisible.mockReturnValue(true)
+
     const otherContent = makeWebsiteContentDetail()
     contentContext = [otherContent]
+    values = { some: "values" }
 
     render = (props = {}) =>
       shallow(
-        <ObjectField field={field} contentContext={contentContext} {...props} />
+        <ObjectField
+          field={field}
+          contentContext={contentContext}
+          values={values}
+          {...props}
+        />
       )
   })
 
@@ -65,5 +81,20 @@ describe("ObjectField", () => {
     expect(wrapper.find("SiteContentField").exists()).toBeFalsy()
     wrapper.find(".object-field-label").simulate("click", new Event("click"))
     expect(wrapper.find("SiteContentField").exists()).toBeTruthy()
+  })
+
+  //
+  ;[true, false].forEach(isVisible => {
+    it(`should hide fields which are ${isVisible ? "" : "not "}visible`, () => {
+      // @ts-ignore
+      siteContent.fieldIsVisible.mockReturnValue(isVisible)
+      const wrapper = render()
+      expect(wrapper.find("SiteContentField")).toHaveLength(
+        isVisible ? field.fields.length : 0
+      )
+      for (const innerField of field.fields) {
+        expect(siteContent.fieldIsVisible).toBeCalledWith(innerField, values)
+      }
+    })
   })
 })

--- a/static/js/components/widgets/ObjectField.tsx
+++ b/static/js/components/widgets/ObjectField.tsx
@@ -46,7 +46,7 @@ export default function ObjectField(props: Props): JSX.Element {
       {collapsed ? null : (
         <div className="object-sub-fields">
           {field.fields
-            ?.filter(innerField => fieldIsVisible(innerField, values))
+            .filter(innerField => fieldIsVisible(innerField, values))
             .map((innerField: ConfigField) => (
               <SiteContentField
                 field={innerField}

--- a/static/js/components/widgets/ObjectField.tsx
+++ b/static/js/components/widgets/ObjectField.tsx
@@ -1,16 +1,19 @@
 import React, { useState, useCallback } from "react"
 
 import SiteContentField from "../forms/SiteContentField"
+import { fieldIsVisible } from "../../lib/site_content"
 
 import {
   ConfigField,
   ObjectConfigField,
   WebsiteContent
 } from "../../types/websites"
+import { SiteFormValues } from "../../types/forms"
 
 interface Props {
   field: ObjectConfigField
   contentContext: WebsiteContent[] | null
+  values: SiteFormValues
 }
 
 /**
@@ -18,7 +21,7 @@ interface Props {
  * to be edited.
  **/
 export default function ObjectField(props: Props): JSX.Element {
-  const { field, contentContext } = props
+  const { field, contentContext, values } = props
 
   const [collapsed, setCollapsed] = useState(field.collapsed ?? false)
   const toggleCollapse = useCallback(
@@ -42,13 +45,15 @@ export default function ObjectField(props: Props): JSX.Element {
       </div>
       {collapsed ? null : (
         <div className="object-sub-fields">
-          {field.fields?.map((field: ConfigField) => (
-            <SiteContentField
-              field={field}
-              key={field.name}
-              contentContext={contentContext}
-            />
-          ))}
+          {field.fields
+            ?.filter(innerField => fieldIsVisible(innerField, values))
+            .map((innerField: ConfigField) => (
+              <SiteContentField
+                field={innerField}
+                key={innerField.name}
+                contentContext={contentContext}
+              />
+            ))}
         </div>
       )}
       {field.help && <span className="help-text">{field.help}</span>}

--- a/static/js/lib/site_content.ts
+++ b/static/js/lib/site_content.ts
@@ -131,7 +131,8 @@ export const isSingletonCollectionItem = (
 ): configItem is SingletonConfigItem => "file" in configItem
 
 /**
- * Creates a value for a payload to be sent to the server, for a given field
+ * Creates a value for a payload to be sent to the server, for a given field. This is used by to
+ * contentFormValuesForPayload to figure out what should go in the payload for a field and nested fields.
  */
 const contentFormValueForField = (
   field: ConfigField,

--- a/static/js/lib/site_content.ts
+++ b/static/js/lib/site_content.ts
@@ -130,6 +130,9 @@ export const isSingletonCollectionItem = (
   configItem: BaseConfigItem
 ): configItem is SingletonConfigItem => "file" in configItem
 
+/**
+ * Creates a value for a payload to be sent to the server, for a given field
+ */
 const contentFormValueForField = (
   field: ConfigField,
   parentField: ConfigField | null,

--- a/static/js/lib/site_content.ts
+++ b/static/js/lib/site_content.ts
@@ -131,8 +131,13 @@ export const isSingletonCollectionItem = (
 ): configItem is SingletonConfigItem => "file" in configItem
 
 /**
- * Creates a value for a payload to be sent to the server, for a given field. This is used by to
- * contentFormValuesForPayload to figure out what should go in the payload for a field and nested fields.
+ * Returns a value for a payload to be sent to the server for a field, given a ConfigField
+ * and the current state of the form (`values`).
+ *
+ * We need to look at the values for the entire form in order to handle
+ * the case of Object fields, where for the 'nested' entries in the 
+ * Object we need to look at the value for their 'parent' field in order
+ * to set them correctly.
  */
 const contentFormValueForField = (
   field: ConfigField,

--- a/static/js/lib/site_content.ts
+++ b/static/js/lib/site_content.ts
@@ -135,7 +135,7 @@ export const isSingletonCollectionItem = (
  * and the current state of the form (`values`).
  *
  * We need to look at the values for the entire form in order to handle
- * the case of Object fields, where for the 'nested' entries in the 
+ * the case of Object fields, where for the 'nested' entries in the
  * Object we need to look at the value for their 'parent' field in order
  * to set them correctly.
  */


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #494 

#### What's this PR do?
Fixes handling of fields inside object fields, and hidden fields in particular:
 - Validation for fields within object fields is disabled when that field is not visible due to a condition that doesn't match
 - Fields within object fields are not visible in the UI if they are not visible due to a condition that doesn't match (or if they're hidden fields)
 - Fields within object fields will send default values as part of the payload if they are not visible due to a condition that doesn't match. This matches the current behavior for fields which aren't nested.
 - Hidden fields will now always send the default value. Previously, the default value was sent when creating a new content object, which meant it was stored in the metadata, and subsequent `PATCH`es would send back the same value. That usually works fine except if you change the `default` value in the schema to something else, or if you add a hidden field after the fact.

#### How should this be manually tested?
Create a new site with a starter having this config:

    {
      "collections": [
        {
          "category": "Content",
          "fields": [
            {
              "label": "Text field",
              "name": "textfield",
              "widget": "text"
            },
            {
              "fields": [
                {
                  "condition": {
                    "equals": "visible",
                    "field": "textfield"
                  },
                  "default": "hiddenvalue",
                  "label": "Hidden field",
                  "name": "hiddenfield",
                  "widget": "hidden"
                }
              ],
              "label": "Object field",
              "name": "objectfield",
              "widget": "object"
            }
          ],
          "folder": "content",
          "label": "Page",
          "name": "page"
        }
      ],
      "content-dir": "content",
      "root-url-path": "/"
    }

- Open your network tab in your browser to record `POST`s. Create two pages: one page should have "visible" in the "Text field" field, and the other should have "invisible" in that field. You should see `"hiddenfield": "hiddenvalue"` in the `POST` request for the page with "visible", and the other should have `"hiddenfield": ""`
- Edit both pages, swapping the values in the "Text field" field so that the page that used to have `visible` now has `invisible`, and vice versa. You should see two `PATCH`es in the network tab. The response for the page with "visible" should now have `"hiddenfield": "hiddenvalue"`and the other one should have `"hiddenfield": ""`