### PR TITLE
set dialog title to reflect when editing, not adding, a menu item

### DIFF
--- a/static/js/components/widgets/MenuField.test.tsx
+++ b/static/js/components/widgets/MenuField.test.tsx
@@ -167,6 +167,32 @@ describe("MenuField", () => {
     )
   })
 
+  it("should put an appropriate title on the modal", () => {
+    ["edit", "add"].forEach(action => {
+      const menuItem = action === "edit" ? dummyInternalMenuItems[0] : null
+      const wrapper = render()
+      expect(wrapper.find("BasicModal").prop("isVisible")).toBe(false)
+      const nestable = wrapper.find("Nestable")
+      let formShowBtn
+      if (menuItem) {
+        const renderedMenuItem = shallow(
+          nestable.prop("renderItem")({ item: menuItem })
+        )
+        formShowBtn = renderedMenuItem.find("button").at(0)
+      } else {
+        formShowBtn = wrapper.find("button.cyan-button")
+      }
+      const preventDefaultStub = jest.fn()
+      formShowBtn.prop("onClick")({ preventDefault: preventDefaultStub })
+      wrapper.update()
+      const modal = wrapper.find("BasicModal")
+      expect(modal.prop("isVisible")).toBe(true)
+      expect(modal.prop("title")).toBe(
+        action === "edit" ? "Edit Navigation Item" : "Add Navigation Item"
+      )
+    })
+  })
+
   it("should show a form to edit existing menu items", () => {
     const menuItem = dummyInternalMenuItems[0]
     const menuItemForm = renderMenuItemForm(menuItem)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

closes #802

#### What's this PR do?

This changes the setup on the MenuField component to use the `ModalState` type to manage the dialog state (editing, adding, or closed) and then, on that basis, makes a change so that when editing the dialog title is set correctly. Before it just always said `Add Navigation Item`.

#### How should this be manually tested?

Read the issue, and make sure the issue is fixed.

#### Screenshots (if appropriate)

<img width="614" alt="Screen Shot 2021-11-17 at 9 13 03 AM" src="https://user-images.githubusercontent.com/6207644/142217027-23c45212-4745-437d-a8b2-fb70c340e874.png">

<img width="624" alt="Screen Shot 2021-11-17 at 9 13 10 AM" src="https://user-images.githubusercontent.com/6207644/142217045-85cc8ac7-d9ff-4068-abd1-b5fa486bbbba.png">
