### PR TITLE
Populate additional fields when publishing via mass_publish

### DIFF
--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -288,6 +288,7 @@ def test_websites_endpoint_preview(
     assert website.has_unpublished_draft is False
     assert website.draft_publish_status == constants.PUBLISH_STATUS_NOT_STARTED
     assert website.draft_publish_status_updated_on == now
+    assert website.draft_last_published_by == editor
     assert website.latest_build_id_draft is None
 
 
@@ -364,6 +365,7 @@ def test_websites_endpoint_publish(  # pylint: disable=too-many-locals
         expected_msg = ""
         mock_publish_website.assert_called_once_with(website.name, VERSION_LIVE)
         assert website.has_unpublished_live is False
+        assert website.live_last_published_by == admin
         assert website.live_publish_status == constants.PUBLISH_STATUS_NOT_STARTED
         assert website.live_publish_status_updated_on == now
         assert website.latest_build_id_live is None


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #839 

#### What's this PR do?
Populates additional `Website` fields for sites published via management command that are required for the `check_incomplete_publish_build_statuses` task to catch any pipeline builds that fail to send back webhook status updates.

#### How should this be manually tested?
Run `python manage.py mass_publish draft --filter <your_website_name> --source studio`
Check that the `draft_publish_status`, `draft_publish_status_updated_on` fields for the `Website` are not `None`
