### PR TITLE
Fix course site config

### DIFF
--- a/localdev/configs/ocw-course-site-config.yml
+++ b/localdev/configs/ocw-course-site-config.yml
@@ -91,7 +91,7 @@ collections:
           - 'Written Assignments with Examples'
       # show the field below only if the type of resource is "image"
       - label: Image Metadata
-        name: metadata
+        name: image_metadata
         widget: object
         condition: { field: filetype, equals: Image }
         fields:
@@ -106,7 +106,7 @@ collections:
             widget: text
       # show the sections below only if the type of resource is "Video"
       - label: Video Metadata
-        name: metadata
+        name: video_metadata
         widget: object
         condition: {field: filetype, equals: Video}
         fields:

--- a/static/js/resources/ocw-course-site-config.json
+++ b/static/js/resources/ocw-course-site-config.json
@@ -126,7 +126,7 @@
             }
           ],
           "label": "Image Metadata",
-          "name": "metadata",
+          "name": "image_metadata",
           "widget": "object"
         },
         {
@@ -152,7 +152,7 @@
             }
           ],
           "label": "Video Metadata",
-          "name": "metadata",
+          "name": "video_metadata",
           "widget": "object"
         },
         {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
N/A

#### What's this PR do?
Fixes a bug where video metadata was always overwriting image metadata because of a shared name.

#### How should this be manually tested?
Run `manage.py override_site_config`
Create an image resource and a video resource, and fill out metdata fields for each.  Reload each and verify the field values were saved.
