### PR TITLE
Tweak WebsiteContent permissions

### DIFF
--- a/websites/permissions.py
+++ b/websites/permissions.py
@@ -267,7 +267,9 @@ class HasWebsiteContentPermission(BasePermission):
             Website, name=view.kwargs.get("parent_lookup_website", None)
         )
         if request.method in SAFE_METHODS:
-            return check_perm(request.user, constants.PERMISSION_VIEW, website)
+            # Give permission to any logged in user, to facilitate content relations between different sites.
+            # In particular, to allow instructor relations from ocw-www in site metadata.
+            return bool(request.user and request.user.is_authenticated)
         if request.data and request.data.get("type") in ADMIN_ONLY_CONTENT:
             return is_site_admin(request.user, website)
         return check_perm(request.user, constants.PERMISSION_EDIT_CONTENT, website)

--- a/websites/permissions_test.py
+++ b/websites/permissions_test.py
@@ -286,6 +286,7 @@ def test_can_view_edit_website_content(
     for [user, safe_perm, unsafe_perm] in [
         [permission_groups.global_admin, True, True],
         [permission_groups.global_author, False, False],
+        [AnonymousUser(), False, False],
         [permission_groups.site_admin, True, True],
         [permission_groups.site_editor, True, (True and not is_admin_only_content)],
         [website.owner, True, True],
@@ -294,12 +295,9 @@ def test_can_view_edit_website_content(
             "type": (ADMIN_ONLY_CONTENT[0] if is_admin_only_content else "resource")
         }
         for method, method_perm in [("GET", safe_perm), ("POST", unsafe_perm)]:
-            assert (
-                permissions.HasWebsiteContentPermission().has_permission(
-                    mocker.Mock(user=user, method=method, data=data), view
-                )
-                is method_perm
-            )
+            assert permissions.HasWebsiteContentPermission().has_permission(
+                mocker.Mock(user=user, method=method, data=data), view
+            ) is (True if (method == "GET" and user.is_authenticated) else method_perm)
 
         for method, method_perm in [("GET", safe_perm), ("PATCH", unsafe_perm)]:
             for content in [


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #738 

#### What's this PR do?
Makes the API request to list `WebsiteContent` objects  viewable to any logged in user, not just collaborators on that associated `Website`.

#### How should this be manually tested?
- Make a new normal user (not superuser) and add it as an admin collaborator to a `Website` (but not to ocw-www)
- Log in as that user, and go to the metadata page for that site.
- You should be able to add new instructors from a populated dropdown list.  There should be no 403 API responses.
