### PR TITLE
Fix several celery task bugs

### DIFF
--- a/content_sync/decorators.py
+++ b/content_sync/decorators.py
@@ -98,7 +98,7 @@ def single_website_task(timeout: int) -> Callable:
                 else:
                     raise BlockingIOError()
             finally:
-                if has_lock:
+                if has_lock and lock.locked():
                     lock.release()
             return return_value
 

--- a/gdrive_sync/tasks_test.py
+++ b/gdrive_sync/tasks_test.py
@@ -308,7 +308,7 @@ def test_import_website_files(
     mock_sync_content = mocker.patch("gdrive_sync.tasks.sync_website_content.si")
     mock_update_status = mocker.patch("gdrive_sync.tasks.update_website_status.si")
     with pytest.raises(mocked_celery.replace_exception_class):
-        import_website_files.delay(website.short_id)
+        import_website_files.delay(website.name)
     assert mock_process_file_result.call_count == 2
     for drive_file in drive_files:
         mock_process_gdrive_file.assert_any_call(drive_file.file_id)
@@ -329,7 +329,7 @@ def test_import_website_files_missing_folder(mocker):
             [],
         ],
     )
-    import_website_files.delay(website.short_id)
+    import_website_files.delay(website.name)
     for folder in [DRIVE_FOLDER_VIDEOS_FINAL, DRIVE_FOLDER_FILES_FINAL]:
         mock_log.assert_any_call(
             "%s for %s", f"Could not find drive subfolder {folder}", website.short_id
@@ -353,7 +353,7 @@ def test_import_website_files_query_error(mocker):
         side_effect=Exception("Error querying google drive"),
     )
     website = WebsiteFactory.create()
-    import_website_files.delay(website.short_id)
+    import_website_files.delay(website.name)
     sync_errors = []
     for folder in [DRIVE_FOLDER_VIDEOS_FINAL, DRIVE_FOLDER_FILES_FINAL]:
         sync_error = (
@@ -377,7 +377,7 @@ def test_import_website_files_processing_error(
         side_effect=Exception("Error processing the file"),
     )
     website = WebsiteFactory.create()
-    import_website_files.delay(website.short_id)
+    import_website_files.delay(website.name)
     sync_errors = []
     for gdfile in LIST_FILE_RESPONSES[0]["files"]:
         sync_errors.append(f"Error processing gdrive file {gdfile.get('name')}")

--- a/websites/views.py
+++ b/websites/views.py
@@ -528,7 +528,7 @@ class WebsiteContentViewSet(
         website = Website.objects.get(name=self.kwargs.get("parent_lookup_website"))
         website.sync_status = WebsiteSyncStatus.PENDING
         website.save()
-        import_website_files.delay(website.short_id)
+        import_website_files.delay(website.name)
         return Response(status=200)
 
 

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -705,7 +705,7 @@ def test_websites_content_gdrive_sync(mocker, drf_client, permission_groups):
             kwargs={"parent_lookup_website": website.name},
         )
     )
-    mock_sync.assert_called_once_with(website.short_id)
+    mock_sync.assert_called_once_with(website.name)
     assert resp.status_code == 200
 
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #735 
Closes #748 
(hopefully, hard to consistently replicate these bugs)

#### What's this PR do?
- For #735, verify that the task is still locked before trying to release it.
- For #748, add the `single_website_task` decorator (and change the function arg to use `website.name` like other functions using this decorator).

#### How should this be manually tested?
- Tests should pass
- You can try running certain tasks simultaneously and check that neither of the bugs described in the above issues occur, for example:
```python
from gdrive_sync.tasks import *
site = Website.objects.get(name=<your_website_name>)
import_website_files.delay(site.name);import_website_files.delay(site.name)
```
