### PR TITLE
add uids to metadata output

### DIFF
--- a/content_sync/serializers.py
+++ b/content_sync/serializers.py
@@ -14,7 +14,7 @@ from main.utils import (
     is_valid_uuid,
     remove_trailing_slashes,
 )
-from websites.constants import CONTENT_MENU_FIELD
+from websites.constants import CONTENT_MENU_FIELD, CONTENT_TYPE_METADATA
 from websites.models import Website, WebsiteContent
 from websites.site_config_api import ConfigItem, SiteConfig
 
@@ -133,8 +133,12 @@ class JsonFileSerializer(BaseContentFileSerializer):
     """Serializer/deserializer class for pure JSON content and files"""
 
     def serialize(self, website_content: WebsiteContent) -> str:
+        metadata = website_content.metadata
+        if website_content.type == CONTENT_TYPE_METADATA:
+            metadata["site_uid"] = str(website_content.website.uuid)
+
         return json.dumps(
-            self.serialize_contents(website_content.metadata, website_content.title),
+            self.serialize_contents(metadata, website_content.title),
             indent=2,
         )
 
@@ -145,7 +149,7 @@ class JsonFileSerializer(BaseContentFileSerializer):
         return self.deserialize_data_file(
             website=website,
             filepath=filepath,
-            parsed_file_data=parsed_file_data,
+            parsed_file_data=dict_without_keys(parsed_file_data, "site_uid"),
         )
 
 

--- a/content_sync/serializers_test.py
+++ b/content_sync/serializers_test.py
@@ -54,7 +54,8 @@ EXAMPLE_JSON = """{
     "Design"
   ],
   "description": "**This** is the description",
-  "title": "Content Title"
+  "title": "Content Title",
+  "site_uid": "site_uid"
 }
 """
 
@@ -280,6 +281,27 @@ def test_data_file_serialize(serializer_cls):
         else yaml.load(file_content, Loader=yaml.SafeLoader)
     )
     assert parsed_file_content == {**metadata, "title": "Content Title"}
+
+
+@pytest.mark.django_db
+def test_metadata_file_serialize():
+    """JsonFileSerializer should create the expected data file contents for sitemetadata files"""
+    metadata = {"metadata1": "dummy value 1", "metadata2": "dummy value 2"}
+    content = WebsiteContentFactory.create(
+        text_id="abcdefg",
+        title="Content Title",
+        type="sitemetadata",
+        metadata=metadata,
+    )
+    site_config = SiteConfig(content.website.starter.config)
+    file_content = JsonFileSerializer(site_config).serialize(website_content=content)
+    parsed_file_content = json.loads(file_content)
+
+    assert parsed_file_content == {
+        **metadata,
+        "site_uid": str(content.website.uuid),
+        "title": "Content Title",
+    }
 
 
 @pytest.mark.django_db

--- a/localdev/configs/ocw-course-site-config.yml
+++ b/localdev/configs/ocw-course-site-config.yml
@@ -672,7 +672,9 @@ collections:
                 Education Policy: [ ]
                 Educational Technology: [ ]
                 Higher Education: [ ]
-
+          - label: "Legacy UID"
+            name: "legacy_uid"
+            widget: "string"
   - category: Settings
     label: Menu
     name: menu

--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -238,6 +238,8 @@ def import_ocw2hugo_sitemetadata(
     metadata["extra_course_numbers"] = ",".join(course_data["extra_course_numbers"])
     metadata["course_image"] = course_data["course_image"]
     metadata["course_image_thumbnail"] = course_data["course_image_thumbnail"]
+    metadata["legacy_uid"] = course_data["legacy_uid"]
+
     with open("static/js/resources/departments.json", "r") as departments_json_file:
         departments_json = json.load(departments_json_file)
         metadata["department_numbers"] = list(

--- a/ocw_import/api_test.py
+++ b/ocw_import/api_test.py
@@ -222,6 +222,7 @@ def test_import_ocw2hugo_course_metadata(settings, root_website):
         "learning_resource_types": ["Problem Sets", "Lecture Notes"],
         "term": "Fall",
         "year": "2007",
+        "legacy_uid": "943e2a4c-3a7f-0e9f-f872-95c7a0cafac6",
     }
 
 

--- a/static/js/resources/ocw-course-site-config.json
+++ b/static/js/resources/ocw-course-site-config.json
@@ -825,6 +825,11 @@
                 }
               },
               "widget": "hierarchical-select"
