### PR TITLE
Fix error when RelationField request goes awry

### DIFF
--- a/static/js/components/widgets/RelationField.test.tsx
+++ b/static/js/components/widgets/RelationField.test.tsx
@@ -26,6 +26,7 @@ import {
 } from "../../types/websites"
 import { ReactWrapper } from "enzyme"
 import { DndContext } from "@dnd-kit/core"
+import { FormError } from "../forms/FormError"
 
 jest.mock("../../lib/api/util", () => ({
   ...jest.requireActual("../../lib/api/util"),
@@ -335,6 +336,23 @@ describe("RelationField", () => {
 
       expect(loadOptionsResponse).toStrictEqual(expectedOptions)
     })
+  })
+
+  it("should display an error message ", async () => {
+    // @ts-ignore
+    global.fetch.mockClear()
+    const fakeResponse = {
+      results:  undefined,
+      count:    0,
+      next:     null,
+      previous: null
+    }
+    // @ts-ignore
+    global.fetch.mockResolvedValue({ json: async () => fakeResponse })
+    const { wrapper } = await render()
+    wrapper.update()
+    const error = wrapper.find(FormError)
+    expect(error.text()).toBe("Unable to fetch entries for this field.")
   })
 
   describe("sortable UI", () => {

--- a/static/js/lib/api/FetchStatus.ts
+++ b/static/js/lib/api/FetchStatus.ts
@@ -1,0 +1,10 @@
+/**
+ * Represent success or error status for a fetch request
+ *
+ * This is really simple at present, but if need be could be extended to include
+ * status codes, messages, etc in both cases.
+ */
+export enum FetchStatus {
+  Ok,
+  Error
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes  #759
related to #738

#### What's this PR do?

If the request made by the RelationField component to fetch results goes awry then it will, currently, blow up the whole page, which is, I think, undesirable.

This changes it so that if the `results` prop comes back undefined then we display a 'hey this didn't work' message.

#### How should this be manually tested?

You'll be able to reproduce the issue which causes the error if you don't have an `ocw-ww` site locally. Then navigate to the `metadata` page in an OCW course and you should see this error. On `master` doing the same should cause the whole React app to crash.

#### Screenshots (if appropriate)

![Screen Shot 2021-11-01 at 10 28 19 AM](https://user-images.githubusercontent.com/6207644/139687856-a473d79c-6f1c-4cb2-b19b-4bc760d55ab9.png)


