### PR TITLE
Descriptive message on front end for publishing warnings

### DIFF
--- a/static/js/components/PublishDrawer.test.tsx
+++ b/static/js/components/PublishDrawer.test.tsx
@@ -1,16 +1,17 @@
 import moment from "moment"
 import sinon, { SinonStub } from "sinon"
 import { act } from "react-dom/test-utils"
+import { isEmpty } from "ramda"
 
 import { siteApiActionUrl, siteApiDetailUrl } from "../lib/urls"
+import { shouldIf } from "../test_util"
+import { makeWebsiteDetail } from "../util/factories/websites"
 import IntegrationTestHelper, {
   TestRenderer
 } from "../util/integration_test_helper"
-import { makeWebsiteDetail } from "../util/factories/websites"
 import PublishDrawer from "./PublishDrawer"
+
 import { Website } from "../types/websites"
-import { shouldIf } from "../test_util"
-import { isEmpty } from "ramda"
 
 describe("PublishDrawer", () => {
   let helper: IntegrationTestHelper,

--- a/static/js/components/PublishDrawer.test.tsx
+++ b/static/js/components/PublishDrawer.test.tsx
@@ -9,6 +9,8 @@ import IntegrationTestHelper, {
 import { makeWebsiteDetail } from "../util/factories/websites"
 import PublishDrawer from "./PublishDrawer"
 import { Website } from "../types/websites"
+import { shouldIf } from "../test_util"
+import { isEmpty } from "ramda"
 
 describe("PublishDrawer", () => {
   let helper: IntegrationTestHelper,
@@ -223,6 +225,19 @@ describe("PublishDrawer", () => {
           expect(wrapper.find(".publish-option-description").text()).toContain(
             "You have unpublished changes."
           )
+        })
+        ;[[], ["error 1", "error2"]].forEach(warnings => {
+          it(`${shouldIf(
+            warnings && !isEmpty(warnings)
+          )} render a warning about missing content`, async () => {
+            website["content_warnings"] = warnings
+            const { wrapper } = await render()
+            const warningText = wrapper.find(".publish-warnings")
+            expect(warningText.exists()).toBe(!isEmpty(warnings))
+            warnings.forEach(warning =>
+              expect(warningText.text()).toContain(warning)
+            )
+          })
         })
 
         it("renders an error message if the publish didn't work", async () => {

--- a/static/js/components/PublishDrawer.tsx
+++ b/static/js/components/PublishDrawer.tsx
@@ -1,15 +1,16 @@
 import React, { useState } from "react"
 import { Modal, ModalBody, ModalHeader } from "reactstrap"
+import { useStore } from "react-redux"
 import { useMutation } from "redux-query-react"
-import moment from "moment"
 import { requestAsync } from "redux-query"
+import moment from "moment"
+import { isEmpty } from "ramda"
 
 import { websiteAction, websiteDetailRequest } from "../query-configs/websites"
-import { Website } from "../types/websites"
 import { isErrorStatusCode } from "../lib/util"
-import { useStore } from "react-redux"
 import PublishStatusIndicator from "./PublishStatusIndicator"
-import { isEmpty } from "ramda"
+
+import { Website } from "../types/websites"
 
 const STAGING = "staging"
 const PRODUCTION = "production"

--- a/static/js/components/PublishDrawer.tsx
+++ b/static/js/components/PublishDrawer.tsx
@@ -9,6 +9,7 @@ import { Website } from "../types/websites"
 import { isErrorStatusCode } from "../lib/util"
 import { useStore } from "react-redux"
 import PublishStatusIndicator from "./PublishStatusIndicator"
+import { isEmpty } from "ramda"
 
 const STAGING = "staging"
 const PRODUCTION = "production"
@@ -144,6 +145,19 @@ export default function PublishDrawer(props: Props): JSX.Element {
       <ModalBody>
         {renderOption(STAGING)}
         {website.is_admin ? renderOption(PRODUCTION) : null}
+        {website.content_warnings && !isEmpty(website.content_warnings) ? (
+          <div className="publish-warnings pt-2">
+            <strong className="text-danger">
+              This site is missing information that could affect publishing
+              output.
+            </strong>
+            <ul className="text-danger">
+              {website.content_warnings.map((warning: string, idx: number) => (
+                <li key={idx}>{warning}</li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
       </ModalBody>
     </Modal>
   )

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -242,6 +242,7 @@ export type Website = WebsiteStatus & {
   gdrive_url: string | null // eslint-disable-line
   has_unpublished_draft: boolean // eslint-disable-line
   has_unpublished_live: boolean // eslint-disable-line
+  content_warnings?: Array<string> // eslint-disable-line
 }
 
 type WebsiteRoleEditable = typeof ROLE_ADMIN | typeof ROLE_EDITOR

--- a/static/js/util/factories/websites.ts
+++ b/static/js/util/factories/websites.ts
@@ -195,7 +195,8 @@ export const makeWebsiteDetail = (): Website => ({
   sync_status:                     null,
   synced_on:                       null,
   sync_errors:                     null,
-  is_admin:                        casual.boolean
+  is_admin:                        casual.boolean,
+  content_warnings:                []
 })
 
 export const makeWebsiteStatus = (website?: Website): WebsiteStatus => {

--- a/websites/api.py
+++ b/websites/api.py
@@ -179,7 +179,7 @@ def fetch_website(filter_value: str) -> Website:
 
 def is_ocw_site(website: Website) -> bool:
     """Return true if the site is an OCW site"""
-    return website.starter.slug == settings.OCW_IMPORT_STARTER_SLUG
+    return website.starter and website.starter.slug == settings.OCW_IMPORT_STARTER_SLUG
 
 
 def update_youtube_thumbnail(website_id: str, metadata: Dict, overwrite=False):
@@ -307,3 +307,30 @@ def update_website_status(
         mail_on_publish(
             website.name, version, status == PUBLISH_STATUS_SUCCEEDED, user.id
         )
+
+
+def incomplete_content_warnings(website):
+    """
+    Return array with error/warning messages for any website content missing expected data
+    (currently: video youtube ids and captions).
+    """
+    missing_youtube_ids = unassigned_youtube_ids(website)
+
+    missing_youtube_ids_titles = [video.title for video in missing_youtube_ids]
+
+    missing_captions_titles = [
+        video.title for video in videos_missing_captions(website)
+    ]
+
+    messages = []
+
+    if len(missing_youtube_ids_titles) > 0:
+        messages.append(
+            f"The following video resources require YouTube IDs: {', '.join(missing_youtube_ids_titles)}"
+        )
+    if len(missing_captions_titles) > 0:
+        messages.append(
+            f"The following videos have missing captions: {', '.join(missing_captions_titles)}"
+        )
+
+    return messages

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -108,9 +108,13 @@ def test_website_serializer(has_starter):
     assert "config" not in serialized_data
 
 
+@pytest.mark.parametrize("warnings", [[], ["error1", "error2"]])
 @pytest.mark.parametrize("drive_folder", [None, "abc123"])
-def test_website_status_serializer(settings, drive_folder):
+def test_website_status_serializer(mocker, settings, drive_folder, warnings):
     """WebsiteStatusSerializer should serialize a Website object with the correct status fields"""
+    mocker.patch(
+        "websites.serializers.incomplete_content_warnings", return_value=warnings
+    )
     settings.DRIVE_UPLOADS_PARENT_FOLDER_ID = "dfg789"
     settings.DRIVE_SERVICE_ACCOUNT_CREDS = {"key": "value"}
     settings.DRIVE_SHARED_ID = "abc123"
@@ -134,6 +138,7 @@ def test_website_status_serializer(settings, drive_folder):
         if drive_folder is not None
         else None
     )
+    assert sorted(serialized_data["content_warnings"]) == sorted(warnings)
     for (key, value) in values.items():
         assert serialized_data.get(key) == value
 

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -234,25 +234,12 @@ def test_websites_endpoint_detail_update(mocker, drf_client):
     mock_create_website_pipeline.assert_not_called()
 
 
-@pytest.mark.parametrize("has_missing_ids", [True, False])
-@pytest.mark.parametrize("has_missing_captions", [True, False])
-def test_websites_endpoint_preview(
-    mocker, drf_client, has_missing_ids, has_missing_captions
-):
+def test_websites_endpoint_preview(mocker, drf_client):
     """A user with admin/edit permissions should be able to request a website preview"""
     mock_trigger_publish = mocker.patch("websites.views.trigger_publish")
     now = datetime.datetime(2020, 1, 1, tzinfo=pytz.utc)
     mocker.patch("websites.views.now_in_utc", return_value=now)
     website = WebsiteFactory.create()
-    video_content = WebsiteContentFactory.create_batch(3, website=website)
-    mocker.patch(
-        "websites.views.unassigned_youtube_ids",
-        return_value=video_content[0:2] if has_missing_ids else [],
-    )
-    mocker.patch(
-        "websites.views.videos_missing_captions",
-        return_value=video_content[1:3] if has_missing_captions else [],
-    )
     editor = UserFactory.create()
     editor.groups.add(website.editor_group)
     drf_client.force_login(editor)
@@ -260,28 +247,6 @@ def test_websites_endpoint_preview(
         reverse("websites_api-preview", kwargs={"name": website.name})
     )
     assert resp.status_code == 200
-    expected_msgs = []
-
-    titles = [content.title for content in video_content]
-
-    if has_missing_ids:
-        expected_msgs.append(
-            f"WARNING: The following video resources require YouTube IDs: {', '.join(titles[0:2])}"
-        )
-
-    if has_missing_captions:
-        if has_missing_ids:
-            missing_titles = titles[2]
-        else:
-            missing_titles = ", ".join(titles[1:3])
-        expected_msgs.append(
-            f"WARNING: The following videos have missing captions: {missing_titles}"
-        )
-
-    if expected_msgs:
-        assert resp.data["details"] == "\n".join(expected_msgs)
-    else:
-        assert resp.data["details"] == ""
     mock_trigger_publish.assert_called_once_with(website.name, VERSION_DRAFT)
     website.refresh_from_db()
     assert website.has_unpublished_draft is False
@@ -308,68 +273,27 @@ def test_websites_endpoint_preview_error(mocker, drf_client):
     assert resp.data == {"details": "422 {}"}
 
 
-@pytest.mark.parametrize("has_missing_ids", [True, False])
-@pytest.mark.parametrize("has_missing_captions", [True, False])
-def test_websites_endpoint_publish(  # pylint: disable=too-many-locals
-    mocker, drf_client, has_missing_ids, has_missing_captions
-):
+def test_websites_endpoint_publish(mocker, drf_client):
     """A user with admin permissions should be able to request a website publish"""
     mock_publish_website = mocker.patch("websites.views.trigger_publish")
     now = datetime.datetime(2020, 1, 1, tzinfo=pytz.utc)
     mocker.patch("websites.views.now_in_utc", return_value=now)
     website = WebsiteFactory.create()
-    video_content = WebsiteContentFactory.create_batch(3, website=website)
-    mocker.patch(
-        "websites.views.unassigned_youtube_ids",
-        return_value=video_content[0:2] if has_missing_ids else [],
-    )
-    mocker.patch(
-        "websites.views.videos_missing_captions",
-        return_value=video_content[1:3] if has_missing_captions else [],
-    )
-    last_published = website.publish_date
     admin = UserFactory.create()
     admin.groups.add(website.admin_group)
     drf_client.force_login(admin)
     resp = drf_client.post(
         reverse("websites_api-publish", kwargs={"name": website.name})
     )
-    assert resp.status_code == 400 if has_missing_ids else 200
+    assert resp.status_code == 200
     website.refresh_from_db()
-    expected_msgs = []
 
-    titles = [content.title for content in video_content]
-
-    if has_missing_ids:
-        expected_msgs.append(
-            f"The following video resources require YouTube IDs: {', '.join(titles[0:2])}"
-        )
-        assert website.publish_date == last_published
-        mock_publish_website.assert_not_called()
-
-    if has_missing_captions:
-        if has_missing_ids:
-            missing_titles = titles[2]
-        else:
-            missing_titles = ", ".join(titles[1:3])
-        expected_msgs.append(
-            f"The following videos have missing captions: {missing_titles}"
-        )
-        assert website.publish_date == last_published
-        mock_publish_website.assert_not_called()
-
-    expected_msg = "\n".join(expected_msgs)
-
-    if not has_missing_ids and not has_missing_captions:
-        expected_msg = ""
-        mock_publish_website.assert_called_once_with(website.name, VERSION_LIVE)
-        assert website.has_unpublished_live is False
-        assert website.live_last_published_by == admin
-        assert website.live_publish_status == constants.PUBLISH_STATUS_NOT_STARTED
-        assert website.live_publish_status_updated_on == now
-        assert website.latest_build_id_live is None
-
-    assert resp.data["details"] == expected_msg
+    mock_publish_website.assert_called_once_with(website.name, VERSION_LIVE)
+    assert website.has_unpublished_live is False
+    assert website.live_last_published_by == admin
+    assert website.live_publish_status == constants.PUBLISH_STATUS_NOT_STARTED
+    assert website.live_publish_status_updated_on == now
+    assert website.latest_build_id_live is None
 
 
 def test_websites_endpoint_publish_denied(mocker, drf_client):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #652

#### What's this PR do?
Shows any content validation warnings in the publish drawer.  Allows publishing to proceed regardless (draft or live) if the user clicks the 'Publish' button in the drawer.

#### How should this be manually tested?
Add a video resource to a site without a youtube id and click 'Publish'.  You should see a warning message indicating that the video is missing a youtube id (and captions too).  Click `Publish` for staging and for production, both should work.
Change the video resource, manually adding in a fake youtube id and caption.  Click 'Publish" again to bring up the drawer. There should no longer be any warnings.


#### Screenshots (if appropriate)

<img width="552" alt="Screen Shot 2021-12-14 at 12 34 35 PM" src="https://user-images.githubusercontent.com/187676/146059221-42be6f6f-864e-4b8e-9808-23c609eb7120.png">

