### PR TITLE
add support for linking to resources in the Markdown editor

### DIFF
--- a/static/js/components/Dialog.test.tsx
+++ b/static/js/components/Dialog.test.tsx
@@ -7,6 +7,7 @@ import Dialog from "./Dialog"
 interface ExtraProps {
   open: boolean
   acceptText?: string
+  altAcceptText?: string
   cancelText?: string
   headerContent: JSX.Element | string
   bodyContent: JSX.Element | string
@@ -20,6 +21,7 @@ describe("Dialog", () => {
   let toggleModalStub: SinonStub,
     onCancelStub: SinonStub,
     onAcceptStub: SinonStub,
+    altOnAcceptStub: SinonStub,
     headerContent: JSX.Element | string,
     bodyContent: JSX.Element | string,
     render: (props: ExtraProps) => ShallowWrapper
@@ -28,11 +30,13 @@ describe("Dialog", () => {
     toggleModalStub = sinon.stub()
     onCancelStub = sinon.stub()
     onAcceptStub = sinon.stub()
+    altOnAcceptStub = sinon.stub()
     render = (props: ExtraProps) =>
       shallow(
         <Dialog
           toggleModal={toggleModalStub}
           onAccept={onAcceptStub}
+          altOnAccept={altOnAcceptStub}
           onCancel={onCancelStub}
           {...props}
         />
@@ -66,10 +70,18 @@ describe("Dialog", () => {
     okButton.simulate("click")
     sinon.assert.calledOnce(onAcceptStub)
 
-    const cancelButton = wrapper
+    const altOkButton = wrapper
       .find("ModalFooter")
       .find("Button")
       .at(1)
+    expect(altOkButton.childAt(0).text()).toBe("OK")
+    altOkButton.simulate("click")
+    sinon.assert.calledOnce(altOnAcceptStub)
+
+    const cancelButton = wrapper
+      .find("ModalFooter")
+      .find("Button")
+      .at(2)
     expect(cancelButton.childAt(0).text()).toBe("Cancel")
     cancelButton.simulate("click")
     sinon.assert.calledOnce(onCancelStub)
@@ -79,12 +91,14 @@ describe("Dialog", () => {
     headerContent = <h1>Header</h1>
     bodyContent = <div>Body</div>
     const acceptText = "Save"
+    const altAcceptText = "Create Draft"
     const cancelText = "Back"
     const wrapper = render({
       open: false,
       headerContent,
       bodyContent,
       acceptText,
+      altAcceptText,
       cancelText
     })
     expect(wrapper.find("Modal").prop("isOpen")).toBe(false)
@@ -94,10 +108,19 @@ describe("Dialog", () => {
       .at(0)
     expect(okButton.childAt(0).text()).toBe(acceptText)
 
+    expect(
+      wrapper
+        .find("ModalFooter")
+        .find("Button")
+        .at(1)
+        .childAt(0)
+        .text()
+    ).toBe(altAcceptText)
+
     const cancelButton = wrapper
       .find("ModalFooter")
       .find("Button")
-      .at(1)
+      .at(2)
     expect(cancelButton.childAt(0).text()).toBe(cancelText)
   })
 

--- a/static/js/components/Dialog.tsx
+++ b/static/js/components/Dialog.tsx
@@ -6,7 +6,9 @@ export interface Props {
   toggleModal: () => void
   onCancel?: () => void
   onAccept?: () => void
+  altOnAccept?: () => void
   acceptText?: string
+  altAcceptText?: string
   cancelText?: string
   headerContent: JSX.Element | string
   bodyContent: JSX.Element | string
@@ -23,8 +25,10 @@ export default function Dialog(props: Props): JSX.Element | null {
     headerContent,
     bodyContent,
     onAccept,
+    altOnAccept,
     onCancel,
     acceptText,
+    altAcceptText,
     cancelText,
     wrapClassName,
     modalClassName,
@@ -55,6 +59,11 @@ export default function Dialog(props: Props): JSX.Element | null {
         {onAccept ? (
           <Button color="primary" onClick={onAccept}>
             {acceptText || "OK"}
+          </Button>
+        ) : null}
+        {altOnAccept ? (
+          <Button color="primary" onClick={altOnAccept}>
+            {altAcceptText || "OK"}
           </Button>
         ) : null}
         <Button color="secondary" onClick={onCancel || toggleModal}>

--- a/static/js/components/widgets/EmbeddedResource.tsx
+++ b/static/js/components/widgets/EmbeddedResource.tsx
@@ -1,11 +1,8 @@
-import { createPortal } from "react-dom"
 import React from "react"
-import { useWebsite } from "../../context/Website"
-import { useRequest } from "redux-query-react"
-import { websiteContentDetailRequest } from "../../query-configs/websites"
-import { useSelector } from "react-redux"
-import { getWebsiteContentDetailCursor } from "../../selectors/websites"
+import { createPortal } from "react-dom"
+
 import { RESOURCE_TYPE_IMAGE, RESOURCE_TYPE_VIDEO } from "../../constants"
+import { useWebsiteContent } from "../../hooks/websiteContent"
 import { SiteFormValue } from "../../types/forms"
 
 interface Props {
@@ -24,20 +21,7 @@ interface Props {
 export default function EmbeddedResource(props: Props): JSX.Element | null {
   const { uuid, el } = props
 
-  const website = useWebsite()
-
-  const contentParams = {
-    name:   website.name,
-    textId: uuid
-  }
-
-  useRequest(websiteContentDetailRequest(contentParams, false))
-
-  const websiteContentDetailSelector = useSelector(
-    getWebsiteContentDetailCursor
-  )
-
-  const resource = websiteContentDetailSelector(contentParams)
+  const resource = useWebsiteContent(uuid)
 
   if (!resource) {
     return null
@@ -46,7 +30,7 @@ export default function EmbeddedResource(props: Props): JSX.Element | null {
     const title = resource.title ?? resource.text_id
 
     if (filetype === RESOURCE_TYPE_IMAGE) {
-      const filename = resource.file!.split("/").slice(-1)
+      const filename = (resource.file ?? "").split("/").slice(-1)[0]
 
       return createPortal(
         <div className="embedded-resource image my-2 d-flex align-items-center">

--- a/static/js/components/widgets/MarkdownEditor.test.tsx
+++ b/static/js/components/widgets/MarkdownEditor.test.tsx
@@ -9,7 +9,12 @@ import {
   FullEditorConfig,
   MinimalEditorConfig
 } from "../../lib/ckeditor/CKEditor"
-import { ADD_RESOURCE } from "../../lib/ckeditor/plugins/ResourceEmbed"
+import {
+  ADD_RESOURCE,
+  CKEDITOR_RESOURCE_UTILS,
+  RESOURCE_EMBED,
+  RESOURCE_LINK
+} from "../../lib/ckeditor/plugins/constants"
 
 jest.mock("@ckeditor/ckeditor5-react", () => ({
   CKEditor: () => <div />
@@ -47,9 +52,9 @@ describe("MarkdownEditor", () => {
         })
         const ckWrapper = wrapper.find("CKEditor")
         expect(ckWrapper.prop("editor")).toBe(ClassicEditor)
-        expect(omit(["resourceEmbed"], ckWrapper.prop("config"))).toEqual(
-          expectedComponent
-        )
+        expect(
+          omit([CKEDITOR_RESOURCE_UTILS], ckWrapper.prop("config"))
+        ).toEqual(expectedComponent)
         expect(ckWrapper.prop("data")).toBe(expectedPropValue)
       })
     })
@@ -60,19 +65,29 @@ describe("MarkdownEditor", () => {
     expect(wrapper.find("ResourcePickerDialog").prop("attach")).toBe("resource")
   })
 
-  it("should render embedded resources", () => {
-    const wrapper = render()
-    const editor = wrapper.find("CKEditor").prop("config")
-    const el = document.createElement("div")
-    // @ts-ignore
-    editor.resourceEmbed.renderResourceEmbed("resource-uuid", el)
-    wrapper.update()
-    expect(
-      wrapper
-        .find("EmbeddedResource")
-        .at(0)
-        .prop("uuid")
-    ).toEqual("resource-uuid")
+  //
+  ;[
+    [RESOURCE_EMBED, "EmbeddedResource"],
+    [RESOURCE_LINK, "ResourceLink"]
+  ].forEach(([embedType, componentDisplayName]) => {
+    it(`should render resources with ${embedType} using ${componentDisplayName}`, () => {
+      const wrapper = render()
+      const editor = wrapper.find("CKEditor").prop("config")
+      const el = document.createElement("div")
+      // @ts-ignore
+      editor[CKEDITOR_RESOURCE_UTILS].renderResource(
+        "resource-uuid",
+        el,
+        embedType
+      )
+      wrapper.update()
+      expect(
+        wrapper
+          .find(componentDisplayName)
+          .at(0)
+          .prop("uuid")
+      ).toEqual("resource-uuid")
+    })
   })
 
   //
@@ -93,7 +108,7 @@ describe("MarkdownEditor", () => {
     const wrapper = render({ attach: "resource" })
     const editor = wrapper.find("CKEditor").prop("config")
     // @ts-ignore
-    editor.resourceEmbed.openResourcePicker()
+    editor[CKEDITOR_RESOURCE_UTILS].openResourcePicker()
     wrapper.update()
     expect(
       wrapper

--- a/static/js/components/widgets/ResourceLink.test.tsx
+++ b/static/js/components/widgets/ResourceLink.test.tsx
@@ -1,0 +1,72 @@
+import ResourceLink from "./ResourceLink"
+import IntegrationTestHelper, {
+  TestRenderer
+} from "../../util/integration_test_helper"
+import { useWebsite } from "../../context/Website"
+import {
+  makeWebsiteContentDetail,
+  makeWebsiteDetail
+} from "../../util/factories/websites"
+import { Website, WebsiteContent } from "../../types/websites"
+import { siteApiContentDetailUrl } from "../../lib/urls"
+import {
+  RESOURCE_TYPE_DOCUMENT,
+  RESOURCE_TYPE_IMAGE,
+  RESOURCE_TYPE_OTHER,
+  RESOURCE_TYPE_VIDEO
+} from "../../constants"
+
+jest.mock("../../context/Website")
+jest.mock("../../hooks/state")
+
+describe("ResourceLink", () => {
+  let helper: IntegrationTestHelper,
+    render: TestRenderer,
+    website: Website,
+    content: WebsiteContent,
+    el: HTMLDivElement
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    website = makeWebsiteDetail()
+    content = makeWebsiteContentDetail()
+    // @ts-ignore
+    useWebsite.mockReturnValue(website)
+
+    helper.mockGetRequest(
+      siteApiContentDetailUrl
+        .param({ name: website.name, textId: content.text_id })
+        .toString(),
+      content
+    )
+
+    el = document.createElement("div")
+    render = helper.configureRenderer(ResourceLink, {
+      uuid: content.text_id,
+      el
+    })
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should render, display some basic information about the resource", async () => {
+    const { wrapper } = await render()
+    expect(wrapper.text().includes(content.title as string)).toBeTruthy()
+  })
+
+  //
+  ;[
+    [RESOURCE_TYPE_IMAGE, "image"],
+    [RESOURCE_TYPE_VIDEO, "movie"],
+    [RESOURCE_TYPE_DOCUMENT, "description"],
+    [RESOURCE_TYPE_OTHER, "attachment"]
+  ].forEach(([resourceType, iconName]) => {
+    it(`should render an appropriate icon for ${resourceType}`, async () => {
+      content.metadata!.filetype = resourceType
+      const { wrapper } = await render()
+      expect(wrapper.find("i").text()).toBe(iconName)
+    })
+  })
+})

--- a/static/js/components/widgets/ResourceLink.tsx
+++ b/static/js/components/widgets/ResourceLink.tsx
@@ -1,0 +1,49 @@
+import React from "react"
+import { createPortal } from "react-dom"
+
+import {
+  RESOURCE_TYPE_IMAGE,
+  RESOURCE_TYPE_VIDEO,
+  RESOURCE_TYPE_DOCUMENT,
+  RESOURCE_TYPE_OTHER
+} from "../../constants"
+import { useWebsiteContent } from "../../hooks/websiteContent"
+
+interface Props {
+  uuid: string
+  el: HTMLElement
+}
+
+const filetypeIconMap = {
+  [RESOURCE_TYPE_IMAGE]:    "image",
+  [RESOURCE_TYPE_VIDEO]:    "movie",
+  [RESOURCE_TYPE_DOCUMENT]: "description",
+  [RESOURCE_TYPE_OTHER]:    "attachment"
+}
+
+/**
+ * Display component for linked resources in the Markdown editor
+ */
+export default function ResourceLink(props: Props): JSX.Element | null {
+  const { uuid, el } = props
+
+  const resource = useWebsiteContent(uuid)
+
+  if (!resource) {
+    return null
+  } else {
+    const title = resource.title
+    const filetype = resource.metadata?.filetype
+    const icon = filetype ?
+      filetypeIconMap[filetype as string] :
+      filetypeIconMap[RESOURCE_TYPE_OTHER]
+
+    return createPortal(
+      <span className="border">
+        <i className="material-icons">{icon}</i>
+        {title}
+      </span>,
+      el
+    )
+  }
+}

--- a/static/js/components/widgets/ResourcePickerDialog.tsx
+++ b/static/js/components/widgets/ResourcePickerDialog.tsx
@@ -10,11 +10,16 @@ import {
 } from "../../constants"
 import ResourcePickerListing from "./ResourcePickerListing"
 import { useDebouncedState } from "../../hooks/state"
+import {
+  CKEResourceNodeType,
+  RESOURCE_EMBED,
+  RESOURCE_LINK
+} from "../../lib/ckeditor/plugins/constants"
 
 interface Props {
   open: boolean
   setOpen: (open: boolean) => void
-  insertEmbed: (id: string) => void
+  insertEmbed: (id: string, variant: CKEResourceNodeType) => void
   attach: string
 }
 
@@ -69,12 +74,32 @@ export default function ResourcePickerDialog(props: Props): JSX.Element {
     [setShowFilterUI]
   )
 
+  const [focusedResource, setFocusedResource] = useState<string | null>(null)
+
+  const embedResource = useCallback(() => {
+    if (focusedResource) {
+      insertEmbed(focusedResource, RESOURCE_EMBED)
+      setOpen(false)
+    }
+  }, [insertEmbed, focusedResource, setOpen])
+
+  const linkResource = useCallback(() => {
+    if (focusedResource) {
+      insertEmbed(focusedResource, RESOURCE_LINK)
+      setOpen(false)
+    }
+  }, [insertEmbed, focusedResource, setOpen])
+
   return (
     <Dialog
       open={open}
       toggleModal={() => setOpen(false)}
       wrapClassName="resource-picker-dialog"
       headerContent="Resources"
+      onAccept={focusedResource ? embedResource : undefined}
+      acceptText="Embed Resource"
+      altOnAccept={focusedResource ? linkResource : undefined}
+      altAcceptText="Link Resource"
       bodyContent={
         <>
           <Nav tabs>
@@ -115,8 +140,8 @@ export default function ResourcePickerDialog(props: Props): JSX.Element {
                   <ResourcePickerListing
                     filetype={tab.filetype}
                     filter={showFilterUI ? filter : null}
-                    insertEmbed={insertEmbed}
-                    setOpen={setOpen}
+                    focusResource={setFocusedResource}
+                    focusedResource={focusedResource}
                     attach={attach}
                   />
                 ) : null}

--- a/static/js/components/widgets/ResourcePickerListing.test.tsx
+++ b/static/js/components/widgets/ResourcePickerListing.test.tsx
@@ -22,7 +22,7 @@ const apiResponse = (results: WebsiteContentListItem[]) => ({
 describe("ResourcePickerListing", () => {
   let helper: IntegrationTestHelper,
     render: TestRenderer,
-    insertEmbedStub: any,
+    focusResourceStub: any,
     setOpenStub: any,
     website: Website,
     contentListingItems: WebsiteContentListItem[][]
@@ -30,15 +30,15 @@ describe("ResourcePickerListing", () => {
   beforeEach(() => {
     helper = new IntegrationTestHelper()
 
-    insertEmbedStub = helper.sandbox.stub()
+    focusResourceStub = helper.sandbox.stub()
     setOpenStub = helper.sandbox.stub()
 
     render = helper.configureRenderer(ResourcePickerListing, {
-      insertEmbed: insertEmbedStub,
-      setOpen:     setOpenStub,
-      attach:      "resource",
-      filter:      null,
-      filetype:    "Video"
+      focusResource: focusResourceStub,
+      setOpen:       setOpenStub,
+      attach:        "resource",
+      filter:        null,
+      filetype:      "Video"
     })
 
     website = makeWebsiteDetail()
@@ -89,7 +89,7 @@ describe("ResourcePickerListing", () => {
     ).toEqual(contentListingItems[0].map(item => item.title))
   })
 
-  it("should call insertEmbed prop with resources", async () => {
+  it("should call focusResource prop with resources", async () => {
     const { wrapper } = await render()
 
     wrapper
@@ -97,8 +97,22 @@ describe("ResourcePickerListing", () => {
       .at(0)
       .simulate("click")
     expect(
-      insertEmbedStub.calledWith(contentListingItems[0][0].text_id)
+      focusResourceStub.calledWith(contentListingItems[0][0].text_id)
     ).toBeTruthy()
+    wrapper.update()
+  })
+
+  it("should put a class on if a resource is focused", async () => {
+    const { wrapper } = await render({
+      focusedResource: contentListingItems[0][0].text_id
+    })
+
+    expect(
+      wrapper
+        .find(".resource-item")
+        .at(0)
+        .prop("className")
+    ).toBe("resource-item focused")
   })
 
   it("should allow the user to filter, sort filetype", async () => {

--- a/static/js/components/widgets/ResourcePickerListing.tsx
+++ b/static/js/components/widgets/ResourcePickerListing.tsx
@@ -11,17 +11,17 @@ import { useSelector } from "react-redux"
 import { getWebsiteContentListingCursor } from "../../selectors/websites"
 
 interface Props {
-  insertEmbed: (id: string) => void
-  setOpen: (open: boolean) => void
+  focusResource: (id: string) => void
   attach: string
   filter: string | null
   filetype: string
+  focusedResource: string | null
 }
 
 export default function ResourcePickerListing(
   props: Props
 ): JSX.Element | null {
-  const { insertEmbed, setOpen, attach, filter, filetype } = props
+  const { focusResource, focusedResource, attach, filter, filetype } = props
   const website = useWebsite()
 
   const listingParams: ContentListingParams = useMemo(
@@ -50,20 +50,24 @@ export default function ResourcePickerListing(
 
   return (
     <div className="resource-picker-listing">
-      {listing.results.map((item, idx) => (
-        <div
-          className="resource-item"
-          key={`${item.text_id}_${idx}`}
-          onClick={(event: SyntheticEvent<HTMLDivElement>) => {
-            event.preventDefault()
+      {listing.results.map((item, idx) => {
+        const className = `resource-item${
+          focusedResource && focusedResource === item.text_id ? " focused" : ""
+        }`
 
-            insertEmbed(item.text_id)
-            setOpen(false)
-          }}
-        >
-          <h4>{item.title}</h4>
-        </div>
-      ))}
+        return (
+          <div
+            className={className}
+            key={`${item.text_id}_${idx}`}
+            onClick={(event: SyntheticEvent<HTMLDivElement>) => {
+              event.preventDefault()
+              focusResource(item.text_id)
+            }}
+          >
+            <h4>{item.title}</h4>
+          </div>
+        )
+      })}
     </div>
   )
 }

--- a/static/js/context/Website.ts
+++ b/static/js/context/Website.ts
@@ -26,7 +26,7 @@ export default WebsiteContext
  * This ensures that we're only reading from the context in a setting
  * where the component has an ancestor component setting the value.
  *
- * Additionally, this simplifies the typing of the context value, since
+ * Additionally, this simplifies the typing of the context value. Since
  * we have a nice run-time guard against a null value we can safely type
  * the return value as `Website`, instead of `Website | null`.
  **/

--- a/static/js/hooks/websiteContent.ts
+++ b/static/js/hooks/websiteContent.ts
@@ -1,0 +1,37 @@
+import { useRequest } from "redux-query-react"
+
+import { useWebsite } from "../context/Website"
+import { websiteContentDetailRequest } from "../query-configs/websites"
+import { useSelector } from "react-redux"
+import { getWebsiteContentDetailCursor } from "../selectors/websites"
+import { WebsiteContent } from "../types/websites"
+
+/**
+ * Hook for fetching and accessing a WebsiteContent object
+ * given a uuid. As easy as:
+ *
+ * ```ts
+ * const content = useWebsiteContent(uuid)
+ * ```
+ *
+ * Note that this hook depends on `useWebsite`, so it must be
+ * called inside of `WebsiteContext.Provider`.
+ */
+export function useWebsiteContent(uuid: string): WebsiteContent | null {
+  const website = useWebsite()
+
+  const contentParams = {
+    name:   website.name,
+    textId: uuid
+  }
+
+  useRequest(websiteContentDetailRequest(contentParams, false))
+
+  const websiteContentDetailSelector = useSelector(
+    getWebsiteContentDetailCursor
+  )
+
+  const resource = websiteContentDetailSelector(contentParams)
+
+  return resource
+}

--- a/static/js/lib/ckeditor/CKEditor.ts
+++ b/static/js/lib/ckeditor/CKEditor.ts
@@ -15,7 +15,10 @@ import ParagraphPlugin from "@ckeditor/ckeditor5-paragraph/src/paragraph"
 
 import Markdown from "./plugins/Markdown"
 import MarkdownMediaEmbed from "./plugins/MarkdownMediaEmbed"
-import ResourceEmbed, { ADD_RESOURCE } from "./plugins/ResourceEmbed"
+import ResourceEmbed from "./plugins/ResourceEmbed"
+import ResourcePicker from "./plugins/ResourcePicker"
+import { ADD_RESOURCE } from "./plugins/constants"
+import ResourceLink from "./plugins/ResourceLink"
 
 export const FullEditorConfig = {
   plugins: [
@@ -34,6 +37,8 @@ export const FullEditorConfig = {
     ListPlugin,
     ParagraphPlugin,
     ResourceEmbed,
+    ResourcePicker,
+    ResourceLink,
     MarkdownMediaEmbed,
     Markdown
   ],

--- a/static/js/lib/ckeditor/plugins/ResourceLink.test.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLink.test.ts
@@ -1,0 +1,31 @@
+import ResourceLink from "./ResourceLink"
+import Markdown from "./Markdown"
+import { createTestEditor, markdownTest } from "./test_util"
+import { turndownService } from "../turndown"
+
+const getEditor = createTestEditor([ResourceLink, Markdown])
+
+describe("ResourceLink plugin", () => {
+  afterEach(() => {
+    turndownService.rules.array = turndownService.rules.array.filter(
+      (rule: any) => rule.filter !== "span"
+    )
+    // @ts-ignore
+    turndownService._customRulesSet = undefined
+  })
+
+  it("should take in and return 'resource' shortcode", async () => {
+    const editor = await getEditor("{{< resource_link 1234567890 >}}")
+    // @ts-ignore
+    expect(editor.getData()).toBe("{{< resource_link 1234567890 >}}")
+  })
+
+  it("should serialize to and from markdown", async () => {
+    const editor = await getEditor("")
+    markdownTest(
+      editor,
+      "{{< resource_link asdfasdfasdfasdf >}}",
+      '<p><span class="resource-link" data-uuid="asdfasdfasdfasdf"></span></p>'
+    )
+  })
+})

--- a/static/js/lib/ckeditor/plugins/ResourcePicker.ts
+++ b/static/js/lib/ckeditor/plugins/ResourcePicker.ts
@@ -1,0 +1,37 @@
+import Plugin from "@ckeditor/ckeditor5-core/src/plugin"
+import ButtonView from "@ckeditor/ckeditor5-ui/src/button/buttonview"
+
+import { ADD_RESOURCE, CKEDITOR_RESOURCE_UTILS } from "./constants"
+
+/**
+ * Plugin for opening the ResourcePicker
+ *
+ * This basically just plucks the `openResourcePicker` callback
+ * out of our `resourceEmbed` object on `editor.config` and then
+ * adds a button to the toolbar which will call that cb on click.
+ */
+export default class ResourcePicker extends Plugin {
+  init(): void {
+    const editor = this.editor
+
+    // @ts-ignore
+    const { openResourcePicker } =
+      this.editor.config.get(CKEDITOR_RESOURCE_UTILS) ?? {}
+
+    editor.ui.componentFactory.add(ADD_RESOURCE, (locale: any) => {
+      const view = new ButtonView(locale)
+
+      view.set({
+        label:    "Add resource",
+        withText: true
+      })
+      // TODO: icon? how to right-justify?
+
+      view.on("execute", () => {
+        openResourcePicker()
+      })
+
+      return view
+    })
+  }
+}

--- a/static/js/lib/ckeditor/plugins/constants.ts
+++ b/static/js/lib/ckeditor/plugins/constants.ts
@@ -1,0 +1,39 @@
+export const ADD_RESOURCE = "addResource"
+
+export const CKEDITOR_RESOURCE_UTILS = "CKEDITOR_RESOURCE_UTILS"
+
+export const RESOURCE_LINK = "resourceLink"
+
+export const RESOURCE_EMBED = "resourceEmbed"
+
+export const RESOURCE_LINK_COMMAND = "insertResourceLink"
+
+export const RESOURCE_EMBED_COMMAND = "insertResourceEmbed"
+
+/**
+ * Union type capturing the possible typs of resource nodes we
+ * support in CKEditor
+ *
+ * CKEResourceNodeType
+ */
+export type CKEResourceNodeType = typeof RESOURCE_LINK | typeof RESOURCE_EMBED
+
+/**
+ * Map resource node type to the corresponding embed command
+ */
+export const ResourceCommandMap: Record<CKEResourceNodeType, string> = {
+  [RESOURCE_LINK]:  RESOURCE_LINK_COMMAND,
+  [RESOURCE_EMBED]: RESOURCE_EMBED_COMMAND
+}
+
+/**
+ * A 'resource renderer'
+ *
+ * A function of this type is passed down from the React component
+ * that wraps CKEditor to the CKEditor config. It can then be called
+ * in the `editingDowncast` handler function on the plugins for
+ * resource links and embeds.
+ */
+export interface RenderResourceFunc {
+  (uuid: string, el: HTMLElement, variant: CKEResourceNodeType): void
+}

--- a/static/scss/resource-embed-widget.scss
+++ b/static/scss/resource-embed-widget.scss
@@ -32,3 +32,11 @@
     }
   }
 }
+
+.resource-link {
+  i {
+    font-size: 16px;
+    vertical-align: middle;
+    margin: 0 2px;
+  }
+}

--- a/static/scss/site-page.scss
+++ b/static/scss/site-page.scss
@@ -78,6 +78,18 @@ $menu-spacing: 20px;
 .resource-picker-listing {
   .resource-item {
     cursor: pointer;
+    padding: 2px;
+    margin: 2px;
+
+    &.focused {
+      border: 2px solid black;
+      padding: 0;
+    }
+
+    h4 {
+      margin-bottom: 0;
+      padding: 2px;
+    }
   }
 }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #541  
closes #542 

#### What's this PR do?

this adds basic support for adding links to resources (not embeds) in the Markdown editor. These are rendered to markdown via the `resource_link` shortcode. In order to support this I added a new CKEditor node type plugin and a new React component to actually render the things when they're added to the editor. I also made some modifications to the resource picker to allow the user to decide whether they want to embed or link to a resource.

#### How should this be manually tested?

Create some resources for one of your courses. Then go to create a new page and check out the markdown editor. If you click 'add resource' you should get a popup as before. The difference is two things:

- if you click on one of the resources, instead of immediately adding it to the editor it will display two buttons along the bottom of the dialog, 'embed' and 'link', and highlight the resource you selected to make it clear it's 'focused'
- if you click those they should do what they say on the tin

I also added a display component for showing the resource links in the editor (see screenshots below).

#### Screenshots (if appropriate)

resource picker with nothing selected:

![Screen Shot 2021-09-07 at 5 05 32 PM](https://user-images.githubusercontent.com/6207644/132410909-81b4137a-8403-4ee0-ab8a-3fda2894b896.png)

with one of the resources selected:

![Screen Shot 2021-09-07 at 5 05 37 PM](https://user-images.githubusercontent.com/6207644/132410933-a49857e4-edcf-482c-aca7-c2ba8ed843a8.png)

a variety of things linked and embedded in the editor:

![Screen Shot 2021-09-07 at 5 05 46 PM](https://user-images.githubusercontent.com/6207644/132410982-3bef710c-1ca2-4482-a85b-999329b4a324.png)
