### PR TITLE
Always unpause pipelines before triggering

### DIFF
--- a/content_sync/api.py
+++ b/content_sync/api.py
@@ -54,13 +54,6 @@ def create_website_publishing_pipeline(website: Website):
     tasks.upsert_website_publishing_pipeline.delay(website.name)
 
 
-@is_publish_pipeline_enabled
-def unpause_publishing_pipeline(website: Website, version: str):
-    """Unpause the publishing pipeline"""
-    pipeline = get_sync_pipeline(website)
-    pipeline.unpause_pipeline(version)
-
-
 @is_sync_enabled
 def update_website_backend(website: Website):
     """ Update the backend content for a website"""
@@ -70,13 +63,13 @@ def update_website_backend(website: Website):
 @is_sync_enabled
 def preview_website(website: Website):
     """ Create a preview for the website on the backend"""
-    tasks.preview_website_backend.delay(website.name, website.draft_publish_date)
+    tasks.preview_website_backend.delay(website.name)
 
 
 @is_sync_enabled
 def publish_website(website: Website):
     """ Publish the website on the backend"""
-    tasks.publish_website_backend.delay(website.name, website.publish_date)
+    tasks.publish_website_backend.delay(website.name)
 
 
 def sync_github_website_starters(

--- a/content_sync/api_test.py
+++ b/content_sync/api_test.py
@@ -4,7 +4,6 @@ from django.db.models.signals import post_save
 from factory.django import mute_signals
 
 from content_sync import api
-from content_sync.api import unpause_publishing_pipeline
 from websites.factories import WebsiteContentFactory, WebsiteFactory
 
 
@@ -138,7 +137,7 @@ def test_preview_website(settings, mocker):
     mock_task = mocker.patch("content_sync.tasks.preview_website_backend")
     website = WebsiteFactory.create()
     api.preview_website(website)
-    mock_task.delay.assert_called_once_with(website.name, website.draft_publish_date)
+    mock_task.delay.assert_called_once_with(website.name)
 
 
 def test_publish_website(settings, mocker):
@@ -147,7 +146,7 @@ def test_publish_website(settings, mocker):
     mock_task = mocker.patch("content_sync.tasks.publish_website_backend")
     website = WebsiteFactory.create()
     api.publish_website(website)
-    mock_task.delay.assert_called_once_with(website.name, website.publish_date)
+    mock_task.delay.assert_called_once_with(website.name)
 
 
 def test_sync_github_website_starters(mocker):
@@ -195,16 +194,3 @@ def test_create_website_publishing_pipeline_disabled(settings, mocker):
     website = WebsiteFactory.create()
     api.create_website_publishing_pipeline(website)
     mock_task.assert_not_called()
-
-
-@pytest.mark.parametrize("version", ["live", "draft"])
-def test_unpause_publishing_pipeline(settings, mocker, version):
-    """unpause_publishing_pipeline should call the expected functions"""
-    settings.CONTENT_SYNC_PIPELINE = (
-        "content_sync.pipelines.concourse.ConcourseGithubPipeline"
-    )
-    mock_pipeline_api = mocker.patch("content_sync.api.get_sync_pipeline")
-    website = WebsiteFactory.create()
-    unpause_publishing_pipeline(website, version)
-    mock_pipeline_api.assert_called_once_with(website)
-    mock_pipeline_api.return_value.unpause_pipeline.assert_called_once_with(version)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #808 

#### What's this PR do?
Always sends a request to unpublish a pipeline before triggering it, just in case.  

#### How should this be manually tested?
- Use AWS and CONCOURSE settings for RC, use a local git org for GIT_ settings
- Create a new site
- Check that its concourse pipeline is paused.
- Publish it.
- Check that its concourse pipeline is unpaused and running.  It will never find your personal repo so terminate it.
- Publish again, there should be no errors in the logs and another concourse build should start, which you can terminate.