### PR TITLE
Poll for gdrive folder if blank on resources page

### DIFF
--- a/static/js/components/RepeatableContentListing.test.tsx
+++ b/static/js/components/RepeatableContentListing.test.tsx
@@ -370,10 +370,15 @@ describe("RepeatableContentListing", () => {
       ).toBe(`Add ${expectedLabel}`)
     })
   })
-
-  it("shows the sync status indicator", async () => {
-    const { wrapper } = await render({ website })
-    expect(wrapper.find("DriveSyncStatusIndicator").exists())
+  //
+  ;[true, false].forEach(gdriveEnabled => {
+    it("shows the sync status indicator", async () => {
+      SETTINGS.gdrive_enabled = gdriveEnabled
+      const { wrapper } = await render({ website })
+      expect(wrapper.find("DriveSyncStatusIndicator").exists()).toBe(
+        gdriveEnabled
+      )
+    })
   })
   //
   ;[
@@ -394,6 +399,7 @@ describe("RepeatableContentListing", () => {
       it(`${
         shouldUpdate ? "polls" : "doesn't poll"
       } the website sync status when sync_status=${status}`, async () => {
+        SETTINGS.gdrive_enabled = true
         const getStatusStub = helper.mockGetRequest(
           siteApiDetailUrl
             .param({ name: website.name })

--- a/static/js/components/RepeatableContentListing.tsx
+++ b/static/js/components/RepeatableContentListing.tsx
@@ -38,13 +38,14 @@ import {
 } from "../types/websites"
 import { createModalState } from "../types/modal_state"
 import { StudioList, StudioListItem } from "./StudioList"
+import { isNil } from "ramda"
 
 export default function RepeatableContentListing(props: {
   configItem: RepeatableConfigItem
 }): JSX.Element | null {
   const store = useStore()
   const { configItem } = props
-
+  const isResource = configItem.name === "resource"
   const website = useWebsite()
 
   const { search } = useLocation()
@@ -77,12 +78,15 @@ export default function RepeatableContentListing(props: {
   useInterval(
     async () => {
       if (
+        SETTINGS.gdrive_enabled &&
+        isResource &&
         website &&
-        website.sync_status &&
-        GOOGLE_DRIVE_SYNC_PROCESSING_STATES.includes(
-          // @ts-ignore
-          website.sync_status
-        )
+        (isNil(website.gdrive_url) ||
+          (website.sync_status &&
+            GOOGLE_DRIVE_SYNC_PROCESSING_STATES.includes(
+              // @ts-ignore
+              website.sync_status
+            )))
       ) {
         const response = await store.dispatch(
           // This will update the DriveSyncStatusIndicator
@@ -170,7 +174,7 @@ export default function RepeatableContentListing(props: {
       <div className="d-flex flex-direction-row align-items-right justify-content-between py-3">
         <h2 className="m-0 p-0">{configItem.label}</h2>
         <div className="noflex">
-          {SETTINGS.gdrive_enabled && configItem.name === "resource" ? (
+          {SETTINGS.gdrive_enabled && isResource ? (
             website.gdrive_url ? (
               <>
                 <div>

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -55,6 +55,18 @@ class WebsiteStarterDetailSerializer(serializers.ModelSerializer):
         fields = WebsiteStarterSerializer.Meta.fields + ["config"]
 
 
+class WebsiteGoogleDriveMixin(serializers.Serializer):
+    """ Serializer for website google drive details"""
+
+    gdrive_url = serializers.SerializerMethodField()
+
+    def get_gdrive_url(self, instance):
+        """ Get the Google Drive folder URL for the site"""
+        if is_gdrive_enabled() and instance.gdrive_folder:
+            return urljoin(gdrive_root_url(), instance.gdrive_folder)
+        return None
+
+
 class WebsiteSerializer(serializers.ModelSerializer):
     """ Serializer for websites """
 
@@ -79,14 +91,15 @@ class WebsiteSerializer(serializers.ModelSerializer):
         extra_kwargs = {"owner": {"write_only": True}}
 
 
-class WebsiteDetailSerializer(serializers.ModelSerializer, RequestUserSerializerMixin):
+class WebsiteDetailSerializer(
+    serializers.ModelSerializer, WebsiteGoogleDriveMixin, RequestUserSerializerMixin
+):
     """ Serializer for websites with serialized config """
 
     starter = WebsiteStarterDetailSerializer(read_only=True)
     is_admin = serializers.SerializerMethodField(read_only=True)
     live_url = serializers.SerializerMethodField()
     draft_url = serializers.SerializerMethodField()
-    gdrive_url = serializers.SerializerMethodField()
 
     def get_is_admin(self, obj):
         """ Determine if the request user is an admin"""
@@ -102,12 +115,6 @@ class WebsiteDetailSerializer(serializers.ModelSerializer, RequestUserSerializer
     def get_draft_url(self, instance):
         """Get the draft url for the site"""
         return instance.get_url(version="draft")
-
-    def get_gdrive_url(self, instance):
-        """ Get the Google Drive folder URL for the site"""
-        if is_gdrive_enabled():
-            return urljoin(gdrive_root_url(), instance.gdrive_folder)
-        return None
 
     def update(self, instance, validated_data):
         """ Remove owner attribute if present, it should not be changed"""
@@ -130,9 +137,10 @@ class WebsiteDetailSerializer(serializers.ModelSerializer, RequestUserSerializer
             "live_publish_status_updated_on",
             "draft_publish_status",
             "draft_publish_status_updated_on",
+            "gdrive_url",
             "sync_status",
-            "synced_on",
             "sync_errors",
+            "synced_on",
         ]
         read_only_fields = [
             "uuid",
@@ -148,13 +156,14 @@ class WebsiteDetailSerializer(serializers.ModelSerializer, RequestUserSerializer
             "live_publish_status_updated_on",
             "draft_publish_status",
             "draft_publish_status_updated_on",
+            "gdrive_url",
             "sync_status",
-            "synced_on",
             "sync_errors",
+            "synced_on",
         ]
 
 
-class WebsiteStatusSerializer(serializers.ModelSerializer):
+class WebsiteStatusSerializer(serializers.ModelSerializer, WebsiteGoogleDriveMixin):
     """Serializer for website status fields"""
 
     class Meta:
@@ -170,9 +179,10 @@ class WebsiteStatusSerializer(serializers.ModelSerializer):
             "live_publish_status_updated_on",
             "draft_publish_status",
             "draft_publish_status_updated_on",
+            "gdrive_url",
             "sync_status",
-            "synced_on",
             "sync_errors",
+            "synced_on",
         ]
         read_only_fields = fields
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #776

#### What's this PR do?
If google drive integration is enabled but a `Website.gdrive_folder` field is blank when a user navigates to the Resources page, poll the API for changes until it is populated.

#### How should this be manually tested?
- Create a new site
- Immediately navigate to its Resources page.  There should be no "Sync w/Google Drive" button (or link) visible yet.
- Wait, it should show shortly.
- Click on the link to make sure it goes to the website-specific folder.
- Make sure the API polling stops after it does show up.
