### PR TITLE
import additional metadata

### DIFF
--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -38,8 +38,6 @@ NON_ID_COURSE_NAMES = [
     "more",
     "physics",
 ]
-DEPARTMENTS_JSON_FILE = open("static/js/resources/departments.json", "r")
-DEPARTMENTS_JSON = json.loads(DEPARTMENTS_JSON_FILE.read())
 
 
 def parse_date(date_string):
@@ -195,21 +193,23 @@ def import_ocw2hugo_sitemetadata(
     metadata["course_description"] = course_data["course_description"]
     metadata["primary_course_number"] = course_data["primary_course_number"]
     metadata["extra_course_numbers"] = ",".join(course_data["extra_course_numbers"])
-    metadata["department_numbers"] = list(
-        map(
-            (
-                lambda course_department: next(
-                    (
-                        department["depNo"]
-                        for department in DEPARTMENTS_JSON
-                        if department["title"] == course_department["department"]
-                    ),
-                    None,
-                )
-            ),
-            course_data["departments"],
+    with open("static/js/resources/departments.json", "r") as departments_json_file:
+        departments_json = json.loads(departments_json_file.read())
+        metadata["department_numbers"] = list(
+            map(
+                (
+                    lambda course_department: next(
+                        (
+                            department["depNo"]
+                            for department in departments_json
+                            if department["title"] == course_department["department"]
+                        ),
+                        None,
+                    )
+                ),
+                course_data["departments"],
+            )
         )
-    )
     metadata["level"] = course_data["level"]["level"]
     metadata["learning_resource_types"] = list(
         map(

--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -193,6 +193,8 @@ def import_ocw2hugo_sitemetadata(
     metadata = {}
     metadata["course_title"] = course_data["course_title"]
     metadata["course_description"] = course_data["course_description"]
+    metadata["primary_course_number"] = course_data["primary_course_number"]
+    metadata["extra_course_numbers"] = ",".join(course_data["extra_course_numbers"])
     metadata["department_numbers"] = list(
         map(
             (
@@ -208,6 +210,14 @@ def import_ocw2hugo_sitemetadata(
             course_data["departments"],
         )
     )
+    metadata["level"] = course_data["level"]["level"]
+    metadata["learning_resource_types"] = list(
+        map(
+            lambda course_feature: course_feature["feature"],
+            course_data["course_features"],
+        )
+    )
+    metadata["topics"] = course_data["topics"]
 
     instructor_contents = []
     for instructor in course_data["instructors"]:

--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -194,7 +194,7 @@ def import_ocw2hugo_sitemetadata(
     metadata["primary_course_number"] = course_data["primary_course_number"]
     metadata["extra_course_numbers"] = ",".join(course_data["extra_course_numbers"])
     with open("static/js/resources/departments.json", "r") as departments_json_file:
-        departments_json = json.loads(departments_json_file.read())
+        departments_json = json.load(departments_json_file)
         metadata["department_numbers"] = list(
             map(
                 (

--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -38,6 +38,8 @@ NON_ID_COURSE_NAMES = [
     "more",
     "physics",
 ]
+DEPARTMENTS_JSON_FILE = open("static/js/resources/departments.json", "r")
+DEPARTMENTS_JSON = json.loads(DEPARTMENTS_JSON_FILE.read())
 
 
 def parse_date(date_string):
@@ -188,6 +190,25 @@ def import_ocw2hugo_sitemetadata(
         log.error("No root web site found, name=%s", settings.ROOT_WEBSITE_NAME)
         return
 
+    metadata = {}
+    metadata["course_title"] = course_data["course_title"]
+    metadata["course_description"] = course_data["course_description"]
+    metadata["department_numbers"] = list(
+        map(
+            (
+                lambda course_department: next(
+                    (
+                        department["depNo"]
+                        for department in DEPARTMENTS_JSON
+                        if department["title"] == course_department["department"]
+                    ),
+                    None,
+                )
+            ),
+            course_data["departments"],
+        )
+    )
+
     instructor_contents = []
     for instructor in course_data["instructors"]:
         uid = instructor["uid"]
@@ -219,18 +240,18 @@ def import_ocw2hugo_sitemetadata(
         )
         instructor_contents.append(instructor_content)
 
+    metadata[INSTRUCTORS_FIELD_NAME] = {
+        "website": website_root.name,
+        "content": [content.text_id for content in instructor_contents],
+    }
+
     WebsiteContent.objects.update_or_create(
         type=CONTENT_TYPE_METADATA,
         website=website,
         defaults={
             "text_id": CONTENT_TYPE_METADATA,
             "title": "Course Metadata",
-            "metadata": {
-                INSTRUCTORS_FIELD_NAME: {
-                    "website": website_root.name,
-                    "content": [content.text_id for content in instructor_contents],
-                }
-            },
+            "metadata": metadata,
         },
     )
 

--- a/ocw_import/api_test.py
+++ b/ocw_import/api_test.py
@@ -146,13 +146,22 @@ def test_import_ocw2hugo_course_metadata(settings, root_website):
     website = Website.objects.get(name=name)
     metadata = WebsiteContent.objects.get(website=website, type=CONTENT_TYPE_METADATA)
     assert metadata.metadata == {
+        "level": "Undergraduate",
+        "topics": [
+            ["Engineering", "Mechanical Engineering", "Solid Mechanics"],
+            ["Engineering", "Aerospace Engineering", "Structural Mechanics"],
+            ["Engineering", "Civil Engineering", "Structural Engineering"]
+        ],
         "instructors": {
-            "content": [
-                "0b39fff4-81fb-b968-8e2d-a0ce16ece1d4",
-                "95041ae9-ab5b-75af-f711-13fcd917f464",
-            ],
-            "website": "ocw-www",
-        }
+            "content": ["0b39fff4-81fb-b968-8e2d-a0ce16ece1d4", "95041ae9-ab5b-75af-f711-13fcd917f464"],
+            "website": "ocw-www"
+        },
+        "course_title": "Engineering Mechanics I",
+        "course_description": "This subject provides an introduction to the mechanics of materials and structures. You will be introduced to and become familiar with all relevant physical properties and fundamental laws governing the behavior of materials and structures and you will learn how to solve a variety of problems of interest to civil and environmental engineers. While there will be a chance for you to put your mathematical skills obtained in 18.01, 18.02, and eventually 18.03 to use in this subject, the emphasis is on the physical understanding of why a material or structure behaves the way it does in the engineering design of materials and structures.\n",
+        "department_numbers": ["1"],
+        "extra_course_numbers": "",
+        "primary_course_number": "1.050",
+        "learning_resource_types": ["Problem Sets", "Lecture Notes"]
     }
 
 

--- a/ocw_import/api_test.py
+++ b/ocw_import/api_test.py
@@ -150,18 +150,21 @@ def test_import_ocw2hugo_course_metadata(settings, root_website):
         "topics": [
             ["Engineering", "Mechanical Engineering", "Solid Mechanics"],
             ["Engineering", "Aerospace Engineering", "Structural Mechanics"],
-            ["Engineering", "Civil Engineering", "Structural Engineering"]
+            ["Engineering", "Civil Engineering", "Structural Engineering"],
         ],
         "instructors": {
-            "content": ["0b39fff4-81fb-b968-8e2d-a0ce16ece1d4", "95041ae9-ab5b-75af-f711-13fcd917f464"],
-            "website": "ocw-www"
+            "content": [
+                "0b39fff4-81fb-b968-8e2d-a0ce16ece1d4",
+                "95041ae9-ab5b-75af-f711-13fcd917f464",
+            ],
+            "website": "ocw-www",
         },
         "course_title": "Engineering Mechanics I",
         "course_description": "This subject provides an introduction to the mechanics of materials and structures. You will be introduced to and become familiar with all relevant physical properties and fundamental laws governing the behavior of materials and structures and you will learn how to solve a variety of problems of interest to civil and environmental engineers. While there will be a chance for you to put your mathematical skills obtained in 18.01, 18.02, and eventually 18.03 to use in this subject, the emphasis is on the physical understanding of why a material or structure behaves the way it does in the engineering design of materials and structures.\n",
         "department_numbers": ["1"],
         "extra_course_numbers": "",
         "primary_course_number": "1.050",
-        "learning_resource_types": ["Problem Sets", "Lecture Notes"]
+        "learning_resource_types": ["Problem Sets", "Lecture Notes"],
     }
 
 

--- a/static/js/resources/departments.json
+++ b/static/js/resources/departments.json
@@ -1,0 +1,149 @@
+[{
+  "title": "Chemistry",
+  "id": "chemistry",
+  "depNo": "5"
+}, {
+  "title": "Biological Engineering",
+  "id": "biological-engineering",
+  "depNo": "20"
+}, {
+  "title": "Aeronautics and Astronautics",
+  "id": "aeronautics-and-astronautics",
+  "depNo": "16"
+}, {
+  "title": "Global Studies and Languages",
+  "id": "global-studies-and-languages",
+  "depNo": "21G"
+}, {
+  "title": "Mathematics",
+  "id": "mathematics",
+  "depNo": "18"
+}, {
+  "title": "Health Sciences and Technology",
+  "id": "health-sciences-and-technology",
+  "depNo": "HST"
+}, {
+  "title": "Edgerton Center",
+  "id": "edgerton-center",
+  "depNo": "EC"
+}, {
+  "title": "Women's and Gender Studies",
+  "id": "womens-and-gender-studies",
+  "depNo": "WGS"
+}, {
+  "title": "Urban Studies and Planning",
+  "id": "urban-studies-and-planning",
+  "depNo": "11"
+}, {
+  "title": "Sloan School of Management",
+  "id": "sloan-school-of-management",
+  "depNo": "15"
+}, {
+  "title": "Anthropology",
+  "id": "anthropology",
+  "depNo": "21A"
+}, {
+  "title": "Engineering Systems Division",
+  "id": "engineering-systems-division",
+  "depNo": "ESD"
+}, {
+  "title": "Chemical Engineering",
+  "id": "chemical-engineering",
+  "depNo": "10"
+}, {
+  "title": "Earth, Atmospheric, and Planetary Sciences",
+  "id": "earth-atmospheric-and-planetary-sciences",
+  "depNo": "12"
+}, {
+  "title": "Music and Theater Arts",
+  "id": "music-and-theater-arts",
+  "depNo": "21M"
+}, {
+  "title": "Athletics, Physical Education and Recreation",
+  "id": "athletics-physical-education-and-recreation",
+  "depNo": "PE"
+}, {
+  "title": "Architecture",
+  "id": "architecture",
+  "depNo": "4"
+}, {
+  "title": "Experimental Study Group",
+  "id": "experimental-study-group",
+  "depNo": "ES"
+}, {
+  "title": "Literature",
+  "id": "literature",
+  "depNo": "21L"
+}, {
+  "title": "Mechanical Engineering",
+  "id": "mechanical-engineering",
+  "depNo": "2"
+}, {
+  "title": "Electrical Engineering and Computer Science",
+  "id": "electrical-engineering-and-computer-science",
+  "depNo": "6"
+}, {
+  "title": "Materials Science and Engineering",
+  "id": "materials-science-and-engineering",
+  "depNo": "3"
+}, {
+  "title": "History",
+  "id": "history",
+  "depNo": "21H"
+}, {
+  "title": "Linguistics and Philosophy",
+  "id": "linguistics-and-philosophy",
+  "depNo": "24"
+}, {
+  "title": "Institute for Data, Systems, and Society",
+  "id": "institute-for-data-systems-and-society",
+  "depNo": "IDS"
+}, {
+  "title": "Biology",
+  "id": "biology",
+  "depNo": "7"
+}, {
+  "title": "Civil and Environmental Engineering",
+  "id": "civil-and-environmental-engineering",
+  "depNo": "1"
+}, {
+  "title": "Comparative Media Studies/Writing",
+  "id": "comparative-media-studies-writing",
+  "depNo": "CMS-W"
+}, {
+  "title": "Nuclear Science and Engineering",
+  "id": "nuclear-engineering",
+  "depNo": "22"
+}, {
+  "title": "Economics",
+  "id": "economics",
+  "depNo": "14"
+}, {
+  "title": "Concourse",
+  "id": "concourse",
+  "depNo": "CC"
+}, {
+  "title": "Brain and Cognitive Sciences",
+  "id": "brain-and-cognitive-sciences",
+  "depNo": "9"
+}, {
+  "title": "Science, Technology, and Society",
+  "id": "science-technology-and-society",
+  "depNo": "STS"
+}, {
+  "title": "Political Science",
+  "id": "political-science",
+  "depNo": "17"
+}, {
+  "title": "Media Arts and Sciences",
+  "id": "media-arts-and-sciences",
+  "depNo": "MAS"
+}, {
+  "title": "Physics",
+  "id": "physics",
+  "depNo": "8"
+}, {
+  "title": "Supplemental Resources",
+  "id": "supplemental-resources",
+  "depNo": "RES"
+}]


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Partially closes https://github.com/mitodl/ocw-studio/issues/579

#### What's this PR do?
Currently, `import_ocw_course_sites` only imports the `instructors` field from the course metadata.  This PR adds importing of:
 - `course_title`
 - `course_description`
 - `primary_course_number`
 - `extra_course_numbers`
 - `departments`
 - `level`
 - `learning_resource_types`
 - `topics`

#### How should this be manually tested?
 - Read the readme and make sure you are set up with proper S3 access to run `import_ocw_course_sites`
 - Make sure you have the `ocw-www` and `ocw-course` starters in your local instance of `ocw-studio`:
   - https://github.com/mitodl/ocw-hugo-projects/blob/main/ocw-www/ocw-studio.yaml
   - https://github.com/mitodl/ocw-hugo-projects/blob/main/ocw-course/ocw-studio.yaml
 - Create a site called `ocw-www` using the `ocw-www` starter
 - Run `docker-compose run web ./manage.py import_ocw_course_sites -b ocw-to-hugo-output-qa --filter 6-080-great-ideas-in-theoretical-computer-science-spring-2008`
 - Browse to http://localhost:8043/sites/6-080-great-ideas-in-theoretical-computer-science-spring-2008/type/metadata and ensure that all metadata properties aside from the course image and course image thumbnail are properly filled out
