### PR TITLE
add resource embed in-editor display

### DIFF
--- a/static/js/components/widgets/EmbeddedResource.test.tsx
+++ b/static/js/components/widgets/EmbeddedResource.test.tsx
@@ -1,0 +1,58 @@
+import EmbeddedResource from "./EmbeddedResource"
+import IntegrationTestHelper, {
+  TestRenderer
+} from "../../util/integration_test_helper"
+import { useWebsite } from "../../context/Website"
+import {
+  makeWebsiteContentDetail,
+  makeWebsiteDetail
+} from "../../util/factories/websites"
+import { Website, WebsiteContent } from "../../types/websites"
+import { siteApiContentDetailUrl } from "../../lib/urls"
+
+jest.mock("../../context/Website")
+jest.mock("../../hooks/state")
+
+describe("EmbeddedResource", () => {
+  let helper: IntegrationTestHelper,
+    render: TestRenderer,
+    website: Website,
+    content: WebsiteContent,
+    el
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    website = makeWebsiteDetail()
+    content = makeWebsiteContentDetail()
+    // @ts-ignore
+    useWebsite.mockReturnValue(website)
+
+    helper.mockGetRequest(
+      siteApiContentDetailUrl
+        .param({ name: website.name, textId: content.text_id })
+        .toString(),
+      content
+    )
+
+    el = document.createElement("div")
+    render = helper.configureRenderer(EmbeddedResource, {
+      uuid: content.text_id,
+      el
+    })
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should render, and display basic info about the resource", async () => {
+    const { wrapper } = await render()
+    expect(wrapper.find(".title").text()).toBe(content.title)
+  })
+
+  it("should render a filetype if it's there in the metadata", async () => {
+    content.metadata!.filetype = "PDF"
+    const { wrapper } = await render()
+    expect(wrapper.find(".filetype").text()).toBe("Filetype: PDF")
+  })
+})

--- a/static/js/components/widgets/EmbeddedResource.tsx
+++ b/static/js/components/widgets/EmbeddedResource.tsx
@@ -1,0 +1,56 @@
+import { createPortal } from "react-dom"
+import React from "react"
+import { useWebsite } from "../../context/Website"
+import { useRequest } from "redux-query-react"
+import { websiteContentDetailRequest } from "../../query-configs/websites"
+import { useSelector } from "react-redux"
+import { getWebsiteContentDetailCursor } from "../../selectors/websites"
+
+interface Props {
+  uuid: string
+  el: HTMLElement
+}
+
+/**
+ * Display component for resources embedded in the Markdown editor
+ *
+ * This is for the editor view layer i.e. for providing some UI when
+ * a user is working in the Markdown editor. This component has nothing
+ * to do with the rendered view of the embedded resource in Markdown
+ * and, subsequently, in Hugo templates.
+ */
+export default function EmbeddedResource(props: Props): JSX.Element | null {
+  const { uuid, el } = props
+
+  const website = useWebsite()
+
+  const contentParams = {
+    name:   website.name,
+    textId: uuid
+  }
+
+  useRequest(websiteContentDetailRequest(contentParams, false))
+
+  const websiteContentDetailSelector = useSelector(
+    getWebsiteContentDetailCursor
+  )
+
+  const resource = websiteContentDetailSelector(contentParams)
+
+  if (!resource) {
+    return null
+  } else {
+    const filetype = resource.metadata?.filetype ?? "..."
+    const title = resource.title ?? resource.text_id
+
+    return createPortal(
+      <div className="embedded-resource my-2">
+        <h3 className="ml-2 title">{title}</h3>
+        <span className="font-italic ml-2 text-gray filetype">
+          Filetype: {filetype}
+        </span>
+      </div>,
+      el
+    )
+  }
+}

--- a/static/js/components/widgets/MarkdownEditor.test.tsx
+++ b/static/js/components/widgets/MarkdownEditor.test.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { shallow } from "enzyme"
 import ClassicEditor from "@ckeditor/ckeditor5-editor-classic/src/classiceditor"
 import sinon, { SinonSandbox } from "sinon"