+            },
+            {
+              "label": "Legacy UID",
+              "name": "legacy_uid",
+              "widget": "string"
             }
           ],
           "file": "data/course.json",

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/data/course.json
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/data/course.json
@@ -49,5 +49,6 @@
   ],
   "other_versions": [],
   "archived_versions": [],
-  "open_learning_library_versions": []
+  "open_learning_library_versions": [],
+  "legacy_uid": "943e2a4c-3a7f-0e9f-f872-95c7a0cafac6"
 }

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/data/course_legacy.json
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/data/course_legacy.json
@@ -80,5 +80,6 @@
       "feature": "Lecture Notes",
       "url": "pages/lecture-notes"
     }
-  ]
+  ],
+  "legacy_uid": "943e2a4c-3a7f-0e9f-f872-95c7a0cafac6"
 }

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/data/course.json
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/data/course.json
@@ -52,5 +52,6 @@
   ],
   "other_versions": [],
   "archived_versions": [],
-  "open_learning_library_versions": []
+  "open_learning_library_versions": [],
+  "legacy_uid": "943e2a4c-3a7f-0e9f-f872-95c7a0cafac6"
 }

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/data/course_legacy.json
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/data/course_legacy.json
@@ -96,5 +96,6 @@
       "feature": "Lecture Notes",
       "url": "pages/lecture-notes"
     }
-  ]
+  ],
+  "legacy_uid": "943e2a4c-3a7f-0e9f-f872-95c7a0cafac6"
 }

--- a/test_ocw2hugo/biology/data/course.json
+++ b/test_ocw2hugo/biology/data/course.json
@@ -23,5 +23,6 @@
   "level": [],
   "other_versions": [],
   "archived_versions": [],
-  "open_learning_library_versions": []
+  "open_learning_library_versions": [],
+  "legacy_uid": ""
 }

--- a/test_ocw2hugo/biology/data/course_legacy.json
+++ b/test_ocw2hugo/biology/data/course_legacy.json
@@ -26,5 +26,6 @@
   "course_image_caption_text": "",
   "publishdate": "2012-01-12T14:12:55-05:00",
   "departments": [],
-  "course_features": []
+  "course_features": [],
+  "legacy_uid": ""
 }

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/data/course.json
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/data/course.json
@@ -43,5 +43,6 @@
   ],
   "other_versions": [],
   "archived_versions": [],
-  "open_learning_library_versions": []
+  "open_learning_library_versions": [],
+  "legacy_uid": "943e2a4c-3a7f-0e9f-f872-95c7a0cafac6"
 }

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/data/course_legacy.json
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/data/course_legacy.json
@@ -74,5 +74,7 @@
       "feature": "Activity Assignments",
       "url": "pages/lesson-1/language-instruction"
     }
-  ]
+  ],
+  "legacy_uid": "943e2a4c-3a7f-0e9f-f872-95c7a0cafac6"
+
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-studio/issues/870

#### What's this PR do?
This PR imports the course uid from Plone courses and adds it to the metadata in studio as legacy_uid.

It also updates the serializer for sitemetadata files to expose ocw-studio uid for the course as site_uid

#### How should this be manually tested?
Update the content of your ocw-course starter with the contents of ocw-studio from https://github.com/mitodl/ocw-hugo-projects/pull/103

Run
```
docker-compose run web ./manage.py import_ocw_course_sites --bucket ocw-to-hugo-output-qa --filter sts-471j-engineering-apollo-the-moon-project-as-a-complex-system-spring-2007 --sync_backend --create_backend
```

Go to the metadata page. Verify that the `Legacy UID` field is set.

Go to https://github.mit.edu/ocw-content-rc/sts.471j-spring-2007/blob/main/data/course.json
and verify that both `legacy_uid`  and `site_uid` are set.

Verify that you can create a new site.

Verify that site_uid is set in the course.json file in the github repo for your new site
