### PR TITLE
Fix flaky test

### DIFF
--- a/static/js/components/SiteContentListing.test.tsx
+++ b/static/js/components/SiteContentListing.test.tsx
@@ -49,8 +49,8 @@ describe("SiteContentListing", () => {
 
   beforeEach(() => {
     helper = new IntegrationTestHelper()
-    repeatableConfigItem = makeRepeatableConfigItem()
-    singletonsConfigItem = makeSingletonsConfigItem()
+    repeatableConfigItem = makeRepeatableConfigItem("repeatable")
+    singletonsConfigItem = makeSingletonsConfigItem("singletons")
     website = makeWebsiteDetail()
     // @ts-ignore
     website.starter = {
@@ -78,15 +78,13 @@ describe("SiteContentListing", () => {
   })
 
   //
-  ;[MockRepeatable, MockSingletons].forEach(child => {
-    it(`renders listing components with the correct props`, async () => {
-      let configItem
-
-      if (child === MockRepeatable) {
-        configItem = repeatableConfigItem
-      } else {
-        configItem = singletonsConfigItem
-      }
+  ;[
+    ["repeatable", MockRepeatable],
+    ["singleton", MockSingletons]
+  ].forEach(([name, child]) => {
+    it(`renders ${name} with the correct props`, async () => {
+      const configItem =
+        child === MockRepeatable ? repeatableConfigItem : singletonsConfigItem
 
       // @ts-ignore
       const params = { name: website.name, contenttype: configItem.name }
@@ -94,6 +92,7 @@ describe("SiteContentListing", () => {
         params
       }))
       const { wrapper } = await render()
+      // @ts-ignore
       const listing = wrapper.find(child)
       expect(listing.exists()).toBe(true)
       expect(listing.props()).toEqual({


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #736 

#### What's this PR do?
Sets a name for the config items instead of using causal to create them. If casual happened to create the same name for both items then there could be a name collision, displaying the wrong component in the UI.

#### How should this be manually tested?
Tests should pass