### PR TITLE
disallow nested tables

### DIFF
--- a/static/js/lib/ckeditor/CKEditor.ts
+++ b/static/js/lib/ckeditor/CKEditor.ts
@@ -19,9 +19,9 @@ import Markdown from "./plugins/Markdown"
 import ResourceEmbed from "./plugins/ResourceEmbed"
 import ResourcePicker from "./plugins/ResourcePicker"
 import { ADD_RESOURCE_EMBED, ADD_RESOURCE_LINK } from "./plugins/constants"
-
 import ResourceLink from "@mitodl/ckeditor5-resource-link/src/link"
 import ResourceLinkMarkdownSyntax from "./plugins/ResourceLinkMarkdownSyntax"
+import DisallowNestedTables from "./plugins/DisallowNestedTables"
 
 export const FullEditorConfig = {
   plugins: [
@@ -45,7 +45,8 @@ export const FullEditorConfig = {
     ResourcePicker,
     ResourceLink,
     ResourceLinkMarkdownSyntax,
-    Markdown
+    Markdown,
+    DisallowNestedTables
   ],
   toolbar: {
     items: [

--- a/static/js/lib/ckeditor/plugins/DisallowNestedTables.ts
+++ b/static/js/lib/ckeditor/plugins/DisallowNestedTables.ts
@@ -1,0 +1,24 @@
+import { editor } from "@ckeditor/ckeditor5-core"
+import {
+  SchemaContext,
+  SchemaCompiledItemDefinition
+} from "@ckeditor/ckeditor5-engine/src/model/schema"
+
+// based on https://ckeditor.com/docs/ckeditor5/latest/features/table.html#disallow-nesting-tables
+export default function DisallowNestedTables(editor: editor.Editor): void {
+  editor.model.schema.addChildCheck(
+    // @ts-ignore
+    (
+      context: SchemaContext,
+      childDefinition: SchemaCompiledItemDefinition
+    ): boolean | undefined => {
+      if (
+        childDefinition.name === "table" &&
+        Array.from(context.getNames()).includes("table")
+      ) {
+        return false
+      }
+      return undefined
+    }
+  )
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #663 

#### What's this PR do?

This adds an [example plugin in the CKEditor docs](https://ckeditor.com/docs/ckeditor5/latest/features/table.html#disallow-nesting-tables) which will disallow putting a table inside of a table.

#### How should this be manually tested?

Add a table in the Markdown editor, and the put your cursor inside of one of hte table cells. Confirm that the table button in the toolbar gets grayed out.

#### Screenshots (if appropriate)

![Screen Shot 2021-10-13 at 9 28 49 AM](https://user-images.githubusercontent.com/6207644/137142152-a666a0b0-18a4-44e2-ac0f-9555f9165a55.png)


#### What GIF best describes this PR or how it makes you feel?
![](https://media.giphy.com/media/uS9epqlhBNQOI/giphy.gif)
