### PR TITLE
refactor fix for deleting orphaned git files

### DIFF
--- a/content_sync/backends/base.py
+++ b/content_sync/backends/base.py
@@ -101,10 +101,8 @@ class BaseSyncBackend(abc.ABC):
         """ Delete any git repo files without corresponding WebsiteContent objects"""
         ...
 
-    def sync_all_content_to_backend(self, delete=False):
+    def sync_all_content_to_backend(self):
         """ Sync all content for the website """
-        if delete:
-            self.delete_orphaned_content_in_backend()
         for sync_state in ContentSyncState.objects.filter(
             content__website=self.website
         ):

--- a/content_sync/backends/base_test.py
+++ b/content_sync/backends/base_test.py
@@ -106,21 +106,16 @@ def test_sync_content_to_backend_delete(mocker):
     mock_delete_content_in_backend.assert_called_once_with(state)
 
 
-@pytest.mark.parametrize("delete", [True, False])
 @pytest.mark.django_db
-def test_sync_all_content_to_backend(mocker, delete):
+def test_sync_all_content_to_backend(mocker):
     """ Verify that sync_all_content_to_backend calls sync_content_to_backend for each piece of content """
     mock_sync_content_to_backend = mocker.patch.object(
         _ImplementedBackend, "sync_content_to_backend", return_value=None
     )
-    mock_delete = mocker.patch.object(
-        _ImplementedBackend, "delete_orphaned_content_in_backend"
-    )
     website = WebsiteFactory.create()
     states = ContentSyncStateFactory.create_batch(5, content__website=website)
     backend = _ImplementedBackend(website)
-    backend.sync_all_content_to_backend(delete=delete)
+    backend.sync_all_content_to_backend()
     assert mock_sync_content_to_backend.call_count == len(states)
-    assert mock_delete.call_count == (1 if delete else 0)
     for state in states:
         mock_sync_content_to_backend.assert_any_call(state)

--- a/content_sync/backends/github.py
+++ b/content_sync/backends/github.py
@@ -95,12 +95,10 @@ class GithubBackend(BaseSyncBackend):
             [path for path in self.api.get_all_file_paths("/") if path not in sitepaths]
         )
 
-    def sync_all_content_to_backend(self, delete=False) -> Commit:
+    def sync_all_content_to_backend(self) -> Commit:
         """
-        Sync all the website's files to Github in one commit, and optionally delete unmatched git repo files
+        Sync all the website's files to Github in one commit
         """
-        if delete:
-            self.delete_orphaned_content_in_backend()
         return self.api.upsert_content_files()
 
     def delete_content_in_backend(self, sync_state: ContentSyncState) -> Commit:

--- a/content_sync/backends/github_test.py
+++ b/content_sync/backends/github_test.py
@@ -100,11 +100,9 @@ def test_delete_content_in_backend(github):
     assert WebsiteContent.objects.filter(id=content.id).first() is None
 
 
-@pytest.mark.parametrize("delete", [True, False])
-def test_sync_all_content_to_backend(github, delete):
+def test_sync_all_content_to_backend(github):
     """Test that sync_all_content_to_backend makes the appropriate api call"""
-    github.backend.sync_all_content_to_backend(delete=delete)
-    assert github.api.batch_delete_files.call_count == (1 if delete else 0)
+    github.backend.sync_all_content_to_backend()
     github.api.upsert_content_files.assert_called_once()
 
 

--- a/content_sync/management/commands/sync_website_to_backend.py
+++ b/content_sync/management/commands/sync_website_to_backend.py
@@ -52,5 +52,7 @@ class Command(BaseCommand):
         self.stdout.write(
             f"Updating website content in backend for '{website.title}'..."
         )
-        backend.sync_all_content_to_backend(delete=should_delete)
+        backend.sync_all_content_to_backend()
+        if should_delete:
+            backend.delete_orphaned_content_in_backend()
         reset_publishing_fields(website.name)


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Recloses #841

#### What's this PR do?
Refactors how orphaned git files are deleted to avoid sync errors on subsequent ocw imports.

#### How should this be manually tested?
- Configure a personal git organization as describe in the README
- Run `docker-compose run web python manage.py import_ocw_course_sites --bucket ocw-to-hugo-output-qa --filter sts-471j-engineering-apollo-the-moon-project-as-a-complex-system-spring-2007 --sync_backend --create_backend --git_delete`
- Add a new page to the site.  Check that the page is added to git.
- Run the import again.  The new page should be deleted in studio and removed from git
- Run the import again.  There should be no git errors in the console log.
