### PR TITLE
Tweak s3 path for gdrive-imported nonvideo files

### DIFF
--- a/gdrive_sync/admin.py
+++ b/gdrive_sync/admin.py
@@ -29,7 +29,7 @@ class DriveFileAdmin(TimestampedModelAdmin):
         "website__short_id",
         "s3_key",
     )
-    autocomplete_fields = ["website", "video"]
+    autocomplete_fields = ["website", "video", "resource"]
     list_display = (
         "name",
         "status",

--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -167,8 +167,10 @@ def streaming_download(drive_file: DriveFile) -> requests.Response:
     return response
 
 
-def stream_to_s3(drive_file: DriveFile, prefix=settings.DRIVE_S3_UPLOAD_PREFIX):
+def stream_to_s3(drive_file: DriveFile, prefix: str = None):
     """ Stream a Google Drive file to S3 """
+    if prefix is None:
+        prefix = settings.DRIVE_S3_UPLOAD_PREFIX
     service = get_drive_service()
     permission = (
         service.permissions()

--- a/gdrive_sync/api_test.py
+++ b/gdrive_sync/api_test.py
@@ -98,7 +98,7 @@ def test_stream_to_s3(settings, mocker, is_video):
     mock_boto3 = mocker.patch("gdrive_sync.api.boto3")
     mock_bucket = mock_boto3.resource.return_value.Bucket.return_value
     drive_file = DriveFileFactory.create()
-    prefix = settings.DRIVE_S3_UPLOAD_PREFIX if is_video else "courses"
+    prefix = None if is_video else "courses"
     api.stream_to_s3(drive_file, prefix=prefix)
     mock_service.return_value.permissions.return_value.create.assert_called_once()
     if is_video:

--- a/gdrive_sync/tasks.py
+++ b/gdrive_sync/tasks.py
@@ -32,11 +32,13 @@ log = logging.getLogger(__name__)
 
 
 @app.task(bind=True)
-def stream_drive_file_to_s3(self, drive_file_id: str):
+def stream_drive_file_to_s3(
+    self, drive_file_id: str, prefix=settings.DRIVE_S3_UPLOAD_PREFIX
+):
     """ Stream a Google Drive file to S3 """
     if settings.DRIVE_SHARED_ID and settings.DRIVE_SERVICE_ACCOUNT_CREDS:
         drive_file = DriveFile.objects.get(file_id=drive_file_id)
-        api.stream_to_s3(drive_file)
+        api.stream_to_s3(drive_file, prefix=prefix)
 
 
 @app.task(bind=True)
@@ -103,9 +105,8 @@ def import_recent_files(self, last_dt: str = None, import_video: bool = False):
         dt_str = last_checked.strftime("%Y-%m-%dT%H:%M:%S.%f")
         query += f" and (modifiedTime > '{dt_str}' or createdTime > '{dt_str}')"
 
-    gdfiles = get_file_list(query=query, fields=fields)
     chains = []
-    for gdfile in gdfiles:
+    for gdfile in get_file_list(query=query, fields=fields):
         drive_file = process_file_result(gdfile, import_video=import_video)
         if drive_file:
             maxLastTime = datetime.strptime(
@@ -119,9 +120,14 @@ def import_recent_files(self, last_dt: str = None, import_video: bool = False):
                 if DRIVE_FOLDER_VIDEOS in drive_file.drive_path
                 else create_resource_from_gdrive
             )
+            s3_prefix = (
+                settings.DRIVE_S3_UPLOAD_PREFIX
+                if import_video
+                else drive_file.website.starter.config.get("root-url-path")
+            )
             chains.append(
                 chain(
-                    stream_drive_file_to_s3.s(drive_file.file_id),
+                    stream_drive_file_to_s3.s(drive_file.file_id, prefix=s3_prefix),
                     chained_task.si(drive_file.file_id),
                 )
             )
@@ -162,7 +168,12 @@ def import_website_files(self, short_id: str):
         if drive_file:
             chains.append(
                 chain(
-                    stream_drive_file_to_s3.s(drive_file.file_id),
+                    stream_drive_file_to_s3.s(
+                        drive_file.file_id,
+                        prefix=drive_file.website.starter.config.get(
+                            "root-url-path"
+                        ).rstrip("/"),
+                    ),
                     create_resource_from_gdrive.si(drive_file.file_id),
                 )
             )

--- a/gdrive_sync/tasks.py
+++ b/gdrive_sync/tasks.py
@@ -32,11 +32,11 @@ log = logging.getLogger(__name__)
 
 
 @app.task(bind=True)
-def stream_drive_file_to_s3(
-    self, drive_file_id: str, prefix=settings.DRIVE_S3_UPLOAD_PREFIX
-):
+def stream_drive_file_to_s3(self, drive_file_id: str, prefix: str = None):
     """ Stream a Google Drive file to S3 """
     if settings.DRIVE_SHARED_ID and settings.DRIVE_SERVICE_ACCOUNT_CREDS:
+        if prefix is None:
+            prefix = settings.DRIVE_S3_UPLOAD_PREFIX
         drive_file = DriveFile.objects.get(file_id=drive_file_id)
         api.stream_to_s3(drive_file, prefix=prefix)
 

--- a/gdrive_sync/tasks_test.py
+++ b/gdrive_sync/tasks_test.py
@@ -211,7 +211,10 @@ def test_import_recent_files_videos(
                     LIST_VIDEO_RESPONSES[i]["files"][0]["id"]
                 )
         elif import_video:  # chained tasks should be run
-            mock_upload_task.assert_any_call(LIST_VIDEO_RESPONSES[i]["files"][0]["id"])
+            mock_upload_task.assert_any_call(
+                LIST_VIDEO_RESPONSES[i]["files"][0]["id"],
+                prefix=settings.DRIVE_S3_UPLOAD_PREFIX,
+            )
             assert (
                 tracker.last_dt
                 == datetime.strptime(
@@ -278,7 +281,10 @@ def test_import_recent_files_novideos(settings, mocker, mocked_celery, import_vi
             import_video=import_video,
         )
         with pytest.raises(AssertionError):
-            mock_upload_task.assert_any_call(LIST_FILE_RESPONSES[1]["files"][0]["id"])
+            mock_upload_task.assert_any_call(
+                LIST_FILE_RESPONSES[1]["files"][0]["id"],
+                prefix=website.starter.config["root-url-path"],
+            )
         if import_video:  # chained tasks should not be run (this is for files only)
             with pytest.raises(AssertionError):
                 mock_upload_task.assert_any_call(
@@ -380,7 +386,9 @@ def test_import_website_files(mocker, mocked_celery):
     )
     assert mock_process_file_result.call_count == 2
     for drive_file in drive_files:
-        mock_stream_task.assert_any_call(drive_file.file_id)
+        mock_stream_task.assert_any_call(
+            drive_file.file_id, prefix=website.starter.config["root-url-path"]
+        )
         mock_create_resource.assert_any_call(drive_file.file_id)
 
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Related to #591 

#### What's this PR do?
Changes the S3 key path of google drive nonvideo files to be the same as manually uploaded files so that they will be copied over by the publishing pipelines.

#### How should this be manually tested?
Follow steps for #604, check that the s3 path is `<website.starter.config.root-url-path>/<site-name>/<filename>`
