### PR TITLE
Failure message for bad concourse builds

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -842,6 +842,7 @@ MITOL_MAIL_MESSAGE_CLASSES = [
     "videos.messages.YouTubeUploadSuccessMessage",
     "videos.messages.YouTubeUploadFailureMessage",
     "websites.messages.PreviewOrPublishSuccessMessage",
+    "websites.messages.PreviewOrPublishFailureMessage",
 ]
 MITOL_MAIL_RECIPIENT_OVERRIDE = get_string(
     name="MITOL_MAIL_RECIPIENT_OVERRIDE",

--- a/websites/messages.py
+++ b/websites/messages.py
@@ -21,3 +21,22 @@ class PreviewOrPublishSuccessMessage(TemplatedMessage):
             ),
             "version": "live",
         }
+
+
+class PreviewOrPublishFailureMessage(TemplatedMessage):
+    """Email message for publish/preview pipeline failure"""
+
+    name = "Website Preview/Publish Pipeline Failed"
+    template_name = "mail/preview_publish_failure"
+
+    @staticmethod
+    def get_debug_template_context() -> dict:
+        """Returns the extra context for the email debugger"""
+        return {
+            "site": SimpleNamespace(
+                name="1-1-computer-science-fall-2024",
+                title="Intro to Computer Science",
+                full_url="https://ocwtest.edu/courses/1-1-computer-science-fall-2024",
+            ),
+            "version": "live",
+        }

--- a/websites/messages.py
+++ b/websites/messages.py
@@ -14,6 +14,7 @@ class PreviewOrPublishSuccessMessage(TemplatedMessage):
     def get_debug_template_context() -> dict:
         """Returns the extra context for the email debugger"""
         return {
+            "user": SimpleNamespace(name="Test User"),
             "site": SimpleNamespace(
                 name="1-1-computer-science-fall-2024",
                 title="Intro to Computer Science",
@@ -33,6 +34,7 @@ class PreviewOrPublishFailureMessage(TemplatedMessage):
     def get_debug_template_context() -> dict:
         """Returns the extra context for the email debugger"""
         return {
+            "user": SimpleNamespace(name="Test User"),
             "site": SimpleNamespace(
                 name="1-1-computer-science-fall-2024",
                 title="Intro to Computer Science",

--- a/websites/templates/mail/preview_publish_failure/body.html
+++ b/websites/templates/mail/preview_publish_failure/body.html
@@ -1,0 +1,19 @@
+{% extends "mail/email_base.html" %}
+
+{% block content %}
+<tr>
+  <td style="padding: 20px;">
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+      <tr>
+        <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
+          <p style="margin: 0 0 10px;">Dear {{ user.name }},</p>
+          <p style="margin: 0 0 10px;">
+            The {{ version }} version of your site <a href="{{ site.url }}">{{ site.title }}</a> failed to complete.
+              Please contact OCW support.
+          </p>
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>
+{% endblock %}

--- a/websites/templates/mail/preview_publish_failure/body.html
+++ b/websites/templates/mail/preview_publish_failure/body.html
@@ -9,7 +9,7 @@
           <p style="margin: 0 0 10px;">Dear {{ user.name }},</p>
           <p style="margin: 0 0 10px;">
             The {{ version }} version of your site <a href="{{ site.url }}">{{ site.title }}</a> failed to complete.
-              Please contact OCW support.
+              Please contact the engineering team.
           </p>
         </td>
       </tr>

--- a/websites/templates/mail/preview_publish_failure/subject.txt
+++ b/websites/templates/mail/preview_publish_failure/subject.txt
@@ -1,0 +1,1 @@
+{{ site_name }}: "{{site.title}}" new {{ version }} version failed to complete


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #565 

#### What's this PR do?
Sends an appropriate email notification (and logs an error) if a website pipeline build fails.

#### How should this be manually tested?
Make sure the following are set:
```
MAILGUN_KEY=<same as on RC>
MAILGUN_URL=<same as on RC>
MAILGUN_SENDER_DOMAIN=<same as on RC>
MITOL_MAIL_RECIPIENT_OVERRIDE=<your email>
MITOL_MAIL_FROM_EMAIL="admin@admin.edu"   
OCW_STUDIO_DRAFT_URL=https://ocw-draft-qa.global.ssl.fastly.net/
OCW_STUDIO_LIVE_URL=https://ocw-live-qa.global.ssl.fastly.net/   
API_BEARER_TOKEN=<some_string_value>
```

For one of your `Website` objects, send these requests:
```
curl -H 'Content-Type: application/json' -H "Authorization: Bearer <settings.API_BEARER_TOKEN>" -d '{"version": "draft","site": "<Website.name>", "success": true}' http://localhost:8043/api/websites/<Website.name>/pipeline_complete/

curl -H 'Content-Type: application/json' -H "Authorization: Bearer <settings.API_BEARER_TOKEN>" -d '{"version": "draft","site": "<Website.name>", "success": false}' http://localhost:8043/api/websites/<Website.name>/pipeline_complete/
```

You should get 2 emails, one indicating your site was successfully published, the other indicating an error.


<img width="695" alt="Screen Shot 2021-09-09 at 1 04 59 PM" src="https://user-images.githubusercontent.com/187676/132732891-a183c161-d32e-4d1c-ad60-1f6be1c119ce.png">

<img width="659" alt="Screen Shot 2021-09-09 at 1 21 30 PM" src="https://user-images.githubusercontent.com/187676/132732912-71581498-0dc2-43b6-b8b3-208f54abc1fa.png">


