### PR TITLE
Update website publish date for singleton content

### DIFF
--- a/static/js/components/SiteContentEditor.test.tsx
+++ b/static/js/components/SiteContentEditor.test.tsx
@@ -66,7 +66,7 @@ describe("SiteContent", () => {
     content: WebsiteContent,
     hideModalStub: SinonStub,
     routeParams: any,
-    refreshStub: SinonStub,
+    fetchWebsiteListingStub: SinonStub,
     successStubs: Record<string, SinonStub>,
     mockContentSchema: FormSchema
 
@@ -84,10 +84,10 @@ describe("SiteContent", () => {
     getContentSchema.mockImplementation(() => mockContentSchema)
     historyPushStub = helper.sandbox.stub()
     hideModalStub = helper.sandbox.stub()
-    refreshStub = helper.sandbox.stub()
+    fetchWebsiteListingStub = helper.sandbox.stub()
     successStubs = {
       hideModal:                  hideModalStub,
-      fetchWebsiteContentListing: refreshStub
+      fetchWebsiteContentListing: fetchWebsiteListingStub
     }
     formikStubs = {
       setErrors:     helper.sandbox.stub(),
@@ -241,6 +241,7 @@ describe("SiteContent", () => {
         // @ts-ignore
         await onSubmit(values, formikStubs)
       })
+      await wrapper.update()
       sinon.assert.calledWith(
         helper.handleRequestStub,
         siteApiContentUrl.param({ name: website.name }).toString(),
@@ -259,7 +260,18 @@ describe("SiteContent", () => {
         }
       )
 
-      sinon.assert.called(refreshStub)
+      sinon.assert.calledWith(
+        helper.handleRequestStub,
+        siteApiDetailUrl.param({ name: website.name }).toString(),
+        "GET",
+        {
+          body:        undefined,
+          headers:     undefined,
+          credentials: undefined
+        }
+      )
+
+      sinon.assert.called(fetchWebsiteListingStub)
       sinon.assert.called(hideModalStub)
       const key = contentDetailKey({
         textId: content.text_id,
@@ -315,7 +327,17 @@ describe("SiteContent", () => {
       }
     )
 
-    sinon.assert.calledWith(refreshStub)
+    sinon.assert.calledWith(
+      helper.handleRequestStub,
+      siteApiDetailUrl.param({ name: website.name }).toString(),
+      "GET",
+      {
+        body:        undefined,
+        headers:     undefined,
+        credentials: undefined
+      }
+    )
+    sinon.assert.calledWith(fetchWebsiteListingStub)
     sinon.assert.calledWith(hideModalStub)
     // @ts-ignore
     expect(store.getState().entities.websiteContentDetails).toStrictEqual({
@@ -464,7 +486,7 @@ describe("SiteContent", () => {
       }
     )
 
-    sinon.assert.notCalled(refreshStub)
+    sinon.assert.notCalled(fetchWebsiteListingStub)
     sinon.assert.notCalled(hideModalStub)
   })
 })

--- a/static/js/components/SiteContentEditor.tsx
+++ b/static/js/components/SiteContentEditor.tsx
@@ -144,9 +144,10 @@ export default function SiteContentEditor(props: Props): JSX.Element | null {
     if (fetchWebsiteContentListing) {
       // refresh to have the new item show up in the listing
       fetchWebsiteContentListing()
-      // and to update the publish status
-      refreshWebsite()
     }
+
+    // update the publish status
+    refreshWebsite()
 
     if (hideModal) {
       // turn off modal on success


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #665 

#### What's this PR do?
Fixes a bug where singleton content like the site metadata wasn't refreshing the website data after update. This PR forces a refresh which causes the flag showing unpublished data to become true, making the publish available.

#### How should this be manually tested?
Go to a course in localhost and publish to staging or production. Click the "Publish" button and the corresponding radio button for staging or production. You should see that it doesn't show a message "You have unpublished changes".

Make a change in the site metadata, and click save. Click publish again and the corresponding radio button. It should now say "You have unpublished changes."
