### PR TITLE
Dont instantiate the YouTubeAPI class unless it has something to do

### DIFF
--- a/videos/youtube.py
+++ b/videos/youtube.py
@@ -329,9 +329,12 @@ def update_youtube_metadata(website: Website, privacy=None):
     """ Update YouTube video metadata via the API """
     if not is_youtube_enabled() or not is_ocw_site(website):
         return
-    youtube = YouTubeApi()
     query_id_field = get_dict_query_field("metadata", settings.YT_FIELD_ID)
-    for video_resource in website.websitecontent_set.filter(
+    video_resources = website.websitecontent_set.filter(
         Q(metadata__resourcetype=RESOURCE_TYPE_VIDEO)
-    ).exclude(Q(**{query_id_field: None}) | Q(**{query_id_field: ""})):
+    ).exclude(Q(**{query_id_field: None}) | Q(**{query_id_field: ""}))
+    if video_resources.count() == 0:
+        return
+    youtube = YouTubeApi()
+    for video_resource in video_resources:
         youtube.update_video(video_resource, privacy=privacy)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #650 

#### What's this PR do?
Checks to see if there are any videos to process before calling `YouTubeApi()`

#### How should this be manually tested?
- Populate all the YouTube env values as described in the README but put fake non-null values for the token values.
- Set `PREPUBLISH_ACTIONS=videos.tasks.update_transcripts_for_website,videos.youtube.update_youtube_metadata` in your .env file
- Preview a new/existing site that has video resources with blank youtube id's.  There should be no errors in the log.
- Preview a new/existing site that has video resources with populated youtube id's.  There should be `oauth2client.client.HttpAccessTokenRefreshError` errors in the log.
