### PR TITLE
Fix attach: "resource"

### DIFF
--- a/localdev/configs/ocw-course-site-config.yml
+++ b/localdev/configs/ocw-course-site-config.yml
@@ -10,11 +10,11 @@ collections:
         name: title
         widget: string
         required: true
-        attach: "resource"
 
       - label: Body
         name: body
         widget: markdown
+        attach: "resource"
 
   - category: Content
     folder: content/resources

--- a/static/js/resources/ocw-course-site-config.json
+++ b/static/js/resources/ocw-course-site-config.json
@@ -4,13 +4,13 @@
       "category": "Content",
       "fields": [
         {
-          "attach": "resource",
           "label": "Title",
           "name": "title",
           "required": true,
           "widget": "string"
         },
         {
+          "attach": "resource",
           "label": "Body",
           "name": "body",
           "widget": "markdown"


### PR DESCRIPTION
#### What are the relevant tickets?
Related to #500 

#### What's this PR do?
Just a quick fix for the schema so that the `attach` is on the markdown field

#### How should this be manually tested?
Update your ocw-course starter with the change to the schema, then view a page. You should see the ResourceEmbedField