### PR TITLE
delete unpublished courses take two

### DIFF
--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -353,24 +353,3 @@ def generate_topics_dict(course_paths, bucket_name):
             subtopic_dict[subtopic] = sorted(subtopic_dict[subtopic])
 
     return topics
-
-
-def delete_unpublished_course(paths=None, filter_str=None):
-    """
-    Remove all unpublished courses based on paths that don't exist anymore
-
-    Args:
-        paths (list of str): list of paths to course data templates
-        filter_str (str): (Optional) If specified, filter courses to remove
-    """
-    if not paths:
-        return
-    course_ids = list(map((lambda key: key.replace("/data/course.json", "", 1)), paths))
-    unpublished_courses = Website.objects.filter(
-        source=WEBSITE_SOURCE_OCW_IMPORT
-    ).exclude(name__in=course_ids)
-    if filter_str:
-        unpublished_courses = unpublished_courses.filter(name__contains=filter_str)
-    if unpublished_courses.count() > 0:
-        log.info("Removing unpublished imported courses: %s", unpublished_courses)
-        unpublished_courses.delete()

--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -353,3 +353,24 @@ def generate_topics_dict(course_paths, bucket_name):
             subtopic_dict[subtopic] = sorted(subtopic_dict[subtopic])
 
     return topics
+
+
+def delete_unpublished_course(paths=None, filter_str=None):
+    """
+    Remove all unpublished courses based on paths that don't exist anymore
+
+    Args:
+        paths (list of str): list of paths to course data templates
+        filter_str (str): (Optional) If specified, filter courses to remove
+    """
+    if not paths:
+        return
+    course_ids = list(map((lambda key: key.replace("/data/course.json", "", 1)), paths))
+    unpublished_courses = Website.objects.filter(
+        source=WEBSITE_SOURCE_OCW_IMPORT
+    ).exclude(name__in=course_ids)
+    if filter_str:
+        unpublished_courses = unpublished_courses.filter(name__contains=filter_str)
+    if unpublished_courses.count() > 0:
+        log.info("Removing unpublished imported courses: %s", unpublished_courses)
+        unpublished_courses.delete()

