### PR TITLE
make UUID check version agnostic by default and add tests

### DIFF
--- a/main/utils.py
+++ b/main/utils.py
@@ -31,7 +31,7 @@ def uuid_string():
     return str(uuid4())
 
 
-def is_valid_uuid(uuid_to_test: str, version: None) -> bool:
+def is_valid_uuid(uuid_to_test: str, version: int=None) -> bool:
     """
     Returns True if the given string is a valid UUID
     """

--- a/main/utils.py
+++ b/main/utils.py
@@ -31,12 +31,15 @@ def uuid_string():
     return str(uuid4())
 
 
-def is_valid_uuid(uuid_to_test: str, version: int = 4) -> bool:
+def is_valid_uuid(uuid_to_test: str, version: None) -> bool:
     """
     Returns True if the given string is a valid UUID
     """
     try:
-        uuid_obj = UUID(uuid_to_test, version=version)
+        if version:
+            uuid_obj = UUID(uuid_to_test, version=version)
+        else:
+            uuid_obj = UUID(uuid_to_test)
     except ValueError:
         return False
     return str(uuid_obj) == uuid_to_test

--- a/main/utils.py
+++ b/main/utils.py
@@ -31,7 +31,7 @@ def uuid_string():
     return str(uuid4())
 
 
-def is_valid_uuid(uuid_to_test: str, version: int=None) -> bool:
+def is_valid_uuid(uuid_to_test: str, version: int = None) -> bool:
     """
     Returns True if the given string is a valid UUID
     """

--- a/main/utils_test.py
+++ b/main/utils_test.py
@@ -5,9 +5,24 @@ from main.utils import (
     are_equivalent_paths,
     get_dirpath_and_filename,
     get_file_extension,
+    is_valid_uuid,
     remove_trailing_slashes,
     valid_key,
 )
+
+
+@pytest.mark.parametrize(
+    "uuid_to_test, version, is_valid",
+    [
+        ["50fe3182-b1c9-ad10-de16-aeaae7f137cd", None, True],
+        ["50fe3182-b1c9-ad10-de16-aeaae7f137cd", 4, False],
+        ["not-a-uuid", None, False],
+        ["28bcec93-eb51-447e-84e1-ed453eea818e", 4, True],
+    ],
+)
+def test_is_valid_uuid(uuid_to_test, version, is_valid):
+    """ is_valid_uuid should return True for a valid UUID, false otherwise """
+    assert is_valid_uuid(uuid_to_test, version) is is_valid
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/497

#### What's this PR do?
Currently, `main.utils.is_valid_uuid` has a `version` argument that defaults to 4.  This works with UUID's generated by `ocw-studio` since we specify version 4 everywhere, but imported legacy data does not conform to version 4 and thus the checks fail.  This PR makes the `is_valid_uuid` function version agnostic by default, allowing you to specify a version if you desire.

#### How should this be manually tested?
 - Spin up `ocw-studio` locally on this branch and make sure your AWS credentials are properly set up to access RC / QA
 - Run `docker-compose run web ./manage.py import_ocw_course_sites -b ocw-to-hugo-output-qa --filter 4-123`
 - Browse to the `WebsiteContent` area of Django admin and put "Architectural Design, Level I: Perceptions and Processes" in the search bar
 - Look at the `navmenu` metadata imported for this course, and ensure that the UUID's in the metadata match the `text_id` of the pages they are supposed to reference.
