### PR TITLE
Rename duplicate names during ocw-import

### DIFF
--- a/websites/api.py
+++ b/websites/api.py
@@ -23,7 +23,10 @@ log = logging.getLogger(__name__)
 
 
 def get_valid_new_filename(
-    website_pk: str, dirpath: Optional[str], filename_base: str
+    website_pk: str,
+    dirpath: Optional[str],
+    filename_base: str,
+    exclude_text_id: Optional[str] = None,
 ) -> str:
     """
     Given a filename to act as a base/prefix, returns a filename that will satisfy unique constraints,
@@ -31,13 +34,15 @@ def get_valid_new_filename(
 
     Examples:
         In database: WebsiteContent(filename="my-filename")...
-            get_valid_new_filename("my-filename") == "my-filename-2"
-        In database: WebsiteContent(filename="my-filename-99")...
-            get_valid_new_filename("my-filename-99") == "my-filename-100"
+            get_valid_new_filename("my-filename") == "my-filename2"
+        In database: WebsiteContent(filename="my-filename99")...
+            get_valid_new_filename("my-filename99") == "my-filename100"
     """
     website_content_qset = WebsiteContent.objects.all_with_deleted().filter(
         website_id=website_pk, dirpath=dirpath
     )
+    if exclude_text_id is not None:
+        website_content_qset = website_content_qset.exclude(text_id=exclude_text_id)
     filename_exists = website_content_qset.filter(filename=filename_base).exists()
     if not filename_exists:
         return filename_base

--- a/websites/models.py
+++ b/websites/models.py
@@ -189,11 +189,6 @@ class WebsiteContent(TimestampedModel, SafeDeleteModel):
         upload_to=upload_file_to, editable=True, null=True, blank=True, max_length=2048
     )
 
-    @staticmethod
-    def generate_filename(title: str) -> str:
-        """Generates a filename from a title value"""
-        return slugify(title)[0:CONTENT_FILENAME_MAX_LEN]
-
     def calculate_checksum(self) -> str:
         """ Returns a calculated checksum of the content """
         return sha256(

--- a/websites/models_test.py
+++ b/websites/models_test.py
@@ -9,7 +9,6 @@ from websites.factories import (
     WebsiteFactory,
     WebsiteStarterFactory,
 )
-from websites.models import WebsiteContent
 
 
 @pytest.mark.parametrize(

--- a/websites/models_test.py
+++ b/websites/models_test.py
@@ -50,25 +50,6 @@ def test_websitecontent_calculate_checksum(metadata, markdown, dirpath, exp_chec
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize(
-    "title, exp_generated_filename",
-    [
-        ["My Title", "my-title"],
-        ["My... Title!", "my-title"],
-        ["My Title My Title My Title", "my-title-my-ti"],
-    ],
-)
-def test_websitecontent_generate_filename(mocker, title, exp_generated_filename):
-    """
-    WebsiteContent.generate_filename should generate a filename from a title with the correct length.
-    """
-    # Set a lower limit for max filename length to test that filenames are truncated appropriately
-    mocker.patch("websites.models.CONTENT_FILENAME_MAX_LEN", 14)
-    generated_filename = WebsiteContent.generate_filename(title=title)
-    assert generated_filename == exp_generated_filename
-
-
-@pytest.mark.django_db
 @pytest.mark.parametrize("has_file_widget", [True, False])
 @pytest.mark.parametrize("has_file", [True, False])
 def test_websitecontent_full_metadata(has_file_widget, has_file):

--- a/websites/views.py
+++ b/websites/views.py
@@ -372,7 +372,7 @@ def _get_derived_website_content_data(
         added_data["filename"] = get_valid_new_filename(
             website_pk=website_pk,
             dirpath=dirpath,
-            filename_base=slug,
+            filename_base=slugify(slug),
         )
     return added_data
 

--- a/websites/views.py
+++ b/websites/views.py
@@ -369,11 +369,10 @@ def _get_derived_website_content_data(
         or request_data.get("metadata", {}).get(slug_key)
     )
     if slug is not None:
-        filename_base = WebsiteContent.generate_filename(slug)
         added_data["filename"] = get_valid_new_filename(
             website_pk=website_pk,
             dirpath=dirpath,
-            filename_base=filename_base,
+            filename_base=slug,
         )
     return added_data
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #557 

#### What's this PR do?
Looks for duplicate filenames in other `WebsiteContent` for the `Website`, and if a duplicate is found, a number is appended to the filename to deduplicate it.

#### How should this be manually tested?

 - Import 18-06sc if you haven't already: `./manage.py import_ocw_course_sites -b ocw-to-hugo-output-qa --filter 18-06sc --limit 1`
 - Find the `WebsiteContent` for that site titled `Meet the TAs` (`451c7be3-3c2f-f17f-4881-adfa981fc5e7`). In the Django shell, change the `dirpath` to `a/b/c` and `filename` to `abc`, to avoid any database constraint errors
 - In the ocw-studio UI create a new page titled "Meet the TAs" with any text for the body. In the Django Shell, edit this newly created `WebsiteContent` to have a dirpath of `content/pages/syllabus`.
 - Run the import again:  `./manage.py import_ocw_course_sites -b ocw-to-hugo-output-qa --filter 18-06sc --limit 1`. It should run without errors. You may see some invalid uuid errors in the logs, those are unrelated to this PR.
 - Look at `WebsiteContent` with text_id = `451c7be3-3c2f-f17f-4881-adfa981fc5e7`. The `dirpath` should be `content/pages/syllabus` and the `filename` should be `meet-the-tas2`
