### PR TITLE
add support for Table shortcodes to Markdown editor

### DIFF
--- a/static/js/lib/ckeditor/CKEditor.ts
+++ b/static/js/lib/ckeditor/CKEditor.ts
@@ -22,6 +22,7 @@ import { ADD_RESOURCE_EMBED, ADD_RESOURCE_LINK } from "./plugins/constants"
 import ResourceLink from "@mitodl/ckeditor5-resource-link/src/link"
 import ResourceLinkMarkdownSyntax from "./plugins/ResourceLinkMarkdownSyntax"
 import DisallowNestedTables from "./plugins/DisallowNestedTables"
+import TableMarkdownSyntax from "./plugins/TableMarkdownSyntax"
 
 export const FullEditorConfig = {
   plugins: [
@@ -45,6 +46,7 @@ export const FullEditorConfig = {
     ResourcePicker,
     ResourceLink,
     ResourceLinkMarkdownSyntax,
+    TableMarkdownSyntax,
     Markdown,
     DisallowNestedTables
   ],

--- a/static/js/lib/ckeditor/plugins/Markdown.test.ts
+++ b/static/js/lib/ckeditor/plugins/Markdown.test.ts
@@ -29,38 +29,4 @@ describe("Markdown CKEditor plugin", () => {
       markdownTest(editor, TEST_MARKDOWN, TEST_HTML)
     })
   })
-
-  describe("tables", () => {
-    it("should support tables", async () => {
-      // TODO why is this passing at the turndown level but failing here?
-      //
-      // figured it out: Tables MUST have a `thead` with `th` elements in it, otherwise turndown doesn't seem to know what to do
-      const editor = await getEditor("")
-      markdownTest(
-        editor,
-        "| Heading 1 | Heading 2 |\n" +
-          "| --- | --- |\n" +
-          "| Cell 1 | Cell 2 |\n" +
-          "| Cell 3 | Cell 4 |",
-        "<table>" +
-          "<thead>" +
-          "<tr>" +
-          "<th>Heading 1</th>" +
-          "<th>Heading 2</th>" +
-          "</tr>" +
-          "</thead>" +
-          "<tbody>" +
-          "<tr>" +
-          "<td>Cell 1</td>" +
-          "<td>Cell 2</td>" +
-          "</tr>" +
-          "<tr>" +
-          "<td>Cell 3</td>" +
-          "<td>Cell 4</td>" +
-          "</tr>" +
-          "</tbody>" +
-          "</table>"
-      )
-    })
-  })
 })

--- a/static/js/lib/ckeditor/plugins/Markdown.ts
+++ b/static/js/lib/ckeditor/plugins/Markdown.ts
@@ -63,6 +63,9 @@ export class MarkdownDataProcessor extends GFMDataProcessor {
   }
 }
 
