### PR TITLE
add 'sortable' option to the Relation field

### DIFF
--- a/localdev/configs/omnibus-site-config.yml
+++ b/localdev/configs/omnibus-site-config.yml
@@ -40,6 +40,23 @@ collections:
           - { label: "State", name: "state", widget: "string", required: false }
           - { label: "Zip Code", name: "zip", widget: "string", required: false }
 
+  - category: Content
+    folder: content/video_galleries
+    label: "Video Gallery"
+    name: video_gallery
+    fields:
+      - label: Videos
+        name: videos
+        widget: relation
+        multiple: true
+        collection: resource
+        display_field: title
+        sortable: true
+        filter:
+          field: "resourcetype"
+          filter_type: "equals"
+          value: "Video"
+
   - name: resource
     label: Resources
     label_singular: Resource
@@ -56,6 +73,15 @@ collections:
         "options": [ "PDF", "Word Doc", "PPT" ],
         "widget": "select"
         }
+      - label: Resource Type
+        name: resourcetype
+        required: true
+        widget: select
+        options:
+          - Image
+          - Video
+          - Document
+          - Other
 
   - name: metadata
     label: Metadata

--- a/static/js/components/SortWrapper.tsx
+++ b/static/js/components/SortWrapper.tsx
@@ -1,0 +1,48 @@
+import React from "react"
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent
+} from "@dnd-kit/core"
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy
+} from "@dnd-kit/sortable"
+
+interface Props<T> {
+  children: React.ReactNode
+  handleDragEnd: (event: DragEndEvent) => void
+  items: T[]
+  generateItemUUID: (item: T) => string
+}
+
+export default function Sortable<T>(props: Props<T>): JSX.Element {
+  const { children, handleDragEnd, items, generateItemUUID } = props
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates
+    })
+  )
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      onDragEnd={handleDragEnd}
+    >
+      <SortableContext
+        items={items.map(generateItemUUID)}
+        strategy={verticalListSortingStrategy}
+      >
+        {children}
+      </SortableContext>
+    </DndContext>
+  )
+}

--- a/static/js/components/SortableItem.test.tsx
+++ b/static/js/components/SortableItem.test.tsx
@@ -1,19 +1,20 @@
 import React from "react"
 import { shallow } from "enzyme"
 
-import SortableWebsiteCollectionItem from "./SortableWebsiteCollectionItem"
+import SortableItem from "./SortableItem"
 import { WebsiteCollectionItem } from "../types/website_collections"
 import { makeWebsiteCollectionItem } from "../util/factories/website_collections"
 
