### PR TITLE
Revert "use static version file as trigger for sites other than ocw-www"

### DIFF
--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -152,14 +152,7 @@ class ConcourseGithubPipeline(BaseSyncPipeline):
 
         site_config = SiteConfig(self.website.starter.config)
         site_url = f"{site_config.root_url_path}/{self.website.name}".strip("/")
-        if self.website.name == settings.ROOT_WEBSITE_NAME:
-            base_url = ""
-            themes_trigger = "true"
-            js_trigger = "false"
-        else:
-            base_url = site_url
-            themes_trigger = "false"
-            js_trigger = "true"
+        base_url = "" if self.website.name == settings.ROOT_WEBSITE_NAME else site_url
         purge_header = (
             ""
             if settings.CONCOURSE_HARD_PURGE
@@ -215,8 +208,6 @@ class ConcourseGithubPipeline(BaseSyncPipeline):
                     .replace("((purge_header))", purge_header)
                     .replace("((version))", version)
                     .replace("((api-token))", settings.API_BEARER_TOKEN or "")
-                    .replace("((js-trigger))", js_trigger)
-                    .replace("((themes-trigger))", themes_trigger)
                 )
             config = json.dumps(yaml.load(config_str, Loader=yaml.SafeLoader))
             log.debug(config)

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -11,12 +11,6 @@ resources:
     source:
       bucket: ol-eng-artifacts
       regexp: ocw-hugo-themes/release-candidate/ocw-hugo-themes-(.*).tgz
-  - name: ocw-static-version
-    type: s3
-    source:
-      bucket: ((ocw-bucket))
-      regexp: static/version\.(.*).txt
-      initial_path: static/version.0.txt
   - name: course-markdown
     type: git
     source:
@@ -49,15 +43,7 @@ jobs:
           params:
             status: "started"
       - get: ocw-hugo-themes
-        trigger: ((themes-trigger))
-        timeout: 5m
-        on_failure:
-          try:
-            put: ocw-studio-webhook
-            params:
-                status: "errored"
-      - get: ocw-static-version
-        trigger: ((js-trigger))
+        trigger: true
         timeout: 5m
         attempts: 3
         on_failure:


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
https://github.com/mitodl/ocw-studio/issues/880

#### What's this PR do?
This reverts #881.  The changes worked for draft pipelines but the new S3 resource threw AccessDenied errors on the live pipeline for reasons that are currently unknown.

```
error listing files: AccessDenied: Access Denied
```
https://cicd-qa.odl.mit.edu/teams/ocw/pipelines/live/resources/ocw-static-version?vars.site=%22ocw-www%22

vs

https://cicd-qa.odl.mit.edu/teams/ocw/pipelines/draft/resources/ocw-static-version?vars.site=%22ocw-www%22