### PR TITLE
switch from storing website UUID to the website name property

### DIFF
--- a/static/js/components/widgets/WebsiteCollectionField.test.tsx
+++ b/static/js/components/widgets/WebsiteCollectionField.test.tsx
@@ -30,7 +30,7 @@ describe("WebsiteCollectionField", () => {
       value: []
     })
     websites = makeWebsiteListing()
-    websiteOptions = formatOptions(websites, "uuid")
+    websiteOptions = formatOptions(websites, "name")
     // @ts-ignore
     useWebsiteSelectOptions.mockReturnValue({
       options:     websiteOptions,
@@ -44,7 +44,7 @@ describe("WebsiteCollectionField", () => {
 
   it("should pass things down to SortableSelect", async () => {
     const value = websites.map(website => ({
-      id:    website.uuid,
+      id:    website.name,
       title: website.title
     }))
 
@@ -60,13 +60,13 @@ describe("WebsiteCollectionField", () => {
   it("should let the user add a website, with UUID and title", async () => {
     const { wrapper } = await render()
     wrapper.update()
-    await triggerSortableSelect(wrapper, [websites[0].uuid])
+    await triggerSortableSelect(wrapper, [websites[0].name])
     expect(onChange).toBeCalledWith({
       target: {
         name:  "test-site-collection",
         value: [
           {
-            id:    websites[0].uuid,
+            id:    websites[0].name,
             title: websites[0].title
           }
         ]

--- a/static/js/components/widgets/WebsiteCollectionField.tsx
+++ b/static/js/components/widgets/WebsiteCollectionField.tsx
@@ -35,7 +35,7 @@ export default function WebsiteCollectionField(props: Props): JSX.Element {
     [onChange, websiteMap, name]
   )
 
-  const { options, loadOptions } = useWebsiteSelectOptions()
+  const { options, loadOptions } = useWebsiteSelectOptions("name")
 
   useEffect(() => {
     setWebsiteMap(cur => {


### PR DESCRIPTION
#### Pre-Flight checklist


- [x] Migrations
  - [x] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
none

#### What's this PR do?

I thought for course collections that storing a website's UUID would be what we need to then be able to render websites in a list in ocw-www, but I goofed and missed that actually the `name` property is what's going to end up being used in the URL to the `data.json` file for each course at render-time, so that's actually the information we need.

Anyway - this PR just makes a small adjustment so that the website `name` is saved in the course collection array rather than the `uuid`.

#### How should this be manually tested?

Course collections should look as normal. If you look at the JSON for one you should see website names rather than UUIDs. The UX should be identical.