### PR TITLE
Run incomplete_publish_build_statuses task only if a pipeline backend is set

### DIFF
--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -15,7 +15,7 @@ from requests import HTTPError
 from content_sync import api
 from content_sync.apis import github
 from content_sync.constants import VERSION_DRAFT, VERSION_LIVE
-from content_sync.decorators import single_task, is_publish_pipeline_enabled
+from content_sync.decorators import is_publish_pipeline_enabled, single_task
 from content_sync.models import ContentSyncState
 from content_sync.pipelines.base import BaseSyncPipeline
 from main.celery import app

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -15,7 +15,7 @@ from requests import HTTPError
 from content_sync import api
 from content_sync.apis import github
 from content_sync.constants import VERSION_DRAFT, VERSION_LIVE
-from content_sync.decorators import single_task
+from content_sync.decorators import single_task, is_publish_pipeline_enabled
 from content_sync.models import ContentSyncState
 from content_sync.pipelines.base import BaseSyncPipeline
 from main.celery import app
@@ -268,6 +268,7 @@ def sync_github_site_configs(url: str, files: List[str], commit: Optional[str] =
 
 
 @app.task(acks_late=True)
+@is_publish_pipeline_enabled
 def check_incomplete_publish_build_statuses():
     """
     Check statuses of concourse builds that have not been updated in a reasonable amount of time

--- a/content_sync/tasks_test.py
+++ b/content_sync/tasks_test.py
@@ -354,7 +354,7 @@ def test_check_incomplete_publish_build_statuses(
     should_check,
     should_update,
     pipeline,
-):  # pylint:disable=too-many-arguments
+):  # pylint:disable=too-many-arguments,too-many-locals
     """check_incomplete_publish_build_statuses should update statuses of pipeline builds"""
     settings.CONTENT_SYNC_PIPELINE = pipeline
     mock_update_status = mocker.patch("content_sync.tasks.update_website_status")

--- a/content_sync/tasks_test.py
+++ b/content_sync/tasks_test.py
@@ -342,10 +342,21 @@ def test_publish_website_batch(mocker, version, prepublish):
         [PUBLISH_STATUS_NOT_STARTED, PUBLISH_STATUS_NOT_STARTED, True, False],
     ],
 )
+@pytest.mark.parametrize(
+    "pipeline", [None, "content_sync.pipelines.concourse.ConcourseGithubPipeline"]
+)
 def test_check_incomplete_publish_build_statuses(
-    settings, mocker, api_mock, old_status, new_status, should_check, should_update
+    settings,
+    mocker,
+    api_mock,
+    old_status,
+    new_status,
+    should_check,
+    should_update,
+    pipeline,
 ):  # pylint:disable=too-many-arguments
     """check_incomplete_publish_build_statuses should update statuses of pipeline builds"""
+    settings.CONTENT_SYNC_PIPELINE = pipeline
     mock_update_status = mocker.patch("content_sync.tasks.update_website_status")
     now = now_in_utc()
     draft_site_in_query = WebsiteFactory.create(
@@ -378,7 +389,7 @@ def test_check_incomplete_publish_build_statuses(
         (draft_site_in_query, VERSION_DRAFT),
         (live_site_in_query, VERSION_LIVE),
     ]:
-        if should_check:
+        if should_check and pipeline is not None:
             api_mock.get_sync_pipeline.assert_any_call(website)
             api_mock.get_sync_pipeline.return_value.get_build_status.assert_any_call(
                 getattr(website, f"latest_build_id_{version}")


### PR DESCRIPTION
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
N/A

#### What's this PR do?
Adds the `@is_publish_pipeline_enabled` decorator to the `content_sync.tasks.check_incomplete_publish_build_statuses` task so that it won't do anything if `settings.CONTENT_SYNC_PIPELINE` is not set.

#### How should this be manually tested?
Tests should pass
You can add a log statement to the beginning of the task, then run `check_incomplete_publish_build_statuses()` in a shell and verify the statement executes only when `settings.CONTENT_SYNC_PIPELINE` is not None
