### PR TITLE
transcript notifications

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -945,6 +945,7 @@ MITOL_MAIL_MESSAGE_CLASSES = [
     "videos.messages.YouTubeUploadFailureMessage",
     "websites.messages.PreviewOrPublishSuccessMessage",
     "websites.messages.PreviewOrPublishFailureMessage",
+    "websites.messages.videoTranscriptingCompleteMessage",
 ]
 MITOL_MAIL_RECIPIENT_OVERRIDE = get_string(
     name="MITOL_MAIL_RECIPIENT_OVERRIDE",

--- a/websites/api.py
+++ b/websites/api.py
@@ -18,7 +18,7 @@ from websites.messages import (
     PreviewOrPublishSuccessMessage,
 )
 from websites.models import Website, WebsiteContent, WebsiteStarter
-from websites.utils import get_dict_field, set_dict_field
+from websites.utils import get_dict_field, get_dict_query_field, set_dict_field
 
 
 log = logging.getLogger(__name__)
@@ -192,11 +192,29 @@ def unassigned_youtube_ids(website: Website) -> List[WebsiteContent]:
     """Return a list of WebsiteContent objects for videos with unassigned youtube ids"""
     if not is_ocw_site(website):
         return []
+    query_resource_type_field = get_dict_query_field(
+        "metadata", settings.FIELD_RESOURCETYPE
+    )
     query_id_field = f"metadata__{'__'.join(settings.YT_FIELD_ID.split('.'))}"
     return WebsiteContent.objects.filter(
         Q(website=website)
-        & Q(metadata__resourcetype=RESOURCE_TYPE_VIDEO)
+        & Q(**{query_resource_type_field: RESOURCE_TYPE_VIDEO})
         & (Q(**{query_id_field: None}) | Q(**{query_id_field: ""}))
+    )
+
+
+def videos_missing_captions(website: Website) -> List[WebsiteContent]:
+    """Return a list of WebsiteContent objects for videos with unassigned captions"""
+    if not is_ocw_site(website):
+        return []
+    query_resource_type_field = get_dict_query_field(
+        "metadata", settings.FIELD_RESOURCETYPE
+    )
+    query_caption_field = get_dict_query_field("metadata", settings.YT_FIELD_CAPTIONS)
+    return WebsiteContent.objects.filter(
+        Q(website=website)
+        & Q(**{query_resource_type_field: RESOURCE_TYPE_VIDEO})
+        & (Q(**{query_caption_field: None}) | Q(**{query_caption_field: ""}))
     )
 
 

--- a/websites/messages.py
+++ b/websites/messages.py
@@ -6,6 +6,25 @@ from mitol.mail.messages import TemplatedMessage
 from content_sync.constants import VERSION_LIVE
 
 
+class VideoTranscriptingCompleteMessage(TemplatedMessage):
+    """Email message for 3play transcription complete"""
+
+    name = "3play transcription complete"
+    template_name = "mail/transcription_complete"
+
+    @staticmethod
+    def get_debug_template_context() -> dict:
+        """Returns the extra context for the email debugger"""
+        return {
+            "user": SimpleNamespace(name="Test User"),
+            "site": SimpleNamespace(
+                name="1-1-computer-science-fall-2024",
+                title="Intro to Computer Science",
+                full_url="https://ocwtest.edu/courses/1-1-computer-science-fall-2024",
+            ),
+        }
+
+
 class PreviewOrPublishSuccessMessage(TemplatedMessage):
     """Email message for publish/preview pipeline success"""
 

--- a/websites/templates/mail/transcription_complete/body.html
+++ b/websites/templates/mail/transcription_complete/body.html
@@ -1,0 +1,19 @@
+{% extends "mail/email_base.html" %}
+
+{% block content %}
+<tr>
+  <td style="padding: 20px;">
+    <table role="presentation" cellspacing="0" cellpadding="0" border="0" width="100%">
+      <tr>
+        <td style="padding: 20px; font-family: sans-serif; font-size: 15px; line-height: 20px; color: #555555;">
+          <p style="margin: 0 0 10px;">Dear {{ user.name }},</p>
+          <p style="margin: 0 0 10px;">
+            Transcripts for all videos for your site <a href="{{ site.url }}">{{ site.title }}</a> have been completed by 3play.
+            Your site is now ready for publication.
+          </p>
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>
+{% endblock %}

--- a/websites/templates/mail/transcription_complete/subject.txt
+++ b/websites/templates/mail/transcription_complete/subject.txt
@@ -1,0 +1,1 @@
+All transcripts complete for {{ site_name }}: "{{site.title}}"


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
<img width="817" alt="Screen Shot 2021-11-10 at 11 06 51 AM" src="https://user-images.githubusercontent.com/1934992/141149235-95be9ca1-a07d-411c-9b29-838a01ed3ebf.png">

#### What are the relevant tickets?
closes https://github.com/mitodl/ocw-studio/issues/782

#### What's this PR do?
This pr
1) Updates the code to send a notification when all the videos for a course have been transcripted
2) Updates the publish task to not publish when there are missing transcripts

#### How should this be manually tested?
Find or create a site. If the site already has video resources, make sure that the "Video Captions (WebVTT) URL" field is filled out for all of them. If there are some video resources with a blank captions url, you can just set it to something

Follow the steps in https://github.com/mitodl/ocw-studio/pull/777. After the transcript is complete you should get an email notification.

Set the "Video Captions (WebVTT) URL" field of the site you just created to blank.  Follow the steps in https://github.com/mitodl/ocw-studio/pull/777 again. You should not get an email notification.

Also, verify that you can publish the site when all video resources have "Video Captions (WebVTT) URL" (and youtube id) set but can't publish when some captions are missing