### PR TITLE
remove course_id prefix on dirpath of imported course content

### DIFF
--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -85,13 +85,17 @@ def import_ocw2hugo_content(bucket, prefix, website):  # pylint:disable=too-many
         prefix (str): S3 prefix for filtering by course
         website (Website): Website to import content for
     """
+    site_prefix = f"{prefix}{website.name}"
     for resp in bucket.meta.client.get_paginator("list_objects").paginate(
-        Bucket=bucket.name, Prefix=f"{prefix}{website.name}/content"
+        Bucket=bucket.name, Prefix=f"{site_prefix}/content"
     ):
         for obj in resp["Contents"]:
             s3_key = obj["Key"]
             s3_content = get_s3_object_and_read(bucket.Object(s3_key)).decode()
-            filepath = obj["Key"].replace(prefix, "")
+            if obj["Key"].startswith(site_prefix):
+                filepath = obj["Key"].replace(site_prefix, "", 1)
+            else:
+                filepath = obj["Key"]
             try:
                 convert_data_to_content(filepath, s3_content, website)
             except:  # pylint:disable=bare-except

--- a/ocw_import/api_test.py
+++ b/ocw_import/api_test.py
@@ -63,7 +63,7 @@ def test_import_ocw2hugo_course_content(settings):
         "This subject provides an introduction to the mechanics of materials"
     )
     assert home_page.filename == "_index"
-    assert home_page.dirpath == "1-050-engineering-mechanics-i-fall-2007/content"
+    assert home_page.dirpath == "content"
 
     related_page = WebsiteContent.objects.get(
         text_id="4f5c3926-e4d5-6974-7f16-131a6f692568"
@@ -73,7 +73,7 @@ def test_import_ocw2hugo_course_content(settings):
     assert related_page.filename == "_index"
     assert (
         related_page.dirpath
-        == "1-050-engineering-mechanics-i-fall-2007/content/sections/related-resources"
+        == "content/sections/related-resources"
     )
 
     matlab_page = WebsiteContent.objects.get(
@@ -91,7 +91,7 @@ def test_import_ocw2hugo_course_content(settings):
     assert lecture_pdf.filename == "lec1"
     assert (
         lecture_pdf.dirpath
-        == "1-050-engineering-mechanics-i-fall-2007/content/sections/lecture-notes"
+        == "content/sections/lecture-notes"
     )
 
 
@@ -197,7 +197,7 @@ def test_import_ocw2hugo_content_log_exception(mocker, settings):
     assert mock_log.call_count == 1
     mock_log.assert_called_once_with(
         "No UUID (text ID): %s",
-        "1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/sections/test_no_uid.md",
+        "/content/sections/test_no_uid.md",
     )
 
 

--- a/ocw_import/api_test.py
+++ b/ocw_import/api_test.py
@@ -71,10 +71,7 @@ def test_import_ocw2hugo_course_content(settings):
     assert related_page.type == CONTENT_TYPE_PAGE
     assert related_page.metadata.get("title") == "Related Resources"
     assert related_page.filename == "_index"
-    assert (
-        related_page.dirpath
-        == "content/sections/related-resources"
-    )
+    assert related_page.dirpath == "content/sections/related-resources"
 
     matlab_page = WebsiteContent.objects.get(
         text_id="c8cd9384-0305-bfbb-46ae-a7e7a8229f57"
@@ -89,10 +86,7 @@ def test_import_ocw2hugo_course_content(settings):
     assert lecture_pdf.type == CONTENT_TYPE_RESOURCE
     assert lecture_pdf.metadata.get("file_type") == "application/pdf"
     assert lecture_pdf.filename == "lec1"
-    assert (
-        lecture_pdf.dirpath
-        == "content/sections/lecture-notes"
-    )
+    assert lecture_pdf.dirpath == "content/sections/lecture-notes"
 
 
 @mock_s3


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/512

#### What's this PR do?
When importing of `ocw-to-hugo` content was added, the `dirpath` property of all imported content was set based on the S3 key from the bucket it was pulled from.  In this bucket, each course is stored in a folder matching the course ID.  The dirpath on the imported content should have this prefix removed, as when the course is subsequently exported to Github by `ocw-studio` it will put the `content` folder in the wrong place.  This PR corrects that by removing the prefix when `dirpath` is set.

#### How should this be manually tested?
 - Make sure you have Github integration set up to both pull in `ocw-to-hugo` data and export published content to Github under your own test organization
 - Import any number of courses using `import_ocw_course_sites`
 - Browse to the site's UI in `ocw-studio` and click the publish button
 - Browse to the repository in Github where your content has been published
 - Ensure that the `content` folder is at the root of the repository

