### PR TITLE
Remove obsolete pages and content during OCW import

### DIFF
--- a/ocw_import/api_test.py
+++ b/ocw_import/api_test.py
@@ -23,7 +23,11 @@ from websites.constants import (
     CONTENT_TYPE_RESOURCE,
     WEBSITE_SOURCE_OCW_IMPORT,
 )
-from websites.factories import WebsiteFactory, WebsiteStarterFactory
+from websites.factories import (
+    WebsiteContentFactory,
+    WebsiteFactory,
+    WebsiteStarterFactory,
+)
 from websites.models import Website, WebsiteContent
 
 
@@ -102,6 +106,17 @@ def test_import_ocw2hugo_course_content(mocker, settings):
         "lec1",
         lecture_pdf.text_id,
     )
+
+    # Any existing content not imported should be deleted
+    obsolete_id = "testing123"
+    WebsiteContentFactory.create(website=website, text_id=obsolete_id)
+    assert WebsiteContent.objects.filter(website=website, text_id=obsolete_id).exists()
+    import_ocw2hugo_course(
+        MOCK_BUCKET_NAME, TEST_OCW2HUGO_PREFIX, s3_key, starter_id=website_starter.id
+    )
+    assert not WebsiteContent.objects.filter(
+        website=website, text_id=obsolete_id
+    ).exists()
 
 
 @mock_s3


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #841 

#### What's this PR do?
When importing an OCW course, deletes any non-metadata/non-menu WebsiteContent that is not present in the fresh import data.

#### How should this be manually tested?
- Import an OCW course, for example `manage.py import_ocw_course_sites --bucket ocw-to-hugo-output-qa --filter 1-00-introduction-to-computers-and-engineering-problem-solving-spring-2012`
- Manually add a new page and/or resource
- Import the course again
- Any of the manually created pages or resources should now be deleted.
