### PR TITLE
Prevent users from creating content with forbidden filenames

### DIFF
--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -31,6 +31,7 @@ from videos.constants import VideoStatus
 from videos.models import Video
 from websites.api import get_valid_new_filename
 from websites.constants import (
+    CONTENT_TYPE_RESOURCE,
     RESOURCE_TYPE_DOCUMENT,
     RESOURCE_TYPE_IMAGE,
     RESOURCE_TYPE_OTHER,
@@ -38,6 +39,7 @@ from websites.constants import (
 )
 from websites.models import Website, WebsiteContent
 from websites.site_config_api import SiteConfig
+from websites.utils import get_valid_base_filename
 
 
 log = logging.getLogger(__name__)
@@ -347,19 +349,22 @@ def create_gdrive_resource_content(drive_file: DriveFile):
         resource = drive_file.resource
         if not resource:
             site_config = SiteConfig(drive_file.website.starter.config)
-            config_item = site_config.find_item_by_name(name="resource")
+            config_item = site_config.find_item_by_name(name=CONTENT_TYPE_RESOURCE)
             dirpath = config_item.file_target if config_item else None
             basename, _ = os.path.splitext(drive_file.name)
+
             filename = get_valid_new_filename(
                 website_pk=drive_file.website.pk,
                 dirpath=dirpath,
-                filename_base=slugify(basename),
+                filename_base=slugify(
+                    get_valid_base_filename(basename, CONTENT_TYPE_RESOURCE)
+                ),
             )
             resource = WebsiteContent.objects.create(
                 website=drive_file.website,
                 title=drive_file.name,
                 file=drive_file.s3_key,
-                type="resource",
+                type=CONTENT_TYPE_RESOURCE,
                 is_page_content=True,
                 dirpath=dirpath,
                 filename=filename,

--- a/gdrive_sync/api_test.py
+++ b/gdrive_sync/api_test.py
@@ -32,6 +32,7 @@ from gdrive_sync.models import DriveFile
 from main.s3_utils import get_s3_resource
 from videos.constants import VideoStatus
 from websites.constants import (
+    CONTENT_FILENAMES_FORBIDDEN,
     CONTENT_TYPE_RESOURCE,
     RESOURCE_TYPE_DOCUMENT,
     RESOURCE_TYPE_IMAGE,
@@ -43,13 +44,21 @@ from websites.models import WebsiteContent
 
 
 pytestmark = pytest.mark.django_db
-# pylint:disable=redefined-outer-name, too-many-arguments
+# pylint:disable=redefined-outer-name, too-many-arguments, unused-argument
 
 
 @pytest.fixture
 def mock_service(mocker):
     """Mock google drive service """
     return mocker.patch("gdrive_sync.api.get_drive_service")
+
+
+@pytest.fixture
+def mock_get_s3_content_type(mocker):
+    """Mock gdrive_sync.api.get_s3_content_type """
+    mocker.patch(
+        "gdrive_sync.api.get_s3_content_type", return_value="application/ms-word"
+    )
 
 
 def test_get_drive_service(settings, mocker):
@@ -391,11 +400,8 @@ def test_walk_gdrive_folder(mocker):
 @pytest.mark.parametrize(
     "mime_type", ["application/pdf", "application/vnd.ms-powerpoint"]
 )
-def test_create_gdrive_resource_content(mocker, mime_type):
+def test_create_gdrive_resource_content(mime_type, mock_get_s3_content_type):
     """create_resource_from_gdrive should create a WebsiteContent object linked to a DriveFile object"""
-    mocker.patch(
-        "gdrive_sync.api.get_s3_content_type", return_value="application/ms-word"
-    )
     filenames = ["word.docx", "word!.docx", "(word?).docx"]
     deduped_names = ["word", "word2", "word3"]
     website = WebsiteFactory.create()
@@ -421,11 +427,23 @@ def test_create_gdrive_resource_content(mocker, mime_type):
         assert drive_file.resource == content
 
 
-def test_create_gdrive_resource_content_update(mocker):
-    """create_resource_from_gdrive should update a WebsiteContent object linked to a DriveFile object"""
-    mocker.patch(
-        "gdrive_sync.api.get_s3_content_type", return_value="application/ms-word"
+def test_create_gdrive_resource_content_forbidden_name(mock_get_s3_content_type):
+    """content for a google drive file with a forbidden name should have its filename attribute modified"""
+    drive_file = DriveFileFactory.create(
+        name=f"{CONTENT_FILENAMES_FORBIDDEN[0]}.pdf",
+        s3_key=f"test/path/{CONTENT_FILENAMES_FORBIDDEN[0]}.pdf",
+        mime_type="application/pdf",
     )
+    create_gdrive_resource_content(drive_file)
+    drive_file.refresh_from_db()
+    assert (
+        drive_file.resource.filename
+        == f"{CONTENT_FILENAMES_FORBIDDEN[0]}-{CONTENT_TYPE_RESOURCE}"
+    )
+
+
+def test_create_gdrive_resource_content_update(mock_get_s3_content_type):
+    """create_resource_from_gdrive should update a WebsiteContent object linked to a DriveFile object"""
     content = WebsiteContentFactory.create(file="test/path/old.doc")
     drive_file = DriveFileFactory.create(
         website=content.website, s3_key="test/path/word.docx", resource=content

--- a/websites/constants.py
+++ b/websites/constants.py
@@ -11,6 +11,7 @@ COURSE_PAGE_LAYOUTS = ["instructor_insights"]
 COURSE_RESOURCE_LAYOUTS = ["pdf", "video"]
 
 CONTENT_FILENAME_MAX_LEN = 125
+CONTENT_FILENAMES_FORBIDDEN = ("index", "_index")
 CONTENT_DIRPATH_MAX_LEN = 300
 CONTENT_FILEPATH_UNIQUE_CONSTRAINT = "unique_page_content_destination"
 

--- a/websites/utils.py
+++ b/websites/utils.py
@@ -40,3 +40,10 @@ def set_dict_field(obj: Dict, field_path: str, value: Any):
 def get_dict_query_field(dict_field_name: str, sub_field: str):
     """Generate django query key for searching a nested json feild"""
     return dict_field_name + "__" + sub_field.replace(".", "__")
+
+
+def get_valid_base_filename(filename: str, content_type: str) -> str:
+    """Avoid forbidden filenames that could confuse hugo"""
+    if filename in constants.CONTENT_FILENAMES_FORBIDDEN:
+        return f"{filename}-{content_type}"
+    return filename

--- a/websites/views.py
+++ b/websites/views.py
@@ -75,7 +75,7 @@ from websites.serializers import (
     WebsiteWriteSerializer,
 )
 from websites.site_config_api import SiteConfig
-from websites.utils import permissions_group_name_for_role
+from websites.utils import get_valid_base_filename, permissions_group_name_for_role
 
 
 log = logging.getLogger(__name__)
@@ -394,7 +394,7 @@ def _get_derived_website_content_data(
         added_data["filename"] = get_valid_new_filename(
             website_pk=website_pk,
             dirpath=dirpath,
-            filename_base=slugify(slug),
+            filename_base=slugify(get_valid_base_filename(slug, content_type)),
         )
     return added_data
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #829 

#### What's this PR do?
- Renames any pages or resources created via the UI that are equal to a list of "forbidden" words (currently "index" and "_index"), but does not apply this to imported OCW sites.

#### How should this be manually tested?
- Import this course:  `manage.py import_ocw_course_sites --bucket ocw-to-hugo-output-qa --filter 1-011-project-evaluation-spring-2011`
- Verify that the `Projects` page for the course has a `filename` of `_index`
- Add a page to a new or existing site and give it a title of `index` or `_index`
- Check that the `filename` for the page is `index-page` (or `_index-page`)
- Add another page with the same title.  The `filename` should end with `-page2`
- Add a file to the site's `final_files` drive folder with a name like `index.jpg` or `index.pdf` and sync the drive.
- Verify that the `WebsiteContent.filename` for the drive file is `index-resource`
