### PR TITLE
serialize type as content_type in Hugo markdown

### DIFF
--- a/content_sync/serializers.py
+++ b/content_sync/serializers.py
@@ -74,7 +74,7 @@ class HugoMarkdownFileSerializer(BaseContentFileSerializer):
             **(website_content.full_metadata or {}),
             "uid": website_content.text_id,
             "title": website_content.title,
-            "type": website_content.type,
+            "content_type": website_content.type,
         }
         # NOTE: yaml.dump adds a newline to the end of its output by default
         return f"---\n{yaml.dump(front_matter)}---\n{website_content.markdown or ''}"
@@ -94,7 +94,7 @@ class HugoMarkdownFileSerializer(BaseContentFileSerializer):
         front_matter_data = yaml.load(md_file_sections[0], Loader=yaml.SafeLoader)
         markdown = md_file_sections[1] if len(md_file_sections) == 2 else None
         text_id = front_matter_data.get("uid", None)
-        content_type = front_matter_data.get("type")
+        content_type = front_matter_data.get("content_type")
         dirpath, filename = get_dirpath_and_filename(
             filepath, expect_file_extension=True
         )

--- a/content_sync/serializers_test.py
+++ b/content_sync/serializers_test.py
@@ -30,7 +30,7 @@ EXAMPLE_UUIDS = [
 
 EXAMPLE_HUGO_MARKDOWN = """---
 title: Example File
-type: page
+content_type: page
 uid: abcdefg
 ---
 # My markdown
@@ -40,7 +40,7 @@ uid: abcdefg
 
 EXAMPLE_HUGO_MARKDOWN_WITH_FILE = """---
 title: Example File
-type: resource
+content_type: resource
 uid: abcdefg
 image: https://test.edu/image.png
 ---
@@ -120,7 +120,7 @@ def test_hugo_file_serialize(markdown, exp_sections):
     assert front_matter_lines == sorted(
         [
             f"title: {content.title}",
-            f"type: {content.type}",
+            f"content_type: {content.type}",
             f"uid: {content.text_id}",
         ]
         + [f"{k}: {v}" for k, v in metadata.items()]


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/638

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/255, we defined how Hugo markdown files would be serialized from `WebsiteContent` objects and vice versa.  We set `type` in the front matter of the produced markdown files to the `type` property on the `WebsiteContent` object, and this had some unintended consequences.  Changes have been made in `ocw-hugo-themes` that support Hugo looking up the layout to use for a given piece of content by the folder it is stored in within the `content` folder.  Hugo calls this the "section."  This PR changes the front matter key that `WebsiteContent.type` is written into from `type` to `content_type`.  This way, it can still be tracked but won't affect Hugo's layout lookup order.

#### How should this be manually tested?
 - Make sure you are set up to test Github syncing of website content.  This is best done by creating your own test Github "organization" and a personal access token that has repo access.  Configure your test org in your `.env` file using the instructions in the readme.  Also, make sure you have the latest version of Hugo installed locally. (https://gohugo.io/getting-started/installing/)
 - Make sure you have the `ocw-course` starter loaded into your local `ocw-studio` instance from https://github.com/mitodl/ocw-hugo-projects/blob/main/ocw-course/ocw-studio.yaml
 - Create a site using the `ocw-course` starter.  Add a page and some resources, go to the metadata section and fill out the bare minimum information (course title, primary course number, department number) and save.  Go to the Menu section and add an internal menu item linking to your page, then publish your site.
 - Inspect the rendered markdown in your test org and verify that the markdown files have `content_type` in the front matter and not `type`
 - Clone `ocw-hugo-themes` (https://github.com/mitodl/ocw-hugo-themes) and if you've never spun up a course site before, run `yarn install` to install dependencies.
 - Clone `ocw-hugo-projects` (https://github.com/mitodl/ocw-hugo-projects)
 - Spin up the webpack dev server by running `npm run start:site:webpack` in `ocw-hugo-themes`
 - Clone your content repo from your test org, and at the root run `hugo server --config /path/to/ocw-hugo-projects/ocw-course/config.yaml --themesDir /path/to/ocw-hugo-themes`
 - Verify that your site is spun up and accessible at http://localhost:1313.  Visit the test page you created and ensure it renders properly.  Then visit the resource pages for your resources by going to http://localhost:1313/resources/<your resource>, replacing the last part with the name of your specific resource.  Verify that the proper type of resource page is rendered for your type of resource and the metadata is displayed.  Note that for documents and images, the actual resource itself will not be displayed but the metadata will be.
 
 #### Screenshots
![image](https://user-images.githubusercontent.com/12089658/136109987-13aba1bb-6f83-4c80-91ad-bb241b7296e7.png)
