### PR TITLE
remove `libelf1` install from github actions configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,9 +122,6 @@ jobs:
         with:
           node-version: "15.14.0"
 
-      - name: Setup environment
-        run: sudo apt-get install libelf1
-
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

none

#### What's this PR do?

I noticed that in the github actions output it looks like `libelf1` isn't actually being installed because it's already present on the ubuntu image used by the github actions runner, so we can save a few seconds by removing the step :)

#### How should this be manually tested?

build should pass, that's it