### PR TITLE
Do not show menu dropdown for global admins or site owner

### DIFF
--- a/static/js/components/SiteCollaboratorList.test.tsx
+++ b/static/js/components/SiteCollaboratorList.test.tsx
@@ -75,6 +75,11 @@ describe("SiteCollaboratorList", () => {
     expect(items.at(0).prop("menuOptions")).toHaveLength(2)
     // Last collaborator in list should not be editable
     expect(items.at(numCollaborators - 1).prop("menuOptions")).toHaveLength(0)
+    // Should be 6 StudioListItems but only 5 menu buttons (none for the permanent admin)
+    expect(items.length).toBe(6)
+    expect(wrapper.find(".transparent-button").length).toBe(
+      collaborators.length
+    )
   })
 
   it("the edit collaborator icon sets correct state and opens the modal", async () => {

--- a/static/js/components/StudioList.tsx
+++ b/static/js/components/StudioList.tsx
@@ -78,7 +78,7 @@ export function StudioListItem(props: ListItemProps): JSX.Element {
           </div>
           <div>
             {children}
-            {menuOptions ? (
+            {menuOptions && menuOptions.length > 0 ? (
               <div className="dropdown">
                 <button
                   className="transparent-button"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #803

#### What's this PR do?
Hides the collaborator menu dropdown for global admins and site owners.

#### How should this be manually tested?
Create a site while logged in as global admin or author.  
Go to the collaborators page for the site.  You should not see the menu dropdown (3 vertical dots) next to your name.
Add another normal user as an editor or admin.  You should see the 3 dots menu and it should work.


#### Screenshots
<img width="484" alt="Screen Shot 2021-12-02 at 2 50 35 PM" src="https://user-images.githubusercontent.com/187676/144492864-59acc7b6-a093-4359-991a-d084f76b4648.png">


