### PR TITLE
Fix the check for missing youtube video ids on publish

### DIFF
--- a/websites/api.py
+++ b/websites/api.py
@@ -199,7 +199,11 @@ def unassigned_youtube_ids(website: Website) -> List[WebsiteContent]:
     return WebsiteContent.objects.filter(
         Q(website=website)
         & Q(**{query_resource_type_field: RESOURCE_TYPE_VIDEO})
-        & (Q(**{query_id_field: None}) | Q(**{query_id_field: ""}))
+        & (
+            Q(**{f"{query_id_field}__isnull": True})
+            | Q(**{f"{query_id_field}": None})
+            | Q(**{query_id_field: ""})
+        )
     )
 
 

--- a/websites/api_test.py
+++ b/websites/api_test.py
@@ -221,7 +221,7 @@ def test_unassigned_youtube_ids(mocker, is_ocw):
     mocker.patch("websites.api.is_ocw_site", return_value=is_ocw)
     website = WebsiteFactory.create()
     WebsiteContentFactory.create_batch(
-        3,
+        4,
         website=website,
         metadata={
             "resourcetype": RESOURCE_TYPE_VIDEO,
@@ -229,6 +229,15 @@ def test_unassigned_youtube_ids(mocker, is_ocw):
         },
     )
     videos_without_ids = []
+    videos_without_ids.append(
+        WebsiteContentFactory.create(
+            website=website,
+            metadata={
+                "resourcetype": RESOURCE_TYPE_VIDEO,
+                "video_metadata": {},
+            },
+        )
+    )
     for yt_id in [None, ""]:
         videos_without_ids.append(
             WebsiteContentFactory.create(
@@ -248,7 +257,7 @@ def test_unassigned_youtube_ids(mocker, is_ocw):
     )
     unassigned_content = unassigned_youtube_ids(website)
     if is_ocw:
-        assert len(unassigned_content) == 2
+        assert len(unassigned_content) == 3
         for content in videos_without_ids:
             assert content in unassigned_content
     else:


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #815 

#### What's this PR do?
Makes sure that video resources with missing youtube ids are detected.

#### How should this be manually tested?
- Copy a video file into a site's `videos_final` folder on Google Drive, then click the 'Sync w/Google Drive` button on the resources page.
- Publish the site to draft.  The response should include a warning about the missing youtube id.
- Publish the site to live.  The response should be a 400 with an error detail about the missing youtube id.
