### PR TITLE
Front-end for google drive syncing

### DIFF
--- a/main/views.py
+++ b/main/views.py
@@ -9,6 +9,8 @@ from django.shortcuts import render
 from mitol.common.utils.webpack import webpack_public_path
 from rest_framework.pagination import LimitOffsetPagination
 
+from gdrive_sync.api import is_gdrive_enabled
+
 
 def _index(request):
     """Render the view for React pages"""
@@ -19,6 +21,7 @@ def _index(request):
         "public_path": webpack_public_path(request),
         "release_version": settings.VERSION,
         "sentry_dsn": settings.SENTRY_DSN,
+        "gdrive_enabled": is_gdrive_enabled(),
     }
 
     user = request.user

--- a/main/views_test.py
+++ b/main/views_test.py
@@ -46,13 +46,25 @@ def test_webpack_url(mocker, settings, client):
         ["markdown-editor-test", True, True],
         ["markdown-editor-test", False, False],
     ],
-)
-def test_react_page(settings, client, name, is_authenticated, expected_success):
+)  # pylint: disable=too-many-arguments
+@pytest.mark.parametrize("is_gdrive_enabled", [True, False])
+def test_react_page(
+    settings,
+    mocker,
+    client,
+    name,
+    is_authenticated,
+    expected_success,
+    is_gdrive_enabled,
+):
     """Verify that JS settings render correctly for pages used to render React pages"""
     settings.GA_TRACKING_ID = "fake"
     settings.ENVIRONMENT = "test"
     settings.VERSION = "4.5.6"
     settings.WEBPACK_USE_DEV_SERVER = False
+    settings.OCW_IMPORT_STARTER_SLUG = "test-course"
+
+    mocker.patch("main.views.is_gdrive_enabled", return_value=is_gdrive_enabled)
 
     user = UserFactory.create()
 
@@ -69,6 +81,7 @@ def test_react_page(settings, client, name, is_authenticated, expected_success):
             "environment": settings.ENVIRONMENT,
             "sentry_dsn": "",
             "release_version": settings.VERSION,
+            "gdrive_enabled": is_gdrive_enabled,
             "user": {
                 "username": user.username,
                 "email": user.email,

--- a/main/views_test.py
+++ b/main/views_test.py
@@ -62,7 +62,6 @@ def test_react_page(
     settings.ENVIRONMENT = "test"
     settings.VERSION = "4.5.6"
     settings.WEBPACK_USE_DEV_SERVER = False
-    settings.OCW_IMPORT_STARTER_SLUG = "test-course"
 
     mocker.patch("main.views.is_gdrive_enabled", return_value=is_gdrive_enabled)
 

--- a/static/js/lib/urls.ts
+++ b/static/js/lib/urls.ts
@@ -40,6 +40,9 @@ export const siteApiContentDetailUrl = siteApiContentUrl.segment(":textId/")
 export const siteApiListingUrl = siteApi.query({
   limit: WEBSITES_PAGE_SIZE
 })
+export const siteApiContentSyncGDriveUrl = siteApiContentUrl.segment(
+  "gdrive_sync/"
+)
 
 // WEBSITE COLLECTIONS API
 

--- a/static/js/query-configs/websites.ts
+++ b/static/js/query-configs/websites.ts
@@ -24,7 +24,8 @@ import {
   siteApiActionUrl,
   siteApiContentListingUrl,
   siteApiContentDetailUrl,
-  siteApiContentUrl
+  siteApiContentUrl,
+  siteApiContentSyncGDriveUrl
 } from "../lib/urls"
 
 import {
@@ -453,4 +454,15 @@ export const createWebsiteContentMutation = (
       ...next
     })
   }
+})
+
+export const syncWebsiteContentMutation = (siteName: string): QueryConfig => ({
+  url:     siteApiContentSyncGDriveUrl.param({ name: siteName }).toString(),
+  options: {
+    method:  "POST",
+    headers: {
+      "X-CSRFTOKEN": getCookie("csrftoken") || ""
+    }
+  },
+  body: {}
 })

--- a/static/js/test_setup.ts
+++ b/static/js/test_setup.ts
@@ -12,6 +12,7 @@ const _createSettings = (): SETTINGS => ({
   environment:     "",
   release_version: "0.0.0",
   sentry_dsn:      "",
+  gdrive_enabled:  false,
   user:            {
     username: "example",
     name:     "Jane Doe",

--- a/static/js/types/globals.d.ts
+++ b/static/js/types/globals.d.ts
@@ -7,6 +7,7 @@ interface SETTINGS {
   environment: string;
   release_version: string;
   sentry_dsn: string;
+  gdrive_enabled: bool;
   user: {
     username: string;
     email: string;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #578

#### What's this PR do?
Adds a front-end button (conditionally, for ocw sites) that sends an API request to sync with Google Drive, and displays a feedback modal.

#### How should this be manually tested?
Follow testing directions for https://github.com/mitodl/ocw-studio/pull/591 but instead of manually going to the `gdrive_sync` API URL, click the 'Sync w/Google Drive' button on the site resources page instead.  The button should only appear if the google drive settings (DRIVE_SERVICE_ACCOUNT_CREDS and DRIVE_SHARED_ID) are assigned values.

#### Screenshots (if appropriate)
<img width="858" alt="Screen Shot 2021-09-24 at 4 35 50 PM" src="https://user-images.githubusercontent.com/187676/134736833-5f252c53-4ba5-47d5-b887-aeba2c52f33d.png">

=================
<img width="575" alt="Screen Shot 2021-09-24 at 8 48 28 AM" src="https://user-images.githubusercontent.com/187676/134736834-b877052d-ed23-4cf0-8844-976069bcb875.png">

=================
<img width="558" alt="Screen Shot 2021-09-24 at 4 36 34 PM" src="https://user-images.githubusercontent.com/187676/134736832-c7bfa7fc-a583-48a5-b073-991574c3c607.png">


