### PR TITLE
Fix some issues with upserting multiple site pipelines

### DIFF
--- a/content_sync/api.py
+++ b/content_sync/api.py
@@ -28,9 +28,11 @@ def get_sync_backend(website: Website) -> BaseSyncBackend:
     return import_string(settings.CONTENT_SYNC_BACKEND)(website)
 
 
-def get_sync_pipeline(website: Website) -> BaseSyncPipeline:
+def get_sync_pipeline(
+    website: Website, api: Optional[object] = None
+) -> BaseSyncPipeline:
     """ Get the configured sync publishing pipeline """
-    return import_string(settings.CONTENT_SYNC_PIPELINE)(website)
+    return import_string(settings.CONTENT_SYNC_PIPELINE)(website, api=api)
 
 
 @is_sync_enabled

--- a/content_sync/api_test.py
+++ b/content_sync/api_test.py
@@ -169,7 +169,7 @@ def test_get_sync_pipeline(settings, mocker, pipeline_api):
         "content_sync.pipelines.concourse.ConcourseGithubPipeline"
     )
     website = WebsiteFactory.create()
-    api.get_sync_pipeline(website)
+    api.get_sync_pipeline(website, api=pipeline_api)
     import_string_mock.assert_any_call(website, api=pipeline_api)
 
 

--- a/content_sync/api_test.py
+++ b/content_sync/api_test.py
@@ -159,7 +159,8 @@ def test_sync_github_website_starters(mocker):
     mock_task.assert_called_once_with(*args, **kwargs)
 
 
-def test_get_sync_pipeline(settings, mocker):
+@pytest.mark.parametrize("pipeline_api", [None, {}])
+def test_get_sync_pipeline(settings, mocker, pipeline_api):
     """ Verify that get_sync_pipeline() imports the pipeline class based on settings.py """
     settings.CONTENT_SYNC_PIPELINE = (
         "content_sync.pipelines.concourse.ConcourseGithubPipeline"
@@ -169,7 +170,7 @@ def test_get_sync_pipeline(settings, mocker):
     )
     website = WebsiteFactory.create()
     api.get_sync_pipeline(website)
-    import_string_mock.assert_any_call(website)
+    import_string_mock.assert_any_call(website, api=pipeline_api)
 
 
 def test_create_website_publishing_pipeline(settings, mocker):

--- a/content_sync/management/commands/backpopulate_pipelines.py
+++ b/content_sync/management/commands/backpopulate_pipelines.py
@@ -1,11 +1,10 @@
 """ Backpopulate website pipelines"""
 from django.conf import settings
-from django.core.management import BaseCommand
+from django.core.management import BaseCommand, CommandError
 from django.db.models import Q
 from mitol.common.utils.datetime import now_in_utc
 
-from content_sync.api import get_sync_backend, get_sync_pipeline
-from content_sync.pipelines.base import BaseSyncPipeline
+from content_sync.tasks import upsert_pipelines
 from websites.models import Website
 
 
@@ -38,10 +37,17 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "-c",
-            "--create_backends",
-            dest="create_backends",
+            "--create_backend",
+            dest="create_backend",
             action="store_true",
             help="Create backends if they do not exist (and sync them too)",
