### PR TITLE
Omit file url from payload

### DIFF
--- a/static/js/lib/site_content.test.ts
+++ b/static/js/lib/site_content.test.ts
@@ -215,7 +215,13 @@ describe("site_content", () => {
           ...makeWebsiteDetail(),
           name: OUR_WEBSITE
         })
-        expect(payload["metadata"]["test-field"]).toStrictEqual(expectedDefault)
+        if (widget === WidgetVariant.File) {
+          expect(payload["metadata"]).toBeUndefined()
+        } else {
+          expect(payload["metadata"]["test-field"]).toStrictEqual(
+            expectedDefault
+          )
+        }
       }
     })
 

--- a/static/js/lib/site_content.ts
+++ b/static/js/lib/site_content.ts
@@ -201,9 +201,12 @@ export const contentFormValuesToPayload = (
         payload[MAIN_PAGE_CONTENT_DB_FIELD] = value
       } else if (field.name === "title") {
         payload[field.name] = value
-      } else if (value instanceof File) {
-        payload["file"] = value
-        hasFileUpload = true
+      } else if (field.widget === WidgetVariant.File) {
+        if (value instanceof File) {
+          payload[field.name] = value
+          hasFileUpload = true
+        }
+        // if value is a string, it came from the GET request and we should ignore it
       } else {
         metadata[field.name] = value
       }


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Fixes #583 

#### What's this PR do?
Omits file field from the payload used to PATCH website content if the value is a URL. This happens when the file was already uploaded and we are getting the URL back from the server in the GET request. Instead, we only want to include the file field when there is a file to be uploaded.

#### How should this be manually tested?
 - Create a new resource and set a file. Click save.
 - Find your `WebsiteContent` which you just created in the Django shell or admin. The `metadata` should not contain any `file` key. If you look at `website_content.file` you should see a `FieldFile` but nothing should be in `metadata`
 - In the UI, edit the resource and click save without making changes. Run `website_content.refresh_from_db()` and look at the metadata again. You should not see any file field containing a url in `metadata`