### PR TITLE
Save file location to WebsiteContent.file for imported OCW courses

### DIFF
--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -135,8 +135,19 @@ def convert_data_to_content(filepath, data, website):  # pylint:disable=too-many
             parent, _ = WebsiteContent.objects.get_or_create(
                 website=website, text_id=str(uuid.UUID(parent_uid))
             )
+        # Assumes that s3 objects will be independently synced to the ocw-studio bucket via devops
+        file_location = content_json.get("file_location", None)
+        if file_location:
+            ocw_prefix = (
+                website.starter.config.get("root-url-path", "courses")
+                if website.starter
+                else "courses"
+            )
+            file_location = file_location.replace("coursemedia", ocw_prefix)
+
         base_defaults = {
             "is_page_content": True,
+            "file": file_location,
             "metadata": content_json,
             "markdown": (s3_content_parts[1] if len(s3_content_parts) == 2 else None),
             "parent": parent,

--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -143,7 +143,7 @@ def convert_data_to_content(filepath, data, website):  # pylint:disable=too-many
                 if website.starter
                 else "courses"
             )
-            file_location = file_location.replace("coursemedia", ocw_prefix)
+            file_location = re.sub(r"^/?coursemedia", ocw_prefix, file_location)
 
         base_defaults = {
             "is_page_content": True,

--- a/ocw_import/api_test.py
+++ b/ocw_import/api_test.py
@@ -1,5 +1,6 @@
 """ Tests for ocw_import.api """
 import json
+import re
 
 import pytest
 from moto import mock_s3
@@ -88,8 +89,8 @@ def test_import_ocw2hugo_course_content(mocker, settings):
     assert lecture_pdf.metadata.get("file_type") == "application/pdf"
     assert lecture_pdf.filename == "file-20"
     assert lecture_pdf.dirpath == "content/resources"
-    assert lecture_pdf.file == lecture_pdf.metadata.get("file_location").replace(
-        "coursemedia", "courses"
+    assert lecture_pdf.file == re.sub(
+        r"^/?coursemedia", "courses", lecture_pdf.metadata.get("file_location")
     )
     get_valid_new_filename_mock.assert_any_call(
         website.pk,

--- a/ocw_import/api_test.py
+++ b/ocw_import/api_test.py
@@ -88,6 +88,9 @@ def test_import_ocw2hugo_course_content(mocker, settings):
     assert lecture_pdf.metadata.get("file_type") == "application/pdf"
     assert lecture_pdf.filename == "file-20"
     assert lecture_pdf.dirpath == "content/resources"
+    assert lecture_pdf.file == lecture_pdf.metadata.get("file_location").replace(
+        "coursemedia", "courses"
+    )
     get_valid_new_filename_mock.assert_any_call(
         website.pk,
         lecture_pdf.dirpath,


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
#561 

#### What's this PR do?
- Saves the `file_location` value of imported OCW course resources to the `WebsiteContent.file` field, with some modifications based on the starter config (default is to replace `coursemedia` with `courses`).

#### How should this be manually tested?
- Run `manage.py import_ocw_course_sites -b ocw-to-hugo-output-qa. --limit 10`
- Check that the `WebsiteContent` resources have populated `file` values equal to the `file_location` in the metadata, but with `coursemedia` replaced by `courses`.  


#### Any background context you want to provide?
Current assumption is that the OCW S3 files will be copied by devops from the legacy bucket to the ocw-studio RC/prod buckets, so no code to do so has been added in this PR.

