### PR TITLE
Ab/update transcript metadata

### DIFF
--- a/app.json
+++ b/app.json
@@ -131,6 +131,10 @@
       "description": "Gdrive folder for video uploads",
       "required": false
     },
+    "FIELD_FILETYPE": {
+      "description": "The site config metadata field for the filetype",
+      "required": false
+    },
     "GA_TRACKING_ID": {
       "description": "Google analytics tracking ID",
       "required": false
@@ -477,6 +481,10 @@
       "description": "Youtube client secret key",
       "required": false
     },
+    "YT_FIELD_CAPTIONS": {
+      "description": "The site config metadata field for the caption url",
+      "required": false
+    },
     "YT_FIELD_DESCRIPTION": {
       "description": "The site config metadata field for YouTube description",
       "required": false
@@ -495,6 +503,10 @@
     },
     "YT_FIELD_THUMBNAIL": {
       "description": "The site config metadata field for YouTube thumbnail url",
+      "required": false
+    },
+    "YT_FIELD_TRANSCRIPT": {
+      "description": "The site config metadata field for the transcript url",
       "required": false
     },
     "YT_PROJECT_ID": {

--- a/main/settings.py
+++ b/main/settings.py
@@ -521,7 +521,19 @@ YT_UPLOAD_LIMIT = get_int(
     default=50,
     description="Max Youtube uploads allowed per day",
 )
+# OCW metadata fields
+FIELD_FILETYPE = get_string(
+    name="FIELD_FILETYPE",
+    default="filetype",
+    description="The site config metadata field for the filetype",
+)
+
 # YouTube OCW metadata fields
+YT_FIELD_CAPTIONS = get_string(
+    name="YT_FIELD_CAPTIONS",
+    default="video_files.video_captions_file",
+    description="The site config metadata field for the caption url",
+)
 YT_FIELD_ID = get_string(
     name="YT_FIELD_ID",
     default="video_metadata.youtube_id",
@@ -546,6 +558,11 @@ YT_FIELD_THUMBNAIL = get_string(
     name="YT_FIELD_THUMBNAIL",
     default="video_files.video_thumbnail_file",
     description="The site config metadata field for YouTube thumbnail url",
+)
+YT_FIELD_TRANSCRIPT = get_string(
+    name="YT_FIELD_TRANSCRIPT",
+    default="video_files.video_transcript_file",
+    description="The site config metadata field for the transcript url",
 )
 
 

--- a/videos/models.py
+++ b/videos/models.py
@@ -3,7 +3,12 @@ from django.db import models
 from django.db.models import CASCADE
 from mitol.common.models import TimestampedModel
 
-from videos.constants import VideoFileStatus, VideoJobStatus, VideoStatus
+from videos.constants import (
+    DESTINATION_YOUTUBE,
+    VideoFileStatus,
+    VideoJobStatus,
+    VideoStatus,
+)
 from websites.models import Website
 from websites.site_config_api import SiteConfig
 
@@ -22,6 +27,16 @@ class Video(TimestampedModel):
             f"{source_folder}_{filename}",
         ]
         return "/".join([part for part in url_parts if part != ""])
+
+    def youtube_id(self):
+        """Returns destination_id of youtube VideoFile object"""
+        youtube_videofile = self.videofiles.filter(
+            destination=DESTINATION_YOUTUBE
+        ).first()
+        if youtube_videofile:
+            return youtube_videofile.destination_id
+        else:
+            return None
 
     source_key = models.CharField(max_length=2048, unique=True)
     website = models.ForeignKey(Website, on_delete=CASCADE, related_name="videos")

--- a/videos/models_test.py
+++ b/videos/models_test.py
@@ -1,0 +1,19 @@
+"""Video models tests"""
+import pytest
+
+from videos.constants import DESTINATION_YOUTUBE
+from videos.factories import VideoFactory, VideoFileFactory
+
+
+# pylint:disable=unused-argument,redefined-outer-name
+pytestmark = pytest.mark.django_db
+
+
+def test_video_youtube_id():
+    """test for Video youtube_id"""
+    video = VideoFactory.create()
+    assert video.youtube_id() is None
+    VideoFileFactory.create(
+        destination=DESTINATION_YOUTUBE, video=video, destination_id="expected_id"
+    )
+    assert video.youtube_id() == "expected_id"

--- a/videos/threeplay_api.py
+++ b/videos/threeplay_api.py
@@ -8,7 +8,6 @@ from django.core.files import File
 
 from videos.constants import DESTINATION_YOUTUBE
 from videos.models import Video
-from websites.models import Website
 
 
 log = logging.getLogger(__name__)
@@ -111,10 +110,3 @@ def update_transcripts_for_video(video: Video) -> bool:
         return True
 
     return False
-
-
-def update_transcripts_for_website(website: Website):
-    """Update transcripts from 3play for every video for a website"""
-
-    for video in website.videos.all():
-        update_transcripts_for_video(video)

--- a/videos/threeplay_api_test.py
+++ b/videos/threeplay_api_test.py
@@ -5,16 +5,14 @@ from io import BytesIO
 import pytest
 
 from videos.constants import DESTINATION_YOUTUBE
-from videos.factories import VideoFactory, VideoFileFactory
+from videos.factories import VideoFileFactory
 from videos.threeplay_api import (
     fetch_file,
     threeplay_remove_tags,
     threeplay_transcript_api_request,
     threeplay_updated_media_file_request,
     update_transcripts_for_video,
-    update_transcripts_for_website,
 )
-from websites.factories import WebsiteFactory
 from websites.site_config_api import SiteConfig
 
 
@@ -152,17 +150,3 @@ def test_update_transcripts_for_video(
         )
     else:
         assert video_file.video.webvtt_transcript_file == ""
-
-
-def test_update_transcripts_for_website(mocker):
-    """test update_transcripts_for_website"""
-    website = WebsiteFactory.create()
-    videos = VideoFactory.create_batch(4, website=website)
-    update_video_transcript = mocker.patch(
-        "videos.threeplay_api.update_transcripts_for_video"
-    )
-
-    update_transcripts_for_website(website)
-
-    for video in videos:
-        update_video_transcript.assert_any_call(video)

--- a/videos/youtube.py
+++ b/videos/youtube.py
@@ -20,7 +20,7 @@ from videos.messages import YouTubeUploadFailureMessage, YouTubeUploadSuccessMes
 from videos.models import VideoFile
 from websites.api import is_ocw_site
 from websites.models import Website, WebsiteContent
-from websites.utils import get_dict_field
+from websites.utils import get_dict_field, get_dict_query_field
 
 
 log = logging.getLogger(__name__)
@@ -275,7 +275,7 @@ def update_youtube_metadata(website: Website, privacy=None):
     if not is_youtube_enabled() or not is_ocw_site(website):
         return
     youtube = YouTubeApi()
-    query_id_field = f"metadata__{'__'.join(settings.YT_FIELD_ID.split('.'))}"
+    query_id_field = get_dict_query_field("metadata", settings.YT_FIELD_ID)
     for video_resource in website.websitecontent_set.filter(
         Q(metadata__filetype="Video")
     ).exclude(Q(**{query_id_field: None}) | Q(**{query_id_field: ""})):

--- a/websites/utils.py
+++ b/websites/utils.py
@@ -30,3 +30,8 @@ def set_dict_field(obj: Dict, field_path: str, value: Any):
     for field in fields[:-1]:
         current_obj = current_obj.get(field)
     current_obj[fields[-1]] = value
+
+
+def get_dict_query_field(dict_field_name: str, sub_field: str):
+    """Generate django query key for searching a nested json feild"""
+    return dict_field_name + "__" + sub_field.replace(".", "__")

--- a/websites/utils_test.py
+++ b/websites/utils_test.py
@@ -3,7 +3,7 @@ import pytest
 
 from websites import constants
 from websites.factories import WebsiteFactory
-from websites.utils import permissions_group_name_for_role
+from websites.utils import get_dict_query_field, permissions_group_name_for_role
 
 
 @pytest.mark.parametrize(
@@ -41,3 +41,11 @@ def test_permissions_group_for_role_invalid(role):
     with pytest.raises(ValueError) as exc:
         permissions_group_name_for_role(role, website)
     assert exc.value.args == (f"Invalid role for a website group: {role}",)
+
+
+def test_get_dict_query_field():
+    """test get_dict_query_field"""
+    assert (
+        get_dict_query_field("metadata", "video_files.video_captions_file")
+        == "metadata__video_files__video_captions_file"
+    )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Migrations
  - [x] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
https://github.com/mitodl/ocw-studio/issues/559

#### What's this PR do?
This PR updates the metadata for ocw video resources with transcript data when transcripts are updated from 3play

#### How should this be manually tested?
1) Set PREPUBLISH_ACTIONS=videos.tasks.update_transcripts_for_website,videos.youtube.update_youtube_metadata
Set THREEPLAY_API_KEY to the "api_key" value from 3play/project api key sandbox/3play_sandbox_api_key file in the team keybase
Set THREEPLAY_PROJECT_ID=51817
Set OCW_IMPORT_STARTER_SLUG=ocw-course

2) Create a website with the ocw-course starter, if you don't have one already
3) Create a `Video` with a `VideoFile` object with destination `youtube` for your website using the directions here: https://github.com/mitodl/ocw-studio/pull/469. 
4) Create a new video resource for a website created with the ocw-course starter, and fill in the Youtube ID field with the id of the video created in step 3
5) Run `PATCH https://api.3playmedia.com/v3/files/6737396/?api_key=<THREEPLAY_API_KEY>&reference_id=<The Youtube ID from steps 3 and 4>` in Postman to create a transcript match
6) Publish or Preview the website. Go to the edit UI for the video resource. The transcript and caption fields should not be blank