### PR TITLE
add 404 page, show it when the user gets a 404 from the site API

### DIFF
--- a/static/js/components/NotFound.tsx
+++ b/static/js/components/NotFound.tsx
@@ -1,0 +1,19 @@
+import React from "react"
+
+interface Props {
+  children?: React.ReactNode
+}
+
+/**
+ * Our 404 component.
+ */
+export default function NotFound(props: Props) {
+  const { children } = props
+
+  return (
+    <div className="w-50 m-auto pt-5">
+      <h1>That's a 404!</h1>
+      {children}
+    </div>
+  )
+}

--- a/static/js/pages/App.tsx
+++ b/static/js/pages/App.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { useSelector } from "react-redux"
 import { Route, Switch } from "react-router"
-import { useRouteMatch } from "react-router-dom"
+import { Link, useRouteMatch } from "react-router-dom"
 import { useRequest } from "redux-query-react"
 
 import SitePage from "./SitePage"
@@ -17,6 +17,8 @@ import { websiteDetailRequest } from "../query-configs/websites"
 import { getWebsiteDetailCursor } from "../selectors/websites"
 import WebsiteContext from "../context/Website"
 import PrivacyPolicyPage from "./PrivacyPolicyPage"
+import NotFound from "../components/NotFound"
+import { sitesBaseUrl } from "../lib/urls"
 
 interface SiteMatchParams {
   name: string
@@ -31,7 +33,7 @@ export default function App(): JSX.Element {
     siteName = siteDetailMatch.params.name
   }
 
-  const [{ isPending: isSiteLoading }] = useRequest(
+  const [{ isPending: isSiteLoading, status }] = useRequest(
     siteName ? websiteDetailRequest(siteName) : null
   )
   const website = useSelector(getWebsiteDetailCursor)(siteName || "")
@@ -46,14 +48,30 @@ export default function App(): JSX.Element {
             <Route exact path="/new-site" component={SiteCreationPage} />
             <Route exact path="/sites" component={SitesDashboard} />
             <Route path="/sites/:name">
-              <WebsiteContext.Provider value={website}>
-                <SitePage isLoading={isSiteLoading} />
-              </WebsiteContext.Provider>
+              {status === 404 ? (
+                <NotFound>
+                  <div>
+                    We couldn't locate a site named "{siteName}". Try returning
+                    to the{" "}
+                    <Link to={sitesBaseUrl.toString()} className="underline">
+                      site index
+                    </Link>
+                    . Sorry!
+                  </div>
+                </NotFound>
+              ) : (
+                <WebsiteContext.Provider value={website}>
+                  <SitePage isLoading={isSiteLoading} />
+                </WebsiteContext.Provider>
+              )}
             </Route>
             <Route path="/collections" component={WebsiteCollectionsPage} />
             <Route path="/privacy-policy" component={PrivacyPolicyPage} />
             <Route path="/markdown-editor">
               <MarkdownEditorTestPage />
+            </Route>
+            <Route path="*">
+              <NotFound />
             </Route>
           </Switch>
         </div>

--- a/static/js/pages/HomePage.tsx
+++ b/static/js/pages/HomePage.tsx
@@ -24,7 +24,7 @@ export default function HomePage(): JSX.Element | null {
           OCW Studio integrates with Google Drive and YouTube via their
           respective APIs. The app can import static files saved in a MIT shared
           Google Drive and also publishes videos to{" "}
-          <a href="https://www.youtube.com/mitocw">
+          <a href="https://www.youtube.com/mitocw" className="underline">
             the MIT OCW channel on YouTube.
           </a>
         </div>

--- a/static/js/pages/SitePage.test.tsx
+++ b/static/js/pages/SitePage.test.tsx
@@ -24,11 +24,14 @@ describe("SitePage", () => {
       siteApiCollaboratorsUrl.param({ name: website.name }).toString(),
       { results: [] }
     )
-    render = helper.configureRenderer(props => (
-      <WebsiteContext.Provider value={website}>
-        <SitePage {...props} />
-      </WebsiteContext.Provider>
-    ))
+    render = helper.configureRenderer(
+      (props = {}) => (
+        <WebsiteContext.Provider value={website}>
+          <SitePage {...props} />
+        </WebsiteContext.Provider>
+      ),
+      { siteName: website.name }
+    )
   })
 
   afterEach(() => {

--- a/static/js/pages/SitePage.tsx
+++ b/static/js/pages/SitePage.tsx
@@ -22,6 +22,7 @@ export default function SitePage(props: SitePageProps): JSX.Element | null {
   if (isLoading) {
     return <div className="site-page std-page-body container">Loading...</div>
   }
+
   if (!website) {
     return null
   }

--- a/static/js/util/integration_test_helper.tsx
+++ b/static/js/util/integration_test_helper.tsx
@@ -94,8 +94,8 @@ export default class IntegrationTestHelper {
    * pass the API url you want to mock and the object which should be
    * returned as the request body!
    */
-  mockGetRequest(url: string, body: unknown): sinon.SinonStub {
-    return this.mockRequest(url, "GET", body, 200)
+  mockGetRequest(url: string, body: unknown, code = 200): sinon.SinonStub {
+    return this.mockRequest(url, "GET", body, code)
   }
 
   /**

--- a/static/scss/common.scss
+++ b/static/scss/common.scss
@@ -23,6 +23,10 @@ a {
   }
 }
 
+a.underline {
+  text-decoration: underline;
+}
+
 .studio-card {
   background-color: white;
   box-shadow: 0 1px rgba(0, 0, 0, 0.23);

--- a/static/scss/home-page.scss
+++ b/static/scss/home-page.scss
@@ -27,10 +27,4 @@
       }
     }
   }
-
-  .description {
-    a {
-      text-decoration: underline;
-    }
-  }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #764

#### What's this PR do?

This adds a 404 page and renders it in the case that the user tries to visit a nonexistent website.

#### How should this be manually tested?

Try going to a site normally - everything should be, well, normal. Then try going to like `/sites/foobasdfasdfasdf` or something (unless of course you happen to already have that site!). You should see a 404 page like in the screenshot.

I also added a 'wildcard match' (see [here](https://reactrouter.com/web/example/no-match)) at the bottom of our `<Switch>` in `App.tsx`. I'm not sure this will ever match anything because we only render certain routes as react routes on the backend, but it's a little security I guess.

#### Screenshots (if appropriate)

![Screen Shot 2021-11-03 at 11 32 30 AM](https://user-images.githubusercontent.com/6207644/140091899-79811e8c-fe97-484d-98bf-17784dc7e27e.png)