### PR TITLE
[proposal] refactor config field validation

### DIFF
--- a/localdev/configs/ocw-course-site-config.yml
+++ b/localdev/configs/ocw-course-site-config.yml
@@ -23,6 +23,7 @@ collections:
     fields:
       - label: Title
         name: title
+        attach: "Resource"
         required: true
         widget: string
       - label: Description

--- a/localdev/configs/ocw-course-site-config.yml
+++ b/localdev/configs/ocw-course-site-config.yml
@@ -23,7 +23,6 @@ collections:
     fields:
       - label: Title
         name: title
-        attach: "Resource"
         required: true
         widget: string
       - label: Description

--- a/websites/config_schema/api.py
+++ b/websites/config_schema/api.py
@@ -1,7 +1,9 @@
 """API for parsing/validating site configs"""
 import os
+import json
 
 import yamale
+from yamale.yamale_error import YamaleError
 import yaml
 from django.conf import settings
 
@@ -44,13 +46,72 @@ def validate_raw_site_config(yaml_to_validate):
     """
     schema = yamale.make_schema(path=SITE_CONFIG_SCHEMA_PATH)
     yamale_data = yamale.make_data(content=yaml_to_validate)
-    yamale.validate(schema, yamale_data)
-    # Retrieve the parsed YAML (Yamale returns a list of lists instead of just the parsed YAML)
-    parsed_data = yamale_data[0][0]
-    # Schema is valid according to the YAML document. Now apply our custom rules...
-    for added_schema_rule in ADDED_SCHEMA_RULES:
-        added_schema_rule.validate(parsed_data, schema_path=SITE_CONFIG_SCHEMA_PATH)
+    print("this is running")
+    try:
+        yamale.validate(schema, yamale_data)
+        # Retrieve the parsed YAML (Yamale returns a list of lists instead of just the parsed YAML)
+        parsed_data = yamale_data[0][0]
+        # Schema is valid according to the YAML document. Now apply our custom rules...
+        for added_schema_rule in ADDED_SCHEMA_RULES:
+            added_schema_rule.validate(parsed_data, schema_path=SITE_CONFIG_SCHEMA_PATH)
+    except YamaleError as e:
+        print('Validation failed!\n')
+        for result in e.results:
+            print("Error validating data with '%s'\n\t" % (result.schema))
+            deduped_split_errors = [ error.split(":") for error in list(set(result.errors))]
 
+            # this dict maps an error path to an array of all the errors that we found at that path
+            # this lets us print *once* the error context and then print all the error messages about it
+            unique_error_paths = {}
+            for [k, v] in deduped_split_errors:
+                if k in unique_error_paths:
+                    unique_error_paths[k].append(v.strip())
+                else:
+                    unique_error_paths[k] = [v.strip()]
+
+            for path, errors in unique_error_paths.items():
+                error_path = list(map(
+                    lambda key : int(key) if key.isnumeric() else key,
+                    path.strip().split(".")
+                ))
+
+                def fetch_data(obj, path):
+                    key, *rest = path
+
+                    if isinstance(obj, list):
+                        if key < len(obj):
+                            if len(rest) > 0:
+                                return fetch_data(obj[key], rest)
+                            else:
+                                return obj[key]
+                        else:
+                            return obj
+                    else:
+                        if key in obj:
+                            if len(rest) > 0:
+                                return fetch_data(obj[key], rest)
+                            else:
+                                return obj[key]
+                        else:
+                            return obj
+
+                error_context = fetch_data(
+                    yamale_data[0][0],
+                    error_path[:-1]
+                )
+                formatted_errors = "\n".join([f"\t{error}" for error in errors])
+                formatted_context = "\n".join([
+                    f"\t{line}" for line in 
+                    json.dumps(
+                    error_context,
+                    indent=4
+                ).split("\n")
+                ])
+
+                print(f"Found errors:\n{formatted_errors}")
+                print(f"At path:\n\t{path}")
+                print(f"In context:\n{formatted_context}\n")
+        exit(1)
 
 def validate_parsed_site_config(config_to_validate):
     """

--- a/websites/config_schema/site-config-schema.yml
+++ b/websites/config_schema/site-config-schema.yml
@@ -5,7 +5,7 @@ collections: list(include('content_item'))
 content_item:
     name: str()
     label: str()
