### PR TITLE
delete unpublished courses originally imported from ocw-to-hugo

### DIFF
--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -348,3 +348,24 @@ def generate_topics_dict(course_paths, bucket_name):
             subtopic_dict[subtopic] = sorted(subtopic_dict[subtopic])
 
     return topics
+
+
+def delete_unpublished_courses(paths=None, filter_str=None):
+    """
+    Remove all unpublished courses based on paths that don't exist anymore
+
+    Args:
+        paths (list of str): list of paths to course data templates
+        filter_str (str): (Optional) If specified, filter courses to remove
+    """
+    if not paths:
+        return
+    course_ids = list(map((lambda key: key.replace("/data/course.json", "", 1)), paths))
+    unpublished_courses = Website.objects.filter(
+        source=WEBSITE_SOURCE_OCW_IMPORT
+    ).exclude(metadata__course_id__in=course_ids)
+    if filter_str:
+        unpublished_courses = unpublished_courses.filter(
+            metadata__course_id__contains=filter_str
+        )
+    unpublished_courses.delete()

--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -367,5 +367,5 @@ def delete_unpublished_courses(paths=None, filter_str=None):
     if filter_str:
         unpublished_courses = unpublished_courses.filter(name__contains=filter_str)
     if unpublished_courses.count() > 0:
-        log.info(f"Removing unpublished imported courses: {unpublished_courses}")
+        log.info("Removing unpublished imported courses: %s", unpublished_courses)
         unpublished_courses.delete()

--- a/ocw_import/api_test.py
+++ b/ocw_import/api_test.py
@@ -319,6 +319,6 @@ def test_delete_unpublished_courses(settings):
     assert Website.objects.all().count() == 3
     assert WebsiteContent.objects.all().count() == 117
     course_paths.pop()
-    delete_unpublished_courses(paths=course_paths)
+    delete_unpublished_courses(paths=course_paths, filter_str="1-201j")
     assert Website.objects.all().count() == 2
     assert WebsiteContent.objects.all().count() == 77

--- a/ocw_import/management/commands/import_ocw_course_sites.py
+++ b/ocw_import/management/commands/import_ocw_course_sites.py
@@ -65,6 +65,13 @@ class Command(BaseCommand):
             action="store_true",
             help="Sync all unsynced courses to the backend",
         )
+        parser.add_argument(
+            "-d",
+            "--delete_unpublished",
+            dest="delete_unpublished",
+            default=True,
+            help="Delete all courses that have been unpublished",
+        )
         super().add_arguments(parser)
 
     def handle(self, *args, **options):
@@ -75,6 +82,7 @@ class Command(BaseCommand):
         bucket_name = options["bucket"]
         filter_str = options["filter"]
         limit = options["limit"]
+        delete_unpublished = options["delete_unpublished"]
 
         if options["list"] is True:
             course_paths = list(
@@ -92,6 +100,7 @@ class Command(BaseCommand):
             prefix=prefix,
             filter_str=filter_str,
             limit=limit,
+            delete_unpublished=delete_unpublished,
             chunk_size=options["chunks"],
         )
         self.stdout.write(f"Starting task {task}...")

--- a/ocw_import/tasks.py
+++ b/ocw_import/tasks.py
@@ -6,7 +6,11 @@ from django.conf import settings
 from mitol.common.utils.collections import chunks
 
 from main.celery import app
-from ocw_import.api import fetch_ocw2hugo_course_paths, import_ocw2hugo_course
+from ocw_import.api import (
+    delete_unpublished_courses,
+    fetch_ocw2hugo_course_paths,
+    import_ocw2hugo_course,
+)
 from websites.models import WebsiteStarter
 
 
@@ -14,15 +18,18 @@ log = logging.getLogger(__name__)
 
 
 @app.task()
