### PR TITLE
add -p to mkdir command before theme asset extraction

### DIFF
--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -108,7 +108,7 @@ jobs:
             args:
             - -exc
             - |
-              mkdir ../ocw-hugo-themes/theme
+              mkdir -p ../ocw-hugo-themes/theme
               tar -xvzf ../ocw-hugo-themes/ocw-hugo-themes-*.tgz -C ../ocw-hugo-themes/theme
               hugo --config ../ocw-hugo-projects/((config-slug))/config.yaml --baseUrl /((base-url)) --themesDir ../ocw-hugo-themes/theme
         on_failure:


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/896

#### What's this PR do?
This PR adds the `-p` argument to a `mkdir` command in the site pipeline definition that's run before extracting the theme assets tarball.  It solves an issue where between retries the directory already exists so an error is thrown without the `-p` argument.

#### How should this be manually tested?
I can't really think of a great way to manually test this change, as the original issue only happens when Concourse is overloaded and specifically retries the `build-course-task` step.  I think it will just have to be deployed to RC and then have a mass publish triggered, watching the latest builds to see if the error in the original issue comes up again.