-    label_singular: str(required=True)
+    label_singular: str(required=False)
     category: str()
     fields: list(include('field'), required=False)
     folder: str(required=False)
@@ -25,33 +25,26 @@ config_field_base_props: &config_field_base_props
     help: str(required=False)
     default: any(required=False)
     condition: include('field_condition', required=False)
-
 markdown_config_field: &markdown_config_field
     << : *config_field_base_props
     widget: str(equals='markdown')
     minimal: bool(required=False)
     attach: str(required=False)
-
 file_config_field: &file_config_field
     << : *config_field_base_props
     widget: str(equals='file')
-
 boolean_config_field: &boolean_config_field
     << : *config_field_base_props
     widget: str(equals='boolean')
-
 text_config_field: &text_config_field
     << : *config_field_base_props
     widget: str(equals='text')
-
 string_config_field: &string_config_field
     << : *config_field_base_props
     widget: str(equals='string')
-
 hidden_config_field: &hidden_config_field
     << : *config_field_base_props
     widget: str(equals='hidden')
-
 select_config_field: &select_config_field
     << : *config_field_base_props
     widget: str(equals='select')
@@ -59,59 +52,56 @@ select_config_field: &select_config_field
     multiple: bool(required=False)
     min: int(required=False)
     max: int(required=False)
-
 object_config_field: &object_config_field
     << : *config_field_base_props
     widget: str(equals='object')
     fields: list(any(
-      *markdown_config_field,
-      *file_config_field,
-      *boolean_config_field,
-      *text_config_field,
-      *string_config_field,
-      *hidden_config_field,
-      *select_config_field,
-      *hierarchical_select_config_field,
-      *relation_config_field,
+      include('markdown_config_field'),
+      include('file_config_field'),
+      include('boolean_config_field'),
+      include('text_config_field'),
+      include('string_config_field'),
+      include('hidden_config_field'),
+      include('select_config_field'),
+      include('hierarchical_select_config_field'),
+      include('relation_config_field'),
       )
       )
     collapsed: bool(required=False)
-
 hierarchical_select_config_field: &hierarchical_select_config_field
     << : *config_field_base_props
     widget: str(equals='hierarchical-select')
     options_map: map(required=False)
+    levels: list(include('level'), required=False)
     min: int(required=False)
     max: int(required=False)
-
 relation_config_field: &relation_config_field
     << : *config_field_base_props
     widget: str(equals='relation')
     display_field: str(required=False)
+    collection: str()
     multiple: bool(required=False)
     min: int(required=False)
     max: int(required=False)
     filter: include('relation_filter', required=False)
     website: str(required=False)
     sortable: bool(required=False)
-
 menu_config_field: &menu_config_field
     << : *config_field_base_props
     widget: str(equals='menu')
     collections: list(str(), required=False)
-
 field: any(
-  *markdown_config_field,
-  *file_config_field,
-  *boolean_config_field,
-  *text_config_field,
-  *string_config_field,
-  *hidden_config_field,
-  *select_config_field,
-  *object_config_field,
-  *hierarchical_select_config_field,
-  *relation_config_field,
-  *menu_config_field,
+  include('markdown_config_field'),
+  include('file_config_field'),
+  include('boolean_config_field'),
+  include('text_config_field'),
+  include('string_config_field'),
+  include('hidden_config_field'),
+  include('select_config_field'),
+  include('object_config_field'),
+  include('hierarchical_select_config_field'),
+  include('relation_config_field'),
+  include('menu_config_field'),
   )
 ---
 field_condition:

--- a/websites/config_schema/site-config-schema.yml
+++ b/websites/config_schema/site-config-schema.yml
@@ -5,7 +5,7 @@ collections: list(include('content_item'))
 content_item:
     name: str()
     label: str()
-    label_singular: str(required=False)
+    label_singular: str(required=True)
     category: str()
     fields: list(include('field'), required=False)
     folder: str(required=False)
@@ -18,29 +18,101 @@ inner_content_item:
     fields: list(include('field'), required=False)
     file: str(required=False)
 ---
