### PR TITLE
Remove if check on dirpath == content/page

### DIFF
--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -124,14 +124,11 @@ def convert_data_to_content(filepath, data, website):  # pylint:disable=too-many
             filepath, expect_file_extension=True
         )
         parent_uid = content_json.get("parent_uid", None)
-        if dirpath == "content/pages":
-            # This is a special type of page
-            content_type = CONTENT_TYPE_PAGE
-        elif dirpath == "content/resources":
+        if dirpath == "content/resources":
             # This is a file
             content_type = CONTENT_TYPE_RESOURCE
         else:
-            # This is a normal page
+            # This is a page
             content_type = CONTENT_TYPE_PAGE
         if parent_uid:
             parent, _ = WebsiteContent.objects.get_or_create(


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Related to #599 

#### What's this PR do?
Removes an if check for `content/pages` since some pages will have nested pages. That part of the if clause and the else clause effectively set the same value, so it makes sense to just remove that part of the if clause and deal with it in the else clause

#### How should this be manually tested?
Import `18-06sc-linear-algebra-fall-2011` and check for a WebsiteContent with `dirpath` = `content/pages/ax-b-and-the-four-subspaces`. The `type` of that object should be `page`