### PR TITLE
put title as default text in a resource link instead of the uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@ckeditor/ckeditor5-widget": "^29.2.0",
     "@dnd-kit/core": "^3.1.1",
     "@dnd-kit/sortable": "^4.0.0",
-    "@mitodl/ckeditor5-resource-link": "29.2.0",
+    "@mitodl/ckeditor5-resource-link": "^29.2.1",
     "@sentry/browser": "^6.10.0",
     "@testing-library/react-hooks": "^7.0.1",
     "@types/ckeditor__ckeditor5-core": "^11.0.3",

--- a/static/js/components/widgets/MarkdownEditor.tsx
+++ b/static/js/components/widgets/MarkdownEditor.tsx
@@ -47,9 +47,17 @@ export default function MarkdownEditor(props: Props): JSX.Element {
   >("closed")
 
   const addResourceEmbed = useCallback(
-    (uuid: string, variant: CKEResourceNodeType) => {
+    (uuid: string, title: string, variant: CKEResourceNodeType) => {
       if (editor.current) {
-        editor.current.execute(ResourceCommandMap[variant], uuid)
+        if (variant === "resourceLink") {
+          // we pass the title down because we want to set that as the
+          // default text in the link, in the case where we're not adding
+          // the link attribute to existing text.
+          editor.current.execute(ResourceCommandMap[variant], uuid, title)
+        } else {
+          editor.current.execute(ResourceCommandMap[variant], uuid)
+        }
+
         // @ts-ignore
         editor.current.editing.view.focus()
       }

--- a/static/js/components/widgets/ResourcePickerDialog.test.tsx
+++ b/static/js/components/widgets/ResourcePickerDialog.test.tsx
@@ -36,9 +36,7 @@ jest.mock("./ResourcePickerListing", () => ({
 const focusResource = (wrapper: ReactWrapper, resource: WebsiteContent) => {
   act(() => {
     // @ts-ignore
-    wrapper.find("ResourcePickerListing").prop("focusResource")(
-      resource.text_id
-    )
+    wrapper.find("ResourcePickerListing").prop("focusResource")(resource)
   })
   wrapper.update()
 }
@@ -109,6 +107,7 @@ describe("ResourcePickerDialog", () => {
 
     expect(insertEmbedStub.args[0]).toStrictEqual([
       resource.text_id,
+      resource.title,
       RESOURCE_LINK
     ])
   })
@@ -132,6 +131,7 @@ describe("ResourcePickerDialog", () => {
 
     expect(insertEmbedStub.args[0]).toStrictEqual([
       resource.text_id,
+      resource.title,
       RESOURCE_EMBED
     ])
   })
@@ -143,7 +143,7 @@ describe("ResourcePickerDialog", () => {
     )
     focusResource(wrapper, resource)
     expect(wrapper.find("ResourcePickerListing").prop("focusedResource")).toBe(
-      resource.text_id
+      resource
     )
   })
 

--- a/static/js/components/widgets/ResourcePickerDialog.tsx
+++ b/static/js/components/widgets/ResourcePickerDialog.tsx
@@ -14,11 +14,12 @@ import {
   ResourceDialogState,
   RESOURCE_EMBED
 } from "../../lib/ckeditor/plugins/constants"
+import { WebsiteContent } from "../../types/websites"
 
 interface Props {
   state: ResourceDialogState
   closeDialog: () => void
-  insertEmbed: (id: string, variant: CKEResourceNodeType) => void
+  insertEmbed: (id: string, title: string, variant: CKEResourceNodeType) => void
   attach: string
 }
 
@@ -58,11 +59,17 @@ export default function ResourcePickerDialog(props: Props): JSX.Element {
     [setFilterDebounced]
   )
 
-  const [focusedResource, setFocusedResource] = useState<string | null>(null)
+  const [focusedResource, setFocusedResource] = useState<WebsiteContent | null>(
+    null
+  )
 
   const addResource = useCallback(() => {
     if (focusedResource && state !== "closed") {
-      insertEmbed(focusedResource, state)
+      insertEmbed(
+        focusedResource.text_id,
+        focusedResource.title ?? focusedResource.text_id,
+        state
+      )
       closeDialog()
     }
   }, [insertEmbed, focusedResource, closeDialog, state])

--- a/static/js/components/widgets/ResourcePickerListing.test.tsx
+++ b/static/js/components/widgets/ResourcePickerListing.test.tsx
@@ -107,15 +107,13 @@ describe("ResourcePickerListing", () => {
       .find(".resource-picker-listing .resource-item")
       .at(0)
       .simulate("click")
-    expect(
-      focusResourceStub.calledWith(contentListingItems[0][0].text_id)
-    ).toBeTruthy()
+    expect(focusResourceStub.calledWith(contentListingItems[0][0])).toBeTruthy()
     wrapper.update()
   })
 
   it("should put a class on if a resource is focused", async () => {
     const { wrapper } = await render({
-      focusedResource: contentListingItems[0][0].text_id
+      focusedResource: contentListingItems[0][0]
     })
 
     expect(

--- a/static/js/components/widgets/ResourcePickerListing.tsx
+++ b/static/js/components/widgets/ResourcePickerListing.tsx
@@ -9,7 +9,7 @@ import {
   RESOURCE_TYPE_VIDEO
 } from "../../constants"
 import { useWebsite } from "../../context/Website"
-import { ContentListingParams } from "../../types/websites"
+import { ContentListingParams, WebsiteContent } from "../../types/websites"
 import { websiteContentListingRequest } from "../../query-configs/websites"
 import {
   getWebsiteContentListingCursor,
@@ -17,11 +17,11 @@ import {
 } from "../../selectors/websites"
 
 interface Props {
-  focusResource: (id: string) => void
+  focusResource: (item: WebsiteContent) => void
   attach: string
   filter: string | null
   resourcetype: string
-  focusedResource: string | null
+  focusedResource: WebsiteContent | null
 }
 
 export default function ResourcePickerListing(
@@ -63,7 +63,9 @@ export default function ResourcePickerListing(
     <div className={className}>
       {listing.results.map((item, idx) => {
         const className = `resource-item${
-          focusedResource && focusedResource === item.text_id ? " focused" : ""
+          focusedResource && focusedResource.text_id === item.text_id ?
+            " focused" :
+            ""
         }`
 
         let imageSrc: string | undefined
@@ -85,7 +87,7 @@ export default function ResourcePickerListing(
             key={`${item.text_id}_${idx}`}
             onClick={(event: SyntheticEvent<HTMLDivElement>) => {
               event.preventDefault()
-              focusResource(item.text_id)
+              focusResource(item)
             }}
           >
             {imageSrc ? (

--- a/yarn.lock
+++ b/yarn.lock
@@ -2021,14 +2021,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mitodl/ckeditor5-resource-link@npm:29.2.0":
-  version: 29.2.0
-  resolution: "@mitodl/ckeditor5-resource-link@npm:29.2.0"
+"@mitodl/ckeditor5-resource-link@npm:^29.2.1":
+  version: 29.2.1
+  resolution: "@mitodl/ckeditor5-resource-link@npm:29.2.1"
   dependencies:
     "@ckeditor/ckeditor5-ui": ^29.2.0
     ckeditor5: ^29.2.0
     lodash-es: ^4.17.15
-  checksum: cd9bef6e335a947fc015d492fa7917a36c34f9ecec29282893ab72dbb38f4ae7d816ad592ac711099a5f5e77bf2d5b3edd09bceba8a16e466dc2a2311884d728
+  checksum: dbcbf7342a5d75d2036485185ef1ec20f965b373e080be9dd134c9d2de3263347c88b9417efe1a155e2f2d01961813a2f990e2f19e9a475f8f0a81c34fbe954f
   languageName: node
   linkType: hard
 
@@ -10020,7 +10020,7 @@ __metadata:
     "@ckeditor/ckeditor5-widget": ^29.2.0
     "@dnd-kit/core": ^3.1.1
     "@dnd-kit/sortable": ^4.0.0
-    "@mitodl/ckeditor5-resource-link": 29.2.0
+    "@mitodl/ckeditor5-resource-link": ^29.2.1
     "@sentry/browser": ^6.10.0
     "@testing-library/react-hooks": ^7.0.1
     "@types/ckeditor__ckeditor5-core": ^11.0.3


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes  #767

#### What's this PR do?

This sets the resource title to be the default text inside of a resource link, rather than the UUID that we're doing currently.

#### How should this be manually tested?

This PR should work as advertised right now. Create a resource with a title, and then add a page to your site (this is all in the `ocw-course` starter). Then you should be able to use the markdown editor to add a link to your nicely-titled resource, and the title of that resource should be the text inside of the link, rather than the uuid.

Before this can merge we need to merge and release https://github.com/mitodl/ckeditor5/pull/8 and update this PR to reference the newly-published package.


#### Screenshots (if appropriate)

<img width="827" alt="Screen Shot 2021-11-23 at 4 16 41 PM" src="https://user-images.githubusercontent.com/6207644/143130891-111f841a-54f6-4997-afa8-c0413423fe58.png">

