### PR TITLE
Change ContentDisposition for videos

### DIFF
--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -202,10 +202,15 @@ def stream_to_s3(drive_file: DriveFile):
         if not drive_file.s3_key:
             drive_file.s3_key = drive_file.get_valid_s3_key()
         drive_file.update_status(DriveFileStatus.UPLOADING)
+        extra_args = {"ContentType": drive_file.mime_type, "ACL": "public-read"}
+
+        if drive_file.mime_type.startswith("video/"):
+            extra_args["ContentDisposition"] = "attachment"
+
         bucket.upload_fileobj(
             Fileobj=streaming_download(drive_file).raw,
             Key=drive_file.s3_key,
-            ExtraArgs={"ContentType": drive_file.mime_type, "ACL": "public-read"},
+            ExtraArgs=extra_args,
         )
         drive_file.update_status(DriveFileStatus.UPLOAD_COMPLETE)
     except:  # pylint:disable=bare-except

--- a/gdrive_sync/api_test.py
+++ b/gdrive_sync/api_test.py
@@ -129,10 +129,23 @@ def test_stream_to_s3(settings, mocker, is_video, current_s3_key):
         expected_key = (
             f"{drive_file.s3_prefix}/{drive_file.website.name}/a-test-file.ext"
         )
+
+    if is_video:
+        expected_extra_args = {
+            "ContentType": drive_file.mime_type,
+            "ACL": "public-read",
+            "ContentDisposition": "attachment",
+        }
+    else:
+        expected_extra_args = {
+            "ContentType": drive_file.mime_type,
+            "ACL": "public-read",
+        }
+
     mock_bucket.upload_fileobj.assert_called_with(
         Fileobj=mocker.ANY,
         Key=expected_key,
-        ExtraArgs={"ContentType": drive_file.mime_type, "ACL": "public-read"},
+        ExtraArgs=expected_extra_args,
     )
     mock_download.assert_called_once_with(drive_file)
     mock_service.return_value.permissions.return_value.delete.assert_called_once()


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-hugo-themes/issues/145

#### What's this PR do?
For courses created through ocw-studio, the video download button in ocw-hugo-themes links to the s3 url for the video. By default, aws plays the video in the browser. Setting "ContentDisposition": "attachment" on the s3 file makes aws download the video when the user clicks on the link instead of streaming it.

#### How should this be manually tested?
Find or create a site locally
Go to the 'videos_final' subfolder in gdrive folder for the site and add a video
Go to the resources ui for your site and click "Sync w/ Google Drive"
Get the drive file object by running
```
from gdrive_sync.models import *
drive_file = DriveFile.objects.order_by('created_on').last()
```
Go to 
https://ol-ocw-studio-app-qa.s3.us-east-1.amazonaws.com/<drive_file.s3_key>

Verify that the video downloads immediately instead of playing in the browser