### PR TITLE
Additional env variables for concourse pipelines

### DIFF
--- a/content_sync/management/commands/backpopulate_pipelines.py
+++ b/content_sync/management/commands/backpopulate_pipelines.py
@@ -28,6 +28,13 @@ class Command(BaseCommand):
             default="",
             help="If specified, only process websites that are based on this starter slug",
         )
+        parser.add_argument(
+            "-source",
+            "--source",
+            dest="source",
+            default="",
+            help="If specified, only process websites that are based on this source",
+        )
 
     def handle(self, *args, **options):
 
@@ -40,6 +47,7 @@ class Command(BaseCommand):
 
         filter_str = options["filter"].lower()
         starter_str = options["starter"]
+        source_str = options["source"]
         is_verbose = options["verbosity"] > 1
 
         total_websites = 0
@@ -53,6 +61,9 @@ class Command(BaseCommand):
 
         if starter_str:
             website_qset = website_qset.filter(starter__slug=starter_str)
+
+        if source_str:
+            website_qset = website_qset.filter(source=source_str)
 
         for website in website_qset.iterator():
             get_sync_pipeline(website).upsert_website_pipeline()

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -137,10 +137,11 @@ class ConcourseGithubPipeline(BaseSyncPipeline):
             if branch == settings.GIT_BRANCH_PREVIEW:
                 version = self.VERSION_DRAFT
                 destination_bucket = settings.AWS_PREVIEW_BUCKET_NAME
+                static_api_url = settings.OCW_STUDIO_DRAFT_URL
             else:
                 version = self.VERSION_LIVE
                 destination_bucket = settings.AWS_PUBLISH_BUCKET_NAME
-
+                static_api_url = settings.OCW_STUDIO_LIVE_URL
             with open(
                 os.path.join(
                     os.path.dirname(__file__), "definitions/concourse/site-pipeline.yml"
@@ -156,6 +157,10 @@ class ConcourseGithubPipeline(BaseSyncPipeline):
                     )
                     .replace("((ocw-hugo-projects-uri))", hugo_projects_url)
                     .replace("((ocw-studio-url))", settings.SITE_BASE_URL)
+                    .replace("((static-api-base-url))", static_api_url)
+                    .replace(
+                        "((ocw-import-starter-slug))", settings.OCW_IMPORT_STARTER_SLUG
+                    )
                     .replace("((ocw-studio-bucket))", settings.AWS_STORAGE_BUCKET_NAME)
                     .replace("((ocw-site-repo))", self.website.short_id)
                     .replace("((ocw-site-repo-branch))", branch)

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -99,6 +99,9 @@ def test_upsert_website_pipelines(
     """The correct concourse API args should be made for a website"""
     settings.ROOT_WEBSITE_NAME = "ocw-www-course"
     settings.API_BEARER_TOKEN = "top-secret-token"
+    settings.OCW_STUDIO_DRAFT_URL = "https://draft.ocw.mit.edu"
+    settings.OCW_STUDIO_LIVE_URL = "https://live.ocw.mit.edu"
+    settings.OCW_IMPORT_STARTER_SLUG = "custom_slug"
     hugo_projects_path = "https://github.com/org/repo"
     starter = WebsiteStarterFactory.create(
         source=STARTER_SOURCE_GITHUB, path=f"{hugo_projects_path}/site"
@@ -140,13 +143,17 @@ def test_upsert_website_pipelines(
     if version == BaseSyncPipeline.VERSION_DRAFT:
         _, kwargs = mock_put_headers.call_args_list[0]
         bucket = settings.AWS_PREVIEW_BUCKET_NAME
+        api_url = settings.OCW_STUDIO_DRAFT_URL
     else:
         _, kwargs = mock_put_headers.call_args_list[1]
         bucket = settings.AWS_PUBLISH_BUCKET_NAME
+        api_url = settings.OCW_STUDIO_LIVE_URL
 
     config_str = json.dumps(kwargs)
 
     assert f"{hugo_projects_path}.git" in config_str
+    assert settings.OCW_IMPORT_STARTER_SLUG in config_str
+    assert api_url in config_str
     assert settings.API_BEARER_TOKEN in config_str
     if home_page:
         assert (

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -47,6 +47,8 @@ jobs:
       - task: build-course-task
         params:
           OCW_STUDIO_BASE_URL: ((ocw-studio-url))
+          STATIC_API_BASE_URL: ((static-api-base-url))
+          OCW_IMPORT_STARTER_SLUG: ((ocw-import-starter-slug))
         config:
           platform: linux
           image_resource:


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #624

#### What's this PR do?
- First, with github integration disabled (comment out your `GIT` vars in .env), create a site with name `ocw-www` and starter with the slug `ocw-www` (same as the starter on RC).
- Set the following env variables to the same as on RC:
```
OCW_STUDIO_BASE_URL
GIT*
AWS*
CONCOURSE*
OCW_STUDIO_DRAFT_URL
OCW_STUDIO_LIVE_URL
```
- Run `manage.py backpopulate_pipelines --filter ocw-www`
- Go to https://cicd-qa.odl.mit.edu/teams/ocw/pipelines/draft/jobs/build-ocw-site/builds/69?vars.site=%22ocw-www%22 and start a new build, it should pass.  When it's done, go to https://ocw-draft-qa.global.ssl.fastly.net/ and you should see a "New Courses" carousel.

