### PR TITLE
"waterfall" triggering scheme for ocw-hugo-themes changes

### DIFF
--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -152,7 +152,14 @@ class ConcourseGithubPipeline(BaseSyncPipeline):
 
         site_config = SiteConfig(self.website.starter.config)
         site_url = f"{site_config.root_url_path}/{self.website.name}".strip("/")
-        base_url = "" if self.website.name == settings.ROOT_WEBSITE_NAME else site_url
+        if self.website.name == settings.ROOT_WEBSITE_NAME:
+            base_url = ""
+            themes_trigger = "true"
+            js_trigger = "false"
+        else:
+            base_url = site_url
+            themes_trigger = "false"
+            js_trigger = "true"
         purge_header = (
             ""
             if settings.CONCOURSE_HARD_PURGE
@@ -208,6 +215,8 @@ class ConcourseGithubPipeline(BaseSyncPipeline):
                     .replace("((purge_header))", purge_header)
                     .replace("((version))", version)
                     .replace("((api-token))", settings.API_BEARER_TOKEN or "")
+                    .replace("((js-trigger))", js_trigger)
+                    .replace("((themes-trigger))", themes_trigger)
                 )
             config = json.dumps(yaml.load(config_str, Loader=yaml.SafeLoader))
             log.debug(config)

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -154,12 +154,12 @@ class ConcourseGithubPipeline(BaseSyncPipeline):
         site_url = f"{site_config.root_url_path}/{self.website.name}".strip("/")
         if self.website.name == settings.ROOT_WEBSITE_NAME:
             base_url = ""
-            themes_trigger = "true"
-            js_trigger = "false"
+            theme_created_trigger = "true"
+            theme_deployed_trigger = "false"
         else:
             base_url = site_url
-            themes_trigger = "false"
-            js_trigger = "true"
+            theme_created_trigger = "false"
+            theme_deployed_trigger = "true"
         purge_header = (
             ""
             if settings.CONCOURSE_HARD_PURGE
@@ -215,8 +215,8 @@ class ConcourseGithubPipeline(BaseSyncPipeline):
                     .replace("((purge_header))", purge_header)
                     .replace("((version))", version)
                     .replace("((api-token))", settings.API_BEARER_TOKEN or "")
-                    .replace("((js-trigger))", js_trigger)
-                    .replace("((themes-trigger))", themes_trigger)
+                    .replace("((theme-deployed-trigger))", theme_deployed_trigger)
+                    .replace("((theme-created-trigger))", theme_created_trigger)
                 )
             config = json.dumps(yaml.load(config_str, Loader=yaml.SafeLoader))
             log.debug(config)

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -10,12 +10,12 @@ resources:
     type: s3
     source:
       bucket: ol-eng-artifacts
-      regexp: ocw-hugo-themes/release-candidate/ocw-hugo-themes-(.*).tgz
+      regexp: ocw-hugo-themes\/release-candidate\/ocw-hugo-themes-(.*).tgz
   - name: ocw-static-version
     type: s3
     source:
       bucket: ((ocw-bucket))
-      regexp: static/version\.(.*).txt
+      regexp: static\/version\.(.*)\.txt
       initial_path: static/version.0.txt
   - name: course-markdown
     type: git
@@ -49,7 +49,7 @@ jobs:
           params:
             status: "started"
       - get: ocw-hugo-themes
-        trigger: ((themes-trigger))
+        trigger: ((theme-created-trigger))
         timeout: 5m
         on_failure:
           try:
@@ -57,7 +57,7 @@ jobs:
             params:
                 status: "errored"
       - get: ocw-static-version
-        trigger: ((js-trigger))
+        trigger: ((theme-deployed-trigger))
         timeout: 5m
         attempts: 3
         on_failure:

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -11,6 +11,12 @@ resources:
     source:
       bucket: ol-eng-artifacts
       regexp: ocw-hugo-themes/release-candidate/ocw-hugo-themes-(.*).tgz
+  - name: ocw-static-version
+    type: s3
+    source:
+      bucket: ((ocw-bucket))
+      regexp: static/version\.(.*).txt
+      initial_path: static/version.0.txt
   - name: course-markdown
     type: git
     source:
@@ -43,7 +49,15 @@ jobs:
           params:
             status: "started"
       - get: ocw-hugo-themes
-        trigger: true
+        trigger: ((themes-trigger))
+        timeout: 5m
+        on_failure:
+          try:
+            put: ocw-studio-webhook
+            params:
+                status: "errored"
+      - get: ocw-static-version
+        trigger: ((js-trigger))
         timeout: 5m
         attempts: 3
         on_failure:


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/880

#### What's this PR do?
Modifies the concourse pipeline so that only the "ocw-www" site is triggered by a a new themes tarball, and other sites should be triggered by a new version file in the static folder uploaded to S3 by the ocw-www pipeline.

#### How should this be manually tested?
This is a bit tricky.  I've already updated the `ocw-www` pipeline and one site pipeline (`cpg-test-course-3`) to use the modified pipeline definition.

You can trigger a new build of the release-candidate themes pipeline, which should include a new `version.<dt-num>.txt` file in the generated tarball.  That should still trigger the ocw-www build, but it will also trigger all the unmodified sites too.  Once the ocw-www build finishes, a `cpg-test-course-3` build should be triggered within a minute or two.

If you want to avoid triggering all. sites, you can try this:
- Manually start another run of the ocw-www pipeline from the UI
- Soon after it completes, start a shell in that build:
    `fly -t rc intercept -j draft/site:ocw-www/build-ocw-site  -b <latest build num> -s copy-s3-buckets  --team ocw`
- Run the following to create a new version file and copy to the static s3 folder:
   ```
   dt=$(date +%s)
   echo $dt >  ocw-hugo-themes/theme/base-theme/dist/static/version.$dt.txt
   aws s3 cp ocw-hugo-themes/theme/base-theme/dist/static/version.$dt.txt  s3://ocw-content-draft-qa/static/version.$dt.txt
   ```
- Keep an eye on the draft pipeline for `cpg-test-course-3`, it should start a new build shortly.
- Do this for both draft and live pipelines in QA
