### PR TITLE
add ocw-www site dependency to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ OCW Studio manages deployments for OCW courses.
 
 ocw_studio follows the same [initial setup steps outlined in the common ODL web app guide](https://github.com/mitodl/handbook/blob/master/common-web-app-guide.md).
 Run through those steps **including the addition of `/etc/hosts` aliases and the optional step for running the
-`createsuperuser` command**.
+`createsuperuser` command**. 
+
+In addition, you should create a starter with `slug=ocw-www` through the admin interface with config data taken from the `ocw-www` starter on RC or production. Then, you should go to the `/sites` UI and create a new site with `name=ocw-www` using the `ocw-www` starter.
 
 
 ### Testing Touchstone login with SAML via SSOCircle


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
I spent a bunch of time yesterday figuring out why the site metadata ui wasn't loading for me. Turns out I was supposed to have a site with name=ocw-www. I added this information to the readme.

#### How should this be manually tested?
None

#### Where should the reviewer start?
N/A
