### PR TITLE
Google Drive Sync Status indicator

### DIFF
--- a/gdrive_sync/api_test.py
+++ b/gdrive_sync/api_test.py
@@ -489,7 +489,8 @@ def test_transcode_gdrive_video_error(settings, mocker):
     )
     mock_log = mocker.patch("gdrive_sync.api.log.exception")
     drive_file = DriveFileFactory.create()
-    transcode_gdrive_video(drive_file)
+    with pytest.raises(ClientError):
+        transcode_gdrive_video(drive_file)
     drive_file.refresh_from_db()
     mock_log.assert_called_once_with(
         "Error creating transcode job for %s", drive_file.video.source_key

--- a/gdrive_sync/constants.py
+++ b/gdrive_sync/constants.py
@@ -60,6 +60,7 @@ class DriveFileStatus:
 class WebsiteSyncStatus:
     """Simple class for possible Website sync statuses"""
 
+    PENDING = "Pending"
     PROCESSING = "Processing"
     COMPLETE = "Complete"
     FAILED = "Failed"

--- a/static/js/components/DriveSyncStatusIndicator.test.tsx
+++ b/static/js/components/DriveSyncStatusIndicator.test.tsx
@@ -1,0 +1,90 @@
+import { act } from "react-dom/test-utils"
+import moment from "moment"
+
+import IntegrationTestHelper, {
+  TestRenderer
+} from "../util/integration_test_helper"
+import DriveSyncStatusIndicator from "./DriveSyncStatusIndicator"
+import { GoogleDriveSyncStatuses } from "../constants"
+import { makeWebsiteDetail } from "../util/factories/websites"
+import { Website } from "../types/websites"
+
+describe("DriveSyncStatusIndicator", () => {
+  let helper: IntegrationTestHelper, render: TestRenderer, website: Website
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+  //
+  ;[
+    [GoogleDriveSyncStatuses.SYNC_STATUS_PROCESSING, []],
+    [GoogleDriveSyncStatuses.SYNC_STATUS_PENDING, []],
+    [GoogleDriveSyncStatuses.SYNC_STATUS_COMPLETE, []],
+    [GoogleDriveSyncStatuses.SYNC_STATUS_ERRORS, ["error1", "error2"]],
+    [GoogleDriveSyncStatuses.SYNC_STATUS_FAILED, ["total failure"]]
+  ].forEach(([status, syncErrors]) => {
+    describe("sync status drawer", () => {
+      beforeEach(() => {
+        website = {
+          ...makeWebsiteDetail(),
+          sync_status: status as GoogleDriveSyncStatuses,
+          sync_errors: syncErrors as Array<string>,
+          synced_on:   "2021-01-01"
+        }
+        render = helper.configureRenderer(DriveSyncStatusIndicator, {
+          website
+        })
+      })
+
+      afterEach(() => {
+        helper.cleanup()
+      })
+
+      it(`renders for status=${status}`, async () => {
+        const { wrapper } = await render()
+        expect(wrapper.text()).toContain(status)
+        expect(wrapper.find(".status-indicator").prop("className")).toContain(
+          status.toString().toLowerCase()
+        )
+      })
+
+      it(`shows details with sync date and ${syncErrors.length} errors in side drawer`, async () => {
+        const { wrapper } = await render()
+        expect(wrapper.find("BasicModal").prop("isVisible")).toBe(false)
+
+        const statusDiv = wrapper.find(".sync-status")
+        act(() => {
+          // @ts-ignore
+          statusDiv.prop("onClick")({ preventDefault: helper.sandbox.stub() })
+        })
+        wrapper.update()
+        const drawer = wrapper.find("BasicModal").at(0)
+        expect(drawer.prop("isVisible")).toBe(true)
+        //@ts-ignore
+        syncErrors.forEach((error: string, idx: number) => {
+          expect(
+            drawer
+              .find("li")
+              .at(idx)
+              .text()
+          ).toBe(error)
+        })
+        expect(drawer.find("li").length).toBe(syncErrors.length)
+        if (syncErrors.length === 0) {
+          expect(
+            drawer
+              .find(".sync-success")
+              .at(0)
+              .text()
+          ).toContain("The latest Google Drive sync was successful.")
+        }
+        expect(drawer.find(".sync-time").text()).toContain(
+          moment(website.synced_on).format("dddd, MMMM D h:mma ZZ")
+        )
+      })
+    })
+  })
+})

--- a/static/js/components/DriveSyncStatusIndicator.tsx
+++ b/static/js/components/DriveSyncStatusIndicator.tsx
@@ -1,0 +1,66 @@
+import React, { MouseEvent as ReactMouseEvent, useState } from "react"
+import moment from "moment"
+
+import BasicModal from "./BasicModal"
+import { Website } from "../types/websites"
+
+export default function DriveSyncStatusIndicator(props: {
+  website: Website
+}): JSX.Element | null {
+  const { website } = props
+
+  const [syncStatusModalState, setSyncStatusModalState] = useState({
+    isVisible: false
+  })
+  const toggleSyncStatusModal = () =>
+    setSyncStatusModalState({
+      isVisible: !syncStatusModalState.isVisible
+    })
+  const onShowSyncDetails = async (
+    event: ReactMouseEvent<HTMLDivElement | HTMLButtonElement, MouseEvent>
+  ) => {
+    event.preventDefault()
+    toggleSyncStatusModal()
+  }
+
+  return (
+    <>
+      <BasicModal
+        isVisible={syncStatusModalState.isVisible}
+        hideModal={() => toggleSyncStatusModal()}
+        title="Google Drive Sync Details"
+        className="right"
+      >
+        {_ => (
+          <div className="m-2">
+            <div className="pb-2 sync-time">
+              Last run at{" "}
+              {moment(website.synced_on).format("dddd, MMMM D h:mma ZZ")}
+            </div>
+            {website.sync_errors && website.sync_errors.length > 0 ? (
+              <ul>
+                {website.sync_errors.map((error: string, idx: number) => (
+                  <li key={idx} className="py-3 listing-result form-error">
+                    {error}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="sync-success">
+                The latest Google Drive sync was successful.
+              </div>
+            )}
+          </div>
+        )}
+      </BasicModal>
+      {website.sync_status ? (
+        <div className="d-flex ml-2 sync-status" onClick={onShowSyncDetails}>
+          <div
+            className={`status-indicator ${website.sync_status.toLowerCase()} mr-1 mt-1`}
+          ></div>
+          <div>Sync status: {website.sync_status}</div>
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/static/js/constants.ts
+++ b/static/js/constants.ts
@@ -171,3 +171,16 @@ export const PUBLISH_STATUS_PROCESSING_STATES = [
   PublishStatuses.PUBLISH_STATUS_PENDING,
   PublishStatuses.PUBLISH_STATUS_NOT_STARTED
 ]
+
+export enum GoogleDriveSyncStatuses {
+  SYNC_STATUS_PROCESSING = "Processing",
+  SYNC_STATUS_PENDING = "Pending",
+  SYNC_STATUS_COMPLETE = "Complete",
+  SYNC_STATUS_FAILED = "Failed",
+  SYNC_STATUS_ERRORS = "Errors"
+}
+
+export const GOOGLE_DRIVE_SYNC_PROCESSING_STATES = [
+  GoogleDriveSyncStatuses.SYNC_STATUS_PENDING,
+  GoogleDriveSyncStatuses.SYNC_STATUS_PROCESSING
+]

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -218,6 +218,9 @@ export interface WebsiteStatus {
   live_publish_status_updated_on: string | null // eslint-disable-line
   draft_publish_status: PublishStatuses | null // eslint-disable-line
   draft_publish_status_updated_on: string | null // eslint-disable-line
+  sync_status: string | null // eslint-disable-line
+  synced_on: string | null // eslint-disable-line
+  sync_errors: Array<string> | null // eslint-disable-line
 }
 
 export type Website = WebsiteStatus & {

--- a/static/js/util/factories/websites.ts
+++ b/static/js/util/factories/websites.ts
@@ -192,6 +192,9 @@ export const makeWebsiteDetail = (): Website => ({
   live_publish_status:             null,
   draft_publish_status_updated_on: null,
   live_publish_status_updated_on:  null,
+  sync_status:                     null,
+  synced_on:                       null,
+  sync_errors:                     null,
   is_admin:                        casual.boolean
 })
 
@@ -210,7 +213,10 @@ export const makeWebsiteStatus = (website?: Website): WebsiteStatus => {
     live_publish_status:             website.live_publish_status,
     draft_publish_status:            website.draft_publish_status,
     live_publish_status_updated_on:  website.live_publish_status_updated_on,
-    draft_publish_status_updated_on: website.draft_publish_status_updated_on
+    draft_publish_status_updated_on: website.draft_publish_status_updated_on,
+    sync_status:                     null,
+    synced_on:                       null,
+    sync_errors:                     null
   }
 }
 

--- a/static/scss/_variables.scss
+++ b/static/scss/_variables.scss
@@ -14,6 +14,8 @@ $studio-text-gray: #b3b3b3;
 $studio-gray: #e4e4e4;
 $studio-red: #a41e34;
 $studio-cyan: #418786;
+$studio-yellow: #fff700;
+$studio-orange: #ff8c00;
 $studio-dark-gray: #5d5d5d;
 $dialog-gray: #d9d9d9;
 $form-control-gray: #ced4da;

--- a/static/scss/content-listing.scss
+++ b/static/scss/content-listing.scss
@@ -2,3 +2,36 @@
   font-size: 36px;
   vertical-align: middle;
 }
+
+.sync-status {
+  font-size: 0.75em;
+  line-height: 1.8em;
+  cursor: pointer;
+}
+
+.status-indicator {
+  height: 12px;
+  width: 12px;
+  border-radius: 50%;
+  display: inline-block;
+
+  &.complete {
+    background-color: $studio-green;
+  }
+
+  &.failed {
+    background-color: $studio-red;
+  }
+
+  &.errors {
+    background-color: $studio-orange;
+  }
+
+  &.processing {
+    background-color: $studio-yellow;
+  }
+
+  &.pending {
+    background-color: $studio-gray;
+  }
+}

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -130,6 +130,9 @@ class WebsiteDetailSerializer(serializers.ModelSerializer, RequestUserSerializer
             "live_publish_status_updated_on",
             "draft_publish_status",
             "draft_publish_status_updated_on",
+            "sync_status",
+            "synced_on",
+            "sync_errors",
         ]
         read_only_fields = [
             "uuid",
@@ -145,6 +148,9 @@ class WebsiteDetailSerializer(serializers.ModelSerializer, RequestUserSerializer
             "live_publish_status_updated_on",
             "draft_publish_status",
             "draft_publish_status_updated_on",
+            "sync_status",
+            "synced_on",
+            "sync_errors",
         ]
 
 
@@ -164,6 +170,9 @@ class WebsiteStatusSerializer(serializers.ModelSerializer):
             "live_publish_status_updated_on",
             "draft_publish_status",
             "draft_publish_status_updated_on",
+            "sync_status",
+            "synced_on",
+            "sync_errors",
         ]
         read_only_fields = fields
 

--- a/websites/views.py
+++ b/websites/views.py
@@ -24,6 +24,7 @@ from content_sync.api import (
     update_website_backend,
 )
 from content_sync.tasks import poll_build_status_until_complete
+from gdrive_sync.constants import WebsiteSyncStatus
 from gdrive_sync.tasks import import_website_files
 from main import features
 from main.permissions import ReadonlyPermission
@@ -525,6 +526,8 @@ class WebsiteContentViewSet(
     def gdrive_sync(self, request, **kwargs):  # pylint:disable=unused-argument
         """ Trigger a task to sync all non-video Google Drive files"""
         website = Website.objects.get(name=self.kwargs.get("parent_lookup_website"))
+        website.sync_status = WebsiteSyncStatus.PENDING
+        website.save()
         import_website_files.delay(website.short_id)
         return Response(status=200)
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes #717 

#### What's this PR do?
- Adds a frontend for displaying and updating a website's current google drive sync status.
- Makes further backend modifications to the sync process

#### How should this be manually tested?
- On a website that has never been synced (after this PR), the sync status indicator will not appear.
- Once the `Sync w/Google Drive` button is clicked for a site, the status indicator should appear from here on out.
- After a sync is triggered, the status indicator should poll every 5 seconds for updates, and adjust the status indicator accordingly.
- After the sync status completes or fails, the polling should stop and the resource list should be updated.
- Clicking on the status indicator should open a drawer showing the last date/time the sync was triggered, and the results/errors of that last sync.


#### Screenshots (if appropriate)
<img width="716" alt="Screen Shot 2021-10-29 at 11 06 40 AM" src="https://user-images.githubusercontent.com/187676/139745350-defb5c56-fbfb-4252-9c9f-20ac1631d719.png">


<img width="714" alt="Screen Shot 2021-10-29 at 11 17 04 AM" src="https://user-images.githubusercontent.com/187676/139745369-b4fa1814-9de8-4cd8-bc3e-90e4d148da7c.png">


<img width="765" alt="Screen Shot 2021-11-01 at 5 31 45 PM" src="https://user-images.githubusercontent.com/187676/139745378-b749773a-cdc0-4e2f-9880-c811a38e379f.png">


<img width="766" alt="Screen Shot 2021-11-01 at 5 35 47 PM" src="https://user-images.githubusercontent.com/187676/139745381-bc776d28-d7b9-40ad-9ba4-b12ac66ef8d3.png">