-describe("SortableWebsiteCollectionItem", () => {
+describe("SortableItem", () => {
   let item: WebsiteCollectionItem, deleteStub: jest.Mock<any, any>
 
   const renderItem = () =>
     shallow(
-      <SortableWebsiteCollectionItem
+      <SortableItem
         deleteItem={deleteStub}
         item={item}
-        id={String(item.id)}
+        id="item-id"
+        title="A TITLE"
       />
     )
 
@@ -30,7 +31,7 @@ describe("SortableWebsiteCollectionItem", () => {
         .at(0)
         .text()
     ).toBe("drag_indicator")
-    expect(wrapper.find(".title").text()).toBe(item.website_title)
+    expect(wrapper.find(".title").text()).toBe("A TITLE")
   })
 
   it("should include a delete button", () => {

--- a/static/js/components/SortableItem.tsx
+++ b/static/js/components/SortableItem.tsx
@@ -2,18 +2,15 @@ import React, { useCallback } from "react"
 import { useSortable } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
 
-import { WebsiteCollectionItem } from "../types/website_collections"
-
-interface Props {
-  item: WebsiteCollectionItem
+interface Props<T> {
+  item: T
   id: string
-  deleteItem: (item: WebsiteCollectionItem) => void
+  deleteItem: (item: T) => void
+  title: string
 }
 
-export default function SortableWebsiteCollectionItem(
-  props: Props
-): JSX.Element {
-  const { item, deleteItem } = props
+export default function SortableItem<T>(props: Props<T>): JSX.Element {
+  const { item, deleteItem, id, title } = props
 
   const {
     attributes,
@@ -22,7 +19,7 @@ export default function SortableWebsiteCollectionItem(
     transform,
     transition
   } = useSortable({
-    id: String(item.id)
+    id
   })
 
   const style = {
@@ -44,7 +41,7 @@ export default function SortableWebsiteCollectionItem(
       {...listeners}
     >
       <span className="material-icons">drag_indicator</span>
-      <div className="title">{item.website_title}</div>
+      <div className="title">{title}</div>
       <span
         className="material-icons ml-auto gray-button hover"
         onClick={deleteItemCB}

--- a/static/js/components/WebsiteCollectionItemsEditor.test.tsx
+++ b/static/js/components/WebsiteCollectionItemsEditor.test.tsx
@@ -44,11 +44,9 @@ describe("WebsiteCollectionItemsEditor", () => {
 
   it("should render, show items", async () => {
     const { wrapper } = await render()
-    expect(
-      wrapper
-        .find("SortableWebsiteCollectionItem")
-        .map(item => item.prop("item"))
-    ).toEqual(items)
+    expect(wrapper.find("SortableItem").map(item => item.prop("item"))).toEqual(
+      items
+    )
   })
 
   it("should render the WebsiteCollectionItemForm", async () => {
@@ -124,7 +122,7 @@ describe("WebsiteCollectionItemsEditor", () => {
     act(() => {
       // @ts-ignore
       wrapper
-        .find("SortableWebsiteCollectionItem")
+        .find("SortableItem")
         .at(0)
         .prop("deleteItem")(item)
     })

--- a/static/js/components/forms/WebsiteCollectionItemForm.tsx
+++ b/static/js/components/forms/WebsiteCollectionItemForm.tsx
@@ -16,7 +16,7 @@ interface Props {
   websiteCollection: WebsiteCollection
 }
 
-const formatOptions = (websites: Website[]) =>
+const formatOptions = (websites: Website[]): Option[] =>
   websites.map(website => ({ label: website.title, value: website.uuid }))
 
 export default function WebsiteCollectionItemForm(props: Props): JSX.Element {

--- a/static/js/components/widgets/RelationField.tsx
+++ b/static/js/components/widgets/RelationField.tsx
@@ -1,11 +1,16 @@
-import React, { useState, useCallback, useEffect } from "react"
-import { equals, curry } from "ramda"
+import React, {
+  useState,
+  useCallback,
+  useEffect,
+  SyntheticEvent,
+  ChangeEvent
+} from "react"
+import { equals, without } from "ramda"
 import { uniqBy } from "lodash"
 
 import SelectField, { Option } from "./SelectField"
 import { debouncedFetch } from "../../lib/api/util"
 import { useWebsite } from "../../context/Website"
-
 import {
   RelationFilter,
   RelationFilterVariant,
@@ -13,31 +18,37 @@ import {
 } from "../../types/websites"
 import { siteApiContentListingUrl } from "../../lib/urls"
 import { PaginatedResponse } from "../../query-configs/utils"
+import { DragEndEvent } from "@dnd-kit/core"
+import { arrayMove } from "@dnd-kit/sortable"
+import SortableItem from "../SortableItem"
+import SortWrapper from "../SortWrapper"
 
-type Props = {
+interface Props {
   name: string
   collection?: string | string[]
   display_field: string // eslint-disable-line camelcase
   multiple: boolean
-  value: any
+  value: string | string[]
   filter?: RelationFilter
   website?: string
   valuesToOmit?: Set<string>
+  sortable?: boolean
   contentContext: WebsiteContent[] | null
   onChange: (event: any) => void
 }
 
-const filterContent = curry((filter: RelationFilter, entry: WebsiteContent) => {
-  if (!filter) {
-    return entry
-  }
-
-  if (filter.filter_type === RelationFilterVariant.Equals) {
-    return equals(entry[filter.field], filter.value)
-  }
-
-  return entry
-})
+/**
+ * Turn a list of WebsiteContent objects into a list of Options, suitable
+ * for use in a SelectField.
+ */
+const formatOptions = (
+  listing: WebsiteContent[],
+  display_field: string // eslint-disable-line camelcase
+): Option[] =>
+  listing.map(entry => ({
+    label: entry[display_field],
+    value: entry.text_id
+  }))
 
 export default function RelationField(props: Props): JSX.Element {
   const {
@@ -49,22 +60,21 @@ export default function RelationField(props: Props): JSX.Element {
     value,
     filter,
     valuesToOmit,
-    onChange
+    onChange,
+    sortable
   } = props
 
-  const formatOptions = useCallback(
-    (listing: WebsiteContent[]) =>
-      listing.map(entry => ({
-        label: entry[display_field],
-        value: entry.text_id
-      })),
-    [display_field] // eslint-disable-line camelcase
-  )
-
   const [options, setOptions] = useState<Option[]>(
-    contentContext ? formatOptions(contentContext) : []
+    contentContext ? formatOptions(contentContext, display_field) : []
   )
   const [defaultOptions, setDefaultOptions] = useState<Option[]>([])
+  const [contentMap, setContentMap] = useState<Map<string, WebsiteContent>>(
+    new Map()
+  )
+
+  const [focusedContent, setFocusedContent] = useState<string | undefined>(
+    undefined
+  )
 
   const contextWebsite = useWebsite()
 
@@ -72,92 +82,103 @@ export default function RelationField(props: Props): JSX.Element {
   // website, else we want to use the cursor to fetch the specified website
   const websiteName = props.website ? props.website : contextWebsite.name
 
-  const handleChange = useCallback(
-    (event: any) => {
-      // When we run renameNestedFields we add a '.content' suffix to the name of the field for RelationField
-      // because the data structure looks like this: { content, website }
-      // where 'content' is either a string or a list of strings.
-      // Validation by yup is easier to work with when the field name ends with .content because
-      // formik validates the value of 'content' instead of '{ content, website }'.
-      // But while that's easier for validation, we still need to send the whole object.
-      // So we need to remove that .content suffix and also add back 'website' when onChange is called.
-      const updatedEvent = {
-        target: {
-          name:  event.target.name.replace(/\.content$/, ""),
-          value: {
-            website: websiteName,
-            content: event.target.value
+  const filterContentListing = useCallback(
+    (results: WebsiteContent[]) => {
+      const valueAsSet = new Set(Array.isArray(value) ? value : [value])
+
+      return results
+        .map(entry => ({
+          ...entry,
+          ...entry.metadata
+        }))
+        .filter(entry => {
+          if (!filter) {
+            return true
           }
-        }
-      }
-      onChange(updatedEvent)
+          switch (filter.filter_type) {
+          case RelationFilterVariant.Equals:
+            return equals(entry[filter.field], filter.value)
+          default:
+            return true
+          }
+        })
+        .filter(entry => {
+          if (!valuesToOmit) {
+            return true
+          } else {
+            // we want to exclude all content which is in the `valuesToOmit`
+            // OR which is already selected (i.e. can be found in the
+            // set `valueAsSet`)
+            return (
+              !valuesToOmit.has(entry.text_id) || valueAsSet.has(entry.text_id)
+            )
+          }
+        })
     },
-    [onChange, websiteName]
+    [filter, value, valuesToOmit]
   )
 
-  const filterContentListing = (results: WebsiteContent[]) => {
-    let newContentListing = results.map((entry: any) => ({
-      ...entry,
-      ...entry.metadata
-    }))
-    if (filter) {
-      newContentListing = newContentListing.filter(filterContent(filter))
-    }
-    if (valuesToOmit) {
-      const valueAsSet = Array.isArray(value) ?
-        new Set(value) :
-        new Set([value])
-      newContentListing = newContentListing.filter(
-        entry =>
-          !valuesToOmit.has(entry.text_id) || valueAsSet.has(entry.text_id)
-      )
-    }
-    return newContentListing
-  }
+  const fetchOptions = useCallback(
+    async (search: string | null, debounce: boolean) => {
+      const params = collection ? { type: collection } : { page_content: true }
+      const url = siteApiContentListingUrl
+        .query({
+          detailed_list:   true,
+          content_context: true,
+          ...(search ? { search: search } : {}),
+          ...params
+        })
+        .param({ name: websiteName })
+        .toString()
 
-  const fetchOptions = async (search: string | null, debounce: boolean) => {
-    const params = collection ? { type: collection } : { page_content: true }
-    const url = siteApiContentListingUrl
-      .query({
-        detailed_list:   true,
-        content_context: true,
-        ...(search ? { search: search } : {}),
-        ...params
+      const response = debounce ?
+        await debouncedFetch("relationfield", 300, url, {
+          credentials: "include"
+        }) :
+        await fetch(url, { credentials: "include" })
+
+      if (!response) {
+        // duplicate, another later instance of loadOptions will handle this instead
+        return
+      }
+      const json: PaginatedResponse<WebsiteContent> = await response.json()
+      const { results } = json
+      setContentMap(cur => {
+        const newMap = new Map(cur)
+        results.forEach(content => {
+          newMap.set(content.text_id, content)
+        })
+        return newMap
       })
-      .param({ name: websiteName })
-      .toString()
+      return formatOptions(filterContentListing(results), display_field)
+    },
+    // eslint-disable-next-line camelcase
+    [filterContentListing, websiteName, display_field, collection]
+  )
 
-    const response = debounce ?
-      await debouncedFetch("relationfield", 300, url, {
-        credentials: "include"
-      }) :
-      await fetch(url, { credentials: "include" })
-
-    if (!response) {
-      // duplicate, another later instance of loadOptions will handle this instead
-      return
-    }
-    const json: PaginatedResponse<WebsiteContent> = await response.json()
-    const { results } = json
-    return formatOptions(filterContentListing(results))
-  }
-
-  const loadOptions = async (inputValue: string) => {
-    const newOptions = await fetchOptions(inputValue, true)
-    if (newOptions) {
-      setOptions(oldOptions => uniqBy([...oldOptions, ...newOptions], "value"))
-    }
-    return newOptions
-  }
+  const loadOptions = useCallback(
+    async (inputValue: string) => {
+      const newOptions = await fetchOptions(inputValue, true)
+      if (newOptions) {
+        setOptions(oldOptions =>
+          uniqBy([...oldOptions, ...newOptions], "value")
+        )
+      }
+      return newOptions
+    },
+    [fetchOptions, setOptions]
+  )
 
   useEffect(() => {
-    // trigger a fetch to get default options for the user to view when they open the dropdown
+    // trigger a fetch to get default options for the user to view when they
+    // open the dropdown
     let mounted = true
     const doFetch = async () => {
       const defaultOptions = await fetchOptions(null, false)
 
       // working around a warning where a setter was used after unmounting
-      // defaultOptions should always be true here since fetchOptions will only ever return null if debounce=true
+      // defaultOptions should always be true here since fetchOptions will only ever
+      // return null if debounce=true
       if (mounted && defaultOptions) {
         setOptions(oldOptions =>
           uniqBy([...oldOptions, ...defaultOptions], "value")
@@ -171,7 +192,142 @@ export default function RelationField(props: Props): JSX.Element {
     }
   }, []) // eslint-disable-line react-hooks/exhaustive-deps
 
-  return (
+  /**
+   * A shim which takes a string or array of strings (the value) and then
+   * constructs a fake event and passed that to the onChange function. The shim
+   * is needed because the onChange function passed in to these components is
+   * typically generated automatically by Formik, so we don't have control over
+   * it per se.
+   */
+  const onChangeShim = useCallback(
+    (value: string | string[]) => {
+      // When we run renameNestedFields we add a '.content' suffix to the name
+      // of the field for RelationField because the data structure looks like
+      // this: { content, website } where 'content' is either a string or a
+      // list of strings.  Validation by yup is easier to work with when the
+      // field name ends with .content because formik validates the value of
+      // 'content' instead of '{ content, website }'.  But while that's easier
+      // for validation, we still need to send the whole object.  So we need to
+      // remove that .content suffix and also add back 'website' when onChange
+      // is called.
+      const updatedEvent = {
+        target: {
+          name:  name.replace(/\.content$/, ""),
+          value: {
+            website: websiteName,
+            content: value
+          }
+        }
+      }
+      onChange(updatedEvent)
+    },
+    [onChange, name, websiteName]
+  )
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      onChangeShim(event.target.value)
+    },
+    [onChangeShim]
+  )
+
+  /**
+   * This callback is only used for the SelectField that
+   * we present as an 'add' interface when this component
+   * is displayin the sortable mode.
+   */
+  const handleAddSortableItem = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      setFocusedContent(event.target.value)
+    },
+    [setFocusedContent]
+  )
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event
+
+      if (over && active.id !== over.id) {
+        onChangeShim(
+          arrayMove(
+            value as string[],
+            value.indexOf(active.id),
+            value.indexOf(over.id)
+          )
+        )
+      }
+    },
+    [onChangeShim, value]
+  )
+
+  /**
+   * For removing an item in the sortable UI
+   */
+  const deleteItem = useCallback(
+    (item: string) => {
+      onChangeShim(without([item], value as string[]))
+    },
+    [onChangeShim, value]
+  )
+
+  /**
+   * Callback for adding a new item to the field value in the sortable UI. If
+   * there is an item 'focused' in the UI (i.e. the user has selected it in the
+   * SelectField) then we add that to the current value and call the change
+   * shim.
+   */
+  const addFocusedItem = useCallback(
+    (event: SyntheticEvent<HTMLButtonElement>) => {
+      event.preventDefault()
+
+      if (focusedContent) {
+        onChangeShim(value.concat(focusedContent))
+        setFocusedContent(undefined)
+      }
+    },
+    [focusedContent, setFocusedContent, onChangeShim, value]
+  )
+
+  return sortable && multiple ? (
+    <>
+      <div className="d-flex">
+        <SelectField
+          name={name}
+          value={focusedContent}
+          onChange={handleAddSortableItem}
+          options={options}
+          loadOptions={loadOptions}
+          defaultOptions={defaultOptions}
+        />
+        <button
+          className="px-4 ml-3 btn cyan-button"
+          disabled={focusedContent === undefined}
+          onClick={addFocusedItem}
+        >
+          Add
+        </button>
+      </div>
+      <SortWrapper
+        handleDragEnd={handleDragEnd}
+        items={(value as string[]) ?? []}
+        generateItemUUID={x => x}
+      >
+        {((value as string[]) ?? []).map(textId => {
+          const content = contentMap.get(textId)
+
+          return (
+            <SortableItem
+              key={textId}
+              title={content ? (content.title as string) : textId}
+              id={textId}
+              item={textId}
+              deleteItem={deleteItem}
+            />
+          )
+        })}
+      </SortWrapper>
+    </>
+  ) : (
     <SelectField
       name={name}
       value={value}

--- a/static/js/lib/api/util.ts
+++ b/static/js/lib/api/util.ts
@@ -53,6 +53,12 @@ export const sharedWait = async (
   resolve()
 }
 
+/**
+ * A debounced fetch function which will make the specified request only if it
+ * is not called again for `delayMillis` ms.
+ *
+ * Especially useful for typeahead option fetching!
+ */
 export const debouncedFetch = async (
   key: string,
   delayMillis: number,

--- a/static/js/lib/site_content.ts
+++ b/static/js/lib/site_content.ts
@@ -67,7 +67,8 @@ const RELATION_EXTRA_PROPS = [
   "min",
   "multiple",
   "filter",
-  "website"
+  "website",
+  "sortable"
 ]
 const MENU_EXTRA_PROPS = ["collections"]
 const HIERARCHICAL_SELECT_EXTRA_PROPS = ["options_map", "levels"]

--- a/static/js/resources/omnibus-site-config.json
+++ b/static/js/resources/omnibus-site-config.json
@@ -87,6 +87,28 @@
       "category": "Content",
       "fields": [
         {
+          "collection": "resource",
+          "display_field": "title",
+          "filter": {
+            "field": "resourcetype",
+            "filter_type": "equals",
+            "value": "Video"
+          },
+          "label": "Videos",
+          "multiple": true,
+          "name": "videos",
+          "sortable": true,
+          "widget": "relation"
+        }
+      ],
+      "folder": "content/video_galleries",
+      "label": "Video Gallery",
+      "name": "video_gallery"
+    },
+    {
+      "category": "Content",
+      "fields": [
+        {
           "label": "Title",
           "name": "title",
           "required": true,
@@ -109,6 +131,18 @@
             "PDF",
             "Word Doc",
             "PPT"
+          ],
+          "required": true,
+          "widget": "select"
+        },
+        {
+          "label": "Resource Type",
+          "name": "resourcetype",
+          "options": [
+            "Image",
+            "Video",
+            "Document",
+            "Other"
           ],
           "required": true,
           "widget": "select"

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -116,6 +116,7 @@ export interface RelationConfigField extends ConfigFieldBaseProps {
   max?: number
   filter?: RelationFilter
   website?: string
+  sortable?: boolean
 }
 
 export interface MenuConfigField extends ConfigFieldBaseProps {

--- a/websites/config_schema/site-config-schema.yml
+++ b/websites/config_schema/site-config-schema.yml
@@ -40,6 +40,7 @@ field:
     website: str(required=False)
     attach: str(required=False)
     levels: list(include('level'), required=False)
+    sortable: bool(required=False)
 ---
 field_condition:
     field: str()


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #687 

#### What's this PR do?

This adds a new option to the 'relation' field which is `sortable`. If `sortable === true` then instead of using a normal react-select multiselect input element, we show a more complicated UI with two elements: 1) a single-select which adds like an 'add' input for selecting new pieces of content, and 2) a 'reordering' area which uses a drag-and-drop UI to allow the user to freely reorder the elements already selected.

#### How should this be manually tested?

I added a 'Video Gallery' content item to the omnibus config, so you can use that to test out how it works. You'll need to create some resources first and then, once you have those, you should be able to create a video gallery and try out the reorderable select there.

#### screens


![Screen Shot 2021-10-19 at 2 08 16 PM](https://user-images.githubusercontent.com/6207644/137966646-dd8fd0b0-74bc-48ca-b9b4-a6be9e4aec38.png)
![Screen Shot 2021-10-19 at 2 08 25 PM](https://user-images.githubusercontent.com/6207644/137966651-331bd5a5-84a9-4dbc-9e79-e9bc64532f49.png)
![Screen Shot 2021-10-19 at 2 08 30 PM](https://user-images.githubusercontent.com/6207644/137966652-e0c72e22-8905-45fa-85c8-c1e68f41c20f.png)
![Screen Shot 2021-10-19 at 2 08 36 PM](https://user-images.githubusercontent.com/6207644/137966655-8713d8aa-a99f-4157-abc0-f997733107be.png)
![Screen Shot 2021-10-19 at 2 08 44 PM](https://user-images.githubusercontent.com/6207644/137966658-c3176c5d-1f3c-4b9b-a11f-5fc26bc9d23c.png)
