### PR TITLE
add display for video resources in markdown editor

### DIFF
--- a/static/js/components/widgets/EmbeddedResource.test.tsx
+++ b/static/js/components/widgets/EmbeddedResource.test.tsx
@@ -9,7 +9,7 @@ import {
 } from "../../util/factories/websites"
 import { Website, WebsiteContent } from "../../types/websites"
 import { siteApiContentDetailUrl } from "../../lib/urls"
-import { RESOURCE_TYPE_IMAGE } from "../../constants"
+import { RESOURCE_TYPE_IMAGE, RESOURCE_TYPE_VIDEO } from "../../constants"
 
 jest.mock("../../context/Website")
 jest.mock("../../hooks/state")
@@ -64,5 +64,19 @@ describe("EmbeddedResource", () => {
     expect(wrapper.find(".resource-info").text()).toBe("baz.png")
     expect(wrapper.find("h3").text()).toBe(content.title)
     expect(wrapper.find("img").prop("src")).toBe(content.file)
+  })
+
+  it("should render a video", async () => {
+    content.metadata!.filetype = RESOURCE_TYPE_VIDEO
+    content.metadata!.description = "My Video!!!"
+    content.metadata!.metadata = { youtube_id: "2XID_W4neJo" }
+    const { wrapper } = await render()
+    expect(wrapper.find(".title").text()).toBe(content.title)
+    expect(wrapper.find(".description").text()).toBe(
+      content.metadata!.description
+    )
+    expect(wrapper.find("iframe").prop("src")).toBe(
+      "https://www.youtube-nocookie.com/embed/2XID_W4neJo"
+    )
   })
 })

--- a/static/js/components/widgets/EmbeddedResource.tsx
+++ b/static/js/components/widgets/EmbeddedResource.tsx
@@ -5,7 +5,8 @@ import { useRequest } from "redux-query-react"
 import { websiteContentDetailRequest } from "../../query-configs/websites"
 import { useSelector } from "react-redux"
 import { getWebsiteContentDetailCursor } from "../../selectors/websites"
-import { RESOURCE_TYPE_IMAGE } from "../../constants"
+import { RESOURCE_TYPE_IMAGE, RESOURCE_TYPE_VIDEO } from "../../constants"
+import { SiteFormValue } from "../../types/forms"
 
 interface Props {
   uuid: string
@@ -54,6 +55,37 @@ export default function EmbeddedResource(props: Props): JSX.Element | null {
             <h3 className="m-2 title">{title}</h3>
             <span className="font-italic mx-2 text-gray resource-info d-block">
               {filename}
+            </span>
+          </div>
+        </div>,
+        el
+      )
+    }
+
+    if (filetype === RESOURCE_TYPE_VIDEO) {
+      const videoMetadata = resource.metadata?.metadata as Record<
+        string,
+        SiteFormValue
+      >
+
+      const youtubeId = (videoMetadata?.youtube_id as string) ?? ""
+
+      return createPortal(
+        <div className="embedded-resource video my-2 d-flex align-items-center">
+          <iframe
+            className="m-2"
+            width="320"
+            height="180"
+            src={`https://www.youtube-nocookie.com/embed/${youtubeId}`}
+            title="YouTube video player"
+            frameBorder="0"
+            allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+          />
+          <div>
+            <h3 className="m-2 title">{title}</h3>
+            <span className="font-italic mx-2 text-gray description resource-info d-block">
+              {resource.metadata?.description ?? ""}
             </span>
           </div>
         </div>,

--- a/static/js/query-configs/websites.ts
+++ b/static/js/query-configs/websites.ts
@@ -362,10 +362,12 @@ export const websiteContentDetailRequest = (
     websiteContentDetails: (
       prev: WebsiteContentDetails,
       next: WebsiteContentDetails
-    ) => ({
-      ...prev,
-      ...next
-    })
+    ) => {
+      return {
+        ...prev,
+        ...next
+      }
+    }
   },
   force: true // some data may be fetched in the collection view which is incomplete
 })

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -236,7 +236,7 @@ export interface WebsiteContentListItem {
 
 export interface WebsiteContent extends WebsiteContentListItem {
   markdown: string | null
-  metadata: null | Record<string, string>
+  metadata: null | Record<string, SiteFormValue>
   content_context: WebsiteContent[] | null // eslint-disable-line camelcase
   file?: string
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #506

#### What's this PR do?

This adds a basic display of a video resource when it has been added to the Markdown editor.

#### How should this be manually tested?

Create a video resource, making sure to fill out the `youtube_id` field. Then add that resource to the body field on a page and check out the way that it's rendered in the editor. You should have a youtube player and the title and description of the video resource.

#### Screenshots (if appropriate)

![Screen Shot 2021-09-01 at 4 02 30 PM](https://user-images.githubusercontent.com/6207644/131736365-f824cfa4-b66c-42b3-adc5-4b13fde04d36.png)