--- a/ocw_import/api_test.py
+++ b/ocw_import/api_test.py
@@ -7,8 +7,8 @@ from moto import mock_s3
 from ocw_import.api import generate_topics_dict, get_short_id, import_ocw2hugo_course
 from ocw_import.conftest import (
     MOCK_BUCKET_NAME,
-    TEST_OCW2HUGO_PATH,
     TEST_OCW2HUGO_PREFIX,
+    get_ocw2hugo_path,
     setup_s3,
 )
 from websites.constants import (
@@ -23,6 +23,8 @@ from websites.models import Website, WebsiteContent
 
 
 pytestmark = pytest.mark.django_db
+
+TEST_OCW2HUGO_PATH = get_ocw2hugo_path("./test_ocw2hugo")
 
 
 @mock_s3

--- a/ocw_import/conftest.py
+++ b/ocw_import/conftest.py
@@ -1,6 +1,7 @@
 """Test config for ocw_import app"""
 import glob
 from os.path import isfile
+from shutil import copytree, rmtree
 
 import pytest
 
@@ -8,12 +9,15 @@ from main.s3_utils import get_s3_resource
 from websites.factories import WebsiteFactory
 
 
-TEST_OCW2HUGO_PREFIX = ""
-TEST_OCW2HUGO_PATH = f"./test_ocw2hugo/{TEST_OCW2HUGO_PREFIX}"
-TEST_OCW2HUGO_FILES = [
-    f for f in glob.glob(TEST_OCW2HUGO_PATH + "**/*", recursive=True) if isfile(f)
-]
 MOCK_BUCKET_NAME = "testbucket"
+TEST_OCW2HUGO_PREFIX = ""
+
+
+def get_ocw2hugo_files(path):
+    TEST_OCW2HUGO_PATH = f"{path}/{TEST_OCW2HUGO_PREFIX}"
+    return [
+        f for f in glob.glob(TEST_OCW2HUGO_PATH + "**/*", recursive=True) if isfile(f)
+    ]
 
 
 def setup_s3(settings):
@@ -29,8 +33,37 @@ def setup_s3(settings):
 
     # Add data to the fake bucket
     test_bucket = conn.Bucket(name=MOCK_BUCKET_NAME)
-    for file in TEST_OCW2HUGO_FILES:
+    test_bucket.objects.all().delete()
+    for file in get_ocw2hugo_files("./test_ocw2hugo"):
         file_key = file.replace("./test_ocw2hugo/", "")
+        with open(file, "r") as f:
+            print(file_key)
+            test_bucket.put_object(Key=file_key, Body=f.read())
+
+
+def setup_s3_tmpdir(settings, tmpdir, courses=None):
+    """
+    Set up the fake s3 data
+    """
+    # Fake the settings
+    settings.AWS_ACCESS_KEY_ID = "abc"
+    settings.AWS_SECRET_ACCESS_KEY = "abc"
+    # Create our fake bucket
+    conn = get_s3_resource()
+    conn.create_bucket(Bucket=MOCK_BUCKET_NAME)
+    # Copy test data to tmpdir
+    rmtree(tmpdir)
+    if courses is not None:
+        for course in courses:
+            copytree(f"./test_ocw2hugo/{course}/", f"{tmpdir}/{course}/")
+    else:
+        copytree("./test_ocw2hugo/", f"{tmpdir}/")
+
+    # Add data to the fake bucket
+    test_bucket = conn.Bucket(name=MOCK_BUCKET_NAME)
+    test_bucket.objects.all().delete()
+    for file in get_ocw2hugo_files(tmpdir):
+        file_key = file.replace(tmpdir, "")
         with open(file, "r") as f:
             test_bucket.put_object(Key=file_key, Body=f.read())
 

--- a/ocw_import/conftest.py
+++ b/ocw_import/conftest.py
@@ -13,8 +13,14 @@ MOCK_BUCKET_NAME = "testbucket"
 TEST_OCW2HUGO_PREFIX = ""
 
 
+def get_ocw2hugo_path(path):
+    """ get the path to ocw-to-hugo test data """
+    return f"{path}/{TEST_OCW2HUGO_PREFIX}"
+
+
 def get_ocw2hugo_files(path):
-    TEST_OCW2HUGO_PATH = f"{path}/{TEST_OCW2HUGO_PREFIX}"
+    """ get the files from an ocw-to-hugo test data directory """
+    TEST_OCW2HUGO_PATH = get_ocw2hugo_path(path)
     return [
         f for f in glob.glob(TEST_OCW2HUGO_PATH + "**/*", recursive=True) if isfile(f)
     ]
@@ -37,7 +43,6 @@ def setup_s3(settings):
     for file in get_ocw2hugo_files("./test_ocw2hugo"):
         file_key = file.replace("./test_ocw2hugo/", "")
         with open(file, "r") as f:
-            print(file_key)
             test_bucket.put_object(Key=file_key, Body=f.read())
 
 
@@ -63,7 +68,7 @@ def setup_s3_tmpdir(settings, tmpdir, courses=None):
     test_bucket = conn.Bucket(name=MOCK_BUCKET_NAME)
     test_bucket.objects.all().delete()
     for file in get_ocw2hugo_files(tmpdir):
-        file_key = file.replace(tmpdir, "")
+        file_key = file.replace(f"{tmpdir}/", "")
         with open(file, "r") as f:
             test_bucket.put_object(Key=file_key, Body=f.read())
 

--- a/ocw_import/conftest.py
+++ b/ocw_import/conftest.py
@@ -20,9 +20,10 @@ def get_ocw2hugo_path(path):
 
 def get_ocw2hugo_files(path):
     """ get the files from an ocw-to-hugo test data directory """
-    TEST_OCW2HUGO_PATH = get_ocw2hugo_path(path)
     return [
-        f for f in glob.glob(TEST_OCW2HUGO_PATH + "**/*", recursive=True) if isfile(f)
+        f
+        for f in glob.glob(get_ocw2hugo_path(path) + "**/*", recursive=True)
+        if isfile(f)
     ]
 
 

--- a/ocw_import/management/commands/import_ocw_course_sites.py
+++ b/ocw_import/management/commands/import_ocw_course_sites.py
@@ -65,6 +65,14 @@ class Command(BaseCommand):
             action="store_true",
             help="Sync all unsynced courses to the backend",
         )
