### PR TITLE
Handle string value for success key returned by concourse pipeline request

### DIFF
--- a/websites/views.py
+++ b/websites/views.py
@@ -200,8 +200,10 @@ class WebsiteViewSet(
         """Process webhook requests from completed preview/publish pipeline runs"""
         data = request.data
         version = data["version"]
+        # success value will come back as a string
+        succeeded = data.get("success", "false").lower() == "true"
         mail_website_admins_on_publish(
-            Website.objects.get(name=name), version, data["success"]
+            Website.objects.get(name=name), version, succeeded
         )
         return Response(status=200)
 

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -342,7 +342,7 @@ def test_websites_endpoint_pipeline_complete(
     drf_client.credentials(HTTP_AUTHORIZATION=f"Bearer {settings.API_BEARER_TOKEN}")
     resp = drf_client.post(
         reverse("websites_api-pipeline-complete", kwargs={"name": website.name}),
-        data={"version": version, "success": success},
+        data={"version": version, "success": f"{success}"},
     )
     mock_mail_website_admins.assert_called_once_with(website, version, success)
     assert resp.status_code == 200


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Related to #565

#### What's this PR do?
The pipeline returns the `success` value as a string, so this PR accounts for that when determining if the pipeline succeeded or failed.  Previously, `"False"` was being interpreted as  `True`

#### How should this be manually tested?
Make sure the following are set:
```
MAILGUN_KEY=<same as on RC>
MAILGUN_URL=<same as on RC>
MAILGUN_SENDER_DOMAIN=<same as on RC>
MITOL_MAIL_RECIPIENT_OVERRIDE=<your email>
MITOL_MAIL_FROM_EMAIL="admin@admin.edu"   
OCW_STUDIO_DRAFT_URL=https://ocw-draft-qa.global.ssl.fastly.net/
OCW_STUDIO_LIVE_URL=https://ocw-live-qa.global.ssl.fastly.net/   
API_BEARER_TOKEN=<some_string_value>
```

For one of your `Website` objects, send these requests:
```
curl -H 'Content-Type: application/json' -H "Authorization: Bearer <settings.API_BEARER_TOKEN>" -d '{"version": "draft","site": "<Website.name>", "success": "True"}' http://localhost:8043/api/websites/<Website.name>/pipeline_complete/

curl -H 'Content-Type: application/json' -H "Authorization: Bearer <settings.API_BEARER_TOKEN>" -d '{"version": "draft","site": "<Website.name>", "success": "False"}' http://localhost:8043/api/websites/<Website.name>/pipeline_complete/
```

You should get 2 emails, one indicating your site was successfully published, the other indicating an error.


<img width="695" alt="Screen Shot 2021-09-09 at 1 04 59 PM" src="https://user-images.githubusercontent.com/187676/132732891-a183c161-d32e-4d1c-ad60-1f6be1c119ce.png">

<img width="659" alt="Screen Shot 2021-09-09 at 1 21 30 PM" src="https://user-images.githubusercontent.com/187676/132732912-71581498-0dc2-43b6-b8b3-208f54abc1fa.png">




