### PR TITLE
Management command for resetting synced checksums and optionally syncing all github repos

### DIFF
--- a/content_sync/apis/github.py
+++ b/content_sync/apis/github.py
@@ -140,6 +140,19 @@ class GithubApiWrapper:
         return self.repo
 
     @retry_on_failure
+    def repo_exists(self):
+        """Return True if the repo already exists"""
+        try:
+            self.org.get_repo(self.website.short_id)
+            return True
+        except GithubException as ge:
+            if ge.status == 404:
+                return False
+            else:
+                raise
+        return False
+
+    @retry_on_failure
     def create_repo(self, **kwargs) -> Repository:
         """
         Create a website repo

--- a/content_sync/apis/github_test.py
+++ b/content_sync/apis/github_test.py
@@ -84,6 +84,20 @@ def patched_destination_filepath(mocker):
     )
 
 
+def test_repo_exists_true(mocker, mock_api_wrapper):
+    """repo_exists should return True"""
+    mock_api_wrapper.org.get_repo.return_value = mocker.Mock()
+    assert mock_api_wrapper.repo_exists() is True
+
+
+def test_repo_exists_false(mock_api_wrapper):
+    """repo_exists should return False"""
+    mock_api_wrapper.org.get_repo.side_effect = GithubException(
+        status=404, data={}, headers={}
+    )
+    assert mock_api_wrapper.repo_exists() is False
+
+
 def test_get_repo(mock_api_wrapper):
     """get_repo should invoke the appropriate PyGithub call"""
     mock_api_wrapper.get_repo()

--- a/content_sync/backends/base.py
+++ b/content_sync/backends/base.py
@@ -17,6 +17,13 @@ class BaseSyncBackend(abc.ABC):
         self.site_config = SiteConfig(website.starter.config)
 
     @abc.abstractmethod
+    def backend_exists(self):  # pragma: no cover
+        """
+        Called to determine if the website backend exists.
+        """
+        ...
+
+    @abc.abstractmethod
     def create_website_in_backend(self):  # pragma: no cover
         """
         Called to create the website in the backend.

--- a/content_sync/backends/base_test.py
+++ b/content_sync/backends/base_test.py
@@ -12,6 +12,9 @@ from websites.factories import WebsiteFactory
 class _ImplementedBackend(BaseSyncBackend):
     """ Not implemented """
 
+    def backend_exists(self):
+        ...
+
     def create_website_in_backend(self):
         ...
 

--- a/content_sync/backends/github.py
+++ b/content_sync/backends/github.py
@@ -31,6 +31,10 @@ class GithubBackend(BaseSyncBackend):
         super().__init__(website)
         self.api = GithubApiWrapper(self.website, self.site_config)
 
