### PR TITLE
add 'published' filter to website listing API

### DIFF
--- a/static/js/components/widgets/WebsiteCollectionField.test.tsx
+++ b/static/js/components/widgets/WebsiteCollectionField.test.tsx
@@ -42,6 +42,11 @@ describe("WebsiteCollectionField", () => {
     helper.cleanup()
   })
 
+  it("should pass published=true to the useWebsiteSelectOptions", async () => {
+    await render()
+    expect(useWebsiteSelectOptions).toBeCalledWith("name", true, true)
+  })
+
   it("should pass things down to SortableSelect", async () => {
     const value = websites.map(website => ({
       id:    website.name,

--- a/static/js/components/widgets/WebsiteCollectionField.tsx
+++ b/static/js/components/widgets/WebsiteCollectionField.tsx
@@ -35,7 +35,7 @@ export default function WebsiteCollectionField(props: Props): JSX.Element {
     [onChange, websiteMap, name]
   )
 
-  const { options, loadOptions } = useWebsiteSelectOptions("name")
+  const { options, loadOptions } = useWebsiteSelectOptions("name", true, true)
 
   useEffect(() => {
     setWebsiteMap(cur => {

--- a/static/js/hooks/websites.test.ts
+++ b/static/js/hooks/websites.test.ts
@@ -52,6 +52,28 @@ describe("website hooks", () => {
       expect(debouncedFetch).toBeCalledTimes(0)
     })
 
+    //
+    ;[true, false].forEach(published => {
+      it(`should set published=${String(
+        published
+      )} if you pass the option`, async () => {
+        const { waitForNextUpdate } = renderHook(() =>
+          useWebsiteSelectOptions("uuid", true, published)
+        )
+        await act(async () => {
+          await waitForNextUpdate()
+        })
+        expect(global.fetch).toBeCalledWith(
+          siteApiListingUrl
+            .query({ offset: 0 })
+            .param({ search: "" })
+            .param({ published })
+            .toString(),
+          { credentials: "include" }
+        )
+      })
+    })
+
     it("should let you issue a debounced request with a search param if you pass a callback", async () => {
       const { result, waitForNextUpdate } = renderHook(useWebsiteSelectOptions)
       const cb = jest.fn()

--- a/static/js/hooks/websites.ts
+++ b/static/js/hooks/websites.ts
@@ -72,7 +72,8 @@ interface ReturnProps {
  */
 export function useWebsiteSelectOptions(
   valueField = "uuid",
-  fetchOnStartup = true
+  fetchOnStartup = true,
+  published: boolean | undefined = undefined
 ): ReturnProps {
   const [options, setOptions] = useState<Option[]>([])
 
@@ -81,6 +82,7 @@ export function useWebsiteSelectOptions(
       const url = siteApiListingUrl
         .query({ offset: 0 })
         .param({ search: inputValue })
+        .param(published !== undefined ? { published } : {})
         .toString()
 
       // using plain fetch rather than redux-query here because this
@@ -110,7 +112,7 @@ export function useWebsiteSelectOptions(
         callback(options)
       }
     },
-    [setOptions, valueField]
+    [setOptions, valueField, published]
   )
 
   // on startup we want to fetch options initially so defaultOptions can

--- a/static/js/query-configs/websites.ts
+++ b/static/js/query-configs/websites.ts
@@ -58,6 +58,7 @@ export const getTransformedWebsiteName = (
 export type WebsiteListingParams = {
   offset: number
   search?: string | null | undefined
+  published?: boolean
 }
 
 export type WebsiteListingResponse = PaginatedResponse<Website>

--- a/websites/views.py
+++ b/websites/views.py
@@ -90,6 +90,7 @@ class WebsiteViewSet(
         website_type = self.request.query_params.get("type", None)
         search = self.request.query_params.get("search", None)
         resourcetype = self.request.query_params.get("resourcetype", None)
+        published = self.request.query_params.get("published", None)
 
         user = self.request.user
         if self.request.user.is_anonymous:
@@ -116,6 +117,11 @@ class WebsiteViewSet(
 
         if website_type is not None:
             queryset = queryset.filter(starter__slug=website_type)
+
+        if published is not None:
+            published = _parse_bool(published)
+            queryset = queryset.filter(publish_date__isnull=not published)
+
         return queryset.select_related("starter").order_by(ordering)
 
     def get_serializer_class(self):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #887

#### What's this PR do?

This PR adds a query param (`published`) to the website API which accepts a boolean value and will filter accordingly on whether websites have already been published or not.

It also makes a change to the `WebsiteCollection` widget to only show published websites in it, ensuring that course content authors can't accidentally create a course collection which references unpublished courses.

#### How should this be manually tested?

You'll need to have both unpublished and published websites locally. Then confirm that if you're making a course collection in `ocw-www` you can only see the published ones as options.