### PR TITLE
Add slug field to set a different value for filenames of content

### DIFF
--- a/websites/config_schema/site-config-schema.yml
+++ b/websites/config_schema/site-config-schema.yml
@@ -10,6 +10,7 @@ content_item:
     fields: list(include('field'), required=False)
     folder: str(required=False)
     files: list(include('inner_content_item'), required=False)
+    slug: str(required=False)
 ---
 inner_content_item:
     name: str()


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #594 
Fixes #499 

#### What's this PR do?
Adds a `slug` field for the schema which describes a field to use to set the filename when the content is exported

#### How should this be manually tested?
 - Update your local ocw-www starter in Django admin. Find the collection for instructors, then add `"slug": "text_id"` to that collection. Click save. It should save successfully if you added this in the right place, otherwise there will be a validation error.
 - In the ocw-studio UI, go to the ocw-www site and add a new instructor
 - View the `WebsiteContent` for the new instructor. The filename field should have a uuid, rather than a slugified title.