### PR TITLE
Fix Youtube API status update call

### DIFF
--- a/videos/youtube.py
+++ b/videos/youtube.py
@@ -231,7 +231,7 @@ class YouTubeApi:
     def update_privacy(self, youtube_id: str, privacy: str):
         """Update the privacy level of a video"""
         self.client.videos().update(
-            part="status", body={"id": youtube_id, "privacyStatus": privacy}
+            part="status", body={"id": youtube_id, "status": {"privacyStatus": privacy}}
         ).execute()
 
     def update_captions(self, resource: WebsiteContent, youtube_id: str):

--- a/videos/youtube_test.py
+++ b/videos/youtube_test.py
@@ -200,7 +200,7 @@ def test_update_video(settings, mocker, youtube_mocker, privacy):
     )
     if privacy is not None:
         youtube_mocker().videos.return_value.update.assert_any_call(
-            part="status", body={"id": youtube_id, "privacyStatus": privacy}
+            part="status", body={"id": youtube_id, "status": {"privacyStatus": privacy}}
         )
 
     mock_update_caption.assert_called_once_with(content, youtube_id)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #872

#### What's this PR do?
Tweaks the Youtube API call for updating video status so that it actually changes the status.

#### How should this be manually tested?
Easiest way is probably on RC via a heroku shell, emulating the change made in this PR:
```python
from videos.youtube import *

api = YouTubeApi()
api.client.videos().update(
    part="status", 
    body={"id": "CiAfN0vVSjg", "status": {"privacyStatus": "public"}}
).execute()
```

You should get this returned from the API:
```python
{'kind': 'youtube#video',
 'etag': 'Upmfc0pFXRX69xC-V80IHAgfWuo',
 'id': 'CiAfN0vVSjg',
 'status': {'uploadStatus': 'processed',
  'privacyStatus': 'public',
  'license': 'youtube',
  'embeddable': False,
  'publicStatsViewable': False}}
```

Then change it back to 'unlisted':
```python
api.client.videos().update(
    part="status", 
    body={"id": "CiAfN0vVSjg", "status": {"privacyStatus": "unlisted"}}
).execute()
```