### PR TITLE
remove unnecessary changes to the webpack config

### DIFF
--- a/webpack.config.shared.js
+++ b/webpack.config.shared.js
@@ -12,6 +12,11 @@ module.exports = {
     module: {
       rules: [
         {
+          // this regex is necessary to explicitly exclude ckeditor stuff
+          test: /static\/.+\.(svg|ttf|woff|woff2|eot|gif)$/,
+          use: "url-loader"
+        },
+        {
           test: /node_modules\/react-nestable\/.+\.svg$/,
           use: "svg-inline-loader?classPrefix"
         },
@@ -25,11 +30,11 @@ module.exports = {
           exclude: /node_modules/
         },
         {
-          test: /.+\.svg$/,
+          test: /ckeditor5-[^/\\]+[/\\]theme[/\\]icons[/\\][^/\\]+\.svg$/,
           use: ["raw-loader"]
         },
         {
-          test: /\.css$/,
+          test: /ckeditor5-[^/\\]+[/\\]theme[/\\].+\.css$/,
           use: [
             {
               loader: "style-loader",


### PR DESCRIPTION
for #589 when I was iterating on the code I was copying the CKEditor
over directly for a bit, and I had to make a bunch of changes to the
webpack config to get that working. Once I started publishing the forked
resource link package as its own npm package those changes were no
longer necessary, and they didn't cause problems in local development,
but they led to some issues on RC.