-field:
-    widget: enum('string', 'text', 'markdown', 'file', 'select', 'boolean', 'hidden', 'object', 'relation', 'menu', 'hierarchical-select')
-    label: str()
+config_field_base_props: &config_field_base_props
     name: str()
-    minimal: bool(required=False)
+    label: str()
     required: bool(required=False)
     help: str(required=False)
-    fields: list(include('field'), required=False)
+    default: any(required=False)
+    condition: include('field_condition', required=False)
+
+markdown_config_field: &markdown_config_field
+    << : *config_field_base_props
+    widget: str(equals='markdown')
+    minimal: bool(required=False)
+    attach: str(required=False)
+
+file_config_field: &file_config_field
+    << : *config_field_base_props
+    widget: str(equals='file')
+
+boolean_config_field: &boolean_config_field
+    << : *config_field_base_props
+    widget: str(equals='boolean')
+
+text_config_field: &text_config_field
+    << : *config_field_base_props
+    widget: str(equals='text')
+
+string_config_field: &string_config_field
+    << : *config_field_base_props
+    widget: str(equals='string')
+
+hidden_config_field: &hidden_config_field
+    << : *config_field_base_props
+    widget: str(equals='hidden')
+
+select_config_field: &select_config_field
+    << : *config_field_base_props
+    widget: str(equals='select')
+    options: list(any(str(), include('option_item')), required=False)
     multiple: bool(required=False)
     min: int(required=False)
     max: int(required=False)
-    options: list(any(str(), include('option_item')), required=False)
+
+object_config_field: &object_config_field
+    << : *config_field_base_props
+    widget: str(equals='object')
+    fields: list(any(
+      *markdown_config_field,
+      *file_config_field,
+      *boolean_config_field,
+      *text_config_field,
+      *string_config_field,
+      *hidden_config_field,
+      *select_config_field,
+      *hierarchical_select_config_field,
+      *relation_config_field,
+      )
+      )
+    collapsed: bool(required=False)
+
+hierarchical_select_config_field: &hierarchical_select_config_field
+    << : *config_field_base_props
+    widget: str(equals='hierarchical-select')
     options_map: map(required=False)
-    default: any(required=False)
-    condition: include('field_condition', required=False)
+    min: int(required=False)
+    max: int(required=False)
+
+relation_config_field: &relation_config_field
+    << : *config_field_base_props
+    widget: str(equals='relation')
     display_field: str(required=False)
-    collection: str(required=False)
-    collections: list(str(), required=False)
+    multiple: bool(required=False)
+    min: int(required=False)
+    max: int(required=False)
     filter: include('relation_filter', required=False)
     website: str(required=False)
-    attach: str(required=False)
-    levels: list(include('level'), required=False)
     sortable: bool(required=False)
+
+menu_config_field: &menu_config_field
+    << : *config_field_base_props
+    widget: str(equals='menu')
+    collections: list(str(), required=False)
+
+field: any(
+  *markdown_config_field,
+  *file_config_field,
+  *boolean_config_field,
+  *text_config_field,
+  *string_config_field,
+  *hidden_config_field,
+  *select_config_field,
+  *object_config_field,
+  *hierarchical_select_config_field,
+  *relation_config_field,
+  *menu_config_field,
+  )
 ---
 field_condition:
     field: str()


### PR DESCRIPTION
#### What are the relevant tickets?

none

#### What's this PR do?

This refactors the config field validation so that instead of having just one type of config field on which we validate all of the fields, we instead declare the various possible config field types (i.e. markdown, string, boolean, etc) separately, so that for each of them we can specify which props are required for them.

This is useful because for instance the relation field must have the `collection` prop defined. If the config field is defined as simply one type, all of the props which aren't present on every variant must be listed as optional (`required=False`). This works, but it leaves us with no way to validate that if a config author adds, for instance, a relation field they must define what collection it is supposed to pull from. Pulling these things out into separate objects lets us do that.

It is a bit funky though! I feel I just learned more about yaml than I really want to know. It may turn out for this reason that we don't want to make this change, but I thought I would propose it to see what everyone thinks.

#### How should this be manually tested?

Make some changes to the site configs that will exercise the new validation thing (like removing a `collection` from a relation field should now invalidate the config, whereas on the main branch that won't cause an error).