### PR TITLE
split reordering UI off from RelationWidget into SortableSelect component

### DIFF
--- a/static/js/components/widgets/RelationField.test.tsx
+++ b/static/js/components/widgets/RelationField.test.tsx
@@ -1,7 +1,7 @@
 import React from "react"
 import { act } from "react-dom/test-utils"
 import R from "ramda"
-import sinon, { SinonStub } from "sinon"
+import { SinonStub } from "sinon"
 
 import RelationField from "./RelationField"
 import { debouncedFetch } from "../../lib/api/util"
@@ -26,7 +26,6 @@ import {
   WebsiteContent
 } from "../../types/websites"
 import { ReactWrapper } from "enzyme"
-import { DndContext } from "@dnd-kit/core"
 import { FormError } from "../forms/FormError"
 import { formatOptions, useWebsiteSelectOptions } from "../../hooks/websites"
 
@@ -436,61 +435,14 @@ describe("RelationField", () => {
         sortable: true,
         value
       })
-      expect(wrapper.find("SortableContext").exists()).toBeTruthy()
-      expect(
-        wrapper
-          .find("SortableContext SortableItem")
-          .map(item => item.prop("id"))
-      ).toStrictEqual(value)
-    })
-
-    it("should allow adding another element", async () => {
-      const { wrapper } = await render({
-        multiple: true,
-        sortable: true,
-        value:    []
-      })
-      await act(async () => {
-        // @ts-ignore
-        wrapper.find("SelectField").prop("onChange")({
-          // @ts-ignore
-          target: { value: "new-uuid" }
-        })
-      })
-      wrapper.update()
-      wrapper.find(".cyan-button").simulate("click")
-      sinon.assert.calledWith(onChange, {
-        target: {
-          name:  "relation_field",
-          value: { website: website.name, content: ["new-uuid"] }
-        }
-      })
-      expect(wrapper.find("SelectField").prop("value")).toBeUndefined()
-    })
-
-    it("should let you drag and drop items to reorder", async () => {
-      const value = ["uuid-1", "uuid-2", "uuid-3"]
-      const { wrapper } = await render({
-        multiple: true,
-        sortable: true,
-        value
-      })
-
-      act(() => {
-        wrapper.find(DndContext)!.prop("onDragEnd")!({
-          active: { id: "uuid-3" },
-          over:   { id: "uuid-1" }
-        } as any)
-      })
-      sinon.assert.calledWith(onChange, {
-        target: {
-          name:  "relation_field",
-          value: {
-            website: website.name,
-            content: ["uuid-3", "uuid-1", "uuid-2"]
-          }
-        }
-      })
+      const sortableSelect = wrapper.find("SortableSelect")
+      expect(sortableSelect.exists()).toBeTruthy()
+      expect(sortableSelect.prop("value")).toStrictEqual(
+        value.map(id => ({
+          id,
+          title: id
+        }))
+      )
     })
   })
 })

--- a/static/js/components/widgets/SortableSelect.test.tsx
+++ b/static/js/components/widgets/SortableSelect.test.tsx
@@ -1,0 +1,106 @@
+import { act } from "react-dom/test-utils"
+import sinon, { SinonStub } from "sinon"
+import { DndContext } from "@dnd-kit/core"
+import casual from "casual"
+
+import IntegrationTestHelper, {
+  TestRenderer
+} from "../../util/integration_test_helper"
+import SortableSelect, { SortableItem } from "./SortableSelect"
+import { Option } from "./SelectField"
+import { zip } from "ramda"
+import { default as SortableItemComponent } from "../SortableItem"
+
+const createFakeOptions = (times: number): Option[] =>
+  Array(times)
+    .fill(0)
+    .map(() => ({
+      value: casual.uuid,
+      label: casual.title
+    }))
+
+describe("SortableSelect", () => {
+  let render: TestRenderer,
+    helper: IntegrationTestHelper,
+    options: Option[],
+    onChange: SinonStub,
+    newOptions: Option[],
+    loadOptions: SinonStub
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    options = createFakeOptions(10)
+    newOptions = createFakeOptions(10)
+    onChange = helper.sandbox.stub()
+    loadOptions = helper.sandbox.stub().resolves(newOptions)
+    render = helper.configureRenderer(SortableSelect, {
+      options,
+      onChange,
+      loadOptions,
+      name:  "test-select",
+      value: []
+    })
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should pass options down to the SelectField", async () => {
+    const { wrapper } = await render()
+    expect(wrapper.find("SelectField").prop("options")).toStrictEqual(options)
+  })
+
+  it("should render sortable items for the current value", async () => {
+    const value: SortableItem[] = options.map(option => ({
+      id:    option.value,
+      title: option.label
+    }))
+
+    const { wrapper } = await render({
+      value
+    })
+
+    zip(value, [...(wrapper.find(SortableItemComponent) as any)]).forEach(
+      ([value, sortableItem]) => {
+        expect(sortableItem.props["title"]).toBe(value.title)
+        expect(sortableItem.props["id"]).toBe(value.id)
+        expect(sortableItem.props["item"]).toBe(value.id)
+      }
+    )
+  })
+
+  it("should allow adding another element", async () => {
+    const { wrapper } = await render()
+    await act(async () => {
+      // @ts-ignore
+      wrapper.find("SelectField").prop("onChange")({
+        // @ts-ignore
+        target: { value: newOptions[0].label }
+      })
+    })
+    wrapper.update()
+    wrapper.find(".cyan-button").simulate("click")
+    sinon.assert.calledWith(onChange, [newOptions[0].label])
+    expect(wrapper.find("SelectField").prop("value")).toBeUndefined()
+  })
+
+  it("should let you drag and drop items to reorder", async () => {
+    const value: SortableItem[] = options.slice(0, 3).map(option => ({
+      id:    option.value,
+      title: option.label
+    }))
+
+    const { wrapper } = await render({
+      value
+    })
+
+    act(() => {
+      wrapper.find(DndContext)!.prop("onDragEnd")!({
+        active: { id: value[2].id },
+        over:   { id: value[0].id }
+      } as any)
+    })
+    sinon.assert.calledWith(onChange, [value[2].id, value[0].id, value[1].id])
+  })
+})

