### PR TITLE
fix video preview bug

### DIFF
--- a/static/js/components/widgets/EmbeddedResource.test.tsx
+++ b/static/js/components/widgets/EmbeddedResource.test.tsx
@@ -69,7 +69,7 @@ describe("EmbeddedResource", () => {
   it("should render a video", async () => {
     content.metadata!.filetype = RESOURCE_TYPE_VIDEO
     content.metadata!.description = "My Video!!!"
-    content.metadata!.metadata = { youtube_id: "2XID_W4neJo" }
+    content.metadata!.video_metadata = { youtube_id: "2XID_W4neJo" }
     const { wrapper } = await render()
     expect(wrapper.find(".title").text()).toBe(content.title)
     expect(wrapper.find(".description").text()).toBe(

--- a/static/js/components/widgets/EmbeddedResource.tsx
+++ b/static/js/components/widgets/EmbeddedResource.tsx
@@ -47,12 +47,12 @@ export default function EmbeddedResource(props: Props): JSX.Element | null {
     }
 
     if (filetype === RESOURCE_TYPE_VIDEO) {
-      const videoMetadata = resource.metadata?.metadata as Record<
+      const videoMetadata = (resource.metadata?.video_metadata ?? {}) as Record<
         string,
         SiteFormValue
       >
 
-      const youtubeId = (videoMetadata?.youtube_id as string) ?? ""
+      const youtubeId = (videoMetadata["youtube_id"] as string) ?? ""
 
       return createPortal(
         <div className="embedded-resource video my-2 d-flex align-items-center">


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Migrations
  - [x] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #564

#### What's this PR do?

this fixes an issue where the video resource embed preview code wasn't updated to account for renaming `metadata` to `video_metadata` on video resources.

#### How should this be manually tested?

Add a video resource which has a `youtube_id` set in its `video_metadata`. Then add it to the markdown editor and confirm that the preview works (i.e. that you can play the youtube video and whatnot).