### PR TITLE
Add all metadata keys w/blank values for imported google drive content

### DIFF
--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -367,7 +367,7 @@ def create_gdrive_resource_content(drive_file: DriveFile):
                 metadata={
                     **SiteConfig(
                         drive_file.website.starter.config
-                    ).generate_item_config(CONTENT_TYPE_RESOURCE, cls=WebsiteContent),
+                    ).generate_item_metadata(CONTENT_TYPE_RESOURCE, cls=WebsiteContent),
                     "resourcetype": resource_type,
                     "file_type": drive_file.mime_type,
                 },

--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -31,6 +31,7 @@ from videos.constants import VideoStatus
 from videos.models import Video
 from websites.api import get_valid_new_filename
 from websites.constants import (
+    CONTENT_TYPE_RESOURCE,
     RESOURCE_TYPE_DOCUMENT,
     RESOURCE_TYPE_IMAGE,
     RESOURCE_TYPE_OTHER,
@@ -364,6 +365,9 @@ def create_gdrive_resource_content(drive_file: DriveFile):
                 dirpath=dirpath,
                 filename=filename,
                 metadata={
+                    **SiteConfig(
+                        drive_file.website.starter.config
+                    ).generate_item_config(CONTENT_TYPE_RESOURCE, cls=WebsiteContent),
                     "resourcetype": resource_type,
                     "file_type": drive_file.mime_type,
                 },

--- a/gdrive_sync/api_test.py
+++ b/gdrive_sync/api_test.py
@@ -412,11 +412,13 @@ def test_create_gdrive_resource_content(mocker, mime_type):
             title=filename,
             type="resource",
             is_page_content=True,
-            metadata={"resourcetype": RESOURCE_TYPE_DOCUMENT, "file_type": mime_type},
         ).first()
         assert content is not None
         assert content.dirpath == "content/resource"
         assert content.filename == deduped_name
+        assert content.metadata["resourcetype"] == RESOURCE_TYPE_DOCUMENT
+        assert content.metadata["file_type"] == mime_type
+        assert content.metadata["image"] == ""
         drive_file.refresh_from_db()
         assert drive_file.resource == content
 

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -271,6 +271,7 @@ def test_update_youtube_statuses(
                     "video_thumbnail_file": f"https://img.youtube.com/vi/{video_file.destination_id}/0.jpg"
                 },
                 "video_metadata": {"youtube_id": video_file.destination_id},
+                "image": "",
             }
     else:
         mock_youtube.assert_not_called()

--- a/websites/config_schema/api_test.py
+++ b/websites/config_schema/api_test.py
@@ -1,6 +1,4 @@
 """Tests for site config schema and validation"""
-import os
-
 import pytest
 import yaml
 
@@ -12,30 +10,12 @@ from websites.config_schema.api import (
 
 # pylint:disable=redefined-outer-name
 
-
-SCHEMA_RESOURCES_DIR = "localdev/configs/"
-SCHEMA_CONFIG_FILE = "ocw-course-site-config.yml"
 VALID_TITLE_FIELD = {
     "name": "title",
     "label": "Title",
     "required": True,
     "widget": "string",
 }
-
-
-@pytest.fixture()
-def site_config_yml(settings):
-    """Fixture that returns the contents of the example site config YAML file in the resource directory"""
-    with open(
-        os.path.join(settings.BASE_DIR, SCHEMA_RESOURCES_DIR, SCHEMA_CONFIG_FILE)
-    ) as f:
-        return f.read().strip()
-
-
-@pytest.fixture()
-def parsed_site_config(site_config_yml):
-    """Fixture that returns the parsed contents of the example site config YAML file in the resource directory"""
-    return yaml.load(site_config_yml, Loader=yaml.SafeLoader)
 
 
 def test_valid_config(site_config_yml):

--- a/websites/conftest.py
+++ b/websites/conftest.py
@@ -1,4 +1,5 @@
 """Test config for websites app"""
+import os
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -15,6 +16,8 @@ from websites.permissions import create_global_groups
 # pylint:disable=redefined-outer-name
 
 FACTORY_SITE_CONFIG_PATH = "localdev/configs/basic-site-config.yml"
+SCHEMA_RESOURCES_DIR = "localdev/configs/"
+SCHEMA_CONFIG_FILE = "ocw-course-site-config.yml"
 
 
 @pytest.fixture()
@@ -64,6 +67,21 @@ def basic_site_config(settings):
         (Path(settings.BASE_DIR) / FACTORY_SITE_CONFIG_PATH).read_text(),
         Loader=yaml.SafeLoader,
     )
