### PR TITLE
check if leftnav exists in 0040_no_zero_menu_weights

### DIFF
--- a/websites/migrations/0040_no_zero_menu_weights.py
+++ b/websites/migrations/0040_no_zero_menu_weights.py
@@ -17,7 +17,9 @@ def increment_decement_weights(apps, forward):
     WebsiteContent = apps.get_model("websites", "WebsiteContent")
     weight_change = 10 if forward else -10
     navmenus = WebsiteContent.objects.filter(
-        type="navmenu", website__source=WEBSITE_SOURCE_STUDIO
+        type="navmenu",
+        website__source=WEBSITE_SOURCE_STUDIO,
+        metadata__leftnav__isnull=False,
     )
     for navmenu in navmenus:
         for menuitem in navmenu.metadata["leftnav"]:


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/786

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/775, we changed the weights of menu items to start at 10 instead of 0 and included a migration to increment all existing weights by 10 to compensate.  This migration does not check for the existence of the `leftnav` key before accessing it and therefore fails on databases with other types of menus.  This PR adds an `isnull` filter to the `WebsiteContent` objects the migration is applied to, making sure it only applies to `navmenu` objects with a `metadata.leftnav` key.

#### How should this be manually tested?
 - Spin up `ocw-studio` locally and make sure you have the [`ocw-course`](https://github.com/mitodl/ocw-hugo-projects/blob/main/ocw-course/ocw-studio.yaml) starter
 - Create a site using the `ocw-course` starter
 - Add a few pages to your course
 - Go to the Menu section and add nav menu entries for your pages and save everything
 - Go to Django admin and find the `navmenu` `WebsiteContent` object for your site and manually edit the metadata, replacing "leftnav" with something else like "rightnav"
 - In a terminal, run `docker-compose run web ./manage.py migrate --fake websites 0039_gdrive_sync_progress` to fake back to the previous migration
 - Run `docker-compose run web ./manage.py migrate websites 0040_no_zero_menu_weights` and make sure you see no errors
