### PR TITLE
Use task decorator to prevent multiple instances of recurring scheduled tasks

### DIFF
--- a/content_sync/decorators_test.py
+++ b/content_sync/decorators_test.py
@@ -1,0 +1,27 @@
+"""Tests for decorators"""
+import pytest
+
+from content_sync.decorators import single_task
+
+
+@pytest.mark.parametrize("has_lock", [False, True])
+@pytest.mark.parametrize("raise_block", [False, True])
+@pytest.mark.parametrize("input_arg", [None, "foo"])
+def test_single_task(mocker, has_lock, raise_block, input_arg):
+    """single_task should only allow 1 instance of inner task to run at same time"""
+    mock_app = mocker.patch("content_sync.decorators.app")
+    mock_app.backend.client.lock.return_value.acquire.side_effect = [True, has_lock]
+
+    func = mocker.Mock(__name__="testfunc")
+    decorated_func = single_task(timeout=2, raise_block=raise_block)
+    args = [input_arg] if input_arg else []
+    decorated_func(func)(*args)
+    if raise_block and not has_lock:
+        with pytest.raises(BlockingIOError):
+            decorated_func(func)(*args)
+    else:
+        decorated_func(func)(*args)
+    mock_app.backend.client.lock.assert_any_call(
+        f"testfunc-id-{input_arg or 'single'}", timeout=2
+    )
+    assert func.call_count == (2 if has_lock else 1)

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -15,7 +15,7 @@ from requests import HTTPError
 from content_sync import api
 from content_sync.apis import github
 from content_sync.constants import VERSION_DRAFT, VERSION_LIVE
-from content_sync.decorators import single_website_task
+from content_sync.decorators import single_task
 from content_sync.models import ContentSyncState
 from content_sync.pipelines.base import BaseSyncPipeline
 from main.celery import app
@@ -173,7 +173,7 @@ def upsert_pipelines(
 
 
 @app.task(acks_late=True, autoretry_for=(BlockingIOError,), retry_backoff=True)
-@single_website_task(10)
+@single_task(10)
 def sync_website_content(website_name: str):
     """ Commit any unsynced files to the backend for a website """
     try:
@@ -189,7 +189,7 @@ def sync_website_content(website_name: str):
 
 
 @app.task(acks_late=True, autoretry_for=(BlockingIOError,), retry_backoff=True)
-@single_website_task(10)
+@single_task(10)
 def publish_website_backend_draft(website_name: str):
     """
     Create a new backend preview for the website.
@@ -203,7 +203,7 @@ def publish_website_backend_draft(website_name: str):
 
 
 @app.task(acks_late=True, autoretry_for=(BlockingIOError,), retry_backoff=True)
-@single_website_task(10)
+@single_task(10)
 def publish_website_backend_live(website_name: str):
     """
     Create a new backend release for the website.


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #820

#### What's this PR do?
Modifies the `single_website_task` decorator for more generic use, and adds it to various scheduled tasks that should only have 1 instance running at a time.


#### How should this be manually tested?
- Add these lines to the beginning of `videos.tasks.update_youtube_statuses` and restart docker containers:
```python
    log.error("Running update_youtube_statuses")
    sleep(10)
```    
- Run the following in a shell:
```python
from videos.tasks import update_youtube_statuses
[update_youtube_statuses.delay() for i in range(5)]
```
- Check the console log, after entering the above command there should be only 1 log output of  "Running update_youtube_statuses"

- Modify the decorator and function kwargs for `videos.tasks.update_youtube_statuses` and restart containers:
```python
@app.task(autoretry_for=(BlockingIOError,), retry_backoff=True, max_retries=10)
@single_task(timeout=settings.YT_STATUS_UPDATE_FREQUENCY, raise_block=True)
```
- Run the same loop as above in a new shell. 
- Check the console log, after entering the above shell command there should eventually be 5 log outputs of  "Running update_youtube_statuses" (and lots of Retry log statements).
