### PR TITLE
Fix task bug caused by decorator

### DIFF
--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -15,7 +15,7 @@ from requests import HTTPError
 from content_sync import api
 from content_sync.apis import github
 from content_sync.constants import VERSION_DRAFT, VERSION_LIVE
-from content_sync.decorators import is_publish_pipeline_enabled, single_task
+from content_sync.decorators import single_task
 from content_sync.models import ContentSyncState
 from content_sync.pipelines.base import BaseSyncPipeline
 from main.celery import app
@@ -271,11 +271,12 @@ def sync_github_site_configs(url: str, files: List[str], commit: Optional[str] =
 
 
 @app.task(acks_late=True)
-@is_publish_pipeline_enabled
 def check_incomplete_publish_build_statuses():
     """
     Check statuses of concourse builds that have not been updated in a reasonable amount of time
     """
+    if not settings.CONTENT_SYNC_PIPELINE:
+        return
     now = now_in_utc()
     wait_dt = now - timedelta(seconds=settings.PUBLISH_STATUS_WAIT_TIME)
     cutoff_dt = now - timedelta(seconds=settings.PUBLISH_STATUS_CUTOFF)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Fixes #https://sentry.io/organizations/mit-office-of-digital-learning/issues/2735518351/?project=5739976&query=is%3Aunresolved

#### What's this PR do?
Fixes a bug caused by a decorator for a celery task

#### How should this be manually tested?
Start docker containers, you should see this in the logs:
```
celery_1        | [2021-12-15 21:09:19,767: INFO/Beat] Scheduler: Sending due task check_incomplete_publish_build_statuses (content_sync.tasks.check_incomplete_publish_build_statuses)
celery_1        | [2021-12-15 21:09:19,780: INFO/MainProcess] Received task: content_sync.tasks.check_incomplete_publish_build_statuses[4fafad9e-3988-471f-902f-b890ce558c1f]
```
