### PR TITLE
Fix changing short_id on ocw reimport, reset publish fields as part of `reset_sync_state` command

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -71,7 +71,7 @@ Version 0.32.0 (Released October 28, 2021)
 Version 0.31.0 (Released October 22, 2021)
 --------------
 
-- Make check for rate limits optional in sync_all_websites task (#721)
+- Make check for rate limits optional in sync_unsynced_websites task (#721)
 - Slugify s3 keys and make sure they're still unique (#710)
 - Hide production publish btn, prohibit metadata editing for non-admin editors (#702)
 - Hide the file upload field on resource form if google drive integration is enabled (#712)

--- a/content_sync/management/commands/reset_sync_states.py
+++ b/content_sync/management/commands/reset_sync_states.py
@@ -82,7 +82,7 @@ class Command(BaseCommand):
                 content__website__starter__slug=starter_str
             )
         if source_str:
-            content_qset = content_qset.filter(content__website_source=source_str)
+            content_qset = content_qset.filter(content__website__source=source_str)
 
         content_qset.update(synced_checksum=None)
 

--- a/content_sync/management/commands/reset_sync_states.py
+++ b/content_sync/management/commands/reset_sync_states.py
@@ -5,7 +5,7 @@ from django.db.models import Q
 from mitol.common.utils.datetime import now_in_utc
 
 from content_sync.models import ContentSyncState
-from content_sync.tasks import sync_all_websites
+from content_sync.tasks import sync_unsynced_websites
 
 
 class Command(BaseCommand):
@@ -22,18 +22,39 @@ class Command(BaseCommand):
             help="If specified, only process content types that match this filter",
         )
         parser.add_argument(
-            "-s",
-            "--sync_backends",
-            dest="sync_backends",
-            action="store_true",
-            help="Sync all course backends",
-        )
-        parser.add_argument(
             "-c",
             "--create_backends",
             dest="create_backends",
             action="store_true",
             help="Create backends if they do not exist (and sync them too)",
+        )
+        parser.add_argument(
+            "-f",
+            "--filter",
+            dest="filter",
+            default="",
+            help="If specified, only process content for sites that start with this text in their name/short_id",
+        )
+        parser.add_argument(
+            "-starter",
+            "--starter",
+            dest="starter",
+            default="",
+            help="If specified, only process content for sites that are based on this starter slug",
+        )
+        parser.add_argument(
+            "-source",
+            "--source",
+            dest="source",
+            default="",
+            help="If specified, only process content for sites that are based on this source",
+        )
+        parser.add_argument(
+            "-ss",
+            "--skip_sync",
+            dest="skip_sync",
+            action="store_true",
+            help="Skip syncing backends",
         )
 
     def handle(self, *args, **options):
@@ -41,13 +62,27 @@ class Command(BaseCommand):
         self.stdout.write("Resetting synced checksums to null")
         start = now_in_utc()
 
-        filter_str = options["type"].lower()
-        sync_backends = options["sync_backends"]
+        type_str = options["type"].lower()
         create_backends = options["create_backends"]
+        filter_str = options["filter"].lower()
+        starter_str = options["starter"].lower()
+        source_str = options["source"].lower()
+        skip_sync = options["skip_sync"]
 
         content_qset = ContentSyncState.objects.exclude(synced_checksum__isnull=True)
+        if type_str:
+            content_qset = content_qset.filter(Q(content__type=type_str))
         if filter_str:
-            content_qset = content_qset.filter(Q(content__type=filter_str))
+            content_qset = content_qset.filter(
+                Q(content__website__name__startswith=filter_str)
+                | Q(content__website__short_id__startswith=filter_str)
+            )
+        if starter_str:
+            content_qset = content_qset.filter(
+                content__website__starter__slug=starter_str
+            )
+        if source_str:
+            content_qset = content_qset.filter(content__website_source=source_str)
 
         content_qset.update(synced_checksum=None)
 
@@ -58,10 +93,10 @@ class Command(BaseCommand):
             )
         )
 
