### PR TITLE
Ignore anything in parentheses for short_id

### DIFF
--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -177,7 +177,7 @@ def get_short_id(name: str, metadata: Dict) -> str:
                 [
                     piece
                     for piece in [
-                        course_num,
+                        re.sub(r"\(.+\)", "", course_num).strip(),
                         metadata.get("term", ""),
                         metadata.get("year", ""),
                     ]

--- a/ocw_import/api_test.py
+++ b/ocw_import/api_test.py
@@ -286,6 +286,7 @@ def test_import_ocw2hugo_content_log_exception(mocker, settings):
         ["5.3", "Spring", "2022", "5.3-spring-2022"],
         ["5.3", "Spring 2022", None, "5.3-spring-2022"],
         ["5.3", "January IAP", "2011", "5.3-january-iap-2011"],
+        ["18.650 (formerly 18.443) ", "Spring", "2015", "18.650-spring-2015"],
         [None, "January IAP", "2011", None],
     ],
 )


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #827 

#### What's this PR do?
- Ignores anything in parentheses from `coursenum` when generating a `short_id` value

#### How should this be manually tested?
- Create a personal git repo as described in the README, and populate `GIT_` settings accordingly
- Use same AWS settings as RC
- Run the following: `manage.py import_ocw_course_sites --bucket ocw-to-hugo-output-qa --filter 18-443-statistics-for-applications --sync_backend  --create_backend`
- Check that the `short_id` values do not have parentheses (`18-650-spring=2015`, etc) and github repos are created for the 3 courses that should have been imported.
