### PR TITLE
Add option to delete git files not matching WebsiteContent in db when syncing

### DIFF
--- a/content_sync/backends/base.py
+++ b/content_sync/backends/base.py
@@ -96,8 +96,15 @@ class BaseSyncBackend(abc.ABC):
         else:
             self.update_content_in_backend(sync_state)
 
-    def sync_all_content_to_backend(self):
+    @abc.abstractmethod
+    def delete_orphaned_content_in_backend(self):
+        """ Delete any git repo files without corresponding WebsiteContent objects"""
+        ...
+
+    def sync_all_content_to_backend(self, delete=False):
         """ Sync all content for the website """
+        if delete:
+            self.delete_orphaned_content_in_backend()
         for sync_state in ContentSyncState.objects.filter(
             content__website=self.website
         ):

--- a/content_sync/backends/base_test.py
+++ b/content_sync/backends/base_test.py
@@ -45,6 +45,9 @@ class _ImplementedBackend(BaseSyncBackend):
     def sync_all_content_to_db(self):
         ...
 
+    def delete_orphaned_content_in_backend(self):
+        ...
+
 
 class _NotImplementedBackend(BaseSyncBackend):
     """ Not implemented """
@@ -103,16 +106,21 @@ def test_sync_content_to_backend_delete(mocker):
     mock_delete_content_in_backend.assert_called_once_with(state)
 
 
+@pytest.mark.parametrize("delete", [True, False])
 @pytest.mark.django_db
-def test_sync_all_content_to_backend(mocker):
+def test_sync_all_content_to_backend(mocker, delete):
     """ Verify that sync_all_content_to_backend calls sync_content_to_backend for each piece of content """
     mock_sync_content_to_backend = mocker.patch.object(
         _ImplementedBackend, "sync_content_to_backend", return_value=None
     )
+    mock_delete = mocker.patch.object(
+        _ImplementedBackend, "delete_orphaned_content_in_backend"
+    )
     website = WebsiteFactory.create()
     states = ContentSyncStateFactory.create_batch(5, content__website=website)
     backend = _ImplementedBackend(website)
-    backend.sync_all_content_to_backend()
+    backend.sync_all_content_to_backend(delete=delete)
     assert mock_sync_content_to_backend.call_count == len(states)
+    assert mock_delete.call_count == (1 if delete else 0)
     for state in states:
         mock_sync_content_to_backend.assert_any_call(state)

--- a/content_sync/management/commands/sync_website_to_backend.py
+++ b/content_sync/management/commands/sync_website_to_backend.py
@@ -27,11 +27,21 @@ class Command(BaseCommand):
                 "of whether or not our db records say that it has been synced before."
             ),
         )
+        parser.add_argument(
+            "--delete",
+            dest="git_delete",
+            action="store_true",
+            help=(
+                "If this flag is added, this command will attempt to delete any files in the git repo that do not"
+                "match any WebsiteContent filepaths"
+            ),
+        )
 
     def handle(self, *args, **options):
         website = fetch_website(options["website"])
         backend = get_sync_backend(website)
         should_create = options["force_create"]
+        should_delete = options["git_delete"]
         if not should_create:
             should_create = not ContentSyncState.objects.filter(
                 content__website=website
@@ -42,5 +52,5 @@ class Command(BaseCommand):
         self.stdout.write(
             f"Updating website content in backend for '{website.title}'..."
         )
-        backend.sync_all_content_to_backend()
+        backend.sync_all_content_to_backend(delete=should_delete)
         reset_publishing_fields(website.name)

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -45,7 +45,11 @@ def sync_content(content_sync_id: str):
 
 
 @app.task(acks_late=True)
-def sync_unsynced_websites(create_backends: bool = False, check_limit: bool = False):
+def sync_unsynced_websites(
+    create_backends: bool = False,
+    check_limit: bool = False,
+    delete: Optional[bool] = False,
+):
     """
     Sync all websites with unsynced content if they have existing repos.
     This should be rarely called, and only in a management command.
@@ -85,7 +89,7 @@ def sync_unsynced_websites(create_backends: bool = False, check_limit: bool = Fa
                             sleep(5)
                 if create_backends or backend.backend_exists():
                     backend.create_website_in_backend()
-                    backend.sync_all_content_to_backend()
+                    backend.sync_all_content_to_backend(delete=delete)
             except RateLimitExceededException:
                 # Too late, can't even check rate limit reset time now so bail
                 raise

--- a/ocw_import/management/commands/import_ocw_course_sites.py
+++ b/ocw_import/management/commands/import_ocw_course_sites.py
@@ -87,6 +87,12 @@ class Command(BaseCommand):
             type=bool,
             help="If True, delete all courses that have been unpublished in the source data",
         )
+        parser.add_argument(
+            "--git_delete",
+            dest="delete_from_git",
+            action="store_true",
+            help="If included, delete any git repo files that don't match WebsiteContent filepaths",
+        )
         super().add_arguments(parser)
 
     def handle(self, *args, **options):
@@ -98,6 +104,7 @@ class Command(BaseCommand):
         filter_str = options["filter"]
         limit = options["limit"]
         delete_unpublished = options["delete_unpublished"]
+        delete_from_git = options["delete_from_git"]
 
         if options["list"] is True:
             course_paths = list(
@@ -131,6 +138,7 @@ class Command(BaseCommand):
             task = sync_unsynced_websites.delay(
                 create_backends=options["create_backend"],
                 check_limit=options["rate_limit"],
+                delete=delete_from_git,
             )
             self.stdout.write(f"Starting task {task}...")
             task.get()


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #807

#### What's this PR do?
Adds an optional `delete` kwarg to the `sync_all_websites` function (used in the `import_ocw_course_sites` command) that will delete any files in the website's git repo that does not match any of the site's `WebsiteContent` or `ContentSyncState` filepaths.

#### How should this be manually tested?
- Create a personal git organization and set up the git .env settings as describe in the README.  Use the same AWS settings as RC.
- On master branch, do the following:
- Import one course with `docker-compose run web python manage.py import_ocw_course_sites --bucket ocw-to-hugo-output-qa --filter "1-012-introduction-to-civil-engineering-design-spring-2002" --sync_backend --create_backend`
- Verify that the repo is created on github, with a `content/pages` folder having files.
- In django admin, delete the website entirely.
- Temporarily tweak `ocw_import.api.convert_data_to_content` to alter filepaths:
  ```python
  "dirpath": f"{dirpath}_modified",
  ```
- Restart your containers and rerun the import on the same site.  Check the repo once more, there will be a `content/pages` and a `content/pages_modified` folder each having the same files.
- Change to this branch and delete the website again.  Also change back the code to normal.  Then run `docker-compose run web python manage.py import_ocw_course_sites --bucket ocw-to-hugo-output-qa --filter "1-012-introduction-to-civil-engineering-design-spring-2002" --sync --create_backend --git_delete`
- Your repo should no longer have the `_modified` directories.
  