### PR TITLE
add license

### DIFF
--- a/localdev/configs/ocw-course-site-config.yml
+++ b/localdev/configs/ocw-course-site-config.yml
@@ -14,7 +14,7 @@ collections:
       - label: Body
         name: body
         widget: markdown
-        attach: "resource"
+        attach: resource
 
   - category: Content
     folder: content/resources
@@ -92,6 +92,21 @@ collections:
           - 'Workshop Videos'
           - 'Written Assignments'
           - 'Written Assignments with Examples'
+      - label: License
+        name: license
+        options:
+          - label: CC-BY-NC-SA
+            value: https://creativecommons.org/licenses/by-nc-sa/4.0/
+          - label: CC-BY
+            value: https://creativecommons.org/licenses/by/4.0/
+          - label: CC-BY-NC
+            value: https://creativecommons.org/licenses/by-nc/4.0/
+          - label: public domain
+            value: https://creativecommons.org/publicdomain/zero/1.0/
+        widget: select
+        default: https://creativecommons.org/licenses/by-nc-sa/4.0/
+        required: true
+
       # show the field below only if the type of resource is "image"
       - label: Image Metadata
         name: image_metadata

--- a/static/js/resources/ocw-course-site-config.json
+++ b/static/js/resources/ocw-course-site-config.json
@@ -109,6 +109,31 @@
           "widget": "select"
         },
         {
+          "default": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+          "label": "License",
+          "name": "license",
+          "options": [
+            {
+              "label": "CC-BY-NC-SA",
+              "value": "https://creativecommons.org/licenses/by-nc-sa/4.0/"
+            },
+            {
+              "label": "CC-BY",
+              "value": "https://creativecommons.org/licenses/by/4.0/"
+            },
+            {
+              "label": "CC-BY-NC",
+              "value": "https://creativecommons.org/licenses/by-nc/4.0/"
+            },
+            {
+              "label": "public domain",
+              "value": "https://creativecommons.org/publicdomain/zero/1.0/"
+            }
+          ],
+          "required": true,
+          "widget": "select"
+        },
+        {
           "condition": {
             "equals": "Image",
             "field": "resourcetype"

--- a/websites/config_schema/site-config-schema.yml
+++ b/websites/config_schema/site-config-schema.yml
@@ -28,7 +28,7 @@ field:
     multiple: bool(required=False)
     min: int(required=False)
     max: int(required=False)
-    options: list(str(), required=False)
+    options: list(any(str(), include('option_item')), required=False)
     options_map: map(required=False)
     default: any(required=False)
     condition: include('field_condition', required=False)
@@ -51,4 +51,8 @@ relation_filter:
 ---
 level:
     name: str()
+    label: str()
+---
+option_item:
+    value: str()
     label: str()


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
closes https://github.com/mitodl/ocw-hugo-projects/issues/45
closes https://github.com/mitodl/ocw-studio/issues/596

#### What's this PR do?
This pr this PR adds a license dropdown to resource objects for courses created with the ocw-course schema and updates the schema validation yaml to allow dropdowns where the label differs from the value

#### How should this be manually tested?
Update a course starter with the contents of ocw-course/ocw-studio.yaml in https://github.com/mitodl/ocw-hugo-projects/pull/78 through the admin interface

Find or create a Website with that starter. 

Create a Resource for the website. Verify that you can set the license and  CC-BY-NC-SA is selected by default. Once the resource is created, find the new WebsiteContent object either in the admin interface or from shell. Verify that `license` is set in the metadata to the correct url value.




