### PR TITLE
Open publish site links in new tab

### DIFF
--- a/static/js/components/PublishDrawer.test.tsx
+++ b/static/js/components/PublishDrawer.test.tsx
@@ -118,6 +118,9 @@ describe("PublishDrawer", () => {
           expect(
             wrapper.find(".publish-option-description a").prop("href")
           ).toBe(website[urlField])
+          expect(
+            wrapper.find(".publish-option-description a").prop("target")
+          ).toBe("_blank")
           expect(wrapper.find(".publish-option-description a").text()).toBe(
             website[urlField]
           )

--- a/static/js/components/PublishDrawer.tsx
+++ b/static/js/components/PublishDrawer.tsx
@@ -95,7 +95,9 @@ export default function PublishDrawer(props: Props): JSX.Element {
         </div>
         {publishOption === option ? (
           <div className="publish-option-description">
-            <a href={siteUrl}>{siteUrl}</a>
+            <a href={siteUrl} target="_blank" rel="noreferrer">
+              {siteUrl}
+            </a>
             <br />
             Last updated:{" "}
             {publishDate ?


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Fixes #728 

#### What's this PR do?
Adds a `target=_blank` to the publish site links

#### How should this be manually tested?
Go to a site and click Publish to open the drawer. Click one of the links under either staging or production, and it should open in a new tab
