### PR TITLE
Only run `update_youtube_thumbnail` when appropriate

### DIFF
--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -218,9 +218,10 @@ class WebsiteContentDetailSerializer(
 
     def update(self, instance, validated_data):
         """Add updated_by to the data"""
-        update_youtube_thumbnail(
-            instance.website.uuid, validated_data.get("metadata"), overwrite=True
-        )
+        if instance.type == "resource":
+            update_youtube_thumbnail(
+                instance.website.uuid, validated_data.get("metadata"), overwrite=True
+            )
         instance = super().update(
             instance, {"updated_by": self.user_from_request(), **validated_data}
         )
@@ -313,9 +314,10 @@ class WebsiteContentCreateSerializer(
             for field in {"is_page_content", "filename", "dirpath"}
             if field in self.context
         }
-        update_youtube_thumbnail(
-            self.context["website_id"], validated_data.get("metadata")
-        )
+        if validated_data.get("type") == "resource":
+            update_youtube_thumbnail(
+                self.context["website_id"], validated_data.get("metadata")
+            )
 
         instance = super().create(
             {


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
N/A

#### What's this PR do?
Fixes a recent bug

#### How should this be manually tested?
Create a new page and new resources for a site with starter.slug == settings.OCW_IMPORT_STARTER_SLUG
For the video resources, enter a youtube id.
No errors should occur.  Reload the video resource, the youtube thumbnail url should be filled out.
