### PR TITLE
publish instructors

### DIFF
--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -192,6 +192,7 @@ def import_ocw2hugo_sitemetadata(
     instructor_contents = []
     for instructor in course_data["instructors"]:
         uid = instructor["uid"]
+        text_id = str(uuid.UUID(uid))
         first_name = instructor.get("first_name", "")
         last_name = instructor.get("last_name", "")
         middle_initial = instructor.get("middle_initial", "")
@@ -201,7 +202,7 @@ def import_ocw2hugo_sitemetadata(
 
         instructor_content, _ = WebsiteContent.objects.update_or_create(
             website=website_root,
-            text_id=str(uuid.UUID(uid)),
+            text_id=text_id,
             defaults={
                 "metadata": {
                     "headless": True,
@@ -212,6 +213,9 @@ def import_ocw2hugo_sitemetadata(
                 },
                 "title": f"{salutation_plus_space}{first_name} {middle_initial_plus_space}{last_name}",
                 "type": CONTENT_TYPE_INSTRUCTOR,
+                "dirpath": "content/instructors",
+                "filename": text_id,
+                "is_page_content": True,
             },
         )
         instructor_contents.append(instructor_content)

--- a/ocw_import/api_test.py
+++ b/ocw_import/api_test.py
@@ -107,11 +107,13 @@ def test_import_ocw2hugo_course_metadata(settings, root_website):
     )
     assert list(
         WebsiteContent.objects.filter(type=CONTENT_TYPE_INSTRUCTOR)
-        .values("title", "metadata")
+        .values("title", "dirpath", "is_page_content", "metadata")
         .order_by("title")
     ) == [
         {
             "title": "Prof. Franz-Josef Ulm",
+            "dirpath": "content/instructors",
+            "is_page_content": True,
             "metadata": {
                 "first_name": "Franz-Josef",
                 "middle_initial": "",
@@ -122,6 +124,8 @@ def test_import_ocw2hugo_course_metadata(settings, root_website):
         },
         {
             "title": "Prof. Markus Buehler",
+            "dirpath": "content/instructors",
+            "is_page_content": True,
             "metadata": {
                 "first_name": "Markus",
                 "middle_initial": "",


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/510

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/409, we added the creation of instructors in the "root website" (`ocw-www`) when importing courses from `ocw-to-hugo`.  Currently, these instructors are not published with the rest of `ocw-www`'s content.  In order for them to be accessible in the published site, we need to change a few things.  This PR sets `is_page_content` to true for imported instructors, and sets the proper dirpath as well as a filename equal to the `text_id`.

#### How should this be manually tested?
 - Spin up `ocw-studio` on this branch and ensure that you have both the `ocw-www` and `ocw-course` starers from `ocw-hugo-projects` in your local instance.  Also, ensure that your local instance is set up to sync to Github and pull content from S3.  To test this, you're going to want to have your own test Github organization.  You'll then need to create a personal access token within Github and put that in your `.env` file before spinning up `ocw-studio`.  The values should look something like:
 ```
GIT_API_URL=https://api.github.com
GIT_ORGANIZATION=<github org here>
GIT_TOKEN=<personal access token here>
```
 - Create a site using the `ocw-www` starter.  You don't need to create any content, the site just needs to exist.
 - Run `docker-compose run web ./manage.py import_ocw_course_sites -b ocw-to-hugo-output-qa --filter 4-123`
 - Browse to the Instructors section of your `ocw-www` site.  You should see Prof. Meejin Yoon and Prof. Muhamet Yildiz.
 - Click the Publish button
 - Browse to your Github org that you created and go to the `ocw-www` repo under there.  Browse to the instructors folder and verify that there are two markdown files there.  The filenames should match the `text_id` of the instructors imported into `ocw-www` and the front matter should include the instructor information.  It should look like this: https://github.com/gumaerc-testorg/ocw-www/tree/main/content/instructors
