### PR TITLE
Adjust query in content_sync.tasks.check_incomplete_publish_build_statuses

### DIFF
--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -284,11 +284,11 @@ def check_incomplete_publish_build_statuses():
         Website.objects.exclude(
             (
                 Q(draft_publish_status__isnull=True)
-                | Q(draft_publish_status__contains=PUBLISH_STATUSES_FINAL)
+                | Q(draft_publish_status__in=PUBLISH_STATUSES_FINAL)
             )
             & (
                 Q(live_publish_status__isnull=True)
-                | Q(live_publish_status__contains=PUBLISH_STATUSES_FINAL)
+                | Q(live_publish_status__in=PUBLISH_STATUSES_FINAL)
             )
         )
         .filter(

--- a/content_sync/tasks_test.py
+++ b/content_sync/tasks_test.py
@@ -370,10 +370,16 @@ def test_check_incomplete_publish_build_statuses(
         draft_publish_status=old_status,
         latest_build_id_draft=1,
     )
-    draft_site_to_exclude = WebsiteFactory.create(
+    draft_site_to_exclude_time = WebsiteFactory.create(
         draft_publish_status_updated_on=now
         - timedelta(seconds=settings.PUBLISH_STATUS_WAIT_TIME - 5),
         draft_publish_status=old_status,
+        latest_build_id_draft=2,
+    )
+    draft_site_to_exclude_status = WebsiteFactory.create(
+        draft_publish_status_updated_on=now
+        - timedelta(seconds=settings.PUBLISH_STATUS_WAIT_TIME + 5),
+        draft_publish_status=PUBLISH_STATUS_SUCCEEDED,
         latest_build_id_draft=2,
     )
     live_site_in_query = WebsiteFactory.create(
@@ -382,10 +388,16 @@ def test_check_incomplete_publish_build_statuses(
         live_publish_status=old_status,
         latest_build_id_live=3,
     )
-    live_site_excluded = WebsiteFactory.create(
+    live_site_excluded_time = WebsiteFactory.create(
         live_publish_status_updated_on=now
         - timedelta(seconds=settings.PUBLISH_STATUS_WAIT_TIME - 5),
         live_publish_status=old_status,
+        latest_build_id_live=4,
+    )
+    live_site_excluded_status = WebsiteFactory.create(
+        live_publish_status_updated_on=now
+        - timedelta(seconds=settings.PUBLISH_STATUS_WAIT_TIME + 5),
+        live_publish_status=None,
         latest_build_id_live=4,
     )
     api_mock.get_sync_pipeline.return_value.get_build_status.return_value = new_status
@@ -411,8 +423,10 @@ def test_check_incomplete_publish_build_statuses(
                     website, version, new_status, mocker.ANY
                 )
     for website, version in [
-        (draft_site_to_exclude, VERSION_DRAFT),
-        (live_site_excluded, VERSION_LIVE),
+        (draft_site_to_exclude_time, VERSION_DRAFT),
+        (draft_site_to_exclude_status, VERSION_DRAFT),
+        (live_site_excluded_time, VERSION_LIVE),
+        (live_site_excluded_status, VERSION_LIVE),
     ]:
         with pytest.raises(AssertionError):
             api_mock.get_sync_pipeline.assert_any_call(website)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
Fixes a query that should be using `in` instead of `contains`.  Does not affect the end result, just cuts down on for loops.

#### How should this be manually tested?
Tests should pass
