### PR TITLE
add .eslintcache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+.eslintcache
 nosetests.xml
 coverage.xml
 *,cover


### PR DESCRIPTION
just a little tweak to the `.gitignore` file, adding `.eslintcache`. This file is written by eslint if you use the `--cache` option (which we're using w/ `lint:cache`).