+
+
+@pytest.fixture()
+def site_config_yml(settings):
+    """Fixture that returns the contents of the example site config YAML file in the resource directory"""
+    with open(
+        os.path.join(settings.BASE_DIR, SCHEMA_RESOURCES_DIR, SCHEMA_CONFIG_FILE)
+    ) as f:
+        return f.read().strip()
+
+
+@pytest.fixture()
+def parsed_site_config(site_config_yml):
+    """Fixture that returns the parsed contents of the example site config YAML file in the resource directory"""
+    return yaml.load(site_config_yml, Loader=yaml.SafeLoader)
 
 
 @pytest.fixture()

--- a/websites/management/commands/update_content_metadata.py
+++ b/websites/management/commands/update_content_metadata.py
@@ -1,0 +1,76 @@
+""" Update content metadata for websites based on a specific starter """
+from django.core.management import BaseCommand
+from django.db import transaction
+from django.db.models import Q
+from websites.site_config_api import SiteConfig
+from websites.models import WebsiteContent, WebsiteStarter
+
+
+class Command(BaseCommand):
+    """ Update content metadata for websites based on a specific starter """
+
+    help = __doc__
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "starter",
+            help="The WebsiteStarter slug to process",
+        )
+        parser.add_argument(
+            "-t",
+            "--type",
+            dest="type",
+            default="resource",
+            help="Only update metadata of this_type (default = resource)",
+        )
+        parser.add_argument(
+            "-f",
+            "--filter",
+            dest="filter",
+            default="",
+            help="If specified, only update metadata for websites with names/short_ids matching this filter",
+        )
+        parser.add_argument(
+            "-s",
+            "--source",
+            dest="source",
+            default="studio",
+            help=f"Only update metadata for websites that are based on this source (default=studio)",
+        )
+
+    def handle(self, *args, **options):
+
+        filter_str = options["filter"].lower()
+        starter_str = options["starter"]
+        source_str = options["source"]
+        type_str = options["type"]
+
+        content_qset = WebsiteContent.objects.filter(
+            website__starter__slug=starter_str, type=type_str
+        )
+        if filter_str:
+            content_qset = content_qset.filter(
+                Q(website__name__startswith=filter_str)
+                | Q(website__short_id__startswith=filter_str)
+            )
+        if source_str:
+            content_qset = content_qset.filter(website__source=source_str)
+
+        self.stdout.write(
+            f"Update {type_str} metadata for websites based on starter {starter_str}, source={source_str}"
+        )
+
+        base_metadata = SiteConfig(
+            WebsiteStarter.objects.get(slug=starter_str).config
+        ).generate_item_metadata(type_str, cls=WebsiteContent)
+        with transaction.atomic():
+            for content in content_qset.iterator():
+                if set(base_metadata.keys()).symmetric_difference(
+                    set(content.metadata.keys())
+                ):
+                    content.metadata = {**base_metadata, **content.metadata}
+                    content.save()
+
+        self.stdout.write(
+            f"Done Updating {type_str} metadata for websites based on starter {starter_str}, source {source_str}"
+        )

--- a/websites/management/commands/update_content_metadata.py
+++ b/websites/management/commands/update_content_metadata.py
@@ -2,8 +2,9 @@
 from django.core.management import BaseCommand
 from django.db import transaction
 from django.db.models import Q
-from websites.site_config_api import SiteConfig
+
 from websites.models import WebsiteContent, WebsiteStarter
+from websites.site_config_api import SiteConfig
 
 
 class Command(BaseCommand):

--- a/websites/site_config_api.py
+++ b/websites/site_config_api.py
@@ -116,25 +116,27 @@ class SiteConfig:
                 return config_item
         return None
 
