### PR TITLE
Fix poll_build_status_until_complete to use celery countdown instead of sleep

### DIFF
--- a/app.json
+++ b/app.json
@@ -207,6 +207,10 @@
       "description": "Max retry attempts to get an S3 object",
       "required": false
     },
+    "MAX_WEBSITE_POLL_SECONDS": {
+      "description": "Maximum number of seconds to poll after a website deploy",
+      "required": false
+    },
     "MEDIA_ROOT": {
       "description": "The root directory for locally stored media. Typically not used.",
       "required": false
@@ -467,6 +471,10 @@
     },
     "VIDEO_S3_TRANSCODE_PREFIX": {
       "description": "Prefix to be used for S3 keys of files transcoded from AWS MediaConvert",
+      "required": false
+    },
+    "WEBSITE_POLL_FREQUENCY": {
+      "description": "Concourse poll frequency in seconds",
       "required": false
     },
     "YT_ACCESS_TOKEN": {

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -238,5 +238,5 @@ def poll_build_status_until_complete(
         # if not past expiration date, check again in 10 seconds
         poll_build_status_until_complete.apply_async(
             args=[website_name, version, datetime_to_expire],
-            countdown=settings.WEBSITE_POLL_FREQUENCY,
+            countdown=settings.CONCOURSE_POLL_FREQUENCY,
         )

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -238,5 +238,5 @@ def poll_build_status_until_complete(
         # if not past expiration date, check again in 10 seconds
         poll_build_status_until_complete.apply_async(
             args=[website_name, version, datetime_to_expire],
-            countdown=settings.CONCOURSE_POLL_FREQUENCY,
+            countdown=settings.WEBSITE_POLL_FREQUENCY,
         )

--- a/content_sync/tasks_test.py
+++ b/content_sync/tasks_test.py
@@ -280,7 +280,7 @@ def test_upsert_web_publishing_pipeline_missing(api_mock, log_mock):
 )
 @pytest.mark.parametrize("version", ["draft", "live"])
 def test_poll_build_status_until_complete(
-    settings, mocker, api_mock, final_status, version
+    mocker, api_mock, final_status, version
 ):
     """poll_build_status_until_complete should repeatedly poll until a finished state is reached"""
     website = WebsiteFactory.create(

--- a/content_sync/tasks_test.py
+++ b/content_sync/tasks_test.py
@@ -279,9 +279,7 @@ def test_upsert_web_publishing_pipeline_missing(api_mock, log_mock):
     ],
 )
 @pytest.mark.parametrize("version", ["draft", "live"])
-def test_poll_build_status_until_complete(
-    mocker, api_mock, final_status, version
-):
+def test_poll_build_status_until_complete(mocker, api_mock, final_status, version):
     """poll_build_status_until_complete should repeatedly poll until a finished state is reached"""
     website = WebsiteFactory.create(
         has_unpublished_live=False, has_unpublished_draft=False

--- a/main/settings.py
+++ b/main/settings.py
@@ -972,3 +972,13 @@ PREPUBLISH_ACTIONS = get_delimited_list(
     default=[],
     description="Actions to perform before publish",
 )
+MAX_WEBSITE_POLL_SECONDS = get_int(
+    name="MAX_WEBSITE_POLL_SECONDS",
+    default=2700,
+    description="Maximum number of seconds to poll after a website deploy",
+)  # 2700 is 45 minutes
+WEBSITE_POLL_FREQUENCY = get_int(
+    name="CONCOURSE_POLL_FREQUENCY",
+    default=5,
+    description="Concourse poll frequency in seconds",
+)

--- a/main/settings.py
+++ b/main/settings.py
@@ -978,7 +978,7 @@ MAX_WEBSITE_POLL_SECONDS = get_int(
     description="Maximum number of seconds to poll after a website deploy",
 )  # 2700 is 45 minutes
 WEBSITE_POLL_FREQUENCY = get_int(
-    name="CONCOURSE_POLL_FREQUENCY",
+    name="WEBSITE_POLL_FREQUENCY",
     default=5,
     description="Concourse poll frequency in seconds",
 )

--- a/websites/views.py
+++ b/websites/views.py
@@ -1,8 +1,8 @@
 """ Views for websites """
-from datetime import timedelta
 import json
 import logging
 import os
+from datetime import timedelta
 
 from django.conf import settings
 from django.contrib.auth.models import Group

--- a/websites/views.py
+++ b/websites/views.py
@@ -1,4 +1,5 @@
 """ Views for websites """
+from datetime import timedelta
 import json
 import logging
 import os
@@ -179,7 +180,13 @@ class WebsiteViewSet(
             website.draft_publish_status = constants.PUBLISH_STATUS_NOT_STARTED
             website.draft_publish_status_updated_on = now_in_utc()
             website.save()
-            poll_build_status_until_complete.delay(website.name, "draft")
+            poll_build_status_until_complete.delay(
+                website.name,
+                "draft",
+                (
+                    timedelta(seconds=settings.MAX_WEBSITE_POLL_SECONDS) + now_in_utc()
+                ).isoformat(),
+            )
             return Response(
                 status=200,
                 data={"details": message},
@@ -210,7 +217,13 @@ class WebsiteViewSet(
             website.live_publish_status = constants.PUBLISH_STATUS_NOT_STARTED
             website.live_publish_status_updated_on = now_in_utc()
             website.save()
-            poll_build_status_until_complete.delay(website.name, "live")
+            poll_build_status_until_complete.delay(
+                website.name,
+                "live",
+                (
+                    timedelta(seconds=settings.MAX_WEBSITE_POLL_SECONDS) + now_in_utc()
+                ).isoformat(),
+            )
             return Response(
                 status=200,
                 data={"details": ""},


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
Fixes `poll_build_status_until_complete` to use celery to call a delayed task rather than `sleep` to delay within the task. `sleep` caused the celery worker to do nothing for 5 seconds, which caused problems with other tasks in queue

#### How should this be manually tested?
Do a publish on a site. You should see a task being executed every 5 seconds or so in the celery logs. At some point you should see a success or failure in the UI, and the task should stop being called in the celery logs
