### PR TITLE
fix small UX oddity on website collection items form

### DIFF
--- a/static/js/components/forms/WebsiteCollectionItemForm.test.tsx
+++ b/static/js/components/forms/WebsiteCollectionItemForm.test.tsx
@@ -128,6 +128,9 @@ describe("WebsiteCollectionItemForm", () => {
     expect(wrapper.find("SelectField").prop("options")).toEqual(
       expectedCombinedOptions
     )
+    expect(wrapper.find("SelectField").prop("defaultOptions")).toEqual(
+      expectedCombinedOptions
+    )
     for (const search of ["searchstring1", "searchstring2"]) {
       expect(debouncedFetch).toBeCalledWith(
         "website-collection",

--- a/static/js/components/forms/WebsiteCollectionItemForm.tsx
+++ b/static/js/components/forms/WebsiteCollectionItemForm.tsx
@@ -87,6 +87,7 @@ export default function WebsiteCollectionItemForm(props: Props): JSX.Element {
               as={SelectField}
               loadOptions={loadOptions}
               placeholder="Find a course to add to this collection"
+              defaultOptions={options}
             />
             <button
               type="submit"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

closes #707

#### What's this PR do?

I noticed that our AsyncSelect on the website collection item form wasn't behaving as I thought it should. This tweak makes sure that `defaultOptions` are set so that clicking into the field does show some options.

#### How should this be manually tested?

Go read the issue, make sure you can repro that behavior on `master`. Then confirm this makes it a bit more natural.