### PR TITLE
Filter resourcetype on backend for website content

### DIFF
--- a/static/js/components/widgets/RelationField.tsx
+++ b/static/js/components/widgets/RelationField.tsx
@@ -1,9 +1,9 @@
 import React, {
-  useState,
+  ChangeEvent,
+  SyntheticEvent,
   useCallback,
   useEffect,
-  SyntheticEvent,
-  ChangeEvent
+  useState
 } from "react"
 import { equals, without } from "ramda"
 import { uniqBy } from "lodash"
@@ -125,7 +125,12 @@ export default function RelationField(props: Props): JSX.Element {
         .query({
           detailed_list:   true,
           content_context: true,
-          ...(search ? { search: search } : {}),
+          ...(search ? { search } : {}),
+          ...(filter &&
+          filter.filter_type === RelationFilterVariant.Equals &&
+          filter.field === "resourcetype" ?
+            { resourcetype: filter.value } :
+            {}),
           ...params
         })
         .param({ name: websiteName })
@@ -153,7 +158,7 @@ export default function RelationField(props: Props): JSX.Element {
       return formatOptions(filterContentListing(results), display_field)
     },
     // eslint-disable-next-line camelcase
-    [filterContentListing, websiteName, display_field, collection]
+    [filterContentListing, websiteName, display_field, collection, filter]
   )
 
   const loadOptions = useCallback(

--- a/websites/factories.py
+++ b/websites/factories.py
@@ -73,7 +73,7 @@ class WebsiteContentFactory(DjangoModelFactory):
     title = factory.Sequence(lambda n: "OCW Site Content %s" % n)
     type = FuzzyChoice([CONTENT_TYPE_PAGE, CONTENT_TYPE_RESOURCE])
     markdown = factory.Faker("text")
-    metadata = factory.Faker("json")
+    metadata = factory.LazyAttribute(lambda _: {})
     filename = factory.Sequence(lambda n: "my-file-%s" % n)
     dirpath = factory.Faker("uri_path", deep=2)
     website = factory.SubFactory(WebsiteFactory)

--- a/websites/views.py
+++ b/websites/views.py
@@ -103,6 +103,7 @@ class WebsiteViewSet(
         ordering = self.request.query_params.get("sort", "-updated_on")
         website_type = self.request.query_params.get("type", None)
         search = self.request.query_params.get("search", None)
+        resourcetype = self.request.query_params.get("resourcetype", None)
 
         user = self.request.user
         if self.request.user.is_anonymous:
@@ -123,6 +124,9 @@ class WebsiteViewSet(
         if search is not None:
             # search query param is used in react-select typeahead, and should match on the title
             queryset = queryset.filter(title__icontains=search)
+
+        if resourcetype is not None:
+            queryset = queryset.filter(metadata__resourcetype=resourcetype)
 
         if website_type is not None:
             queryset = queryset.filter(starter__slug=website_type)


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Fixes #741 

#### What's this PR do?
- Add `resourcetype` parameter to filter on the backend
- Adjust frontend code to use this parameter if it exists as a filter in the schema

#### How should this be manually tested?
 - Go to the site metadata for `18-06-linear-algebra-spring-2010` in your local instance
 - Scroll down to "Course image" and type "18". You should see a list of image results. On `master` you won't see any results for this.