### PR TITLE
remove some unnecessary mocks of `global.fetch`

### DIFF
--- a/static/js/components/widgets/RelationField.test.tsx
+++ b/static/js/components/widgets/RelationField.test.tsx
@@ -34,7 +34,6 @@ jest.mock("../../lib/api/util", () => ({
   ...jest.requireActual("../../lib/api/util"),
   debouncedFetch: jest.fn()
 }))
-global.fetch = jest.fn()
 
 jest.mock("../../hooks/websites", () => ({
   ...jest.requireActual("../../hooks/websites"),

--- a/static/js/hooks/websites.test.ts
+++ b/static/js/hooks/websites.test.ts
@@ -21,7 +21,6 @@ describe("website hooks", () => {
       debouncedFetch.mockReturnValue({
         json: () => ({ results: websites })
       })
-      global.fetch = jest.fn()
       // @ts-ignore
       global.fetch.mockReturnValue({
         json: () => ({ results: websites })

--- a/static/js/lib/api/util.test.ts
+++ b/static/js/lib/api/util.test.ts
@@ -4,10 +4,6 @@ jest.mock("waait")
 import { debouncedFetch, sharedWait } from "./util"
 
 describe("api utility functions", () => {
-  beforeEach(() => {
-    global.fetch = jest.fn()
-  })
-
   it("waits", async () => {
     await Promise.all([
       sharedWait("key", 30),


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

none

#### What's this PR do?

In #813 I added a mock of `global.fetch` in our 'global' `beforeEach` function, making a few places where we do the same elsewhere in tests redundant, so I went and removed them. Just doing a little housekeeping I guess :)

#### How should this be manually tested?

This is a testing change only, so it should be good enough to just confirm that the build is passing.