+import { omit } from "ramda"
 
 import MarkdownEditor from "./MarkdownEditor"
 import {
@@ -44,15 +45,32 @@ describe("MarkdownEditor", () => {
         })
         const ckWrapper = wrapper.find("CKEditor")
         expect(ckWrapper.prop("editor")).toBe(ClassicEditor)
-        expect(ckWrapper.prop("config")).toBe(expectedComponent)
+        expect(omit(["resourceEmbed"], ckWrapper.prop("config"))).toEqual(
+          expectedComponent
+        )
         expect(ckWrapper.prop("data")).toBe(expectedPropValue)
       })
     })
   })
 
-  it("should pass attach down ato a ResourceEmbedField", () => {
+  it("should pass attach down to a ResourceEmbedField", () => {
     const wrapper = render({ attach: "resource" })
     expect(wrapper.find("ResourceEmbedField").prop("attach")).toBe("resource")
+  })
+
+  it("should render embedded resources", () => {
+    const wrapper = render()
+    const editor = wrapper.find("CKEditor").prop("config")
+    const el = document.createElement("div")
+    // @ts-ignore
+    editor.resourceEmbed.renderResourceEmbed("resource-uuid", el)
+    wrapper.update()
+    expect(
+      wrapper
+        .find("EmbeddedResource")
+        .at(0)
+        .prop("uuid")
+    ).toEqual("resource-uuid")
   })
 
   //

--- a/static/js/components/widgets/MarkdownEditor.tsx
+++ b/static/js/components/widgets/MarkdownEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useRef } from "react"
+import React, { useCallback, useMemo, useRef, useState } from "react"
 import { CKEditor } from "@ckeditor/ckeditor5-react"
 import { editor } from "@ckeditor/ckeditor5-core"
 import ClassicEditor from "@ckeditor/ckeditor5-editor-classic/src/classiceditor"
@@ -8,6 +8,7 @@ import {
   MinimalEditorConfig
 } from "../../lib/ckeditor/CKEditor"
 import ResourceEmbedField from "./ResourceEmbedField"
+import EmbeddedResource from "./EmbeddedResource"
 import { RESOURCE_EMBED_COMMAND } from "../../lib/ckeditor/plugins/ResourceEmbed"
 
 export interface Props {
@@ -18,6 +19,8 @@ export interface Props {
   minimal?: boolean
   attach?: string
 }
+
+type RenderQueueEntry = [string, HTMLElement]
 
 /**
  * A component for editing Markdown using CKEditor.
@@ -43,23 +46,64 @@ export default function MarkdownEditor(props: Props): JSX.Element {
     [editor]
   )
 
+  const [renderQueue, setRenderQueue] = useState<RenderQueueEntry[]>([])
+
+  const renderResourceEmbed = useCallback(
+    (uuid: string, el: HTMLElement) => {
+      setRenderQueue(xs => [...xs, [uuid, el]])
+    },
+    [setRenderQueue]
+  )
+
+  const editorConfig = useMemo(() => {
+    if (minimal) {
+      return MinimalEditorConfig
+    } else {
+      // this render function is stuck into the editor config
+      // our ResourceEmbed plugin can pull the callback out,
+      // and then use it to render resources within the editor.
+      return {
+        ...FullEditorConfig,
+        resourceEmbed: { renderResourceEmbed }
+      }
+    }
+  }, [minimal, renderResourceEmbed])
+
+  const onChangeCB = useCallback(
+    (_event: any, editor: any) => {
+      const data = editor.getData()
+      if (onChange) {
+        onChange({ target: { name: name ?? "", value: data } })
+      }
+
+      // we have to do some manual 'garbage collection' of a sort here
+      // CKEditor doesn't delete nodes but just removes them from the editor
+      // so if we don't clean up this list we'll keep rendering our EmbeddedResource
+      // component into a bunch of detached DOM nodes and get a memory leak.
+      //
+      // filtering the queue to only dom nodes which are contained within document.body
+      // should retain any nodes corresponding to resources currently in the editor
+      // and remove those corresponding to what the user has deleted.
+      setRenderQueue(xs => xs.filter(entry => document.body.contains(entry[1])))
+    },
+    [onChange, setRenderQueue, name]
+  )
+
   return (
     <>
       <CKEditor
         editor={ClassicEditor}
-        config={minimal ? MinimalEditorConfig : FullEditorConfig}
+        config={editorConfig}
         data={value ?? ""}
         onReady={setEditorRef}
-        onChange={(_event: any, editor: any) => {
-          const data = editor.getData()
-          if (onChange) {
-            onChange({ target: { name: name ?? "", value: data } })
-          }
-        }}
+        onChange={onChangeCB}
       />
       {attach && attach.length !== 0 ? (
         <ResourceEmbedField insertEmbed={addResourceEmbed} attach={attach} />
       ) : null}
+      {renderQueue.map(([uuid, el]) => (
+        <EmbeddedResource key={uuid} uuid={uuid} el={el} />
+      ))}
     </>
   )
 }

--- a/static/js/lib/ckeditor/plugins/ResourceEmbed.test.tsx
+++ b/static/js/lib/ckeditor/plugins/ResourceEmbed.test.tsx
@@ -8,7 +8,7 @@ const getEditor = createTestEditor([ResourceEmbed, Markdown])
 describe("ResourceEmbed plugin", () => {
   afterEach(() => {
     turndownService.rules.array = turndownService.rules.array.filter(
-      (rule: any) => rule.filter !== "figure"
+      (rule: any) => rule.filter !== "figure" && rule.filter !== "section"
     )
     // @ts-ignore
     turndownService._customRulesSet = undefined
@@ -25,7 +25,7 @@ describe("ResourceEmbed plugin", () => {
     markdownTest(
       editor,
       "{{< resource asdfasdfasdfasdf >}}",
-      `<section>asdfasdfasdfasdf</section>`
+      '<section data-uuid="asdfasdfasdfasdf"></section>'
     )
   })
 })

--- a/static/js/pages/SitePage.test.tsx
+++ b/static/js/pages/SitePage.test.tsx
@@ -41,15 +41,11 @@ describe("SitePage", () => {
         name: website.name
       }
     }))
-    helper.handleRequestStub
-      .withArgs(
-        siteApiDetailUrl.param({ name: website.name }).toString(),
-        "GET"
-      )
-      .returns({
-        body:   website,
-        status: 200
-      })
+
+    helper.mockGetRequest(
+      siteApiDetailUrl.param({ name: website.name }).toString(),
+      website
+    )
   })
 
   afterEach(() => {

--- a/static/js/pages/SitesDashboard.test.tsx
+++ b/static/js/pages/SitesDashboard.test.tsx
@@ -47,12 +47,10 @@ describe("SitesDashboard", () => {
       previous: null,
       count:    10
     }
-    helper.handleRequestStub
-      .withArgs(siteApiListingUrl.param({ offset: 0 }).toString(), "GET")
-      .returns({
-        body:   response,
-        status: 200
-      })
+    helper.mockGetRequest(
+      siteApiListingUrl.param({ offset: 0 }).toString(),
+      response
+    )
     render = helper.configureRenderer(
       SitesDashboard,
       {
@@ -110,15 +108,10 @@ describe("SitesDashboard", () => {
         response.next = hasNextLink ? "next" : null
         response.previous = hasPrevLink ? "prev" : null
         const startingOffset = 20
-        helper.handleRequestStub
-          .withArgs(
-            siteApiListingUrl.query({ offset: startingOffset }).toString(),
-            "GET"
-          )
-          .returns({
-            body:   response,
-            status: 200
-          })
+        helper.mockGetRequest(
+          siteApiListingUrl.query({ offset: startingOffset }).toString(),
+          response
+        )
         const { wrapper } = await render({
           location: {
             search: `offset=${startingOffset}`

--- a/static/js/pages/WebsiteCollectionsPage.test.tsx
+++ b/static/js/pages/WebsiteCollectionsPage.test.tsx
@@ -25,30 +25,20 @@ describe("CollectionsPage", () => {
     collections = times(20, makeWebsiteCollection)
 
     // first page
-    helper.handleRequestStub
-      .withArgs(collectionsApiUrl.param({ offset: 0 }).toString(), "GET")
-      .returns({
-        body: {
-          results:  collections.slice(0, 10),
-          next:     "https://example.com",
-          previous: null,
-          count:    20
-        },
-        status: 200
-      })
+    helper.mockGetRequest(collectionsApiUrl.param({ offset: 0 }).toString(), {
+      results:  collections.slice(0, 10),
+      next:     "https://example.com",
+      previous: null,
+      count:    20
+    })
 
     // second page
-    helper.handleRequestStub
-      .withArgs(collectionsApiUrl.param({ offset: 10 }).toString(), "GET")
-      .returns({
-        body: {
-          results:  collections.slice(10),
-          next:     null,
-          previous: "https://example.com",
-          count:    20
-        },
-        status: 200
-      })
+    helper.mockGetRequest(collectionsApiUrl.param({ offset: 10 }).toString(), {
+      results:  collections.slice(10),
+      next:     null,
+      previous: "https://example.com",
+      count:    20
+    })
 
     render = helper.configureRenderer(WebsiteCollectionsPage)
   })

--- a/static/js/selectors/websites.ts
+++ b/static/js/selectors/websites.ts
@@ -65,7 +65,10 @@ export const getWebsiteCollaboratorDetailCursor = createSelector(
 export const getWebsiteContentDetailCursor = createSelector(
   (state: ReduxState) => state.entities?.websiteContentDetails ?? {},
   (content: Record<string, WebsiteContent>) =>
-    memoize((params: ContentDetailParams) => content[contentDetailKey(params)])
+    memoize(
+      (params: ContentDetailParams): WebsiteContent | null =>
+        content[contentDetailKey(params)] ?? null
+    )
 )
 
 interface WebsiteContentItem {

--- a/static/js/util/integration_test_helper.tsx
+++ b/static/js/util/integration_test_helper.tsx
@@ -47,12 +47,12 @@ export default class IntegrationTestHelper {
       .stub(networkInterfaceFuncs, "makeRequest")
       .callsFake((url, method, options) => ({
         execute: callback => {
-          const response = this.handleRequestStub(url, method, options)
+          const response = this.handleRequestStub(url, method, options) ?? {}
           const err = null
-          const resStatus = (response && response.status) || 0
-          const resBody = (response && response.body) || undefined
-          const resText = (response && response.text) || undefined
-          const resHeaders = (response && response.header) || undefined
+          const resStatus = response.status ?? 0
+          const resBody = response.body ?? undefined
+          const resText = response.text ?? undefined
+          const resHeaders = response.header ?? undefined
 
           callback(err, resStatus, resBody, resText, resHeaders)
         },
@@ -63,6 +63,19 @@ export default class IntegrationTestHelper {
     this.realWarn = console.warn
     // eslint-disable-next-line @typescript-eslint/no-empty-function
     console.warn = () => {}
+  }
+
+  /**
+   * Convenience method for mocking out a GET request
+   *
+   * pass the API url you want to mock and the object which should be
+   * returned as the request body!
+   */
+  mockGetRequest(url: string, body: unknown): void {
+    this.handleRequestStub.withArgs(url, "GET").returns({
+      body,
+      status: 200
+    })
   }
 
   cleanup(unmount = true): void {
@@ -77,6 +90,22 @@ export default class IntegrationTestHelper {
     console.warn = this.realWarn
   }
 
+  /**
+   * Configure the integration test renderer!
+   *
+   * Takes a component, some defaultProps, and a defaultState for
+   * the Redux store and returns a render function which can be used
+   * to render the component and then make assertions and so on about it.
+   *
+   * Usage example:
+   *
+   * ```ts
+   * const render = helper.configureRenderer(
+   *   MyComponent, { prop: 'default value' }
+   * )
+   * const { wrapper, store } = await render()
+   * ```
+   */
   configureRenderer(
     Component: ComponentType<any> | FunctionComponent<any>,
     defaultProps = {},

--- a/static/scss/resource-embed-widget.scss
+++ b/static/scss/resource-embed-widget.scss
@@ -12,3 +12,9 @@
     }
   }
 }
+
+.ck-editor {
+  .embedded-resource {
+    border: 1px solid $studio-gray;
+  }
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

closes #503

#### What's this PR do?

This adds a sort of MVP / placeholder display of embedded resources in the Markdown editor. For now, it just says the title of the resource and the 'filetype' metadata if it's set on the resource.

This is *not* intended to be a final version of the UI, but a sort of minimal placeholder to get the stuff in place for rendering resources with a react component in the editor. There are follow-up issues for making the UI more specific to the different resources.

#### How should this be manually tested?

Edit a 'page' and insert some resources into it. You should see a little box with some information about the resource in it in the editor. Saving and editing this data should work without issues.

#### screens

![Screen Shot 2021-08-18 at 2 10 08 PM](https://user-images.githubusercontent.com/6207644/129950112-8ca459d2-2a8a-439c-9c6c-e8259fb81ed4.png)
