### PR TITLE
Fix bug in create_gdrive_folders

### DIFF
--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -235,7 +235,7 @@ def create_gdrive_folders(website_short_id: str) -> bool:
     query = f"{base_query}name = '{website_short_id}'"
 
     fields = "nextPageToken, files(id, name, parents)"
-    folders = query_files(query=query, fields=fields)
+    folders = list(query_files(query=query, fields=fields))
 
     if settings.DRIVE_UPLOADS_PARENT_FOLDER_ID:
         filtered_folders = []

--- a/gdrive_sync/api_test.py
+++ b/gdrive_sync/api_test.py
@@ -166,13 +166,20 @@ def test_create_gdrive_folders(  # pylint:disable=too-many-locals,too-many-argum
     settings.DRIVE_SHARED_ID = "test_drive"
     settings.DRIVE_UPLOADS_PARENT_FOLDER_ID = parent_folder
 
+    empty_yield = iter([])
     if folder_exists:
         existing_list_response = [{"id": site_folder_id, "parents": ["first_parent"]}]
     else:
         existing_list_response = []
 
     mock_list_files = mocker.patch(
-        "gdrive_sync.api.query_files", side_effect=[existing_list_response, [], [], []]
+        "gdrive_sync.api.query_files",
+        side_effect=[
+            iter(existing_list_response),
+            empty_yield,
+            empty_yield,
+            empty_yield,
+        ],
     )
 
     if parent_folder_in_ancestors:
@@ -357,7 +364,9 @@ def test_walk_gdrive_folder(mocker):
             {"id": "subfolder2b.mp4", "mimeType": "application/pdf"},
         ],
     ]
-    mock_query_files = mocker.patch("gdrive_sync.api.query_files", side_effect=files)
+    mock_query_files = mocker.patch(
+        "gdrive_sync.api.query_files", side_effect=iter(files)
+    )
     assert (list(walk_gdrive_folder("folderId", "field1,field2,field3"))) == [
         item
         for sublist in files


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Fixes #691 

#### What's this PR do?
Fixes a bug in `gdrive_sync.api.create_gdrive_folders` that occurs if `settings.DRIVE_UPLOADS_PARENT_FOLDER_ID` is `None`

#### How should this be manually tested?
- Copy values for `DRIVE_SERVICE_ACCOUNT_CREDS` and `DRIVE_SHARED_ID` from RC, but not `DRIVE_UPLOADS_PARENT_FOLDER_ID` (remove it or set it to nothing)
- Create a new website.  There should be a new folder (and subfolders) created for it at https://drive.google.com/drive/folders/0AErNBMZMmOz3Uk9PVA
