### PR TITLE
support merging of table cells

### DIFF
--- a/static/js/lib/ckeditor/plugins/Markdown.ts
+++ b/static/js/lib/ckeditor/plugins/Markdown.ts
@@ -4,8 +4,10 @@ import GFMDataProcessor from "@ckeditor/ckeditor5-markdown-gfm/src/gfmdataproces
 import { editor } from "@ckeditor/ckeditor5-core"
 
 import MarkdownConfigPlugin from "./MarkdownConfigPlugin"
+import { ATTRIBUTE_REGEX } from "./constants"
 
 import { turndownService } from "../turndown"
+import { buildAttrsString } from "./util"
 
 /**
  * Data processor for CKEditor which implements conversion to / from Markdown
@@ -63,8 +65,8 @@ export class MarkdownDataProcessor extends GFMDataProcessor {
   }
 }
 
-const TD_CONTENT_REGEX = /<td>([\S\s]*?)<\/td>/g
-const TH_CONTENT_REGEX = /<th>([\S\s]*?)<\/th>/g
+const TD_CONTENT_REGEX = /<td.*?>([\S\s]*?)<\/td>/g
+const TH_CONTENT_REGEX = /<th(?!ead).*?>([\S\s]*?)<\/th>/g
 
 /**
  * Plugin implementing Markdown for CKEditor
@@ -94,20 +96,31 @@ export default class Markdown extends MarkdownConfigPlugin {
       turndownService._customRulesSet = true
     }
 
+    function formatTableCell(
+      el: string,
+      html: string,
+      contents: string
+    ): string {
+      const attrs = html.match(ATTRIBUTE_REGEX)
+      return `<${el}${buildAttrsString(attrs)}>${converter.makeHtml(
+        contents
+      )}</${el}>`
+    }
+
     function md2html(md: string): string {
       return converter
         .makeHtml(md)
-        .replace(
-          TD_CONTENT_REGEX,
-          (_match, contents) => `<td>${converter.makeHtml(contents)}</td>`
+        .replace(TD_CONTENT_REGEX, (_match, contents) =>
+          formatTableCell("td", _match, contents)
         )
-        .replace(
-          TH_CONTENT_REGEX,
-          (_match, contents) => `<th>${converter.makeHtml(contents)}</th>`
+        .replace(TH_CONTENT_REGEX, (_match, contents) =>
+          formatTableCell("th", _match, contents)
         )
     }
 
     function html2md(html: string): string {
+      console.log(html)
+      console.log(turndownService.turndown(html))
       return turndownService.turndown(html)
     }
 

--- a/static/js/lib/ckeditor/plugins/Markdown.ts
+++ b/static/js/lib/ckeditor/plugins/Markdown.ts
@@ -119,8 +119,6 @@ export default class Markdown extends MarkdownConfigPlugin {
     }
 
     function html2md(html: string): string {
-      console.log(html)
-      console.log(turndownService.turndown(html))
       return turndownService.turndown(html)
     }
 

--- a/static/js/lib/ckeditor/plugins/TableMarkdownSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/TableMarkdownSyntax.ts
@@ -16,13 +16,15 @@ export default class TableMarkdownSyntax extends MarkdownSyntaxPlugin {
   get showdownExtension() {
     return function resourceExtension(): Showdown.ShowdownExtension[] {
       return TABLE_ELS.map(el => {
-        const shortcodeRegex = new RegExp(`{{< ${el}(open|close) >}}`, "g")
+        const shortcodeRegex = new RegExp(`{{< ${el}(open|close)(.*) >}}`, "g")
 
         return {
           type:    "lang",
           regex:   shortcodeRegex,
           replace: (_s: string, position: Position) => {
-            return position === "open" ? `<${el}>` : `</${el}>`
+            const attrs = _s.split(" ").filter(part => part.includes("="))
+            const attrsString = attrs.length > 0 ? attrs.map(arg => ` ${arg}`) : ""
+            return position === "open" ? `<${el}${attrsString}>` : `</${el}>`
           }
         }
       })
@@ -37,7 +39,12 @@ export default class TableMarkdownSyntax extends MarkdownSyntaxPlugin {
         replacement: (content: string, node: Turndown.Node): string => {
           const name = node.nodeName.toLowerCase()
           const normalizedContent = content.replace("\n\n", "\n")
-          return `{{< ${name}open >}}${normalizedContent}{{< ${name}close >}}`
+          const attributes = node.hasAttributes() ?
+            Array.from(node.attributes)
+              .map(attr => ` ${attr.name}="${attr.value}"`)
+              .join("") :
+            ""
+          return `{{< ${name}open${attributes} >}}${normalizedContent}{{< ${name}close >}}`
         }
       }
     }

--- a/static/js/lib/ckeditor/plugins/TableMarkdownSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/TableMarkdownSyntax.ts
@@ -42,8 +42,14 @@ export default class TableMarkdownSyntax extends MarkdownSyntaxPlugin {
           const name = node.nodeName.toLowerCase()
           const normalizedContent = content.replace("\n\n", "\n")
           //@ts-ignore
-          const attributes = node.hasAttributes()            ? //@ts-ignore
-            buildAttrsString(Array.from(node.attributes)) :
+          const attributes = node.hasAttributes() ?
+            buildAttrsString(
+              //@ts-ignore
+              Array.from(node.attributes).map(
+                //@ts-ignore
+                attr => `${attr.name}="${attr.value}"`
+              )
+            ) :
             ""
           return `{{< ${name}open${attributes} >}}${normalizedContent}{{< ${name}close >}}`
         }

--- a/static/js/lib/ckeditor/plugins/constants.ts
+++ b/static/js/lib/ckeditor/plugins/constants.ts
@@ -56,6 +56,14 @@ export const TABLE_ELS: TurndownService.TagName[] = [
   "tfoot"
 ]
 
+// A whitelist of attributes that can be assigned to table cells
 export const TABLE_ALLOWED_ATTRS: string[] = ["colspan", "rowspan"]
 
+/**
+ * A regex designed to extract attributes from html tags or shortcodes
+ *
+ * It starts with matching 1 or more of anything but whitespace, then
+ * an equals sign followed by a single or double quote. The regex ends
+ * with a double quote and captures anything in between the quotes.
+ */
 export const ATTRIBUTE_REGEX = /(\S+)=["']?((?:.(?!["']?\s+(?:\S+)=|\s*\/?[>"']))+.)["']?/g

--- a/static/js/lib/ckeditor/plugins/constants.ts
+++ b/static/js/lib/ckeditor/plugins/constants.ts
@@ -55,3 +55,7 @@ export const TABLE_ELS: TurndownService.TagName[] = [
   "thead",
   "tfoot"
 ]
+
+export const TABLE_ALLOWED_ATTRS: string[] = ["colspan", "rowspan"]
+
+export const ATTRIBUTE_REGEX = /(\S+)=["']?((?:.(?!["']?\s+(?:\S+)=|\s*\/?[>"']))+.)["']?/g

--- a/static/js/lib/ckeditor/plugins/util.ts
+++ b/static/js/lib/ckeditor/plugins/util.ts
@@ -1,0 +1,13 @@
+import { TABLE_ALLOWED_ATTRS } from "./constants"
+
+export function buildAttrsString(attrs: RegExpMatchArray | null): string {
+  return attrs ?
+    attrs
+      .map(attr =>
+        TABLE_ALLOWED_ATTRS.some(allowedAttr => attr.includes(allowedAttr)) ?
+          ` ${attr}` :
+          ""
+      )
+      .join("") :
+    ""
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/898
Related to https://github.com/mitodl/ocw-studio/issues/569

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/645, we added support for editing tables in our implementation of CKEditor.  In https://github.com/mitodl/ocw-studio/pull/744, we set up the table editor to output a shortcode representation of a table instead of the standard markdown syntax.  The last remaining item in https://github.com/mitodl/ocw-studio/issues/569 has to do with being able to edit tables on imported legacy courses.  Currently, `ocw-to-hugo` generates tables using the Github flavored markdown table syntax, and is being changed to use the shortcode based syntax we've come up with instead.  In the legacy courses, the OCW team makes heavy use of `colspan` and `rowspan` to merge cells.  This PR adds support for the merging of cells, as well as interpreting the `colspan` and `rowspan` attributes that will be added to legacy courses moving forward when they are imported.  When parsing the attributes on HTML tags or shortcodes, these attributes are filtered against a whitelist stored in `static/js/lib/ckeditor/plugins/constants.ts`.

#### How should this be manually tested?
 - Make sure your `.env` is configured to publish to a test organization in Github and spin up your local instance of `ocw-studio` on this branch
 - Create a test site with the `ocw-course` starter and add a test page
 - Add a table to your page and merge some cells, making sure to try it both horizontally (`colspan`) and vertically (`rowspan`)
 - Add some varied content to your cells; bold and italic text, embedded images, videos, etc.
 - Save your page and recall it, verifying that the table comes back in the exact same structure you saved it in
 - Make sure your site's required metadata is filled out and publish the site to your Github test org
 - Inspect the markdown output and ensure that you see `colspan` and `rowspan` attributes in the correct spots

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/12089658/149593792-10441b65-cba4-45dd-8ece-c5874af6b446.png)
![image](https://user-images.githubusercontent.com/12089658/149593815-b13319c3-29c0-42d3-b9ca-dfe4ece7022f.png)