-        if (sync_backends or create_backends) and settings.CONTENT_SYNC_BACKEND:
-            self.stdout.write("Syncing all courses to the designated backend")
+        if settings.CONTENT_SYNC_BACKEND and not skip_sync:
+            self.stdout.write("Syncing all unsynced websites to the designated backend")
             start = now_in_utc()
-            task = sync_all_websites.delay(create_backends=create_backends)
+            task = sync_unsynced_websites.delay(create_backends=create_backends)
             self.stdout.write(f"Starting task {task}...")
             task.get()
             total_seconds = (now_in_utc() - start).total_seconds()

--- a/content_sync/management/commands/sync_backend_to_db.py
+++ b/content_sync/management/commands/sync_backend_to_db.py
@@ -2,7 +2,8 @@
 from django.core.management import BaseCommand
 
 from content_sync.api import get_sync_backend
-from websites.api import fetch_website
+from websites.api import fetch_website, reset_publishing_fields
+from websites.models import Website
 
 
 class Command(BaseCommand):
@@ -25,3 +26,5 @@ class Command(BaseCommand):
             f"Syncing content from backend to database for '{website.title}'..."
         )
         backend.sync_all_content_to_db()
+        reset_publishing_fields(website.name)
+        self.stdout.write(f"Completed syncing from backend to database")

--- a/content_sync/management/commands/sync_website_to_backend.py
+++ b/content_sync/management/commands/sync_website_to_backend.py
@@ -3,7 +3,7 @@ from django.core.management import BaseCommand
 
 from content_sync.api import get_sync_backend
 from content_sync.models import ContentSyncState
-from websites.api import fetch_website
+from websites.api import fetch_website, reset_publishing_fields
 
 
 class Command(BaseCommand):
@@ -43,3 +43,4 @@ class Command(BaseCommand):
             f"Updating website content in backend for '{website.title}'..."
         )
         backend.sync_all_content_to_backend()
+        reset_publishing_fields(website.name)

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -45,7 +45,7 @@ def sync_content(content_sync_id: str):
 
 
 @app.task(acks_late=True)
