### PR TITLE
switch over to the `mockRequest` functions in some test files

### DIFF
--- a/static/js/components/PublishDrawer.test.tsx
+++ b/static/js/components/PublishDrawer.test.tsx
@@ -26,9 +26,10 @@ describe("PublishDrawer", () => {
       has_unpublished_live:  true,
       is_admin:              true
     }
-    refreshWebsiteStub = helper.handleRequestStub
-      .withArgs(siteApiDetailUrl.param({ name: website.name }).toString())
-      .returns({ body: website, status: 200 })
+    refreshWebsiteStub = helper.mockGetRequest(
+      siteApiDetailUrl.param({ name: website.name }).toString(),
+      website
+    )
     render = helper.configureRenderer(
       PublishDrawer,
       {
@@ -199,18 +200,16 @@ describe("PublishDrawer", () => {
         })
 
         it("renders an error message if the publish didn't work", async () => {
-          const actionStub = helper.handleRequestStub
-            .withArgs(
-              siteApiActionUrl
-                .param({
-                  name:   website.name,
-                  action: api
-                })
-                .toString()
-            )
-            .returns({
-              status: 500
-            })
+          const actionStub = helper.mockPostRequest(
+            siteApiActionUrl
+              .param({
+                name:   website.name,
+                action: api
+              })
+              .toString(),
+            {},
+            500
+          )
           const { wrapper } = await render()
           await act(async () => {
             // @ts-ignore
@@ -240,18 +239,15 @@ describe("PublishDrawer", () => {
         })
 
         it("publish button sends the expected request", async () => {
-          const actionStub = helper.handleRequestStub
-            .withArgs(
-              siteApiActionUrl
-                .param({
-                  name:   website.name,
-                  action: api
-                })
-                .toString()
-            )
-            .returns({
-              status: 200
-            })
+          const actionStub = helper.mockPostRequest(
+            siteApiActionUrl
+              .param({
+                name:   website.name,
+                action: api
+              })
+              .toString(),
+            {}
+          )
           const { wrapper } = await render()
           await act(async () => {
             // @ts-ignore

--- a/static/js/components/RepeatableContentListing.test.tsx
+++ b/static/js/components/RepeatableContentListing.test.tsx
@@ -84,20 +84,15 @@ describe("RepeatableContentListing", () => {
         results: apiResponse.results.map(item => item.text_id)
       }
     }
-    helper.handleRequestStub
-      .withArgs(
-        siteApiContentListingUrl
-          .param({
-            name: website.name
-          })
-          .query({ offset: 0, type: configItem.name })
-          .toString(),
-        "GET"
-      )
-      .returns({
-        body:   apiResponse,
-        status: 200
-      })
+    helper.mockGetRequest(
+      siteApiContentListingUrl
+        .param({
+          name: website.name
+        })
+        .query({ offset: 0, type: configItem.name })
+        .toString(),
+      apiResponse
+    )
 
     render = helper.configureRenderer(
       props => (
@@ -156,19 +151,15 @@ describe("RepeatableContentListing", () => {
     [500, "Something went wrong syncing with Google Drive"]
   ].forEach(([status, message]) => {
     it("Clicking the gdrive sync button should open a feedback modal", async () => {
-      helper.handleRequestStub
-        .withArgs(
-          siteApiContentSyncGDriveUrl
-            .param({
-              name: website.name
-            })
-            .toString(),
-          "POST"
-        )
-        .returns({
-          body:   {},
-          status: status
-        })
+      helper.mockPostRequest(
+        siteApiContentSyncGDriveUrl
+          .param({
+            name: website.name
+          })
+          .toString(),
+        {},
+        status as number
+      )
       SETTINGS.gdrive_enabled = true
       const { wrapper } = await render()
       const syncLink = wrapper.find("button.sync")
@@ -221,17 +212,12 @@ describe("RepeatableContentListing", () => {
   it("should show each content item with edit links", async () => {
     for (const item of contentListingItems) {
       // when the edit button is tapped the detail view is requested, so mock each one out
-      helper.handleRequestStub
-        .withArgs(
-          siteApiContentDetailUrl
-            .param({ name: website.name, textId: item.text_id })
-            .toString(),
-          "GET"
-        )
-        .returns({
-          body:   item,
-          status: 200
-        })
+      helper.mockGetRequest(
+        siteApiContentDetailUrl
+          .param({ name: website.name, textId: item.text_id })
+          .toString(),
+        item
+      )
     }
 
     const { wrapper } = await render()
@@ -288,23 +274,18 @@ describe("RepeatableContentListing", () => {
           makeWebsiteContentListItem(),
           makeWebsiteContentListItem()
         ]
-        helper.handleRequestStub
-          .withArgs(
-            siteApiContentListingUrl
-              .param({ name: website.name })
-              .query({ offset: startingOffset, type: configItem.name })
-              .toString(),
-            "GET"
-          )
-          .returns({
-            body: {
-              next:     hasNextLink ? "next" : null,
-              previous: hasPrevLink ? "prev" : null,
-              count:    2,
-              results:  nextPageItems
-            },
-            status: 200
-          })
+        helper.mockGetRequest(
+          siteApiContentListingUrl
+            .param({ name: website.name })
+            .query({ offset: startingOffset, type: configItem.name })
+            .toString(),
+          {
+            next:     hasNextLink ? "next" : null,
+            previous: hasPrevLink ? "prev" : null,
+            count:    2,
+            results:  nextPageItems
+          }
+        )
 
         helper.browserHistory.push({ search: `offset=${startingOffset}` })
 

--- a/static/js/components/SiteCollaboratorDrawer.test.tsx
+++ b/static/js/components/SiteCollaboratorDrawer.test.tsx
@@ -79,20 +79,16 @@ describe("SiteCollaboratorDrawerTest", () => {
     })
 
     it("edits a collaborator role and closes the dialog on success", async () => {
-      editCollaboratorStub = helper.handleRequestStub
-        .withArgs(
-          siteApiCollaboratorsDetailUrl
-            .param({
-              name:   website.name,
-              userId: collaborator.user_id
-            })
-            .toString(),
-          "PATCH"
-        )
-        .returns({
-          body:   collaborator,
-          status: 201
-        })
+      editCollaboratorStub = helper.mockPatchRequest(
+        siteApiCollaboratorsDetailUrl
+          .param({
+            name:   website.name,
+            userId: collaborator.user_id
+          })
+          .toString(),
+        collaborator,
+        201
+      )
       const { wrapper } = await render({ collaborator })
       const form = wrapper.find("SiteCollaboratorForm")
       const onSubmit = form.prop("onSubmit")
@@ -117,21 +113,16 @@ describe("SiteCollaboratorDrawerTest", () => {
           role: errorMsg
         }
       }
-      editCollaboratorStub = helper.handleRequestStub
-        .withArgs(
-          siteApiCollaboratorsDetailUrl
-            .param({
-              name:   website.name,
-              userId: collaborator.user_id
-            })
-            .toString(),
-
-          "PATCH"
-        )
-        .returns({
-          body:   errorResp,
-          status: 400
-        })
+      editCollaboratorStub = helper.mockPatchRequest(
+        siteApiCollaboratorsDetailUrl
+          .param({
+            name:   website.name,
+            userId: collaborator.user_id
+          })
+          .toString(),
+        errorResp,
+        400
+      )
       const { wrapper } = await render({ collaborator })
       const form = wrapper.find("SiteCollaboratorForm")
       const onSubmit = form.prop("onSubmit")
@@ -156,20 +147,16 @@ describe("SiteCollaboratorDrawerTest", () => {
       const errorResp = {
         errors: errorMsg
       }
-      editCollaboratorStub = helper.handleRequestStub
-        .withArgs(
-          siteApiCollaboratorsDetailUrl
-            .param({
-              name:   website.name,
-              userId: collaborator.user_id
-            })
-            .toString(),
-          "PATCH"
-        )
-        .returns({
-          body:   errorResp,
-          status: 400
-        })
+      editCollaboratorStub = helper.mockPatchRequest(
+        siteApiCollaboratorsDetailUrl
+          .param({
+            name:   website.name,
+            userId: collaborator.user_id
+          })
+          .toString(),
+        errorResp,
+        400
+      )
       const { wrapper } = await render({ collaborator })
       const form = wrapper.find("SiteCollaboratorForm")
       const onSubmit = form.prop("onSubmit")
@@ -197,15 +184,10 @@ describe("SiteCollaboratorDrawerTest", () => {
     })
 
     it("creates a new collaborator", async () => {
-      addCollaboratorStub = helper.handleRequestStub
-        .withArgs(
-          siteApiCollaboratorsUrl.param({ name: website.name }).toString(),
-          "POST"
-        )
-        .returns({
-          body:   makeWebsiteCollaborator(),
-          status: 201
-        })
+      addCollaboratorStub = helper.mockPostRequest(
+        siteApiCollaboratorsUrl.param({ name: website.name }).toString(),
+        makeWebsiteCollaborator()
+      )
       const { wrapper } = await render()
       const form = wrapper.find("SiteCollaboratorForm")
       const onSubmit = form.prop("onSubmit")
@@ -232,15 +214,11 @@ describe("SiteCollaboratorDrawerTest", () => {
           role:  errorMsg
         }
       }
-      addCollaboratorStub = helper.handleRequestStub
-        .withArgs(
-          siteApiCollaboratorsUrl.param({ name: website.name }).toString(),
-          "POST"
-        )
-        .returns({
-          body:   errorResp,
-          status: 400
-        })
+      addCollaboratorStub = helper.mockPostRequest(
+        siteApiCollaboratorsUrl.param({ name: website.name }).toString(),
+        errorResp,
+        400
+      )
       const { wrapper } = await render()
       const form = wrapper.find("SiteCollaboratorForm")
       const onSubmit = form.prop("onSubmit")
@@ -266,15 +244,11 @@ describe("SiteCollaboratorDrawerTest", () => {
       const errorResp = {
         errors: errorMsg
       }
-      addCollaboratorStub = helper.handleRequestStub
-        .withArgs(
-          siteApiCollaboratorsUrl.param({ name: website.name }).toString(),
-          "POST"
-        )
-        .returns({
-          body:   errorResp,
-          status: 400
-        })
+      addCollaboratorStub = helper.mockPostRequest(
+        siteApiCollaboratorsUrl.param({ name: website.name }).toString(),
+        errorResp,
+        400
+      )
       const { wrapper } = await render()
       const form = wrapper.find("SiteCollaboratorForm")
       const onSubmit = form.prop("onSubmit")

--- a/static/js/components/SiteCollaboratorList.test.tsx
+++ b/static/js/components/SiteCollaboratorList.test.tsx
@@ -49,15 +49,10 @@ describe("SiteCollaboratorList", () => {
         queries: {}
       }
     )
-    helper.handleRequestStub
-      .withArgs(
-        siteApiCollaboratorsUrl.param({ name: website.name }).toString(),
-        "GET"
-      )
-      .returns({
-        body:   { results: concat(collaborators, permanentAdmins) },
-        status: 200
-      })
+    helper.mockGetRequest(
+      siteApiCollaboratorsUrl.param({ name: website.name }).toString(),
+      { results: concat(collaborators, permanentAdmins) }
+    )
   })
 
   afterEach(() => {
@@ -103,19 +98,15 @@ describe("SiteCollaboratorList", () => {
   it("the delete collaborator dialog works as expected", async () => {
     const collaborator = collaborators[0]
     const numCollaborators = concat(collaborators, permanentAdmins).length
-    deleteCollaboratorStub = helper.handleRequestStub
-      .withArgs(
-        siteApiCollaboratorsDetailUrl
-          .param({
-            name:   website.name,
-            userId: collaborator.user_id
-          })
-          .toString(),
-        "DELETE"
-      )
-      .returns({
-        status: 204
-      })
+    deleteCollaboratorStub = helper.mockDeleteRequest(
+      siteApiCollaboratorsDetailUrl
+        .param({
+          name:   website.name,
+          userId: collaborator.user_id
+        })
+        .toString(),
+      {}
+    )
     const { wrapper } = await render()
     const deleteIcon = wrapper.find("button.item-action-button").at(1)
     act(() => {

--- a/static/js/components/WebsiteCollectionEditor.test.tsx
+++ b/static/js/components/WebsiteCollectionEditor.test.tsx
@@ -37,10 +37,9 @@ describe("WebsiteCollectionEditor", () => {
 
   describe("adding a new website collection", () => {
     beforeEach(() => {
-      helper.handleRequestStub.withArgs(collectionsApiUrl.toString()).returns({
-        body:   { id: 32 },
-        status: 200
-      })
+      helper.mockGetRequest(collectionsApiUrl.toString(), { id: 32 })
+
+      helper.mockPostRequest(collectionsApiUrl.toString(), {})
     })
 
     it("should pass initial values down to the form", async () => {
@@ -102,19 +101,18 @@ describe("WebsiteCollectionEditor", () => {
 
     beforeEach(() => {
       collection = makeWebsiteCollection()
-
-      helper.handleRequestStub
-        .withArgs(
-          collectionsApiDetailUrl
-            .param({
-              collectionId: collection.id
-            })
-            .toString()
-        )
-        .returns({
-          body:   collection,
-          status: 200
-        })
+      helper.mockGetRequest(
+        collectionsApiDetailUrl
+          .param({ collectionId: collection.id })
+          .toString(),
+        collection
+      )
+      helper.mockPatchRequest(
+        collectionsApiDetailUrl
+          .param({ collectionId: collection.id })
+          .toString(),
+        collection
+      )
     })
 
     it("should pass values from focused collection down to form", async () => {

--- a/static/js/components/WebsiteCollectionItemsEditor.test.tsx
+++ b/static/js/components/WebsiteCollectionItemsEditor.test.tsx
@@ -30,12 +30,10 @@ describe("WebsiteCollectionItemsEditor", () => {
       websiteCollection: collection
     })
 
-    helper.handleRequestStub
-      .withArgs(wcItemsApiUrl.param({ collectionId: collection.id }).toString())
-      .returns({
-        body:   items,
-        status: 200
-      })
+    helper.mockGetRequest(
+      wcItemsApiUrl.param({ collectionId: collection.id }).toString(),
+      items
+    )
   })
 
   afterEach(() => {
@@ -69,19 +67,14 @@ describe("WebsiteCollectionItemsEditor", () => {
 
     const itemToMove = items[6]
 
-    helper.handleRequestStub
-      .withArgs(
-        wcItemsApiDetailUrl
-          .param({ collectionId: collection.id, itemId: items[6].id })
-          .toString()
-      )
-      .returns({
-        status: 200,
-        body:   {
-          id: items[6].id
-        }
-      })
-
+    helper.mockPatchRequest(
+      wcItemsApiDetailUrl
+        .param({ collectionId: collection.id, itemId: items[6].id })
+        .toString(),
+      {
+        id: items[6].id
+      }
+    )
     act(() => {
       wrapper.find(DndContext)!.prop("onDragEnd")!({
         active: { id: String(itemToMove.id) },
@@ -109,15 +102,13 @@ describe("WebsiteCollectionItemsEditor", () => {
     const { wrapper } = await render()
     const [item] = items
 
-    helper.handleRequestStub
-      .withArgs(
-        wcItemsApiDetailUrl
-          .param({ collectionId: collection.id, itemId: item.id })
-          .toString()
-      )
-      .returns({
-        status: 204
-      })
+    helper.mockDeleteRequest(
+      wcItemsApiDetailUrl
+        .param({ collectionId: collection.id, itemId: item.id })
+        .toString(),
+      {},
+      204
+    )
 
     act(() => {
       // @ts-ignore

--- a/static/js/components/forms/WebsiteCollectionItemForm.test.tsx
+++ b/static/js/components/forms/WebsiteCollectionItemForm.test.tsx
@@ -28,11 +28,10 @@ describe("WebsiteCollectionItemForm", () => {
       websiteCollection
     })
 
-    helper.handleRequestStub
-      .withArgs(
-        wcItemsApiUrl.param({ collectionId: websiteCollection.id }).toString()
-      )
-      .returns({ status: 200 })
+    helper.mockGetRequest(
+      wcItemsApiUrl.param({ collectionId: websiteCollection.id }).toString(),
+      {}
+    )
   })
 
   afterEach(() => {
@@ -53,7 +52,10 @@ describe("WebsiteCollectionItemForm", () => {
 
   it("onSubmit should issue request then resetForm", async () => {
     const resetFormStub = helper.sandbox.stub()
-
+    helper.mockPostRequest(
+      wcItemsApiUrl.param({ collectionId: websiteCollection.id }).toString(),
+      { website: "hey!" }
+    )
     const { wrapper } = await render()
     act(() => {
       wrapper

--- a/static/js/pages/SiteCreationPage.test.tsx
+++ b/static/js/pages/SiteCreationPage.test.tsx
@@ -37,10 +37,7 @@ describe("SiteCreationPage", () => {
       }
     )
 
-    helper.handleRequestStub.withArgs(startersApi.toString(), "GET").returns({
-      body:   starters,
-      status: 200
-    })
+    helper.mockGetRequest(startersApi.toString(), starters)
   })
 
   afterEach(() => {
@@ -67,12 +64,7 @@ describe("SiteCreationPage", () => {
     })
 
     it("that creates a new site and redirect on success", async () => {
-      createWebsiteStub = helper.handleRequestStub
-        .withArgs(siteApi.toString(), "POST")
-        .returns({
-          body:   website,
-          status: 201
-        })
+      createWebsiteStub = helper.mockPostRequest(siteApi.toString(), website)
       const { wrapper } = await render()
       const form = wrapper.find("SiteForm")
       const onSubmit = form.prop("onSubmit")
@@ -95,18 +87,18 @@ describe("SiteCreationPage", () => {
         siteDetailUrl.param({ name: website.name }).toString()
       )
     })
+
     it("that sets form errors if the API request fails", async () => {
       const errorResp = {
         errors: {
           title: errorMsg
         }
       }
-      createWebsiteStub = helper.handleRequestStub
-        .withArgs(siteApi.toString(), "POST")
-        .returns({
-          body:   errorResp,
-          status: 400
-        })
+      createWebsiteStub = helper.mockPostRequest(
+        siteApi.toString(),
+        errorResp,
+        400
+      )
       const { wrapper } = await render()
       const form = wrapper.find("SiteForm")
       const onSubmit = form.prop("onSubmit")
@@ -130,16 +122,16 @@ describe("SiteCreationPage", () => {
       })
       sinon.assert.notCalled(historyPushStub)
     })
+
     it("that sets a status if the API request fails with a string error message", async () => {
       const errorResp = {
         errors: errorMsg
       }
-      createWebsiteStub = helper.handleRequestStub
-        .withArgs(siteApi.toString(), "POST")
-        .returns({
-          body:   errorResp,
-          status: 400
-        })
+      createWebsiteStub = helper.mockPostRequest(
+        siteApi.toString(),
+        errorResp,
+        400
+      )
       const { wrapper } = await render()
       const form = wrapper.find("SiteForm")
       const onSubmit = form.prop("onSubmit")

--- a/static/js/pages/SitePage.test.tsx
+++ b/static/js/pages/SitePage.test.tsx
@@ -20,15 +20,10 @@ describe("SitePage", () => {
       ...makeWebsiteDetail(),
       name: siteName
     }
-    helper.handleRequestStub
-      .withArgs(
-        siteApiCollaboratorsUrl.param({ name: website.name }).toString(),
-        "GET"
-      )
-      .returns({
-        body:   { results: [] },
-        status: 200
-      })
+    helper.mockGetRequest(
+      siteApiCollaboratorsUrl.param({ name: website.name }).toString(),
+      { results: [] }
+    )
     render = helper.configureRenderer(props => (
       <WebsiteContext.Provider value={website}>
         <SitePage {...props} />

--- a/static/js/util/integration_test_helper.tsx
+++ b/static/js/util/integration_test_helper.tsx
@@ -78,11 +78,11 @@ export default class IntegrationTestHelper {
 
   mockRequest(
     url: string,
-    method: "GET" | "POST" | "PATCH",
+    method: "GET" | "POST" | "PATCH" | "DELETE",
     responseBody: unknown,
     code: number
-  ): void {
-    this.handleRequestStub.withArgs(url, method).returns({
+  ): sinon.SinonStub {
+    return this.handleRequestStub.withArgs(url, method).returns({
       body:   responseBody,
       status: code
     })
@@ -94,22 +94,29 @@ export default class IntegrationTestHelper {
    * pass the API url you want to mock and the object which should be
    * returned as the request body!
    */
-  mockGetRequest(url: string, body: unknown): void {
-    this.mockRequest(url, "GET", body, 200)
+  mockGetRequest(url: string, body: unknown): sinon.SinonStub {
+    return this.mockRequest(url, "GET", body, 200)
   }
 
   /**
    * Convenience method for mocking out a POST request
    */
-  mockPostRequest(url: string, body: unknown): void {
-    this.mockRequest(url, "POST", body, 201)
+  mockPostRequest(url: string, body: unknown, code = 201): sinon.SinonStub {
+    return this.mockRequest(url, "POST", body, code)
   }
 
   /**
    * Convenience method for mocking out a PATCH request
    */
-  mockPatchRequest(url: string, body: unknown): void {
-    this.mockRequest(url, "PATCH", body, 200)
+  mockPatchRequest(url: string, body: unknown, code = 200): sinon.SinonStub {
+    return this.mockRequest(url, "PATCH", body, code)
+  }
+
+  /**
+   * Convenience method for mocking out a DELETE request
+   */
+  mockDeleteRequest(url: string, body: unknown, code = 204): sinon.SinonStub {
+    return this.mockRequest(url, "DELETE", body, code)
   }
 
   cleanup(unmount = true): void {


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

Just a testing change, a little bit ago I added some methods to the `IntegrationTestHelper` like `mockGetRequest`, `mockPostRequest`, etc. This basically just updates some test code to use those methods instead of calling `handleRequestStub.returns()` and so on.

#### How should this be manually tested?

if the tests are passing and the code looks sane then we're good :)