+    def backend_exists(self):
+        """Determine if the website repo exists"""
+        return self.api.repo_exists()
+
     def create_website_in_backend(self) -> Repository:
         """
         Create a Website git repo with 3 branches.  Requires ~6 API calls.

--- a/content_sync/backends/github_test.py
+++ b/content_sync/backends/github_test.py
@@ -44,6 +44,13 @@ def patched_file_serialize(mocker):
     )
 
 
+@pytest.mark.parametrize("exists", [True, False])
+def test_backend_exists(github, exists):
+    """backend_exists should return the expected boolean value"""
+    github.api.repo_exists.return_value = exists
+    assert github.backend.backend_exists() is exists
+
+
 def test_create_website_in_backend(github):
     """ Test that the create_website_in_backend function completes without errors and calls expected api functions"""
     github.backend.create_website_in_backend()

--- a/content_sync/management/commands/backpopulate_pipelines.py
+++ b/content_sync/management/commands/backpopulate_pipelines.py
@@ -35,6 +35,13 @@ class Command(BaseCommand):
             default="",
             help="If specified, only process websites that are based on this source",
         )
+        parser.add_argument(
+            "-c",
+            "--create_backends",
+            dest="create_backends",
+            action="store_true",
+            help="Create backends if they do not exist (and sync them too)",
+        )
 
     def handle(self, *args, **options):
 
@@ -49,6 +56,7 @@ class Command(BaseCommand):
         starter_str = options["starter"]
         source_str = options["source"]
         is_verbose = options["verbosity"] > 1
+        create_backends = options["create_backends"]
 
         total_websites = 0
 
@@ -67,6 +75,9 @@ class Command(BaseCommand):
 
         for website in website_qset.iterator():
             backend = get_sync_backend(website)
+            if create_backends:
+                backend.create_website_in_backend()
+                backend.sync_all_content_to_backend()
             if backend.backend_exists():
                 get_sync_pipeline(website).upsert_website_pipeline()
                 total_websites += 1

--- a/content_sync/management/commands/backpopulate_pipelines.py
+++ b/content_sync/management/commands/backpopulate_pipelines.py
@@ -4,7 +4,7 @@ from django.core.management import BaseCommand
 from django.db.models import Q
 from mitol.common.utils.datetime import now_in_utc
 
-from content_sync.api import get_sync_pipeline
+from content_sync.api import get_sync_backend, get_sync_pipeline
 from websites.models import Website
 
 
@@ -66,8 +66,10 @@ class Command(BaseCommand):
             website_qset = website_qset.filter(source=source_str)
 
         for website in website_qset.iterator():
-            get_sync_pipeline(website).upsert_website_pipeline()
-            total_websites += 1
+            backend = get_sync_backend(website)
+            if backend.backend_exists():
+                get_sync_pipeline(website).upsert_website_pipeline()
+                total_websites += 1
 
             if is_verbose:
                 self.stdout.write(f"{website.name} pipeline created or updated")

--- a/content_sync/management/commands/reset_sync_states.py
+++ b/content_sync/management/commands/reset_sync_states.py
@@ -1,0 +1,70 @@
+"""Reset ContentSyncState synced checksums to None"""
+from django.conf import settings
+from django.core.management import BaseCommand
+from django.db.models import Q
+from mitol.common.utils.datetime import now_in_utc
+
+from content_sync.models import ContentSyncState
+from content_sync.tasks import sync_all_websites
+
+
+class Command(BaseCommand):
+    """Reset ContentSyncState synced checksums to None"""
+
+    help = __doc__
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "-t",
+            "--type",
+            dest="type",
+            default="",
+            help="If specified, only process content types that match this filter",
+        )
+        parser.add_argument(
+            "-s",
+            "--sync_backends",
+            dest="sync_backends",
+            action="store_true",
+            help="Sync all course backends",
+        )
+        parser.add_argument(
+            "-c",
+            "--create_backends",
+            dest="create_backends",
+            action="store_true",
+            help="Create backends if they do not exist (and sync them too)",
+        )
+
+    def handle(self, *args, **options):
+
+        self.stdout.write("Resetting synced checksums to null")
+        start = now_in_utc()
+
+        filter_str = options["type"].lower()
+        sync_backends = options["sync_backends"]
+        create_backends = options["create_backends"]
+
+        content_qset = ContentSyncState.objects.exclude(synced_checksum__isnull=True)
+        if filter_str:
+            content_qset = content_qset.filter(Q(content__type=filter_str))
+
+        content_qset.update(synced_checksum=None)
+
+        total_seconds = (now_in_utc() - start).total_seconds()
+        self.stdout.write(
+            "Clearing of content sync state complete, took {} seconds".format(
+                total_seconds
+            )
+        )
+
+        if (sync_backends or create_backends) and settings.CONTENT_SYNC_BACKEND:
+            self.stdout.write("Syncing all courses to the designated backend")
+            start = now_in_utc()
+            task = sync_all_websites.delay(create_backends=create_backends)
+            self.stdout.write(f"Starting task {task}...")
+            task.get()
+            total_seconds = (now_in_utc() - start).total_seconds()
+            self.stdout.write(
+                "Backend sync finished, took {} seconds".format(total_seconds)
+            )

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -73,6 +73,7 @@ def sync_all_websites(create_backends: bool = False):
                         # wait a bit between websites to avoid using up the hourly API rate limit
                         sleep(5)
                 if create_backends or backend.backend_exists():
+                    backend.create_website_in_backend()
                     backend.sync_all_content_to_backend()
             except RateLimitExceededException:
                 # Too late, can't even check rate limit reset time now so bail

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -37,10 +37,10 @@ def sync_content(content_sync_id: str):
 
 
 @app.task(acks_late=True)
-def sync_all_websites():
+def sync_all_websites(create_backends: bool = False):
     """
-    Sync all websites with unsynced content.  This should be rarely called, and only
-    in a management command.
+    Sync all websites with unsynced content if they have existing repos.
+    This should be rarely called, and only in a management command.
     """
     from content_sync.backends.github import (  # pylint:disable=import-outside-toplevel
         GithubBackend,
@@ -72,8 +72,8 @@ def sync_all_websites():
                     else:
                         # wait a bit between websites to avoid using up the hourly API rate limit
                         sleep(5)
-
-                backend.sync_all_content_to_backend()
+                if create_backends or backend.backend_exists():
+                    backend.sync_all_content_to_backend()
             except RateLimitExceededException:
                 # Too late, can't even check rate limit reset time now so bail
                 raise
@@ -139,6 +139,7 @@ def preview_website_backend(website_name: str):
             import_string(action)(website)
 
         backend = api.get_sync_backend(website)
+        backend.sync_all_content_to_backend()
         backend.create_backend_preview()
     except:  # pylint:disable=bare-except
         log.exception("Error previewing site %s", website.name)
@@ -157,6 +158,7 @@ def publish_website_backend(website_name: str):
             import_string(action)(website)
 
         backend = api.get_sync_backend(website)
+        backend.sync_all_content_to_backend()
         backend.create_backend_release()
     except:  # pylint:disable=bare-except
         log.exception("Error publishing site %s", website.name)


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #641
Closes #642 

#### What's this PR do?
- Adds a new `reset_sync_states` management command that will reset `synced_checksum` of all `ContentSyncState` objects to `None` (optionally filtering by type), and optionally resyncing all existing website github repos afterward.
- Syncs a github repo just before publishing or previewing.

#### How should this be manually tested?
- Set up a personal github organization and associated .env vars as described in the README
- In a shell, check the number of `ContentSyncState` objects returned by these queries:
  ```python
  ContentSyncState.objects.filter(content__type="resource").count()
  ContentSyncState.objects.filter(content__type="resource").filter(synced_checksum__isnull=True).count()
  ```
- Run `python manage.py reset_sync_states --type resource` in another terminal
- Run the above queries again, they should both return the same number.
- Run `python manage.py reset_sync_states --type resource --sync_backends` in another terminal.  Any websites that have existing repos in your git organization should be updated.
- Run `python manage.py reset_sync_states --type resource --sync_backends. --create_backends` in another terminal.  Any websites that do not have existing repos in your git organization should have them created (and updated).

