### PR TITLE
Only show "Add resource" button when attach field is set

### DIFF
--- a/static/js/components/widgets/MarkdownEditor.test.tsx
+++ b/static/js/components/widgets/MarkdownEditor.test.tsx
@@ -9,6 +9,7 @@ import {
   FullEditorConfig,
   MinimalEditorConfig
 } from "../../lib/ckeditor/CKEditor"
+import { ADD_RESOURCE } from "../../lib/ckeditor/plugins/ResourceEmbed"
 
 jest.mock("@ckeditor/ckeditor5-react", () => ({
   CKEditor: () => <div />
@@ -41,7 +42,8 @@ describe("MarkdownEditor", () => {
       } MarkdownEditor with value=${String(value)}`, () => {
         const wrapper = render({
           minimal,
-          value
+          value,
+          attach: "attach"
         })
         const ckWrapper = wrapper.find("CKEditor")
         expect(ckWrapper.prop("editor")).toBe(ClassicEditor)
@@ -71,6 +73,20 @@ describe("MarkdownEditor", () => {
         .at(0)
         .prop("uuid")
     ).toEqual("resource-uuid")
+  })
+
+  //
+  ;[true, false].forEach(hasAttach => {
+    it(`${
+      hasAttach ? "should" : "shouldn't"
+    } have an add resource button since attach ${
+      hasAttach ? "was" : "wasn't"
+    } set`, () => {
+      const wrapper = render(hasAttach ? { attach: "resource" } : {})
+      const editorConfig = wrapper.find("CKEditor").prop("config")
+      // @ts-ignore
+      expect(editorConfig.toolbar.items.includes(ADD_RESOURCE)).toBe(hasAttach)
+    })
   })
 
   it("should open the resource picker", () => {

--- a/static/js/components/widgets/MarkdownEditor.tsx
+++ b/static/js/components/widgets/MarkdownEditor.tsx
@@ -76,8 +76,8 @@ export default function MarkdownEditor(props: Props): JSX.Element {
         resourceEmbed: { renderResourceEmbed, openResourcePicker },
         toolbar:       {
           ...FullEditorConfig.toolbar,
-          items: FullEditorConfig.toolbar.items.filter(item =>
-            hasAttach ? true : item !== ADD_RESOURCE
+          items: FullEditorConfig.toolbar.items.filter(
+            item => hasAttach || item !== ADD_RESOURCE
           )
         }
       }
@@ -118,8 +118,7 @@ export default function MarkdownEditor(props: Props): JSX.Element {
           open={resourcePickerOpen}
           setOpen={setResourcePickerOpen}
           insertEmbed={addResourceEmbed}
-          // @ts-ignore
-          attach={attach}
+          attach={attach as string}
         />
       ) : null}
       {renderQueue.map(([uuid, el], idx) => (

--- a/static/js/components/widgets/MarkdownEditor.tsx
+++ b/static/js/components/widgets/MarkdownEditor.tsx
@@ -8,7 +8,10 @@ import {
   MinimalEditorConfig
 } from "../../lib/ckeditor/CKEditor"
 import EmbeddedResource from "./EmbeddedResource"
-import { RESOURCE_EMBED_COMMAND } from "../../lib/ckeditor/plugins/ResourceEmbed"
+import {
+  ADD_RESOURCE,
+  RESOURCE_EMBED_COMMAND
+} from "../../lib/ckeditor/plugins/ResourceEmbed"
 import ResourcePickerDialog from "./ResourcePickerDialog"
 
 export interface Props {
@@ -60,6 +63,7 @@ export default function MarkdownEditor(props: Props): JSX.Element {
     setResourcePickerOpen(true)
   }, [setResourcePickerOpen])
 
+  const hasAttach = attach && attach.length > 0
   const editorConfig = useMemo(() => {
     if (minimal) {
       return MinimalEditorConfig
@@ -69,10 +73,16 @@ export default function MarkdownEditor(props: Props): JSX.Element {
       // and then use it to render resources within the editor.
       return {
         ...FullEditorConfig,
-        resourceEmbed: { renderResourceEmbed, openResourcePicker }
+        resourceEmbed: { renderResourceEmbed, openResourcePicker },
+        toolbar:       {
+          ...FullEditorConfig.toolbar,
+          items: FullEditorConfig.toolbar.items.filter(item =>
+            hasAttach ? true : item !== ADD_RESOURCE
+          )
+        }
       }
     }
-  }, [minimal, renderResourceEmbed, openResourcePicker])
+  }, [minimal, renderResourceEmbed, openResourcePicker, hasAttach])
 
   const onChangeCB = useCallback(
     (_event: any, editor: any) => {
@@ -103,11 +113,12 @@ export default function MarkdownEditor(props: Props): JSX.Element {
         onReady={setEditorRef}
         onChange={onChangeCB}
       />
-      {attach && attach.length > 0 ? (
+      {hasAttach ? (
         <ResourcePickerDialog
           open={resourcePickerOpen}
           setOpen={setResourcePickerOpen}
           insertEmbed={addResourceEmbed}
+          // @ts-ignore
           attach={attach}
         />
       ) : null}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Fixes #529 

#### What's this PR do?
Hides the Add resource button 

#### How should this be manually tested?
For any of the imported courses, add a new page. You should see a "Add resource" button in the "Body" section of the UI. Click it and a modal should show up.

Go to the site metadata for the same course. You should not see an "Add resource" button on the course description field.