### PR TITLE
add simple display for image resources in markdown editor

### DIFF
--- a/static/js/components/widgets/EmbeddedResource.test.tsx
+++ b/static/js/components/widgets/EmbeddedResource.test.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../util/factories/websites"
 import { Website, WebsiteContent } from "../../types/websites"
 import { siteApiContentDetailUrl } from "../../lib/urls"
+import { RESOURCE_TYPE_IMAGE } from "../../constants"
 
 jest.mock("../../context/Website")
 jest.mock("../../hooks/state")
@@ -53,6 +54,15 @@ describe("EmbeddedResource", () => {
   it("should render a filetype if it's there in the metadata", async () => {
     content.metadata!.filetype = "PDF"
     const { wrapper } = await render()
-    expect(wrapper.find(".filetype").text()).toBe("Filetype: PDF")
+    expect(wrapper.find(".resource-info").text()).toBe("Filetype: PDF")
+  })
+
+  it("should render an image", async () => {
+    content.metadata!.filetype = RESOURCE_TYPE_IMAGE
+    content.file = "https://example.com/foo/bar/baz.png"
+    const { wrapper } = await render()
+    expect(wrapper.find(".resource-info").text()).toBe("baz.png")
+    expect(wrapper.find("h3").text()).toBe(content.title)
+    expect(wrapper.find("img").prop("src")).toBe(content.file)
   })
 })

--- a/static/js/components/widgets/EmbeddedResource.tsx
+++ b/static/js/components/widgets/EmbeddedResource.tsx
@@ -5,6 +5,7 @@ import { useRequest } from "redux-query-react"
 import { websiteContentDetailRequest } from "../../query-configs/websites"
 import { useSelector } from "react-redux"
 import { getWebsiteContentDetailCursor } from "../../selectors/websites"
+import { RESOURCE_TYPE_IMAGE } from "../../constants"
 
 interface Props {
   uuid: string
@@ -43,10 +44,27 @@ export default function EmbeddedResource(props: Props): JSX.Element | null {
     const filetype = resource.metadata?.filetype ?? "..."
     const title = resource.title ?? resource.text_id
 
+    if (filetype === RESOURCE_TYPE_IMAGE) {
+      const filename = resource.file!.split("/").slice(-1)
+
+      return createPortal(
+        <div className="embedded-resource image my-2 d-flex align-items-center">
+          <img className="img-fluid m-2" src={resource.file} />
+          <div>
+            <h3 className="m-2 title">{title}</h3>
+            <span className="font-italic mx-2 text-gray resource-info d-block">
+              {filename}
+            </span>
+          </div>
+        </div>,
+        el
+      )
+    }
+
     return createPortal(
       <div className="embedded-resource my-2">
         <h3 className="ml-2 title">{title}</h3>
-        <span className="font-italic ml-2 text-gray filetype">
+        <span className="font-italic ml-2 text-gray resource-info">
           Filetype: {filetype}
         </span>
       </div>,

--- a/static/js/query-configs/websites.ts
+++ b/static/js/query-configs/websites.ts
@@ -1,5 +1,15 @@
 import { ActionPromiseValue, QueryConfig } from "redux-query"
-import { merge, reject, propEq, compose, evolve, when, assoc, map } from "ramda"
+import {
+  merge,
+  reject,
+  propEq,
+  compose,
+  evolve,
+  when,
+  assoc,
+  map,
+  mergeDeepRight
+} from "ramda"
 
 import { nextState, PaginatedResponse } from "./utils"
 import { getCookie } from "../lib/api/util"
@@ -321,13 +331,7 @@ export const websiteContentListingRequest = (
         ...prev,
         ...next
       }),
-      websiteContentDetails: (
-        prev: WebsiteContentDetails,
-        next: WebsiteContentDetails
-      ) => ({
-        ...prev,
-        ...next
-      })
+      websiteContentDetails: mergeDeepRight
     },
     force: true // try to prevent stale information
   }

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -238,6 +238,7 @@ export interface WebsiteContent extends WebsiteContentListItem {
   markdown: string | null
   metadata: null | Record<string, string>
   content_context: WebsiteContent[] | null // eslint-disable-line camelcase
+  file?: string
 }
 
 export interface ContentListingParams {

--- a/static/scss/resource-embed-widget.scss
+++ b/static/scss/resource-embed-widget.scss
@@ -16,5 +16,19 @@
 .ck-editor {
   .embedded-resource {
     border: 1px solid $studio-gray;
+
+    img {
+      max-height: 225px;
+      // CKEditor puts a min-width property on images
+      // which screws everything up, so we need to unset
+      // it here
+      min-width: initial !important;
+      max-width: 175px !important;
+    }
+
+    .resource-info {
+      font-size: 14px;
+      word-break: break-all;
+    }
   }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #504
part of #454

#### What's this PR do?

This adds a basic display for Image resources, which shows a sort of thumbnail of the image and a few pieces of info about it.

#### How should this be manually tested?

Add an image resource to a course. Then go and embed that image into a page in the same course - you should see a display like what's below in the editor.

#### Screenshots (if appropriate)

<img width="548" alt="Screen Shot 2021-08-31 at 3 49 41 PM" src="https://user-images.githubusercontent.com/6207644/131566762-500ee199-c574-4352-80fd-aa066c655bfd.png">