-def import_ocw2hugo_course_paths(paths=None, bucket_name=None, prefix=None):
+def import_ocw2hugo_course_paths(
+    paths=None, bucket_name=None, prefix=None, filter_str=None, delete_unpublished=True
+):
     """
     Import all ocw2hugo courses & content
 
     Args:
-        paths (list of str): list of course url paths
+        paths (list of str): list of paths to course data templates
         bucket_name (str): S3 bucket name
         prefix (str): S3 prefix before start of course_id path
-
+        filter_str (str): (Optional) If specified along with delete_unpublished, filter deleted websites
+        delete_unpublished (bool): (Optional) If true, delete courses that are no longer in S3
     """
     if not paths:
         return
@@ -36,20 +43,29 @@ def import_ocw2hugo_course_paths(paths=None, bucket_name=None, prefix=None):
         import_ocw2hugo_course(
             bucket_name, prefix, path, starter_id=course_site_starter_id
         )
+    if delete_unpublished:
+        delete_unpublished_courses(paths, filter_str)
 
 
 @app.task(bind=True)
 def import_ocw2hugo_courses(
-    self, bucket_name=None, prefix=None, filter_str=None, limit=None, chunk_size=100
+    self,
+    bucket_name=None,
+    prefix=None,
+    filter_str=None,
+    limit=None,
+    delete_unpublished=True,
+    chunk_size=100,
 ):  # pylint:disable=too-many-arguments
     """
-    Import all ocw2hugo courses & content
+    Import all ocw2hugo courses & content and remove unpublished courses
 
     Args:
         bucket_name (str): S3 bucket name
         prefix (str): (Optional) S3 prefix before start of course_id path
         filter_str (str): (Optional) If specified, only yield course paths containing this string
         limit (int or None): (Optional) If specified, limits the number of courses imported
+        delete_unpublished (bool): (Optional) If true, delete courses that are no longer in S3
         chunk_size (int): Number of courses to process per task
     """
     if not bucket_name:
@@ -62,7 +78,11 @@ def import_ocw2hugo_courses(
     course_tasks = celery.group(
         [
             import_ocw2hugo_course_paths.si(
-                paths=paths, bucket_name=bucket_name, prefix=prefix
+                paths=paths,
+                bucket_name=bucket_name,
+                prefix=prefix,
+                filter_str=filter_str,
+                delete_unpublished=delete_unpublished,
             )
             for paths in chunks(course_paths, chunk_size=chunk_size)
         ]


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/522

#### What's this PR do?
When courses are unpublished in the current Plone based OCW system, this information propagates through the system and eventually `ocw-to-hugo` will see this and decide not to output data for that course.  In `ocw-studio`, `import_ocw_course_sites` sources its data from an S3 bucket filled with `ocw-to-hugo` output.  Since `ocw-studio` is not set up to handle this, when courses are unpublished and subsequently removed from the bucket, the `Website` objects linger in the database.  This PR adds functionality that by default will remove sites for courses that are no longer present in the `ocw-to-hugo` output bucket.  You might also notice that the `Website` name property is now being sourced from the folder name and not from `course_id` in the metadata, as this metadata property will soon be removed.

#### How should this be manually tested?
Since `import_ocw_course_sites` is only set up to use S3, a fake S3 bucket can be mocked in unit testing (and it is) but when it comes to running a manual test it's a bit more tricky.

 - Spin up `ocw-studio` locally and make sure you have S3 credentials configured
 - Make sure you have the `ocw-www` and `ocw-course` website starters from https://github.com/mitodl/ocw-hugo-projects loaded into your local instance and create an empty `ocw-www` site named `ocw-www`
 - Run `docker-compose run web ./manage.py import_ocw_course_sites -b ocw-to-hugo-output-qa --filter 5-310`
 - Drop into a Django shell with `docker-compose run web ./manage.py shell`
 - Run the following:
```
from websites.models import Website
Website.objects.all().count()
```
- Verify that the number of websites returned is 3
- Insert a line into `ocw_import/api.py` after line 360 to spoof one of the courses being removed from S3:
`paths = ["15-310-managerial-psychology-laboratory-spring-2003/data/course.json"]`
- Rebuild your docker containers
- Re-run the same `import_ocw_course_sites` command from above
- Re-run the same check in a Django shell and verify that the amount of `Website` objects is now 2
