### PR TITLE
use theme assets from RC for now

### DIFF
--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -10,7 +10,7 @@ resources:
     type: s3
     source:
       bucket: ol-eng-artifacts
-      regexp: ocw-hugo-themes/release/ocw-hugo-themes-(.*).tgz
+      regexp: ocw-hugo-themes/release-candidate/ocw-hugo-themes-(.*).tgz
   - name: course-markdown
     type: git
     source:


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Partially resolves https://github.com/mitodl/ocw-studio/issues/685

#### What's this PR do?
When we set up the Concourse integration, the `release` branch of `ocw-hugo-themes` was hard coded into the pipeline definition.  This PR changes that to `release-candidate` for now so we can test `ocw-hugo-themes` changes using the RC instance of `ocw-studio`.

#### How should this be manually tested?
 - Set your env variables to the same as RC
 - Create a test course and add some basic content and metadata to it, enough to save and publish it
 - Run `docker-compose run web ./manage.py backpopulate_pipelines --filter <site slug>`, replacing `<site slug>` with the test course you just created
 - Click the preview button on your test site
 - Go to https://cicd-qa.odl.mit.edu/?search=team%3A%22ocw%22%20group%3A%22draft%22 and find your pipeline
 - Verify that a build has been triggered and that the first step is pulling the `release-candidate` version of `ocw-hugo-themes` as in the screenshot


#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/137042682-d3251294-ac2a-4eb2-aa1f-05f9dd3edff6.png)
