### PR TITLE
Youtube metadata update

### DIFF
--- a/app.json
+++ b/app.json
@@ -465,12 +465,36 @@
       "description": "Youtube access token",
       "required": false
     },
+    "YT_CATEGORY_ID": {
+      "description": "Default video category ID for youtube",
+      "required": false
+    },
     "YT_CLIENT_ID": {
       "description": "Youtube Client ID",
       "required": false
     },
     "YT_CLIENT_SECRET": {
       "description": "Youtube client secret key",
+      "required": false
+    },
+    "YT_FIELD_DESCRIPTION": {
+      "description": "The site config metadata field for YouTube description",
+      "required": false
+    },
+    "YT_FIELD_ID": {
+      "description": "The site config metadata field for YouTube ID",
+      "required": false
+    },
+    "YT_FIELD_SPEAKERS": {
+      "description": "The site config metadata field for YouTube speakers",
+      "required": false
+    },
+    "YT_FIELD_TAGS": {
+      "description": "The site config metadata field for YouTube video tags",
+      "required": false
+    },
+    "YT_FIELD_THUMBNAIL": {
+      "description": "The site config metadata field for YouTube thumbnail url",
       "required": false
     },
     "YT_PROJECT_ID": {

--- a/main/settings.py
+++ b/main/settings.py
@@ -489,6 +489,11 @@ VIDEO_S3_TRANSCODE_PREFIX = get_string(
 YT_ACCESS_TOKEN = get_string(
     name="YT_ACCESS_TOKEN", default="", description="Youtube access token"
 )
+YT_CATEGORY_ID = get_int(
+    name="YT_CATEGORY_ID",
+    default=27,
+    description="Default video category ID for youtube",
+)
 YT_CLIENT_ID = get_string(
     name="YT_CLIENT_ID", default="", description="Youtube Client ID"
 )
@@ -516,6 +521,33 @@ YT_UPLOAD_LIMIT = get_int(
     default=50,
     description="Max Youtube uploads allowed per day",
 )
+# YouTube OCW metadata fields
+YT_FIELD_ID = get_string(
+    name="YT_FIELD_ID",
+    default="video_metadata.youtube_id",
+    description="The site config metadata field for YouTube ID",
+)
+YT_FIELD_DESCRIPTION = get_string(
+    name="YT_FIELD_DESCRIPTION",
+    default="description",
+    description="The site config metadata field for YouTube description",
+)
+YT_FIELD_SPEAKERS = get_string(
+    name="YT_FIELD_SPEAKERS",
+    default="video_metadata.video_speakers",
+    description="The site config metadata field for YouTube speakers",
+)
+YT_FIELD_TAGS = get_string(
+    name="YT_FIELD_TAGS",
+    default="video_metadata.video_tags",
+    description="The site config metadata field for YouTube video tags",
+)
+YT_FIELD_THUMBNAIL = get_string(
+    name="YT_FIELD_THUMBNAIL",
+    default="video_files.video_thumbnail_file",
+    description="The site config metadata field for YouTube thumbnail url",
+)
+
 
 UPDATE_TAGGED_3PLAY_TRANSCRIPT_FREQUENCY = get_int(
     name="UPDATE_TAGGED_3PLAY_TRANSCRIPT_FREQUENCY",

--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -14,23 +14,13 @@ from videos.models import Video, VideoFile
 from videos.youtube import (
     API_QUOTA_ERROR_MSG,
     YouTubeApi,
+    is_youtube_enabled,
     mail_youtube_upload_failure,
     mail_youtube_upload_success,
 )
 
 
 log = logging.getLogger()
-
-
-def is_youtube_enabled() -> bool:
-    """ Returns True if youtube is enabled """
-    return (
-        settings.YT_ACCESS_TOKEN
-        and settings.YT_REFRESH_TOKEN
-        and settings.YT_CLIENT_ID
-        and settings.YT_CLIENT_SECRET
-        and settings.YT_PROJECT_ID
-    )
 
 
 @app.task

--- a/websites/api.py
+++ b/websites/api.py
@@ -1,12 +1,14 @@
 """API functionality for websites"""
-from typing import Optional
+from typing import Dict, List, Optional
 from uuid import UUID
 
+from django.conf import settings
 from django.db.models import Q, QuerySet
 from mitol.common.utils import max_or_none
 
 from websites.constants import CONTENT_FILENAME_MAX_LEN
 from websites.models import Website, WebsiteContent, WebsiteStarter
+from websites.utils import get_dict_field, set_dict_field
 
 
 def get_valid_new_filename(
@@ -139,3 +141,35 @@ def fetch_website(filter_value: str) -> Website:
         website_results, key=lambda _website: 1 if _website.name == filter_value else 2
     )
     return next(sorted_results)
+
+
+def is_ocw_site(website: Website) -> bool:
+    """Return true if the site is an OCW site"""
+    return website.starter.slug == settings.OCW_IMPORT_STARTER_SLUG
+
+
+def update_youtube_thumbnail(website_id: str, metadata: Dict, overwrite=False):
+    """ Assign a youtube thumbnail url if appropriate to a website's metadata"""
+    website = Website.objects.get(uuid=website_id)
+    if is_ocw_site(website):
+        youtube_id = get_dict_field(metadata, settings.YT_FIELD_ID)
+        if youtube_id and (
+            not get_dict_field(metadata, settings.YT_FIELD_THUMBNAIL) or overwrite
+        ):
+            set_dict_field(
+                metadata,
+                settings.YT_FIELD_THUMBNAIL,
+                f"https://img.youtube.com/vi/{youtube_id}/0.jpg",
+            )
+
+
+def unassigned_youtube_ids(website: Website) -> List[WebsiteContent]:
+    """Return a list of WebsiteContent objects for videos with unassigned youtube ids"""
+    if not is_ocw_site(website):
+        return []
+    query_id_field = f"metadata__{'__'.join(settings.YT_FIELD_ID.split('.'))}"
+    return WebsiteContent.objects.filter(
+        Q(website=website)
+        & Q(metadata__filetype="Video")
+        & (Q(**{query_id_field: None}) | Q(**{query_id_field: ""}))
+    )

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -18,6 +18,7 @@ from gdrive_sync.tasks import create_gdrive_folder_if_not_exists
 from main.serializers import RequestUserSerializerMixin
 from users.models import User
 from websites import constants
+from websites.api import update_youtube_thumbnail
 from websites.models import (
     Website,
     WebsiteCollection,
@@ -217,6 +218,9 @@ class WebsiteContentDetailSerializer(
 
     def update(self, instance, validated_data):
         """Add updated_by to the data"""
+        update_youtube_thumbnail(
+            instance.website.uuid, validated_data.get("metadata"), overwrite=True
+        )
         instance = super().update(
             instance, {"updated_by": self.user_from_request(), **validated_data}
         )
@@ -309,6 +313,10 @@ class WebsiteContentCreateSerializer(
             for field in {"is_page_content", "filename", "dirpath"}
             if field in self.context
         }
+        update_youtube_thumbnail(
+            self.context["website_id"], validated_data.get("metadata")
+        )
+
         instance = super().create(
             {
                 "website_id": self.context["website_id"],

--- a/websites/utils.py
+++ b/websites/utils.py
@@ -1,4 +1,5 @@
 """Websites utils"""
+from typing import Any, Dict
 
 from websites import constants
 
@@ -11,3 +12,21 @@ def permissions_group_name_for_role(role, website):
         return f"{constants.ROLE_GROUP_MAPPING[role]}{website.uuid.hex}"
     else:
         raise ValueError(f"Invalid role for a website group: {role}")
+
+
+def get_dict_field(obj: Dict, field_path: str) -> Any:
+    """Return the value of a potentially nested dict path"""
+    fields = field_path.split(".")
+    current_obj = obj
+    for field in fields[:-1]:
+        current_obj = current_obj.get(field)
+    return current_obj.get(fields[-1])
+
+
+def set_dict_field(obj: Dict, field_path: str, value: Any):
+    """Set the value of a potentially nested dict path"""
+    fields = field_path.split(".")
+    current_obj = obj
+    for field in fields[:-1]:
+        current_obj = current_obj.get(field)
+    current_obj[fields[-1]] = value


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable
  - [x] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
Closes #545

#### What's this PR do?
- Autopopulates the youtube thumbnail field for video resources of ocw sites if/when the Youtube ID field is manually populated.
- Checks to see if any video resources have unassigned youtube ids before previewing/publishing an OCW site.  Previews will proceed but a warning will be sent in the response.  Publishing will be aborted and an error will be returned in the response.
- Updates youtube metadata for all of an OCW website's video resources when a preview/publish request is made.  This is done first, so that if it fails (ie quota limit exceeded), then the rest of the preview/publish process is aborted.
- Front end feedback for warnings/errors is not included, it will be done as part of #386 

#### How should this be manually tested?
Testing successful youtube uploads and updates will require setting up a personal account for now, the one used for RC will always fail due to a daily quota limit of 0.  How to do so is described in the README, and you can follow the instructions for testing uploads in PR #484.

Once you have videos uploaded to Youtube, you can test the functionality in this PR as follows:
- Set `OCW_IMPORT_STARTER_SLUG=ocw-course` in your `.env` file (and make sure you have a starter with that slug, same config as on RC).
- Create a new video resource for a website created with the `ocw-course` starter, and fill in the `Youtube ID` field with the id of one of your uploaded youtube videos.  Also fill in the description and the "Youtube Speakers" and 'Youtube Tags' fields. Then save.
- Edit the above resource.  Check that the "Video Thumbnail URL" field is populated with `https://img.youtube.com/vi/<youtube_id>/0.jpg`.  This URL actually won't work yet on your personal account because all your videos are being uploaded as private due to your app not being verified.  This should hopefully not be an issue on RC or production.
- With your network tab open in your browser, click 'Preview' and 'Publish'.  Both should return 200 responses with no warnings about missing youtube ids (assuming you only have this 1 video resource for the website).
- Check the video you uploaded to youtube.  Your video resource title should now be the youtube title, the description should be a combination of the 'Description' and 'Youtube Speakers' fields, and the youtube tags should equal your video resource tags.  Your video will still be private due to your app being unverified.
- Create another video resource with a blank Youtube ID.  Preview and publish again.  The preview response should still be a 200, but with a warning about 1 of your videos not having a Youtube ID.  The publish response should have a 400 status with an error about that video.
- Try to repeat the above with a different website based on a different starter.  The preview and publish responses should always return a 200 status.
