### PR TITLE
add site search

### DIFF
--- a/static/js/hooks/effect.ts
+++ b/static/js/hooks/effect.ts
@@ -1,0 +1,21 @@
+import { DependencyList, EffectCallback, useEffect } from "react"
+
+/**
+ * A debounced useEffect! Usage for this hook is identical to
+ * 'vanilla' `useEffect`, except for the fact that your effect will
+ * return at most every `delay` ms.
+ */
+export function useDebouncedEffect(
+  effect: EffectCallback,
+  deps: DependencyList,
+  delay = 200
+) {
+  useEffect(() => {
+    const id = setTimeout(effect, delay)
+
+    return () => {
+      clearTimeout(id)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [...deps, effect, delay])
+}

--- a/static/js/hooks/state.ts
+++ b/static/js/hooks/state.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react"
+import { useState, useCallback, ChangeEvent } from "react"
 import { debounce, DebouncedFunc } from "lodash"
 
 /**
@@ -33,4 +33,24 @@ export function useDebouncedState<T>(
   )
 
   return [state, setStateDebounced]
+}
+
+type TextInputRetProps = [string, (e: ChangeEvent<HTMLInputElement>) => void]
+
+/**
+ * A little utility hook for the boilerplate you need to hold the state
+ * for a single text input.
+ */
+export function useTextInputState(initialValue = ""): TextInputRetProps {
+  const [inputState, setInputState] = useState<string>(initialValue)
+
+  const setSearchInputCB = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      e.preventDefault()
+      setInputState(e.target.value)
+    },
+    [setInputState]
+  )
+
+  return [inputState, setSearchInputCB]
 }

--- a/static/js/query-configs/websites.ts
+++ b/static/js/query-configs/websites.ts
@@ -55,12 +55,19 @@ export const getTransformedWebsiteName = (
   return transformedWebsiteKeys[0]
 }
 
+export type WebsiteListingParams = {
+  offset: number
+  search?: string | null | undefined
+}
+
 export type WebsiteListingResponse = PaginatedResponse<Website>
 
 export type WebsitesListing = Record<string, PaginatedResponse<string>>
 
-export const websiteListingRequest = (offset: number): QueryConfig => ({
-  url:       siteApiListingUrl.query({ offset }).toString(),
+export const websiteListingRequest = (
+  params: WebsiteListingParams
+): QueryConfig => ({
+  url:       siteApiListingUrl.query(params).toString(),
   transform: (body: WebsiteListingResponse) => {
     const details = {}
     for (const site of body.results) {
@@ -69,7 +76,7 @@ export const websiteListingRequest = (offset: number): QueryConfig => ({
 
     return {
       websitesListing: {
-        [`${offset}`]: {
+        [params.offset]: {
           ...body,
           results: body.results.map(result => result.name)
         }

--- a/static/scss/dashboard.scss
+++ b/static/scss/dashboard.scss
@@ -7,4 +7,9 @@
   .site-description {
     color: $studio-text-gray;
   }
+
+  .site-search-input {
+    height: 45px;
+    width: unset;
+  }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #745 

#### What's this PR do?

This PR adds a site search input to the sites index page (`/sites`) which the user can use to filter the sites. This makes it much easier to navigate to a particular site, especially when dealing with a larger number of sites.

#### How should this be manually tested?

Go to `/sites` and try it out! The filtering should work more or less sensibly.


#### Screenshots (if appropriate)

<img width="1680" alt="Screen Shot 2021-12-08 at 11 33 33 AM" src="https://user-images.githubusercontent.com/6207644/145247466-224001c5-9ebc-4f99-9d6b-83ae4d181209.png">
<img width="1699" alt="Screen Shot 2021-12-08 at 11 33 39 AM" src="https://user-images.githubusercontent.com/6207644/145247472-8a862761-e757-4541-9a00-901d82a01c8b.png">
<img width="1475" alt="Screen Shot 2021-12-08 at 11 33 49 AM" src="https://user-images.githubusercontent.com/6207644/145247473-57d530ff-2aad-4244-a8cd-14f1994bb832.png">