-    def generate_item_config(self, name: str, cls: object = None) -> Dict:
-        """Generate a dict with blank keys for the specified item"""
+    def generate_item_metadata(self, name: str, cls: object = None) -> Dict:
+        """Generate a metadata dict with blank keys for the specified item"""
         item_dict = {}
         item = self.find_item_by_name(name)
         if not item:
             return item_dict
         for config_field in self.iter_item_fields(item):
             key = config_field.field["name"]
-            subfields = config_field.field.get("fields")
-            if subfields:
-                item_dict[key] = {}
-            else:
-                value = [] if config_field.field.get("multiple", False) is True else ""
-                if config_field.parent_field is None:
-                    # add the key if it is not a class attribute or no class was supplied
-                    if not cls or not hasattr(cls, key):
-                        item_dict[key] = value
+            # Do not add class/object attributes to the metadata (ex: WebsiteContent.title)
+            if not cls or not hasattr(cls, key):
+                subfields = config_field.field.get("fields")
+                if subfields:
+                    item_dict[key] = {}
                 else:
-                    item_dict[config_field.parent_field["name"]][key] = value
+                    value = (
+                        [] if config_field.field.get("multiple", False) is True else ""
+                    )
+                    if config_field.parent_field is None:
+                        item_dict[key] = value
+                    else:
+                        item_dict[config_field.parent_field["name"]][key] = value
         return item_dict
 
     def find_item_by_filepath(self, filepath: str) -> Optional[ConfigItem]:

--- a/websites/site_config_api_test.py
+++ b/websites/site_config_api_test.py
@@ -5,6 +5,7 @@ from websites.constants import (
     WEBSITE_CONFIG_CONTENT_DIR_KEY,
     WEBSITE_CONFIG_DEFAULT_CONTENT_DIR,
 )
+from websites.models import WebsiteContent
 from websites.site_config_api import ConfigItem, SiteConfig
 
 
@@ -160,3 +161,26 @@ def test_find_file_field(basic_site_config, content_type, field_name):
         assert file_field["name"] == "image"
     else:
         assert file_field is None
+
+
+@pytest.mark.parametrize("cls", [None, WebsiteContent])
+def test_generate_item_metadata(parsed_site_config, cls):
+    """generate_item_metadata should return the expected dict"""
+    class_data = {} if cls else {"title": "", "file": ""}
+    expected_data = {
+        "description": "",
+        "resourcetype": "",
+        "file_type": "",
+        "learning_resource_types": [],
+        "license": "",
+        "image_metadata": {"image-alt": "", "caption": "", "credit": ""},
+        "video_metadata": {"youtube_id": "", "video_speakers": "", "video_tags": ""},
+        "video_files": {
+            "video_thumbnail_file": "",
+            "video_captions_file": "",
+            "video_transcript_file": "",
+        },
+        **class_data,
+    }
+    site_config = SiteConfig(parsed_site_config)
+    assert site_config.generate_item_metadata("resource", cls) == expected_data


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Fixes #859 

#### What's this PR do?
Adds all metadata keys with blank values for content imported from Google Drive

#### How should this be manually tested?
Set up a personal github org as describe in the README. 
Use the same `.env` values as RC for `CONCOURSE_`, but also set `CONCOURSE_IS_PRIVATE_REPO=False`
Create a new site.
Import an image from google drive.  Do not edit its metadata.
Add that image as the course image and thumbnail for the site metadata.
Publish the site.  The hugo task in the pipeline build should succeed without hugo errors.

Assuming you already have content created previously with missing keys, run this new management command:

```manage.py update_content_metadata ocw-course```

This should fill in any missing keys without overwriting existing values.  By default it should only run for resource content created via studio (not ocw-import).

To avoid cluttering Concourse RC too much, you can delete your pipeline after testing with `fly` (download links are in the footer at https://cicd-qa.odl.mit.edu/):
```
fly -t rc login -c https://cicd-qa.odl.mit.edu
fly -t rc destroy-pipeline -p draft/site:<your_site-name> --team ocw
fly -t rc destroy-pipeline -p live/site:<your_site-name> --team ocw
```
