### PR TITLE
Fix outdated starter configs, add instruction to update them in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ Run through those steps **including the addition of `/etc/hosts` aliases and the
 
 In addition, you should create a starter with `slug=ocw-www` through the admin interface with config data taken from the `ocw-www` starter on RC or production. Then, you should go to the `/sites` UI and create a new site with `name=ocw-www` using the `ocw-www` starter.
 
+Finally, create/update additional starters with the following command:
+
+    ```
+    docker-compose run web python manage.py override_site_config
+    ```
 
 ### Testing Touchstone login with SAML via SSOCircle
 
@@ -181,8 +186,6 @@ manage.py import_ocw_course_sites -b <bucket_name>
 This project includes some tools that simplify development with starter projects and site configs. These tools allow you to do the following:
 - Define entire starter projects within this repo and load them into your database
 - Override the site config for starters with a particular `slug` value
-
-See the [README in localdev/starters](localdev/starters/) for instructions.
 
 
 # Enabling GitHub integration

--- a/localdev/configs/basic-site-config.yml
+++ b/localdev/configs/basic-site-config.yml
@@ -1,3 +1,4 @@
+---
 content-dir: content
 root-url-path: "sites"
 collections:

--- a/localdev/configs/default-course-config.yml
+++ b/localdev/configs/default-course-config.yml
@@ -1,0 +1,19 @@
+---
+content-dir: content
+root-url-path: "sites"
+collections:
+  - label: "Page"
+    name: "page"
+    category: Content
+    folder: content/pages
+    fields:
+      - {label: "Title", name: "title", widget: "string", required: true}
+      - {label: "Content", name: "content", widget: "markdown"}
+
+  - label: "Resource"
+    name: "resource"
+    category: Content
+    folder: content/resources
+    fields:
+      - {label: "Title", name: "title", widget: "string", required: true}
+      - {label: "Description", name: "description", widget: "markdown"}

--- a/localdev/management/commands/override_site_config.py
+++ b/localdev/management/commands/override_site_config.py
@@ -28,6 +28,7 @@ class Command(BaseCommand):
             ),
             ("localdev/configs/omnibus-site-config.yml", OMNIBUS_STARTER_SLUG),
             ("localdev/configs/ocw-www.yml", OCW_WWW_STARTER_SLUG),
+            ("localdev/configs/default-course-config.yml", "course"),
         )
 
     def _get_config_paths(self):

--- a/localdev/starters/example-starter/ocw-studio.yml
+++ b/localdev/starters/example-starter/ocw-studio.yml
@@ -1,7 +1,9 @@
 root-url-path: "courses"
+content-dir: content
 collections:
   - label: "Page"
     name: "page"
+    folder: content/pages
     fields:
-      - {label: "Title", name: "title", widget: "string"}
+      - {label: "Title", name: "title", widget: "string", required: true}
       - {label: "Body", name: "body", widget: "markdown"}

--- a/static/js/resources/basic-course-config.json
+++ b/static/js/resources/basic-course-config.json
@@ -1,0 +1,44 @@
+{
+  "collections": [
+    {
+      "category": "Content",
+      "fields": [
+        {
+          "label": "Title",
+          "name": "title",
+          "required": true,
+          "widget": "string"
+        },
+        {
+          "label": "Content",
+          "name": "content",
+          "widget": "markdown"
+        }
+      ],
+      "folder": "content/pages",
+      "label": "Page",
+      "name": "page"
+    },
+    {
+      "category": "Content",
+      "fields": [
+        {
+          "label": "Title",
+          "name": "title",
+          "required": true,
+          "widget": "string"
+        },
+        {
+          "label": "Description",
+          "name": "description",
+          "widget": "markdown"
+        }
+      ],
+      "folder": "content/resources",
+      "label": "Resource",
+      "name": "resource"
+    }
+  ],
+  "content-dir": "content",
+  "root-url-path": "sites"
+}

--- a/static/js/resources/default-course-config.json
+++ b/static/js/resources/default-course-config.json
@@ -1,0 +1,44 @@
+{
+  "collections": [
+    {
+      "category": "Content",
+      "fields": [
+        {
+          "label": "Title",
+          "name": "title",
+          "required": true,
+          "widget": "string"
+        },
+        {
+          "label": "Content",
+          "name": "content",
+          "widget": "markdown"
+        }
+      ],
+      "folder": "content/pages",
+      "label": "Page",
+      "name": "page"
+    },
+    {
+      "category": "Content",
+      "fields": [
+        {
+          "label": "Title",
+          "name": "title",
+          "required": true,
+          "widget": "string"
+        },
+        {
+          "label": "Description",
+          "name": "description",
+          "widget": "markdown"
+        }
+      ],
+      "folder": "content/resources",
+      "label": "Resource",
+      "name": "resource"
+    }
+  ],
+  "content-dir": "content",
+  "root-url-path": "sites"
+}


### PR DESCRIPTION

#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #698 

#### What's this PR do?
- Updates outdated starter config files
- Adds instruction to run `manage.py override_site_config` in the README

#### How should this be manually tested?
- Run `manage.py override_site_config` to update starter configs
- Create new sites based on the sample starters ("OCW Course Hugo Starter",  "Omnibus Starter", etc)
- Create new pages for each site.  You should not get a blank page with JS errors on any of them.