+const TD_CONTENT_REGEX = /<td>([\S\s]*?)<\/td>/g
+const TH_CONTENT_REGEX = /<th>([\S\s]*?)<\/th>/g
+
 /**
  * Plugin implementing Markdown for CKEditor
  *
@@ -77,9 +80,10 @@ export default class Markdown extends MarkdownConfigPlugin {
     const { showdownExtensions, turndownRules } = this.getMarkdownConfig()
 
     const converter = new Converter({
-      tables:     true,
       extensions: showdownExtensions
     })
+
+    converter.setFlavor("github")
 
     // @ts-ignore
     if (!turndownService._customRulesSet) {
@@ -91,7 +95,16 @@ export default class Markdown extends MarkdownConfigPlugin {
     }
 
     function md2html(md: string): string {
-      return converter.makeHtml(md)
+      return converter
+        .makeHtml(md)
+        .replace(
+          TD_CONTENT_REGEX,
+          (_match, contents) => `<td>${converter.makeHtml(contents)}</td>`
+        )
+        .replace(
+          TH_CONTENT_REGEX,
+          (_match, contents) => `<th>${converter.makeHtml(contents)}</th>`
+        )
     }
 
     function html2md(html: string): string {

--- a/static/js/lib/ckeditor/plugins/TableMarkdownSyntax.test.tsx
+++ b/static/js/lib/ckeditor/plugins/TableMarkdownSyntax.test.tsx
@@ -1,0 +1,84 @@
+jest.mock("@ckeditor/ckeditor5-utils/src/version")
+
+import { equals } from "ramda"
+import Markdown from "./Markdown"
+import { createTestEditor, markdownTest } from "./test_util"
+import { turndownService } from "../turndown"
+import ParagraphPlugin from "@ckeditor/ckeditor5-paragraph/src/paragraph"
+
+import TableMarkdownSyntax from "./TableMarkdownSyntax"
+import { TABLE_ELS } from "./constants"
+
+const getEditor = createTestEditor([
+  ParagraphPlugin,
+  TableMarkdownSyntax,
+  Markdown
+])
+
+describe("table shortcodes", () => {
+  afterEach(() => {
+    turndownService.rules.array = turndownService.rules.array.filter(
+      (rule: any) => !equals(rule.filter, TABLE_ELS)
+    )
+    // @ts-ignore
+    turndownService._customRulesSet = undefined
+  })
+
+  it("should transform a table with rows, content", async () => {
+    const editor = await getEditor("")
+    markdownTest(
+      editor,
+      "{{< tableopen >}}{{< tbodyopen >}}{{< tropen >}}{{< tdopen >}}\nmy _row_\n{{< tdclose >}}{{< trclose >}}{{< tbodyclose >}}{{< tableclose >}}",
+      `<table>
+        <tbody>
+          <tr>
+            <td><p>my <em>row</em></p></td>
+          </tr>
+        </tbody>
+      </table>`
+    )
+  })
+
+  it("should transform a table which has lists and so on in it", async () => {
+    const editor = await getEditor("")
+    markdownTest(
+      editor,
+      "{{< tableopen >}}{{< tbodyopen >}}{{< tropen >}}{{< tdopen >}}\n- foo\n- _bar_\n{{< tdclose >}}{{< tdopen >}}\n# Heading\n{{< tdclose >}}{{< trclose >}}{{< tbodyclose >}}{{< tableclose >}}",
+      `<table>
+        <tbody>
+          <tr>
+            <td>
+              <ul>
+                <li>foo</li>
+                <li><em>bar</em></li>
+              </ul>
+            </td>
+            <td><h1 id="heading">Heading</h1></td>
+          </tr>
+        </tbody>
+      </table>`
+    )
+  })
+
+  it("should transform a table with a header", async () => {
+    const editor = await getEditor("")
+    markdownTest(
+      editor,
+      "{{< tableopen >}}{{< theadopen >}}{{< tropen >}}{{< thopen >}}\nA **column**\n{{< thclose >}}{{< thopen >}}\nAnother column\n{{< thclose >}}{{< trclose >}}{{< theadclose >}}{{< tbodyopen >}}{{< tropen >}}{{< tdopen >}}\ndata\n{{< tdclose >}}{{< tdopen >}}\ndata\n{{< tdclose >}}{{< trclose >}}{{< tbodyclose >}}{{< tableclose >}}",
+      `<table>
+        <thead>
+          <tr>
+            <th><p>A <strong>column</strong></p></th>
+            <th><p>Another column</p></th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><p>data</p></td>
+            <td><p>data</p></td>
+          </tr>
+        </tbody>
+      </table>`
+    )
+  })
+})

--- a/static/js/lib/ckeditor/plugins/TableMarkdownSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/TableMarkdownSyntax.ts
@@ -1,0 +1,45 @@
+import Turndown from "turndown"
+import Showdown from "showdown"
+
+import MarkdownSyntaxPlugin from "./MarkdownSyntaxPlugin"
+import { TurndownRule } from "../../../types/ckeditor_markdown"
+
+import { TABLE_ELS } from "./constants"
+
+type Position = "open" | "close"
+
+export default class TableMarkdownSyntax extends MarkdownSyntaxPlugin {
+  static get pluginName(): string {
+    return "TableMarkdownSyntax"
+  }
+
+  get showdownExtension() {
+    return function resourceExtension(): Showdown.ShowdownExtension[] {
+      return TABLE_ELS.map(el => {
+        const shortcodeRegex = new RegExp(`{{< ${el}(open|close) >}}`, "g")
+
+        return {
+          type:    "lang",
+          regex:   shortcodeRegex,
+          replace: (_s: string, position: Position) => {
+            return position === "open" ? `<${el}>` : `</${el}>`
+          }
+        }
+      })
+    }
+  }
+
+  get turndownRule(): TurndownRule {
+    return {
+      name: "TableMarkdownSyntax",
+      rule: {
+        filter:      TABLE_ELS,
+        replacement: (content: string, node: Turndown.Node): string => {
+          const name = node.nodeName.toLowerCase()
+          const normalizedContent = content.replace("\n\n", "\n")
+          return `{{< ${name}open >}}${normalizedContent}{{< ${name}close >}}`
+        }
+      }
+    }
+  }
+}

--- a/static/js/lib/ckeditor/plugins/constants.ts
+++ b/static/js/lib/ckeditor/plugins/constants.ts
@@ -11,6 +11,7 @@ export const RESOURCE_LINK = "resourceLink"
 export const RESOURCE_EMBED_COMMAND = "insertResourceEmbed"
 
 import { RESOURCE_LINK_COMMAND } from "@mitodl/ckeditor5-resource-link/src/constants"
+import TurndownService from "turndown"
 
 /**
  * Union type capturing the possible typs of resource nodes we
@@ -44,3 +45,13 @@ export type ResourceDialogState =
   | typeof RESOURCE_LINK
   | typeof RESOURCE_EMBED
   | "closed"
+
+export const TABLE_ELS: TurndownService.TagName[] = [
+  "table",
+  "tbody",
+  "th",
+  "td",
+  "tr",
+  "thead",
+  "tfoot"
+]

--- a/static/js/lib/ckeditor/turndown.test.ts
+++ b/static/js/lib/ckeditor/turndown.test.ts
@@ -1,4 +1,5 @@
-import { turndownService } from "./turndown"
+import { TABLE_ELS } from "./plugins/constants"
+import { ruleMatches, turndownService } from "./turndown"
 
 const turndownTest = (html: string, markdown: string) => {
   expect(turndownService.turndown(html)).toEqual(markdown)
@@ -39,48 +40,15 @@ describe("turndown service", () => {
     turndownTest("<ul><li>first item</li><li></li></ul>", "- first item\n-")
   })
 
-  it("should support tables", () => {
-    turndownTest(
-      "<table>" +
-        "<thead>" +
-        "<tr>" +
-        "<th>Heading 1</th>" +
-        "<th>Heading 2</th>" +
-        "</tr>" +
-        "</thead>" +
-        "<tbody>" +
-        "<tr>" +
-        "<td>Cell 1</td>" +
-        "<td>Cell 2</td>" +
-        "</tr>" +
-        "<tr>" +
-        "<td>Cell 3</td>" +
-        "<td>Cell 4</td>" +
-        "</tr>" +
-        "</tbody>" +
-        "</table>",
-      "| Heading 1 | Heading 2 |\n" +
-        "| --- | --- |\n" +
-        "| Cell 1 | Cell 2 |\n" +
-        "| Cell 3 | Cell 4 |"
-    )
-
-    turndownTest(
-      "<table>" +
-        "<thead>" +
-        "<tr>" +
-        "<th>name</th>" +
-        "<th>phone #</th>" +
-        "</tr>" +
-        "</thead>" +
-        "<tbody>" +
-        "<tr>" +
-        "<td>joe</td>" +
-        "<td>111-111-1111</td>" +
-        "</tr>" +
-        "</tbody>" +
-        "</table>",
-      "| name | phone # |\n" + "| --- | --- |\n" + "| joe | 111-111-1111 |"
-    )
+  it("should override any rules that match table elements", () => {
+    expect(
+      turndownService.rules.array.filter(rule =>
+        TABLE_ELS.some(el => {
+          const element = document.createElement(el)
+          document.body.appendChild(element)
+          return ruleMatches(rule, element)
+        })
+      )
+    ).toStrictEqual([])
   })
 })

--- a/static/js/test_constants.ts
+++ b/static/js/test_constants.ts
@@ -19,7 +19,7 @@ also have some
 
 good stuff.`
 
-export const TEST_HTML = `<h2 id="aheading">A heading</h2>
+export const TEST_HTML = `<h2 id="a-heading">A heading</h2>
 <p>Amazing stuff! Paragraphs!</p>
 <p>And another paragraph!</p>
 <p><strong>bold</strong> and even <em>ita<strong>lic and bold</strong> text</em></p>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #743 
closes #673
closes #672

#### What's this PR do?

This PR implements shortcode-based support for tables in Markdown. This gets us around the limitations of the Github Flavored Markdown tables, which are pretty limited (no line breaks, etc) and should let us allow content authors to use tables in the way they're used to.

Read issue #743 for details of why the shortcodes are set up the way they are, how they are intended to work, etc. 

#### How should this be manually tested?

Try out creating tables in the Markdown editor. You should be able to:

- create tables of various sizes
- use Markdown syntax inside of table cells
- use shortcodes inside of table cells

Then go into the admin to check the saved Markdown. It should be using shortcodes to delimit all the table elements.