### PR TITLE
fix image alignment issue

### DIFF
--- a/static/js/components/widgets/ResourcePickerListing.tsx
+++ b/static/js/components/widgets/ResourcePickerListing.tsx
@@ -89,7 +89,9 @@ export default function ResourcePickerListing(
             }}
           >
             {imageSrc ? (
-              <img className="img-fluid w-100" src={imageSrc} />
+              <div className="img-wrapper">
+                <img className="img-fluid w-100" src={imageSrc} />
+              </div>
             ) : null}
             <h4>{item.title}</h4>
           </div>

--- a/static/scss/resource-picker-dialog.scss
+++ b/static/scss/resource-picker-dialog.scss
@@ -1,6 +1,7 @@
 .resource-picker-listing {
   display: grid;
   grid-template-columns: repeat(5, 1fr);
+  grid-auto-rows: minmax(120px, auto);
   column-gap: 10px;
   row-gap: 10px; // sass-lint:disable-line no-misspelled-properties
 
@@ -13,7 +14,6 @@
       background-color: initial;
       border-radius: 0;
       padding: 10px 0;
-      margin: 0;
 
       &:not(:last-child) {
         border-bottom: 1px solid $studio-gray;
@@ -29,7 +29,7 @@
     cursor: pointer;
     background-color: $dialog-gray;
     border-radius: 5px;
-    margin: 2px;
+    min-width: 0;
 
     &.focused {
       border: 2px solid black;
@@ -47,6 +47,7 @@
 
     img {
       height: 100px;
+      max-width: 100%;
       object-fit: cover;
       border-radius: 3px 3px 0 0;
     }

--- a/static/scss/site-page.scss
+++ b/static/scss/site-page.scss
@@ -68,48 +68,6 @@ $menu-spacing: 20px;
   }
 }
 
-.resource-picker-listing {
-  .resource-item {
-    cursor: pointer;
-    padding: 2px;
-    margin: 2px;
-
-    &.focused {
-      border: 2px solid black;
-      padding: 0;
-    }
-
-    h4 {
-      margin-bottom: 0;
-      padding: 2px;
-    }
-  }
-}
-
-.resource-picker-dialog {
-  .tab-content {
-    padding: 20px 0;
-  }
-
-  .nav-tabs {
-    border-bottom: 1px solid $dialog-gray;
-
-    .nav-item {
-      margin-left: 10px;
-      margin-right: 2px;
-      background-color: $dialog-gray;
-      border-top: 1px solid $dialog-gray;
-      border-left: 1px solid $dialog-gray;
-      border-right: 1px solid $dialog-gray;
-
-      &.active {
-        //border-bottom: white;
-        background-color: white;
-      }
-    }
-  }
-}
-
 .publish-option {
   a {
     text-decoration: underline;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes  #681

#### What's this PR do?

there was a styling / alignment issue with the grid of options we show in the resource picker. this just does a little css fiddling to fix that.

#### How should this be manually tested?

go to a page and open the resource picker. you shouldn't see any weird stretching (like what's shown in the issue)


#### screen

<img width="860" alt="Screen Shot 2021-10-28 at 3 57 04 PM" src="https://user-images.githubusercontent.com/6207644/139326679-db733e7c-4a6b-4500-ba78-314d7dc971e2.png">