--- a/static/js/components/widgets/SortableSelect.tsx
+++ b/static/js/components/widgets/SortableSelect.tsx
@@ -1,0 +1,132 @@
+import React, {
+  ChangeEvent,
+  SyntheticEvent,
+  useCallback,
+  useState
+} from "react"
+import SelectField, { Option } from "./SelectField"
+import SortableItem from "../SortableItem"
+import SortWrapper from "../SortWrapper"
+import { DragEndEvent } from "@dnd-kit/core"
+import { arrayMove } from "@dnd-kit/sortable"
+
+export interface SortableItem {
+  // the UUID for this item
+  id: string
+  // title, used to display a sortable entry in the list
+  title: string
+}
+
+interface Props {
+  value: SortableItem[]
+  // The onChange function takes an array of item IDs as an argument
+  onChange: (update: string[]) => void
+  options: Option[]
+  defaultOptions?: Option[]
+  loadOptions: (inputValue: string) => Promise<Option[] | undefined>
+  name: string
+}
+
+export default function SortableSelect(props: Props) {
+  const { options, loadOptions, defaultOptions, value, onChange, name } = props
+
+  const [focusedContent, setFocusedContent] = useState<string | undefined>(
+    undefined
+  )
+
+  /**
+   * Callback for adding a new item to the field value in the sortable UI. If
+   * there is an item 'focused' in the UI (i.e. the user has selected it in the
+   * SelectField) then we add that to the current value and call the change
+   * shim.
+   */
+  const addFocusedItem = useCallback(
+    (event: SyntheticEvent<HTMLButtonElement>) => {
+      event.preventDefault()
+
+      if (focusedContent) {
+        onChange(value.map(item => item.id).concat(focusedContent))
+        setFocusedContent(undefined)
+      }
+    },
+    [focusedContent, setFocusedContent, onChange, value]
+  )
+
+  /**
+   * This callback is only used for the SelectField that
+   * we present as an 'add' interface when this component
+   * is displayin the sortable mode.
+   */
+  const handleAddSortableItem = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => {
+      setFocusedContent(event.target.value)
+    },
+    [setFocusedContent]
+  )
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event
+
+      if (over && active.id !== over.id) {
+        const valueToUse = value.map(item => item.id)
+
+        const movedArray = arrayMove(
+          valueToUse,
+          valueToUse.indexOf(active.id),
+          valueToUse.indexOf(over.id)
+        )
+
+        onChange(movedArray)
+      }
+    },
+    [onChange, value]
+  )
+
+  /**
+   * For removing an item in the sortable UI
+   */
+  const deleteItem = useCallback(
+    (toDelete: string) => {
+      onChange(value.map(item => item.id).filter(item => item !== toDelete))
+    },
+    [onChange, value]
+  )
+
+  return (
+    <>
+      <div className="d-flex">
+        <SelectField
+          name={name}
+          value={focusedContent}
+          onChange={handleAddSortableItem}
+          options={options}
+          loadOptions={loadOptions}
+          defaultOptions={defaultOptions}
+        />
+        <button
+          className="px-4 ml-3 btn cyan-button"
+          disabled={focusedContent === undefined}
+          onClick={addFocusedItem}
+        >
+          Add
+        </button>
+      </div>
+      <SortWrapper
+        handleDragEnd={handleDragEnd}
+        items={value.map(item => item.id)}
+        generateItemUUID={x => x}
+      >
+        {value.map(item => (
+          <SortableItem
+            key={item.id}
+            title={item.title}
+            id={item.id}
+            item={item.id}
+            deleteItem={deleteItem}
+          />
+        ))}
+      </SortWrapper>
+    </>
+  )
+}

--- a/static/js/util/integration_test_helper.tsx
+++ b/static/js/util/integration_test_helper.tsx
@@ -119,6 +119,9 @@ export default class IntegrationTestHelper {
     return this.mockRequest(url, "DELETE", body, code)
   }
 
+  /**
+   * Clean up after yourself!
+   */
   cleanup(unmount = true): void {
     this.actions = []
     this.sandbox.restore()


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

none

#### What's this PR do?


I'm doing this in preparation for work we want to refactor course collections. We want to add a new field type so that we can have course collections (i.e. content author defined collections of courses, like 'Python-based programming courses', 'Math courses with video lectures,' or something like that) be defined as content collections, like pages, resources, and the like, which live in a site like `ocw-www`.

For this we could add more functionality to our existing `RelationField` component, but I'm a little reluctant to do that because it's already quite a large, complicated component. Instead I think it makes sense to add a new `WebsiteCollectionField` field which will implement this functionality.

In order to do _that_, I want to pull out the portion of the current `RelationField` implementation which is concerned with reordering a list, so that we can reuse that UI for the `WebsiteCollectionField`. This PR basically does that, pulling that code out into a new `SortableSelect` component which we'll be able to depend on for both things.



#### How should this be manually tested?

Try out some fields which use the `RelationField` with the `cross-site` and `sortable` option. It should all work as before with no differences at all.