### PR TITLE
Trim content from destination url

### DIFF
--- a/content_sync/utils.py
+++ b/content_sync/utils.py
@@ -46,13 +46,11 @@ def get_destination_url(
     """
     if content.is_page_content:
         filename = "" if content.filename == "_index" else content.filename
-        prefix = f"{content.website.name}/{site_config.content_dir}"
-        dirpath = (
-            content.dirpath.replace(prefix, "", 1)
-            if content.dirpath.startswith(prefix)
-            else content.dirpath
-        )
-        return os.path.join(dirpath, filename)
+        url_with_content = os.path.join(content.dirpath, filename)
+        content_dir_prefix = f"{site_config.content_dir}/"
+        if url_with_content.startswith(content_dir_prefix):
+            url_with_content = url_with_content[len(content_dir_prefix) :]
+        return url_with_content
     log.error(
         "Cannot get destination URL because is_page_content is false (content: %s)",
         (content.id, content.text_id),

--- a/content_sync/utils_test.py
+++ b/content_sync/utils_test.py
@@ -1,9 +1,12 @@
 """Content sync utility functionality tests"""
 import pytest
 
-from content_sync.utils import get_destination_filepath
+from content_sync.utils import get_destination_filepath, get_destination_url
 from websites.factories import WebsiteContentFactory, WebsiteStarterFactory
 from websites.site_config_api import ConfigItem, SiteConfig
+
+
+pytestmark = pytest.mark.django_db
 
 
 @pytest.mark.parametrize(
@@ -54,8 +57,61 @@ def test_get_destination_url_errors(mocker):
         is_page_content=False,
         type=config_item_name,
     )
-    return_value = get_destination_filepath(
+    return_value = get_destination_url(
         content=content, site_config=SiteConfig(starter.config)
     )
     patched_log.error.assert_called_once()
     assert return_value is None
+
+
+@pytest.mark.parametrize(
+    "is_page_content, dirpath, filename, expected",
+    [
+        [True, "content/pages", "_index", "pages/"],
+        [True, "content/pages", "hx_network", "pages/hx_network"],
+        [
+            True,
+            "content/pages/lecture-notes",
+            "java_3d_lecture",
+            "pages/lecture-notes/java_3d_lecture",
+        ],
+        [True, "content/resources", "image", "resources/image"],
+        [False, "", "", None],
+    ],
+)
+def test_get_destination_url(is_page_content, dirpath, filename, expected):
+    """get_destination_url should create a url for a piece of content"""
+    content = WebsiteContentFactory.create(
+        is_page_content=is_page_content, dirpath=dirpath, filename=filename
+    )
+    assert (
+        get_destination_url(content, SiteConfig(content.website.starter.config))
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    "is_page_content, dirpath, filename, expected",
+    [
+        [True, "content/pages", "_index", "content/pages/_index.md"],
+        [True, "content/pages", "hx_network", "content/pages/hx_network.md"],
+        [
+            True,
+            "content/pages/lecture-notes",
+            "java_3d_lecture",
+            "content/pages/lecture-notes/java_3d_lecture.md",
+        ],
+        [True, "content/resources", "image", "content/resources/image.md"],
+        [False, "", "", None],
+        [False, "config/_default/menus.yaml", "menus.yaml", None],
+    ],
+)
+def test_get_destination_filepath(is_page_content, dirpath, filename, expected):
+    """get_destination_filepath should create the filepath for a piece of content"""
+    content = WebsiteContentFactory.create(
+        is_page_content=is_page_content, dirpath=dirpath, filename=filename
+    )
+    assert (
+        get_destination_filepath(content, SiteConfig(content.website.starter.config))
+        == expected
+    )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #626 

#### What's this PR do?
Remove `content/` prefix from output urls

#### How should this be manually tested?
 - Add an internal link to a site
 - Publish the site and look at the markdown files in github. The link should start with `pages` or `resources` or whatever is relevant for your content.