### PR TITLE
add support for 'website collection' field

### DIFF
--- a/localdev/configs/ocw-www.yml
+++ b/localdev/configs/ocw-www.yml
@@ -29,6 +29,24 @@ collections:
         sortable: true
 
   - category: Content
+    folder: content/course_collections
+    label: "Course Collections"
+    name: "course_collections"
+    fields:
+      - label: Title
+        name: title
+        widget: string
+        required: true
+
+      - label: Description
+        name: description
+        widget: markdown
+
+      - label: Courses
+        name: courses
+        widget: website-collection
+
+  - category: Content
     folder: content/promos
     label: Promo
     name: promos

--- a/static/js/components/forms/validation.ts
+++ b/static/js/components/forms/validation.ts
@@ -102,6 +102,10 @@ export const getFieldSchema = (
     schema = yup.array()
     break
   }
+  case WidgetVariant.WebsiteCollection: {
+    schema = yup.array()
+    break
+  }
   case WidgetVariant.HierarchicalSelect: {
     schema = minMax(yup.array(), field)
     break

--- a/static/js/components/widgets/SortableSelect.test.tsx
+++ b/static/js/components/widgets/SortableSelect.test.tsx
@@ -10,6 +10,7 @@ import SortableSelect, { SortableItem } from "./SortableSelect"
 import { Option } from "./SelectField"
 import { zip } from "ramda"
 import { default as SortableItemComponent } from "../SortableItem"
+import { triggerSortableSelect } from "./test_util"
 
 const createFakeOptions = (times: number): Option[] =>
   Array(times)
@@ -72,15 +73,7 @@ describe("SortableSelect", () => {
 
   it("should allow adding another element", async () => {
     const { wrapper } = await render()
-    await act(async () => {
-      // @ts-ignore
-      wrapper.find("SelectField").prop("onChange")({
-        // @ts-ignore
-        target: { value: newOptions[0].label }
-      })
-    })
-    wrapper.update()
-    wrapper.find(".cyan-button").simulate("click")
+    await triggerSortableSelect(wrapper, newOptions[0].label)
     sinon.assert.calledWith(onChange, [newOptions[0].label])
     expect(wrapper.find("SelectField").prop("value")).toBeUndefined()
   })

--- a/static/js/components/widgets/SortableSelect.tsx
+++ b/static/js/components/widgets/SortableSelect.tsx
@@ -23,8 +23,11 @@ interface Props {
   onChange: (update: string[]) => void
   options: Option[]
   defaultOptions?: Option[]
-  loadOptions: (inputValue: string) => Promise<Option[] | undefined>
   name: string
+  loadOptions: (
+    inputValue: string,
+    callback: (options: Option[]) => void
+  ) => void
 }
 
 export default function SortableSelect(props: Props) {
@@ -52,12 +55,7 @@ export default function SortableSelect(props: Props) {
     [focusedContent, setFocusedContent, onChange, value]
   )
 
-  /**
-   * This callback is only used for the SelectField that
-   * we present as an 'add' interface when this component
-   * is displayin the sortable mode.
-   */
-  const handleAddSortableItem = useCallback(
+  const setFocusedContentCB = useCallback(
     (event: ChangeEvent<HTMLSelectElement>) => {
       setFocusedContent(event.target.value)
     },
@@ -99,7 +97,7 @@ export default function SortableSelect(props: Props) {
         <SelectField
           name={name}
           value={focusedContent}
-          onChange={handleAddSortableItem}
+          onChange={setFocusedContentCB}
           options={options}
           loadOptions={loadOptions}
           defaultOptions={defaultOptions}

--- a/static/js/components/widgets/WebsiteCollectionField.test.tsx
+++ b/static/js/components/widgets/WebsiteCollectionField.test.tsx
@@ -1,0 +1,76 @@
+import IntegrationTestHelper, {
+  TestRenderer
+} from "../../util/integration_test_helper"
+import WebsiteCollectionField from "./WebsiteCollectionField"
+
+import { formatOptions, useWebsiteSelectOptions } from "../../hooks/websites"
+import { Website } from "../../types/websites"
+import { makeWebsiteListing } from "../../util/factories/websites"
+import { triggerSortableSelect } from "./test_util"
+import { Option } from "./SelectField"
+
+jest.mock("../../hooks/websites", () => ({
+  ...jest.requireActual("../../hooks/websites"),
+  useWebsiteSelectOptions: jest.fn()
+}))
+
+describe("WebsiteCollectionField", () => {
+  let helper: IntegrationTestHelper,
+    render: TestRenderer,
+    onChange: jest.Mock,
+    websites: Website[],
+    websiteOptions: Option[]
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    onChange = jest.fn()
+    render = helper.configureRenderer(WebsiteCollectionField, {
+      onChange,
+      name:  "test-site-collection",
+      value: []
+    })
+    websites = makeWebsiteListing()
+    websiteOptions = formatOptions(websites, "uuid")
+    // @ts-ignore
+    useWebsiteSelectOptions.mockReturnValue({
+      options:     websiteOptions,
+      loadOptions: jest.fn()
+    })
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("should pass things down to SortableSelect", async () => {
+    const value = websites.map(website => ({
+      id:    website.uuid,
+      title: website.title
+    }))
+
+    const { wrapper } = await render({
+      value
+    })
+    const sortableSelect = wrapper.find("SortableSelect")
+    expect(sortableSelect.prop("value")).toStrictEqual(value)
+    expect(sortableSelect.prop("options")).toStrictEqual(websiteOptions)
+    expect(sortableSelect.prop("defaultOptions")).toStrictEqual(websiteOptions)
+  })
+
+  it("should let the user add a website, with UUID and title", async () => {
+    const { wrapper } = await render()
+    wrapper.update()
+    await triggerSortableSelect(wrapper, [websites[0].uuid])
+    expect(onChange).toBeCalledWith({
+      target: {
+        name:  "test-site-collection",
+        value: [
+          {
+            id:    websites[0].uuid,
+            title: websites[0].title
+          }
+        ]
+      }
+    })
+  })
+})

--- a/static/js/components/widgets/WebsiteCollectionField.tsx
+++ b/static/js/components/widgets/WebsiteCollectionField.tsx
@@ -1,0 +1,60 @@
+import React, { useCallback, useEffect, useState } from "react"
+
+import SortableSelect, { SortableItem } from "./SortableSelect"
+import { useWebsiteSelectOptions } from "../../hooks/websites"
+
+interface Props {
+  name: string
+  onChange: (event: any) => void
+  value: SortableItem[]
+}
+
+export default function WebsiteCollectionField(props: Props): JSX.Element {
+  const { name, onChange, value } = props
+
+  const [websiteMap, setWebsiteMap] = useState<Map<string, string>>(
+    new Map(value.map(item => [item.id, item.title]))
+  )
+
+  /**
+   * A little shim where we make a fake event 🤫
+   */
+  const onChangeShim = useCallback(
+    (value: string[]) => {
+      const updatedEvent = {
+        target: {
+          name:  name.replace(/\.content$/, ""),
+          value: value.map(id => ({
+            id,
+            title: websiteMap.get(id) ?? id
+          }))
+        }
+      }
+      onChange(updatedEvent)
+    },
+    [onChange, websiteMap, name]
+  )
+
+  const { options, loadOptions } = useWebsiteSelectOptions()
+
+  useEffect(() => {
+    setWebsiteMap(cur => {
+      const newMap = new Map(cur)
+      options.forEach(({ value, label }) => {
+        newMap.set(value, label)
+      })
+      return newMap
+    })
+  }, [options, setWebsiteMap])
+
+  return (
+    <SortableSelect
+      name={name}
+      value={value}
+      onChange={onChangeShim}
+      options={options}
+      defaultOptions={options}
+      loadOptions={loadOptions}
+    />
+  )
+}

--- a/static/js/components/widgets/test_util.ts
+++ b/static/js/components/widgets/test_util.ts
@@ -1,0 +1,21 @@
+import { ReactWrapper } from "enzyme"
+import { act } from "react-dom/test-utils"
+
+/**
+ * A little helper function to find the SelectField
+ * inside of another component and call its onChange
+ * handler with a specific value.
+ *
+ * Just to DRY up some boilerplate!
+ */
+export async function triggerSortableSelect(wrapper: ReactWrapper, value: any) {
+  await act(async () => {
+    // @ts-ignore
+    wrapper.find("SelectField").prop("onChange")({
+      // @ts-ignore
+      target: { value }
+    })
+  })
+  wrapper.update()
+  wrapper.find(".cyan-button").simulate("click")
+}

--- a/static/js/lib/site_content.test.ts
+++ b/static/js/lib/site_content.test.ts
@@ -6,6 +6,7 @@ import SelectField from "../components/widgets/SelectField"
 import BooleanField from "../components/widgets/BooleanField"
 import RelationField from "../components/widgets/RelationField"
 import MenuField from "../components/widgets/MenuField"
+import WebsiteCollectionField from "../components/widgets/WebsiteCollectionField"
 
 import {
   makeWebsiteDetail,
@@ -406,6 +407,7 @@ describe("site_content", () => {
         [WidgetVariant.Relation, RelationField],
         [WidgetVariant.Menu, MenuField],
         [WidgetVariant.HierarchicalSelect, HierarchicalSelectField],
+        [WidgetVariant.WebsiteCollection, WebsiteCollectionField],
         ["unexpected_type", "input"]
       ].forEach(([widget, expected]) => {
         const field = makeWebsiteConfigField({

--- a/static/js/lib/site_content.ts
+++ b/static/js/lib/site_content.ts
@@ -8,6 +8,7 @@ import BooleanField from "../components/widgets/BooleanField"
 import RelationField from "../components/widgets/RelationField"
 import MenuField from "../components/widgets/MenuField"
 import HierarchicalSelectField from "../components/widgets/HierarchicalSelectField"
+import WebsiteCollectionField from "../components/widgets/WebsiteCollectionField"
 
 import { objectToFormData } from "./util"
 import {
@@ -46,6 +47,8 @@ export const componentFromWidget = (
     return BooleanField
   case WidgetVariant.Text:
     return "textarea"
+  case WidgetVariant.String:
+    return "input"
   case WidgetVariant.Hidden:
     return null
   case WidgetVariant.Relation:
@@ -54,6 +57,8 @@ export const componentFromWidget = (
     return MenuField
   case WidgetVariant.HierarchicalSelect:
     return HierarchicalSelectField
+  case WidgetVariant.WebsiteCollection:
+    return WebsiteCollectionField
   default:
     return "input"
   }
@@ -295,6 +300,8 @@ const defaultForField = (
   case WidgetVariant.HierarchicalSelect:
     return []
   case WidgetVariant.Menu:
+    return []
+  case WidgetVariant.WebsiteCollection:
     return []
   default:
     return ""

--- a/static/js/resources/ocw-www.json
+++ b/static/js/resources/ocw-www.json
@@ -46,6 +46,30 @@
           "widget": "string"
         },
         {
+          "label": "Description",
+          "name": "description",
+          "widget": "markdown"
+        },
+        {
+          "label": "Courses",
+          "name": "courses",
+          "widget": "website-collection"
+        }
+      ],
+      "folder": "content/course_collections",
+      "label": "Course Collections",
+      "name": "course_collections"
+    },
+    {
+      "category": "Content",
+      "fields": [
+        {
+          "label": "Title",
+          "name": "title",
+          "required": true,
+          "widget": "string"
+        },
+        {
           "label": "Subtitle",
           "name": "subtitle",
           "widget": "string"

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -22,7 +22,8 @@ export enum WidgetVariant {
   Object = "object",
   Relation = "relation",
   Menu = "menu",
-  HierarchicalSelect = "hierarchical-select"
+  HierarchicalSelect = "hierarchical-select",
+  WebsiteCollection = "website-collection"
 }
 
 export interface FieldValueCondition {
@@ -68,6 +69,10 @@ export interface StringConfigField extends ConfigFieldBaseProps {
 
 export interface HiddenConfigField extends ConfigFieldBaseProps {
   widget: WidgetVariant.Hidden
+}
+
+export interface WebsiteCollectionConfigField extends ConfigFieldBaseProps {
+  widget: WidgetVariant.WebsiteCollection
 }
 
 export interface SelectConfigField extends ConfigFieldBaseProps {
@@ -148,6 +153,7 @@ export type ConfigField =
   | RelationConfigField
   | MenuConfigField
   | HierarchicalSelectConfigField
+  | WebsiteCollectionConfigField
 
 export interface BaseConfigItem {
   name: string

--- a/websites/config_schema/site-config-schema.yml
+++ b/websites/config_schema/site-config-schema.yml
@@ -19,7 +19,7 @@ inner_content_item:
     file: str(required=False)
 ---
 field:
-    widget: enum('string', 'text', 'markdown', 'file', 'select', 'boolean', 'hidden', 'object', 'relation', 'menu', 'hierarchical-select')
+    widget: enum('string', 'text', 'markdown', 'file', 'select', 'boolean', 'hidden', 'object', 'relation', 'menu', 'hierarchical-select', 'website-collection')
     label: str()
     name: str()
     minimal: bool(required=False)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #886 

#### What's this PR do?

This PR adds a new type of site content field called a `WebsiteCollection`. This is designed to be a reorderable list of other websites in the application, which can be used to support something along the lines of the course collection feature that exists on current OCW prod. Under the hood it uses the `SortableSelect` component I introduced in #869.

#### How should this be manually tested?

I modified the checked-in ocw-www configuration, so if you have a site configured to use that starter you should be able to just `override_site_configs` and then see the relevant changes pop up. Basically, there will now be a `Course Collections` resource, and editing them should work like in the video below. You should be able to search for sites in the select box, add them, remove them, etc.

#### Screenshots (if appropriate)

this shows some basic use of the field:

https://user-images.githubusercontent.com/6207644/148134197-2c6bbb6f-3830-4a9d-a0bd-9f92b0b2bc8d.mov




