### PR TITLE
Use text_id from frontend when creating WebsiteContent

### DIFF
--- a/websites/migrations/0036_fix_sitemetadata_textid.py
+++ b/websites/migrations/0036_fix_sitemetadata_textid.py
@@ -1,0 +1,30 @@
+from django.db import migrations
+
+
+def set_textid_for_sitemetadata(apps, schema_editor):
+    """
+    At this point all text_id with type=sitemetadata should also have text_id=sitemetadata, but there was a bug where
+    WebsiteContent objects were created with a different text_id. This picks the first WebsiteContent arbitrarily
+    and updates it to have text_id=sitemetadata, and deletes the others.
+    """
+    Website = apps.get_model("websites", "Website")
+    for website in Website.objects.all():
+        contents = list(website.websitecontent_set.filter(type="sitemetadata"))
+        if len(contents) == 0:
+            continue
+        for content in contents[1:]:
+            # note that SafeDeleteModel isn't used in migrations so this is a regular delete
+            content.delete()
+
+        contents[0].text_id = "sitemetadata"
+        contents[0].save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("websites", "0035_website_publish"),
+    ]
+
+    operations = [
+        migrations.RunPython(set_textid_for_sitemetadata, migrations.RunPython.noop)
+    ]

--- a/websites/views.py
+++ b/websites/views.py
@@ -349,7 +349,9 @@ def _get_derived_website_content_data(
     request_data: dict, site_config: SiteConfig, website_pk: str
 ) -> dict:
     """Derives values that should be added to the request data if a WebsiteContent object is being created"""
-    added_data = {"text_id": uuid_string()}
+    added_data = {}
+    if "text_id" not in request_data:
+        added_data["text_id"] = uuid_string()
     content_type = request_data.get("type")
     config_item = (
         site_config.find_item_by_name(name=content_type)

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -722,6 +722,33 @@ def test_websites_content_create(drf_client, global_admin_user):
     assert resp.data["text_id"] == str(content.text_id)
 
 
+def test_websites_content_create_with_textid(drf_client, global_admin_user):
+    """If a text_id is added when POSTing to the WebsiteContent, we should use that instead of creating a uuid"""
+    drf_client.force_login(global_admin_user)
+    website = WebsiteFactory.create()
+    payload = {
+        "type": "sitemetadata",
+        "metadata": {
+            "course_title": "a title",
+        },
+        "text_id": "sitemetadata",
+    }
+    resp = drf_client.post(
+        reverse(
+            "websites_content_api-list",
+            kwargs={
+                "parent_lookup_website": website.name,
+            },
+        ),
+        data=payload,
+    )
+    assert resp.status_code == 201
+    content = website.websitecontent_set.get()
+    assert content.type == payload["type"]
+    assert resp.data["text_id"] == str(content.text_id)
+    assert content.text_id == "sitemetadata"
+
+
 @pytest.mark.parametrize(
     "root_url_path, expected_prefix",
     [


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #654 

#### What's this PR do?
I added code in #600 to set the text_id in the view when creating websitecontent so we could use it to create the slug fieldname. However the site metadata is set with a special text_id which is now being overwritten

#### How should this be manually tested?
 - Create a new site with the ocw-course starter
 - Enter some information and save. Refresh the browser. The updated information should show up in the browser.