### PR TITLE
Fix bug so slug field is used for filename

### DIFF
--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -315,7 +315,7 @@ class WebsiteContentCreateSerializer(
         user = self.user_from_request()
         added_context_data = {
             field: self.context[field]
-            for field in {"is_page_content", "filename", "dirpath"}
+            for field in {"is_page_content", "filename", "dirpath", "text_id"}
             if field in self.context
         }
         if validated_data.get("type") == "resource":


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Bug fix for #600 

#### What's this PR do?
Add `text_id` to be passed through to the website context. We are generating `text_id` in `_get_derived_website_content_data` which is used by the serializer context. However it was being filtered out of `WebsiteContentCreateSerializer`, which meant the default uuid generated by the model was used instead for `text_id`. This changes that to use the uuid passed in so that `text_id` and `filename` match up.

#### How should this be manually tested?
Update the ocw-www schema to the latest on ocw-hugo-projects if you haven't already. Then go to site ocw-www and create a new instructor. In the django admin or shell look at that instructor. Verify that the `filename` matches `text_id` on that `WebsiteContent`