+        )
+        parser.add_argument(
+            "-ch",
+            "--chunks",
+            dest="chunk_size",
+            default=500,
+            help="Set chunk size for task processing",
         )
         parser.add_argument(
             "-u",
@@ -58,20 +64,18 @@ class Command(BaseCommand):
             return
 
         self.stdout.write("Creating website pipelines")
-        start = now_in_utc()
 
         filter_str = options["filter"].lower()
         starter_str = options["starter"]
         source_str = options["source"]
+        chunk_size = int(options["chunk_size"])
+        create_backend = options["create_backend"]
         is_verbose = options["verbosity"] > 1
-        create_backends = options["create_backends"]
         unpause = options["unpause"]
-
-        total_websites = 0
 
         if filter_str:
             website_qset = Website.objects.filter(
-                Q(name__icontains=filter_str) | Q(title__icontains=filter_str)
+                Q(name__startswith=filter_str) | Q(title__startswith=filter_str)
             )
         else:
             website_qset = Website.objects.all()
@@ -82,29 +86,32 @@ class Command(BaseCommand):
         if source_str:
             website_qset = website_qset.filter(source=source_str)
 
-        for website in website_qset.iterator():
-            backend = get_sync_backend(website)
-            if create_backends:
-                backend.create_website_in_backend()
-                backend.sync_all_content_to_backend()
-            if backend.backend_exists():
-                pipeline = get_sync_pipeline(website)
-                pipeline.upsert_website_pipeline()
-                if unpause:
-                    for version in [
-                        BaseSyncPipeline.VERSION_LIVE,
-                        BaseSyncPipeline.VERSION_DRAFT,
-                    ]:
-                        pipeline.unpause_pipeline(version)
-                total_websites += 1
+        website_names = list(website_qset.values_list("name", flat=True))
 
-            if is_verbose:
-                self.stdout.write(f"{website.name} pipeline created or updated")
+        if is_verbose:
+            self.stdout.write(
+                f"Upserting pipelines for the following sites: {','.join(website_names)}"
+            )
+
+        start = now_in_utc()
+        task = upsert_pipelines.delay(
+            website_names,
+            chunk_size=chunk_size,
+            create_backend=create_backend,
+            unpause=unpause,
+        )
+
+        self.stdout.write(
+            f"Started celery task {task} to upsert pipelines for {len(website_names)} sites"
+        )
+
+        self.stdout.write("Waiting on task...")
+
+        result = task.get()
+        if set(result) != {True}:
+            raise CommandError(f"Some errors occurred: {result}")
 
         total_seconds = (now_in_utc() - start).total_seconds()
         self.stdout.write(
-            "Creation of website pipelines finished, took {} seconds".format(
-                total_seconds
-            )
+            "Pipeline upserts finished, took {} seconds".format(total_seconds)
         )
-        self.stdout.write(f"{total_websites} websites processed")

--- a/content_sync/management/commands/backpopulate_pipelines.py
+++ b/content_sync/management/commands/backpopulate_pipelines.py
@@ -40,7 +40,7 @@ class Command(BaseCommand):
             "--create_backend",
             dest="create_backend",
             action="store_true",
-            help="Create backends if they do not exist (and sync them too)",
+            help="Create website backend if it does not exist (and sync it too)",
         )
         parser.add_argument(
             "-ch",

--- a/content_sync/pipelines/base.py
+++ b/content_sync/pipelines/base.py
@@ -1,5 +1,6 @@
 """ Sync abstract base """
 import abc
+from typing import Optional
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -15,7 +16,7 @@ class BaseSyncPipeline(abc.ABC):
     VERSION_LIVE = VERSION_LIVE
     VERSION_DRAFT = VERSION_DRAFT
 
-    def __init__(self, website: Website):
+    def __init__(self, website: Website, api: Optional[object] = None):
         """Make sure all required settings are present"""
         missing_settings = []
         for setting_name in self.MANDATORY_SETTINGS:
@@ -31,6 +32,7 @@ class BaseSyncPipeline(abc.ABC):
                 )
             )
         self.website = website
+        self.api = api
 
     @abc.abstractmethod
     def upsert_website_pipeline(self):  # pragma: no cover

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -94,8 +94,9 @@ def test_upsert_website_pipeline_missing_settings(settings):
 @pytest.mark.parametrize("home_page", [True, False])
 @pytest.mark.parametrize("pipeline_exists", [True, False])
 @pytest.mark.parametrize("hard_purge", [True, False])
+@pytest.mark.parametrize("with_api", [True, False])
 def test_upsert_website_pipelines(  # pylint: disable=too-many-arguments
-    mocker, settings, version, home_page, pipeline_exists, hard_purge
+    mocker, settings, version, home_page, pipeline_exists, hard_purge, with_api
 ):  # pylint:disable=too-many-locals
     """The correct concourse API args should be made for a website"""
     settings.CONCOURSE_HARD_PURGE = hard_purge
