### PR TITLE
Filter out unpublished content from REST API

### DIFF
--- a/static/js/components/widgets/RelationField.tsx
+++ b/static/js/components/widgets/RelationField.tsx
@@ -71,6 +71,7 @@ export default function RelationField(props: Props): JSX.Element {
   // if website: websitename param is set, then we want to use the context
   // website, else we want to use the cursor to fetch the specified website
   const websiteName = props.website ? props.website : contextWebsite.name
+  const differentSite = !props.website || (props.website !== contextWebsite.name)
 
   const handleChange = useCallback(
     (event: any) => {
@@ -119,8 +120,9 @@ export default function RelationField(props: Props): JSX.Element {
     const params = collection ? { type: collection } : { page_content: true }
     const url = siteApiContentListingUrl
       .query({
-        detailed_list:   true,
-        content_context: true,
+        detailed_list:    true,
+        content_context:  true,
+        hide_unpublished: differentSite,
         ...(search ? { search: search } : {}),
         ...params
       })

--- a/websites/views.py
+++ b/websites/views.py
@@ -400,6 +400,7 @@ class WebsiteContentViewSet(
         search = self.request.query_params.get("search")
         filetype = self.request.query_params.get("filetype")
         types = _get_value_list_from_query_params(self.request.query_params, "type")
+        hide_unpublished = self.request.query_params.get("hide_unpublished")
 
         queryset = WebsiteContent.objects.filter(
             website__name=parent_lookup_website
@@ -415,6 +416,11 @@ class WebsiteContentViewSet(
                 )
             else:
                 queryset = queryset.filter(metadata__filetype=filetype)
+
+        if _parse_bool(hide_unpublished):
+            queryset = queryset.filter(
+                content_sync_state__synced_checksum__isnull=False
+            )
 
         if "page_content" in self.request.query_params:
             queryset = queryset.filter(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #520 

#### What's this PR do?
Adds a filter to the website content REST API so that unpublished content is not visible

#### How should this be manually tested?
TBD

View the website content list view REST (for example `http://localhost:8043/api/websites/res-8-001-applied-geometric-algebra-spring-2009/content/`) for a website you imported but never published. It should have no content. A website which is published should have some content in the REST API.