+        parser.add_argument(
+            "-d",
+            "--delete_unpublished",
+            dest="delete_unpublished",
+            default=True,
+            type=bool,
+            help="If True, delete all courses that have been unpublished in the source data"
+        )
         super().add_arguments(parser)
 
     def handle(self, *args, **options):
@@ -75,6 +83,7 @@ class Command(BaseCommand):
         bucket_name = options["bucket"]
         filter_str = options["filter"]
         limit = options["limit"]
+        delete_unpublished = options["delete_unpublished"]
 
         if options["list"] is True:
             course_paths = list(
@@ -92,6 +101,7 @@ class Command(BaseCommand):
             prefix=prefix,
             filter_str=filter_str,
             limit=limit,
+            delete_unpublished=delete_unpublished,
             chunk_size=options["chunks"],
         )
         self.stdout.write(f"Starting task {task}...")

--- a/ocw_import/management/commands/import_ocw_course_sites.py
+++ b/ocw_import/management/commands/import_ocw_course_sites.py
@@ -71,7 +71,7 @@ class Command(BaseCommand):
             dest="delete_unpublished",
             default=True,
             type=bool,
-            help="If True, delete all courses that have been unpublished in the source data"
+            help="If True, delete all courses that have been unpublished in the source data",
         )
         super().add_arguments(parser)
 

--- a/ocw_import/tasks_test.py
+++ b/ocw_import/tasks_test.py
@@ -1,9 +1,17 @@
 """ Tests for ocw_import.tasks """
+from tempfile import TemporaryDirectory
+
 import pytest
 from moto import mock_s3
 
-from ocw_import.conftest import MOCK_BUCKET_NAME, TEST_OCW2HUGO_PREFIX, setup_s3
+from ocw_import.conftest import (
+    MOCK_BUCKET_NAME,
+    TEST_OCW2HUGO_PREFIX,
+    setup_s3,
+    setup_s3_tmpdir,
+)
 from ocw_import.tasks import import_ocw2hugo_course_paths, import_ocw2hugo_courses
+from websites.models import Website
 
 
 # pylint:disable=too-many-arguments
@@ -62,3 +70,37 @@ def test_import_ocw2hugo_courses_nobucket(mocker):
             bucket_name=None, prefix=TEST_OCW2HUGO_PREFIX, chunk_size=100
         )
     assert mock_import_paths.call_count == 0
+
+
+@mock_s3
+def test_import_ocw2hugo_courses_delete_unpublished(settings, mocker, mocked_celery):
+    mock_delete_unpublished_courses = mocker.patch(
+        "ocw_import.tasks.delete_unpublished_courses.si"
+    )
+    settings.OCW_IMPORT_STARTER_SLUG = "course"
+    tmpdir = TemporaryDirectory()
+    setup_s3_tmpdir(settings, tmpdir.name)
+    with pytest.raises(mocked_celery.replace_exception_class):
+        import_ocw2hugo_courses.delay(
+            bucket_name=MOCK_BUCKET_NAME, prefix=TEST_OCW2HUGO_PREFIX
+        )
+    mock_delete_unpublished_courses.assert_called_with(
+        paths=[
+            "/1-050-engineering-mechanics-i-fall-2007/data/course.json",
+            "/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/data/course.json",
+            "/biology/data/course.json",
+        ]
+    )
+    tmpdir.cleanup()
+    tmpdir = TemporaryDirectory()
+    setup_s3_tmpdir(
+        settings, tmpdir.name, courses=["1-050-engineering-mechanics-i-fall-2007"]
+    )
+    with pytest.raises(mocked_celery.replace_exception_class):
+        import_ocw2hugo_courses.delay(
+            bucket_name=MOCK_BUCKET_NAME, prefix=TEST_OCW2HUGO_PREFIX
+        )
+    mock_delete_unpublished_courses.assert_called_with(
+        paths=["/1-050-engineering-mechanics-i-fall-2007/data/course.json"]
+    )
+    tmpdir.cleanup()

