### PR TITLE
Update local ocw course site config to match ocw-hugo-projects

### DIFF
--- a/localdev/configs/ocw-course-site-config.yml
+++ b/localdev/configs/ocw-course-site-config.yml
@@ -104,6 +104,35 @@ collections:
           - label: Credit
             name: credit
             widget: text
+      # show the sections below only if the type of resource is "Video"
+      - label: Video Metadata
+        name: metadata
+        widget: object
+        condition: {field: filetype, equals: Video}
+        fields:
+        - label: Youtube ID
+          name: youtube_id
+          widget: string
+        - label: Youtube Speakers
+          name: video_speakers
+          widget: string
+        - label: Youtube Tags (comma separated; max 100 characters)
+          name: video_tags
+          widget: text
+      - label: Video Files
+        name: video_files
+        widget: object
+        condition: {field: filetype, equals: Video}
+        fields:
+        - label: Video Thumbnail URL
+          name: video_thumbnail_file
+          widget: string
+        - label: Video Captions (WebVTT) URL
+          name: video_captions_file
+          widget: string
+        - label: Video Transcript (PDF) URL
+          name: video_transcript_file
+          widget: string
 
   - category: Settings
     name: metadata

--- a/static/js/resources/ocw-course-site-config.json
+++ b/static/js/resources/ocw-course-site-config.json
@@ -128,6 +128,58 @@
           "label": "Image Metadata",
           "name": "metadata",
           "widget": "object"
+        },
+        {
+          "condition": {
+            "equals": "Video",
+            "field": "filetype"
+          },
+          "fields": [
+            {
+              "label": "Youtube ID",
+              "name": "youtube_id",
+              "widget": "string"
+            },
+            {
+              "label": "Youtube Speakers",
+              "name": "video_speakers",
+              "widget": "string"
+            },
+            {
+              "label": "Youtube Tags (comma separated; max 100 characters)",
+              "name": "video_tags",
+              "widget": "text"
+            }
+          ],
+          "label": "Video Metadata",
+          "name": "metadata",
+          "widget": "object"
+        },
+        {
+          "condition": {
+            "equals": "Video",
+            "field": "filetype"
+          },
+          "fields": [
+            {
+              "label": "Video Thumbnail URL",
+              "name": "video_thumbnail_file",
+              "widget": "string"
+            },
+            {
+              "label": "Video Captions (WebVTT) URL",
+              "name": "video_captions_file",
+              "widget": "string"
+            },
+            {
+              "label": "Video Transcript (PDF) URL",
+              "name": "video_transcript_file",
+              "widget": "string"
+            }
+          ],
+          "label": "Video Files",
+          "name": "video_files",
+          "widget": "object"
         }
       ],
       "folder": "content/resources",


### PR DESCRIPTION
PR https://github.com/mitodl/ocw-hugo-projects/pull/61 should be reviewed first.

#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-hugo-projects/issues/56

#### What's this PR do?
Updates the local `ocw-course-site-config.yml` file to match the ocw-course config on ocw-hugo-projects based on PR https://github.com/mitodl/ocw-hugo-projects/pull/61

#### How should this be manually tested?
- Run `manage.py override_site_config`
- Create a new resource, file type 'Video', the new fields should show up and you should be able to enter and save values for them.  Do the same for file type "Image", the fields relevant to that filetype should appear instead.

