### PR TITLE
Set site-id metadata during pipeline s3 sync

### DIFF
--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -127,7 +127,6 @@ class ConcourseGithubPipeline(BaseSyncPipeline):
         site_config = SiteConfig(self.website.starter.config)
         site_url = f"{site_config.root_url_path}/{self.website.name}".strip("/")
         base_url = "" if self.website.name == settings.ROOT_WEBSITE_NAME else site_url
-        purge_url = "purge_all" if not base_url else f"purge/{site_url}"
         hugo_projects_url = urljoin(
             f"{starter_path_url.scheme}://{starter_path_url.netloc}",
             f"{'/'.join(starter_path_url.path.strip('/').split('/')[:2])}.git",  # /<org>/<repo>.git
@@ -168,7 +167,7 @@ class ConcourseGithubPipeline(BaseSyncPipeline):
                     .replace("((base-url))", base_url)
                     .replace("((site-url))", site_url)
                     .replace("((site-name))", self.website.name)
-                    .replace("((purge-url))", purge_url)
+                    .replace("((purge-url))", f"purge/{self.website.name}")
                     .replace("((version))", version)
                     .replace("((api-token))", settings.API_BEARER_TOKEN)
                 )

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -160,22 +160,18 @@ def test_upsert_website_pipelines(
             f"s3 sync s3://{settings.AWS_STORAGE_BUCKET_NAME}/{website.name} s3://{bucket}/{website.name}"
             in config_str
         )
-
-        assert f"aws s3 sync course-markdown/public s3://{bucket}/\\\\n" in config_str
-
-        assert "purge_all" in config_str
+        assert f"aws s3 sync course-markdown/public s3://{bucket}/" in config_str
     else:
         assert (
             f"s3 sync s3://{settings.AWS_STORAGE_BUCKET_NAME}/courses/{website.name} s3://{bucket}/courses/{website.name}"
             in config_str
         )
-
         assert (
-            f"aws s3 sync course-markdown/public s3://{bucket}/courses/{website.name}\\\\n"
+            f"aws s3 sync course-markdown/public s3://{bucket}/courses/{website.name}"
             in config_str
         )
-
-        assert f"purge/courses/{website.name}" in config_str
+    assert f"purge/{website.name}" in config_str
+    assert f" --metadata site-id={website.name}" in config_str
     mock_put.assert_any_call(url_path.replace("config", "unpause"))
 
 

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -92,9 +92,9 @@ jobs:
             args:
             - -exc
             - |
-              aws s3 sync course-markdown/public s3://((ocw-bucket))/((base-url))
-              aws s3 sync s3://((ocw-studio-bucket))/((site-url)) s3://((ocw-bucket))/((site-url))
-              if [[ "((base-url))" == "" ]]; then aws s3 sync ocw-hugo-themes/theme/base-theme/dist s3://((ocw-bucket)); fi
+              aws s3 sync course-markdown/public s3://((ocw-bucket))/((base-url)) --metadata site-id=((site-name))
+              aws s3 sync s3://((ocw-studio-bucket))/((site-url)) s3://((ocw-bucket))/((site-url)) --metadata site-id=((site-name))
+              if [[ "((base-url))" == "" ]]; then aws s3 sync ocw-hugo-themes/theme/base-theme/dist s3://((ocw-bucket)) --metadata site-id=((site-name)); fi
         on_failure:
           try:
             put: ocw-studio-webhook


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #658 

#### What's this PR do?
Changes the pipeline definition to add s3 "site-id" metadata to be used for fastly purging.

#### How should this be manually tested?
The site "course-mb-1" on RC has been updated with this new pipeline configuration.  
- Look at 'page 3' of the site as it currently exists first (https://ocw-draft-qa.global.ssl.fastly.net/courses/course-mb-1/pages/page-3/).
- Go to https://ocw-studio-rc.odl.mit.edu/sites/course-mb-1/type/page/ and modify the text on page 3, then click the Publish->Staging/Publish buttons.
- You can check the build process at https://cicd-qa.odl.mit.edu/teams/ocw/pipelines/draft/jobs/build-ocw-site/builds/141?vars.site=%22course-mb-1%22 or add yourself as a collaborator to the site and wait for the email.
- Once publishing is complete, refresh the page 3 link above, you should see your modified text.