@@ -131,7 +132,9 @@ def test_upsert_website_pipelines(  # pylint: disable=too-many-arguments
     mock_put_headers = mocker.patch(
         "content_sync.pipelines.concourse.ConcourseApi.put_with_headers"
     )
-    pipeline = ConcourseGithubPipeline(website)
+    existing_api = ConcourseApi("a", "b", "c", "d") if with_api else None
+    pipeline = ConcourseGithubPipeline(website, api=existing_api)
+    assert (pipeline.api == existing_api) is with_api
     pipeline.upsert_website_pipeline()
 
     mock_get.assert_any_call(url_path)

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -126,7 +126,7 @@ def upsert_website_publishing_pipeline(website_name: str):
 def upsert_website_pipeline_batch(
     website_names: List[str], create_backend=False, unpause=False
 ):
-    """ Create/update a pipeline for previewing & publishing a website """
+    """ Create/update publishing pipelines for multiple websites"""
     api_instance = None
     for website_name in website_names:
         website = Website.objects.get(name=website_name)
@@ -152,7 +152,7 @@ def upsert_website_pipeline_batch(
 def upsert_pipelines(
     self, website_names: List[str], chunk_size=500, create_backend=False, unpause=False
 ):
-    """ Upsert pipelines"""
+    """ Chunk and group batches of pipeline upserts for a specified list of websites"""
     tasks = []
     for website_subset in chunks(
         sorted(website_names),

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -3,12 +3,13 @@ import logging
 from time import sleep
 from typing import List, Optional
 
+import celery
 from dateutil.parser import parse
 from django.conf import settings
 from django.db.models import F, Q
 from django.utils.module_loading import import_string
 from github.GithubException import RateLimitExceededException
-from mitol.common.utils import now_in_utc, pytz
+from mitol.common.utils import chunks, now_in_utc, pytz
 
 from content_sync import api
 from content_sync.apis import github
@@ -119,6 +120,50 @@ def upsert_website_publishing_pipeline(website_name: str):
     else:
         pipeline = api.get_sync_pipeline(website)
         pipeline.upsert_website_pipeline()
+
+
+@app.task(acks_late=True)
+def upsert_website_pipeline_batch(
+    website_names: List[str], create_backend=False, unpause=False
+):
+    """ Create/update a pipeline for previewing & publishing a website """
+    api_instance = None
+    for website_name in website_names:
+        website = Website.objects.get(name=website_name)
+        if create_backend:
+            backend = api.get_sync_backend(website)
+            backend.create_website_in_backend()
+            backend.sync_all_content_to_backend()
+        pipeline = api.get_sync_pipeline(website, api=api_instance)
+        if not api_instance:
+            # Keep using the same api instance to minimize multiple authentication calls
+            api_instance = pipeline.api
+        pipeline.upsert_website_pipeline()
+        if unpause:
+            for version in [
+                BaseSyncPipeline.VERSION_LIVE,
+                BaseSyncPipeline.VERSION_DRAFT,
+            ]:
+                pipeline.unpause_pipeline(version)
+    return True
+
+
+@app.task(bind=True)
+def upsert_pipelines(
+    self, website_names: List[str], chunk_size=500, create_backend=False, unpause=False
+):
+    """ Upsert pipelines"""
+    tasks = []
+    for website_subset in chunks(
+        sorted(website_names),
+        chunk_size=chunk_size,
+    ):
+        tasks.append(
+            upsert_website_pipeline_batch.s(
+                website_subset, create_backend=create_backend, unpause=unpause
+            )
+        )
+    raise self.replace((celery.group(tasks)))
 
 
 @app.task(acks_late=True, autoretry_for=(BlockingIOError,), retry_backoff=True)

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -163,7 +163,7 @@ def upsert_pipelines(
                 website_subset, create_backend=create_backend, unpause=unpause
             )
         )
-    raise self.replace((celery.group(tasks)))
+    raise self.replace(celery.group(tasks))
 
 
 @app.task(acks_late=True, autoretry_for=(BlockingIOError,), retry_backoff=True)

--- a/content_sync/tasks_test.py
+++ b/content_sync/tasks_test.py
@@ -286,7 +286,7 @@ def test_upsert_web_publishing_pipeline_missing(api_mock, log_mock):
 @pytest.mark.parametrize("create_backend", [True, False])
 @pytest.mark.parametrize("unpause", [True, False])
 @pytest.mark.parametrize("chunk_size, chunks", [[3, 1], [2, 2]])
-def test_upsert_pipelines(
+def test_upsert_pipelines(  # pylint:disable=too-many-arguments, unused-argument
     mocker, mocked_celery, create_backend, unpause, chunk_size, chunks
 ):
     """upsert_pipelines calls upsert_pipeline_batch with correct arguments"""

--- a/content_sync/tasks_test.py
+++ b/content_sync/tasks_test.py
@@ -11,6 +11,7 @@ from mitol.common.utils import now_in_utc
 from pytest import fixture
 
 from content_sync import tasks
+from content_sync.constants import VERSION_DRAFT, VERSION_LIVE
 from content_sync.factories import ContentSyncStateFactory
 from content_sync.pipelines.base import BaseSyncPipeline
 from users.factories import UserFactory
@@ -280,6 +281,62 @@ def test_upsert_web_publishing_pipeline_missing(api_mock, log_mock):
         "fake",
     )
     api_mock.get_sync_pipeline.assert_not_called()
+
+
+@pytest.mark.parametrize("create_backend", [True, False])
+@pytest.mark.parametrize("unpause", [True, False])
+@pytest.mark.parametrize("chunk_size, chunks", [[3, 1], [2, 2]])
+def test_upsert_pipelines(
+    mocker, mocked_celery, create_backend, unpause, chunk_size, chunks
+):
+    """upsert_pipelines calls upsert_pipeline_batch with correct arguments"""
+    websites = WebsiteFactory.create_batch(3)
+    website_names = sorted([website.name for website in websites])
+    mock_batch = mocker.patch("content_sync.tasks.upsert_website_pipeline_batch.s")
+    with pytest.raises(TabError):
+        tasks.upsert_pipelines.delay(
+            website_names,
+            create_backend=create_backend,
+            unpause=unpause,
+            chunk_size=chunk_size,
+        )
+    mock_batch.assert_any_call(
+        website_names[0:chunk_size], create_backend=create_backend, unpause=unpause
+    )
+    if chunks > 1:
+        mock_batch.assert_any_call(
+            website_names[chunk_size:], create_backend=create_backend, unpause=unpause
+        )
+
+
+@pytest.mark.parametrize("create_backend", [True, False])
+@pytest.mark.parametrize("unpause", [True, False])
+def test_upsert_website_pipeline_batch(mocker, create_backend, unpause):
+    """upsert_website_pipeline_batch should make the expected function calls"""
+    mock_get_backend = mocker.patch("content_sync.tasks.api.get_sync_backend")
+    mock_get_pipeline = mocker.patch("content_sync.tasks.api.get_sync_pipeline")
+    websites = WebsiteFactory.create_batch(2)
+    website_names = sorted([website.name for website in websites])
+    tasks.upsert_website_pipeline_batch(
+        website_names, create_backend=create_backend, unpause=unpause
+    )
+    mock_get_pipeline.assert_any_call(websites[0], api=None)
+    mock_get_pipeline.assert_any_call(websites[1], api=mocker.ANY)
+    if create_backend:
+        for website in websites:
+            mock_get_backend.assert_any_call(website)
+        mock_backend = mock_get_backend.return_value
+        assert mock_backend.create_website_in_backend.call_count == 2
+        assert mock_backend.sync_all_content_to_backend.call_count == 2
+    else:
+        mock_get_backend.assert_not_called()
+    mock_pipeline = mock_get_pipeline.return_value
+    assert mock_pipeline.upsert_website_pipeline.call_count == 2
+    if unpause:
+        mock_pipeline.unpause_pipeline.assert_any_call(VERSION_DRAFT)
+        mock_pipeline.unpause_pipeline.assert_any_call(VERSION_LIVE)
+    else:
+        mock_pipeline.unpause_pipeline.assert_not_called()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #790
Closes #791 

#### What's this PR do?
Modifies the `backpopulate_pipelines` command to make pipeline upsert requests in parallel batches of chunked tasks.  This new batch task reuses a `ConcourseApi` instance to cut down on authentication requests.  
Also added a `retry_on_error` decoration on `ConcourseApi.auth()`

#### How should this be manually tested?
- Make sure you also have the same settings as RC for AWS_, CONCOURSE_* and GIT_*
- Import 20 or so ocw legacy sites if you haven't already done so with `manage.py import_ocw_course_sites --bucket ocw-to-hugo-output-qa` (you will need RC AWS settings)
- Run `manage.py backpopulate_pipelines  -ch 4 --source ocw-import
- Check the celery log, you should eventually see about 5 instances (assuming 20 sites) of `content_sync.tasks.upsert_website_pipeline_batch` run and succeed, without any errors being logged.