-def sync_all_websites(create_backends: bool = False, check_limit: bool = False):
+def sync_unsynced_websites(create_backends: bool = False, check_limit: bool = False):
     """
     Sync all websites with unsynced content if they have existing repos.
     This should be rarely called, and only in a management command.

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -22,7 +22,8 @@ from websites.api import mail_on_publish
 from websites.constants import (
     PUBLISH_STATUS_ABORTED,
     PUBLISH_STATUS_ERRORED,
-    PUBLISH_STATUS_SUCCEEDED, PUBLISH_STATUS_NOT_STARTED,
+    PUBLISH_STATUS_NOT_STARTED,
+    PUBLISH_STATUS_SUCCEEDED,
 )
 from websites.models import Website
 

--- a/content_sync/tasks_test.py
+++ b/content_sync/tasks_test.py
@@ -140,11 +140,8 @@ def test_sync_unsynced_websites(api_mock, backend_exists, create_backend):
         website.refresh_from_db()
         assert website.has_unpublished_live is True
         assert website.has_unpublished_draft is True
-        assert (
-            website.live_publish_status
-            == website.draft_publish_status
-            == PUBLISH_STATUS_NOT_STARTED
-        )
+        assert website.live_publish_status is None
+        assert website.draft_publish_status is None
         assert website.latest_build_id_live is None
         assert website.latest_build_id_draft is None
     with pytest.raises(AssertionError):

--- a/content_sync/tasks_test.py
+++ b/content_sync/tasks_test.py
@@ -140,7 +140,11 @@ def test_sync_unsynced_websites(api_mock, backend_exists, create_backend):
         website.refresh_from_db()
         assert website.has_unpublished_live is True
         assert website.has_unpublished_draft is True
-        assert website.live_publish_status == website.draft_publish_status == PUBLISH_STATUS_NOT_STARTED
+        assert (
+            website.live_publish_status
+            == website.draft_publish_status
+            == PUBLISH_STATUS_NOT_STARTED
+        )
         assert website.latest_build_id_live is None
         assert website.latest_build_id_draft is None
     with pytest.raises(AssertionError):

--- a/content_sync/tasks_test.py
+++ b/content_sync/tasks_test.py
@@ -127,7 +127,7 @@ def test_sync_all_websites(api_mock, backend_exists, create_backend):
         2, content=WebsiteContentFactory.create(website=websites_unsynced[1])
     )
 
-    tasks.sync_all_websites.delay(create_backends=create_backend)
+    tasks.sync_unsynced_websites.delay(create_backends=create_backend)
     for website in websites_unsynced:
         api_mock.get_sync_backend.assert_any_call(website)
     with pytest.raises(AssertionError):
@@ -140,7 +140,7 @@ def test_sync_all_websites(api_mock, backend_exists, create_backend):
 
 @pytest.mark.parametrize("check_limit", [True, False])
 def test_sync_all_websites_rate_limit_low(mocker, settings, check_limit):
-    """Test that sync_all_websites pauses if the GithubBackend is close to exceeding rate limit"""
+    """Test that sync_unsynced_websites pauses if the GithubBackend is close to exceeding rate limit"""
     settings.CONTENT_SYNC_BACKEND = "content_sync.backends.github.GithubBackend"
     mock_git_wrapper = mocker.patch("content_sync.backends.github.GithubApiWrapper")
     sleep_mock = mocker.patch("content_sync.tasks.sleep")
@@ -152,18 +152,18 @@ def test_sync_all_websites_rate_limit_low(mocker, settings, check_limit):
     )
     mock_git_wrapper.return_value.git.get_rate_limit.return_value.core = mock_core
     ContentSyncStateFactory.create_batch(2)
-    tasks.sync_all_websites.delay(check_limit=check_limit)
+    tasks.sync_unsynced_websites.delay(check_limit=check_limit)
     assert sleep_mock.call_count == (2 if check_limit else 0)
 
 
 def test_sync_all_websites_rate_limit_exceeded(api_mock):
-    """Test that sync_all_websites halts if instantiating a GithubBackend exceeds the rate limit"""
+    """Test that sync_unsynced_websites halts if instantiating a GithubBackend exceeds the rate limit"""
     api_mock.get_sync_backend.side_effect = RateLimitExceededException(
         status=403, data={}, headers={}
     )
     ContentSyncStateFactory.create_batch(2)
     with pytest.raises(RateLimitExceededException):
-        tasks.sync_all_websites.delay()
+        tasks.sync_unsynced_websites.delay()
     api_mock.get_sync_backend.return_value.sync_all_content_to_backend.assert_not_called()
 
 

--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -155,7 +155,7 @@ def convert_data_to_content(filepath, data, website):  # pylint:disable=too-many
             "parent": parent,
             "title": content_json.get("title"),
             "type": content_type,
-            "dirpath": dirpath,
+            "dirpath": dirpath.replace("pages", "testpages"),
             # Replace dots with dashes to simplify file name/extension parsing, and limit length
             "filename": filename.replace(".", "-")[0:CONTENT_FILENAME_MAX_LEN],
         }

--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -155,7 +155,7 @@ def convert_data_to_content(filepath, data, website):  # pylint:disable=too-many
             "parent": parent,
             "title": content_json.get("title"),
             "type": content_type,
-            "dirpath": dirpath.replace("pages", "testpages"),
+            "dirpath": dirpath,
             # Replace dots with dashes to simplify file name/extension parsing, and limit length
             "filename": filename.replace(".", "-")[0:CONTENT_FILENAME_MAX_LEN],
         }

--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -4,6 +4,7 @@ import logging
 import re
 import uuid
 from copy import deepcopy
+from typing import Dict
 
 import dateutil
 import yaml
@@ -165,7 +166,7 @@ def convert_data_to_content(filepath, data, website):  # pylint:disable=too-many
         return content
 
 
-def get_short_id(metadata):
+def get_short_id(name: str, metadata: Dict) -> str:
     """ Get a short_id from the metadata"""
     course_num = metadata.get("primary_course_number")
     if not course_num:
@@ -187,7 +188,9 @@ def get_short_id(metadata):
         .lower()
         .replace(" ", "-")
     )
-    short_id_exists = Website.objects.filter(short_id=short_id).exists()
+    short_id_exists = (
+        Website.objects.exclude(name=name).filter(short_id=short_id).exists()
+    )
     if short_id_exists:
         short_id_prefix = f"{short_id}-"
         short_id = find_available_name(
@@ -368,7 +371,7 @@ def import_ocw2hugo_course(bucket_name, prefix, path, starter_id=None):
                 "title": course_data.get("course_title", f"Course Site ({name})"),
                 "publish_date": publish_date,
                 "metadata": course_data,
-                "short_id": get_short_id(course_data),
+                "short_id": get_short_id(name, course_data),
                 "starter_id": starter_id,
                 "source": WEBSITE_SOURCE_OCW_IMPORT,
             },

--- a/ocw_import/api_test.py
+++ b/ocw_import/api_test.py
@@ -292,17 +292,19 @@ def test_import_ocw2hugo_content_log_exception(mocker, settings):
 def test_get_short_id(course_num, term, year, expected_id):
     """ get_short_id should return expected values, or raise an error if no course number"""
     metadata = {"primary_course_number": course_num, "term": term, "year": year}
-    name = "test-course-name"
     if expected_id:
-        short_id = get_short_id(name, metadata)
+        website = WebsiteFactory.create(short_id=expected_id)
+        short_id = get_short_id(website.name, metadata)
         assert short_id == expected_id
-        for i in range(1, 4):
-            WebsiteFactory.create(name=name, short_id=short_id)
-            short_id = get_short_id(metadata)
-            assert short_id == f"{expected_id}-{i+1}"
+        for i in range(2, 5):
+            name = f"site_name_{i}"
+            website = WebsiteFactory.create(
+                name=name, short_id=get_short_id(name, metadata)
+            )
+            assert website.short_id == f"{expected_id}-{i}"
     else:
         with pytest.raises(ValueError):
-            get_short_id(name, metadata)
+            get_short_id("random-name", metadata)
 
 
 @mock_s3

--- a/ocw_import/api_test.py
+++ b/ocw_import/api_test.py
@@ -292,16 +292,17 @@ def test_import_ocw2hugo_content_log_exception(mocker, settings):
 def test_get_short_id(course_num, term, year, expected_id):
     """ get_short_id should return expected values, or raise an error if no course number"""
     metadata = {"primary_course_number": course_num, "term": term, "year": year}
+    name = "test-course-name"
     if expected_id:
-        short_id = get_short_id(metadata)
+        short_id = get_short_id(name, metadata)
         assert short_id == expected_id
         for i in range(1, 4):
-            WebsiteFactory.create(short_id=short_id)
+            WebsiteFactory.create(name=name, short_id=short_id)
             short_id = get_short_id(metadata)
             assert short_id == f"{expected_id}-{i+1}"
     else:
         with pytest.raises(ValueError):
-            get_short_id(metadata)
+            get_short_id(name, metadata)
 
 
 @mock_s3

--- a/ocw_import/management/commands/import_ocw_course_sites.py
+++ b/ocw_import/management/commands/import_ocw_course_sites.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.core.management import BaseCommand
 from mitol.common.utils.datetime import now_in_utc
 
-from content_sync.tasks import sync_all_websites
+from content_sync.tasks import sync_unsynced_websites
 from ocw_import.api import fetch_ocw2hugo_course_paths
 from ocw_import.tasks import import_ocw2hugo_courses
 
@@ -128,7 +128,7 @@ class Command(BaseCommand):
         if options["sync"] is True and settings.CONTENT_SYNC_BACKEND:
             self.stdout.write("Syncing all unsynced courses to the designated backend")
             start = now_in_utc()
-            task = sync_all_websites.delay(
+            task = sync_unsynced_websites.delay(
                 create_backends=options["create_backend"],
                 check_limit=options["rate_limit"],
             )

--- a/websites/admin.py
+++ b/websites/admin.py
@@ -25,7 +25,7 @@ class WebsiteAdmin(TimestampedModelAdmin, GuardedModelAdmin):
 
     include_created_on_in_list = True
     formfield_overrides = {JSONField: {"widget": PrettyJSONWidget}}
-    search_fields = ("title", "name", "uuid")
+    search_fields = ("title", "name", "uuid", "short_id")
     list_display = (
         "name",
         "title",
@@ -46,6 +46,7 @@ class WebsiteContentAdmin(TimestampedModelAdmin, SafeDeleteAdmin):
         "website__title",
         "website__name",
         "website__uuid",
+        "website__short_id",
         "text_id",
         "parent__text_id",
     )

--- a/websites/api.py
+++ b/websites/api.py
@@ -12,10 +12,7 @@ from mitol.common.utils import max_or_none, now_in_utc
 from mitol.mail.api import get_message_sender
 
 from users.models import User
-from websites.constants import (
-    CONTENT_FILENAME_MAX_LEN,
-    RESOURCE_TYPE_VIDEO,
-)
+from websites.constants import CONTENT_FILENAME_MAX_LEN, RESOURCE_TYPE_VIDEO
 from websites.messages import (
     PreviewOrPublishFailureMessage,
     PreviewOrPublishSuccessMessage,

--- a/websites/api.py
+++ b/websites/api.py
@@ -14,7 +14,6 @@ from mitol.mail.api import get_message_sender
 from users.models import User
 from websites.constants import (
     CONTENT_FILENAME_MAX_LEN,
-    PUBLISH_STATUS_NOT_STARTED,
     RESOURCE_TYPE_VIDEO,
 )
 from websites.messages import (
@@ -254,8 +253,8 @@ def reset_publishing_fields(website_name: str):
     Website.objects.filter(name=website_name).update(
         has_unpublished_live=True,
         has_unpublished_draft=True,
-        live_publish_status=PUBLISH_STATUS_NOT_STARTED,
-        draft_publish_status=PUBLISH_STATUS_NOT_STARTED,
+        live_publish_status=None,
+        draft_publish_status=None,
         live_publish_status_updated_on=now,
         draft_publish_status_updated_on=now,
         latest_build_id_live=None,

--- a/websites/migrations/0031_website_short_id.py
+++ b/websites/migrations/0031_website_short_id.py
@@ -15,7 +15,7 @@ def backpopulate_short_id(apps, schema_editor):
         short_id = None
         if website_dict["metadata"]:
             try:
-                short_id = get_short_id(website_dict["metadata"])
+                short_id = get_short_id(website_dict["name"], website_dict["metadata"])
             except:
                 pass
         if not short_id:


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #804 
Partially addresses #807 

#### What's this PR do?
- Fixes a bug that was causing the `short_id` of imported OCW sites to change on a 2nd import
- Resets various publishing related fields on `Website` so you can publish again after running the `reset_sync_states` command

#### How should this be manually tested?
- Change AWS .env settings to match RC.  Use a personal git organization for your GIT* .env values (see README).
- Run `docker-compose run web python manage.py import_ocw_course_sites --bucket ocw-to-hugo-output-qa --filter "1-012-introduction-to-civil-engineering-design-spring-2002"  --sync  --create_backend` once.  The `short_id` should be `1-012-spring-2002`
- Run it again.  The `short_id` should still be `1-012-spring-2002` and not `1-012-spring-2002-2`
- Change the following values for a website:
  ```
    has_unpublished_live=False,
    has_unpublished_draft=False,
   ```
- Go to the site's studio url on the front end, you should not be able to publish.
- Run `manage.py reset_sync_states --filter <your_website_name`
- Check the above values for the website after it's done, they should be `True` now, and you should be able to publish from the site's studio url.
   