### PR TITLE
Only send publish success/failure emails to the user requesting a publish task

### DIFF
--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -195,7 +195,6 @@ class ConcourseGithubPipeline(BaseSyncPipeline):
                     .replace("((purge-url))", f"purge/{self.website.name}")
                     .replace("((purge_header))", purge_header)
                     .replace("((version))", version)
-                    .replace("((api-token))", settings.API_BEARER_TOKEN)
                 )
             config = json.dumps(yaml.load(config_str, Loader=yaml.SafeLoader))
             log.debug(config)

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -101,7 +101,6 @@ def test_upsert_website_pipelines(  # pylint: disable=too-many-arguments
     """The correct concourse API args should be made for a website"""
     settings.CONCOURSE_HARD_PURGE = hard_purge
     settings.ROOT_WEBSITE_NAME = "ocw-www-course"
-    settings.API_BEARER_TOKEN = "top-secret-token"
     settings.OCW_STUDIO_DRAFT_URL = "https://draft.ocw.mit.edu"
     settings.OCW_STUDIO_LIVE_URL = "https://live.ocw.mit.edu"
     settings.OCW_IMPORT_STARTER_SLUG = "custom_slug"
@@ -156,7 +155,6 @@ def test_upsert_website_pipelines(  # pylint: disable=too-many-arguments
     assert f"{hugo_projects_path}.git" in config_str
     assert settings.OCW_IMPORT_STARTER_SLUG in config_str
     assert api_url in config_str
-    assert settings.API_BEARER_TOKEN in config_str
     if home_page:
         assert (
             f"s3 sync s3://{settings.AWS_STORAGE_BUCKET_NAME}/{website.name} s3://{bucket}/{website.name}"

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -22,18 +22,6 @@ resources:
     source:
       uri: ((ocw-hugo-projects-uri))
       branch: ((ocw-hugo-projects-branch))
-  - name: ocw-studio-webhook
-    type: http-api
-    source:
-        uri: ((ocw-studio-url))/api/websites/((site-name))/pipeline_complete/
-        method: POST
-        headers:
-            Authorization: "Bearer {bearer_token}"
-        json:
-            version: ((version))
-            site: ((base-url))
-            success: "{succeeded}"
-        bearer_token: ((api-token))
 jobs:
   - name: build-ocw-site
     serial: true
@@ -71,11 +59,6 @@ jobs:
               mkdir ../ocw-hugo-themes/theme
               tar -xvzf ../ocw-hugo-themes/ocw-hugo-themes-*.tgz -C ../ocw-hugo-themes/theme
               hugo --config ../ocw-hugo-projects/((config-slug))/config.yaml --baseUrl /((base-url)) --themesDir ../ocw-hugo-themes/theme
-        on_failure:
-          try:
-            put: ocw-studio-webhook
-            params:
-                succeeded: false
       - task: copy-s3-buckets
         config:
           inputs:
@@ -95,11 +78,6 @@ jobs:
               aws s3 sync course-markdown/public s3://((ocw-bucket))/((base-url)) --metadata site-id=((site-name))
               aws s3 sync s3://((ocw-studio-bucket))/((site-url)) s3://((ocw-bucket))/((site-url)) --metadata site-id=((site-name))
               if [[ "((base-url))" == "" ]]; then aws s3 sync ocw-hugo-themes/theme/base-theme/dist s3://((ocw-bucket)) --metadata site-id=((site-name)); fi
-        on_failure:
-          try:
-            put: ocw-studio-webhook
-            params:
-                succeeded: false
       - task: clear-cdn-cache
         config:
           platform: linux
@@ -115,13 +93,3 @@ jobs:
               - -H
               - 'Fastly-Key: ((fastly.api_token))'((purge_header))
               - https://api.fastly.com/service/((fastly.service_id))/((purge-url))
-        on_success:
-          try:
-            put: ocw-studio-webhook
-            params:
-                succeeded: true
-        on_failure:
-          try:
-            put: ocw-studio-webhook
-            params:
-                succeeded: false

--- a/websites/api_test.py
+++ b/websites/api_test.py
@@ -4,13 +4,14 @@ from uuid import UUID
 import factory
 import pytest
 
+from users.factories import UserFactory
 from websites.api import (
     detect_mime_type,
     fetch_website,
     get_valid_new_filename,
     get_valid_new_slug,
     is_ocw_site,
-    mail_website_admins_on_publish,
+    mail_on_publish,
     unassigned_youtube_ids,
     update_youtube_thumbnail,
 )
@@ -255,37 +256,29 @@ def test_unassigned_youtube_ids(mocker, is_ocw):
 
 @pytest.mark.parametrize("success", [True, False])
 @pytest.mark.parametrize("version", ["live", "draft"])
-def test_mail_website_admins_on_publish(
-    settings, mocker, success, version, permission_groups
-):
-    """mail_website_admins_on_publish should send correct email to correct users"""
+def test_mail_on_publish(settings, mocker, success, version, permission_groups):
+    """mail_on_publish should send correct email to correct users"""
     settings.OCW_STUDIO_LIVE_URL = "http://test.live.edu/"
     settings.OCW_STUDIO_DRAFT_URL = "http://test.draft.edu"
-    mock_log = mocker.patch("websites.api.log.error")
     mock_get_message_sender = mocker.patch("websites.api.get_message_sender")
     mock_sender = mock_get_message_sender.return_value.__enter__.return_value
     message = (
         PreviewOrPublishSuccessMessage if success else PreviewOrPublishFailureMessage
     )
     website = permission_groups.websites[0]
-    mail_website_admins_on_publish(website, version, success)
+    user = UserFactory.create()
+    mail_on_publish(website.name, version, success, user.id)
     mock_get_message_sender.assert_called_once_with(message)
-    if not success:
-        mock_log.assert_called_once_with(
-            "%s version build failed for site %s", version, website.name
-        )
-    assert mock_sender.build_and_send_message.call_count == 2
-    for user in [website.owner]:
-        mock_sender.build_and_send_message.assert_any_call(
-            user,
-            {
-                "site": {
-                    "title": website.title,
-                    "url": f"http://test.{version}.edu/{website.starter.config['root-url-path']}/{website.name}",
-                },
-                "version": version,
+    mock_sender.build_and_send_message.assert_any_call(
+        user,
+        {
+            "site": {
+                "title": website.title,
+                "url": f"http://test.{version}.edu/{website.starter.config['root-url-path']}/{website.name}",
             },
-        )
+            "version": version,
+        },
+    )
 
 
 def test_detect_mime_type(mocker):


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #755 

#### What's this PR do?
- Removes the webhook task from the concourse pipeline definition, and removes the webhook view 
- Sends publish success/failure emails from within the `content_sync.tasks.poll_build_status_until_complete` task instead, and only to the user who requested the publish task.

#### How should this be manually tested?
- Use RC values for concourse integration in your .env file
- Set `MAX_WEBSITE_POLL_SECONDS=300` in your .env file so you won't be waiting too long if a pipeline doesn't complete.
-  Create a new site, add content, and publish.  
- The new pipeline on concourse-ci should run and not send a webhook request back after completion/failure.  You should still get an email.

#### Any background context you want to provide?
Once this is on RC, all the existing pipelines should be updated via the `backpopulate_pipelines` management command to remove the webhook requests. 