--- a/ocw_import/tasks_test.py
+++ b/ocw_import/tasks_test.py
@@ -109,7 +109,6 @@ def test_import_ocw2hugo_courses_delete_unpublished(settings, mocker, mocked_cel
     mock_delete_unpublished_courses = mocker.patch(
         "ocw_import.tasks.delete_unpublished_courses.si"
     )
-    settings.OCW_IMPORT_STARTER_SLUG = "course"
     tmpdir = TemporaryDirectory()
     setup_s3_tmpdir(settings, tmpdir.name)
     with pytest.raises(mocked_celery.replace_exception_class):
@@ -128,3 +127,21 @@ def test_import_ocw2hugo_courses_delete_unpublished(settings, mocker, mocked_cel
         )
     mock_delete_unpublished_courses.assert_called_with(paths=SINGLE_COURSE_PATHS)
     tmpdir.cleanup()
+
+
+@mock_s3
+def test_import_ocw2hugo_courses_delete_unpublished_false(
+    settings, mocker, mocked_celery
+):
+    """ import_ocw2hugo_courses should not call delete_unpublished when the argument is false """
+    mock_delete_unpublished_courses = mocker.patch(
+        "ocw_import.tasks.delete_unpublished_courses.si"
+    )
+    setup_s3(settings)
+    with pytest.raises(mocked_celery.replace_exception_class):
+        import_ocw2hugo_courses.delay(
+            bucket_name=MOCK_BUCKET_NAME,
+            prefix=TEST_OCW2HUGO_PREFIX,
+            delete_unpublished=False,
+        )
+    mock_delete_unpublished_courses.assert_not_called()

--- a/ocw_import/tasks_test.py
+++ b/ocw_import/tasks_test.py
@@ -4,18 +4,30 @@ from tempfile import TemporaryDirectory
 import pytest
 from moto import mock_s3
 
+from ocw_import.api import import_ocw2hugo_course
 from ocw_import.conftest import (
     MOCK_BUCKET_NAME,
     TEST_OCW2HUGO_PREFIX,
     setup_s3,
     setup_s3_tmpdir,
 )
-from ocw_import.tasks import import_ocw2hugo_course_paths, import_ocw2hugo_courses
+from ocw_import.tasks import (
+    delete_unpublished_courses,
+    import_ocw2hugo_course_paths,
+    import_ocw2hugo_courses,
+)
 from websites.models import Website
 
 
 # pylint:disable=too-many-arguments
 pytestmark = pytest.mark.django_db
+
+ALL_COURSES_PATHS = [
+    "1-050-engineering-mechanics-i-fall-2007/data/course.json",
+    "1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/data/course.json",
+    "biology/data/course.json",
+]
+SINGLE_COURSE_PATHS = ["1-050-engineering-mechanics-i-fall-2007/data/course.json"]
 
 
 @pytest.mark.parametrize(
@@ -73,7 +85,27 @@ def test_import_ocw2hugo_courses_nobucket(mocker):
 
 
 @mock_s3
+def test_delete_unpublished_courses(settings, course_starter):
+    """ delete_unpublished_courses should remove Website objects when they aren't present in the passed in list of paths """
+    setup_s3(settings)
+    settings.OCW_IMPORT_STARTER_SLUG = "course"
+    for course_path in ALL_COURSES_PATHS:
+        import_ocw2hugo_course(
+            MOCK_BUCKET_NAME,
+            TEST_OCW2HUGO_PREFIX,
+            course_path,
+            starter_id=course_starter.id,
+        )
+    assert Website.objects.all().count() == 3
+    delete_unpublished_courses(paths=ALL_COURSES_PATHS)
+    assert Website.objects.all().count() == 3
+    delete_unpublished_courses(paths=SINGLE_COURSE_PATHS)
+    assert Website.objects.all().count() == 2
+
+
+@mock_s3
 def test_import_ocw2hugo_courses_delete_unpublished(settings, mocker, mocked_celery):
+    """ import_ocw2hugo_courses should call delete_unpublished when courses have been removed from the ocw-to-hugo directory """
     mock_delete_unpublished_courses = mocker.patch(
         "ocw_import.tasks.delete_unpublished_courses.si"
     )
@@ -84,13 +116,7 @@ def test_import_ocw2hugo_courses_delete_unpublished(settings, mocker, mocked_cel
         import_ocw2hugo_courses.delay(
             bucket_name=MOCK_BUCKET_NAME, prefix=TEST_OCW2HUGO_PREFIX
         )
-    mock_delete_unpublished_courses.assert_called_with(
-        paths=[
-            "/1-050-engineering-mechanics-i-fall-2007/data/course.json",
-            "/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/data/course.json",
-            "/biology/data/course.json",
-        ]
-    )
+    mock_delete_unpublished_courses.assert_called_with(paths=ALL_COURSES_PATHS)
     tmpdir.cleanup()
     tmpdir = TemporaryDirectory()
     setup_s3_tmpdir(
@@ -100,7 +126,5 @@ def test_import_ocw2hugo_courses_delete_unpublished(settings, mocker, mocked_cel
         import_ocw2hugo_courses.delay(
             bucket_name=MOCK_BUCKET_NAME, prefix=TEST_OCW2HUGO_PREFIX
         )
-    mock_delete_unpublished_courses.assert_called_with(
-        paths=["/1-050-engineering-mechanics-i-fall-2007/data/course.json"]
-    )
+    mock_delete_unpublished_courses.assert_called_with(paths=SINGLE_COURSE_PATHS)
     tmpdir.cleanup()


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/522

#### What's this PR do?
When courses are unpublished in the current Plone based OCW system, this information propagates through the system and eventually `ocw-to-hugo` will see this and decide not to output data for that course.  In `ocw-studio`, `import_ocw_course_sites` sources its data from an S3 bucket filled with `ocw-to-hugo` output.  Since `ocw-studio` is not set up to handle this, when courses are unpublished and subsequently removed from the bucket, the `Website` objects linger in the database.  This PR adds functionality that by default will remove sites for courses that are no longer present in the `ocw-to-hugo` output bucket.

#### How should this be manually tested?
Since `import_ocw_course_sites` is only set up to use S3, a fake S3 bucket can be mocked in unit testing (and it is) but when it comes to running a manual test it's a bit more tricky.

 - Spin up `ocw-studio` locally and make sure you have S3 credentials configured
 - Make sure you have the `ocw-www` and `ocw-course` website starters from https://github.com/mitodl/ocw-hugo-projects loaded into your local instance and create an empty `ocw-www` site named `ocw-www`
 - Run `docker-compose run web ./manage.py import_ocw_course_sites -b ocw-to-hugo-output-qa --filter 5-310`
 - Drop into a Django shell with `docker-compose run web ./manage.py shell`
 - Run the following:
```
from websites.models import Website
Website.objects.all().count()
```
- Verify that the number of websites returned is 3
- Insert a line into `ocw_import/tasks.py` after line 86 to spoof one of the courses being removed from S3:
`course_paths = ["15-310-managerial-psychology-laboratory-spring-2003/data/course.json"]`
- Rebuild your docker containers
- Re-run the same `import_ocw_course_sites` command from above
- Re-run the same check in a Django shell and verify that the amount of `Website` objects is now 2
