### PR TITLE
Throttle batch management commands that invoke the git API

### DIFF
--- a/app.json
+++ b/app.json
@@ -147,6 +147,14 @@
       "description": "Google analytics tracking ID",
       "required": false
     },
+    "GITHUB_RATE_LIMIT_CHECK": {
+      "description": "True if the github domain has API rate limits",
+      "required": false
+    },
+    "GITHUB_RATE_LIMIT_CUTOFF": {
+      "description": "Number of remaining Github API calls that triggers throttling",
+      "required": false
+    },
     "GITHUB_WEBHOOK_BRANCH": {
       "description": "Github branch to filter webhook requests against",
       "required": false

--- a/main/settings.py
+++ b/main/settings.py
@@ -916,6 +916,18 @@ GITHUB_WEBHOOK_BRANCH = get_string(
     description="Github branch to filter webhook requests against",
     required=False,
 )
+GITHUB_RATE_LIMIT_CHECK = get_bool(
+    name="GITHUB_RATE_LIMIT_CHECK",
+    default=False,
+    description="True if the github domain has API rate limits",
+    required=False,
+)
+GITHUB_RATE_LIMIT_CUTOFF = get_int(
+    name="GITHUB_RATE_LIMIT_CUTOFF",
+    default=100,
+    description="Number of remaining Github API calls that triggers throttling",
+    required=False,
+)
 OCW_IMPORT_STARTER_SLUG = get_string(
     name="OCW_IMPORT_STARTER_SLUG",
     default="course",

--- a/ocw_import/management/commands/import_ocw_course_sites.py
+++ b/ocw_import/management/commands/import_ocw_course_sites.py
@@ -73,13 +73,6 @@ class Command(BaseCommand):
             help="Create backends if they don't exist",
         )
         parser.add_argument(
-            "-r",
-            "--rate_limit",
-            dest="rate_limit",
-            action="store_true",
-            help="Check the rate limit when making git api requests",
-        )
-        parser.add_argument(
             "-d",
             "--delete_unpublished",
             dest="delete_unpublished",
@@ -137,7 +130,6 @@ class Command(BaseCommand):
             start = now_in_utc()
             task = sync_unsynced_websites.delay(
                 create_backends=options["create_backend"],
-                check_limit=options["rate_limit"],
                 delete=delete_from_git,
             )
             self.stdout.write(f"Starting task {task}...")


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable
  - [x] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
Closes #905

#### What's this PR do?
Adds a `throttle_git_backend_calls` function that is used in various website batch tasks:
- sync_unsynced_websites
- publish_website_batch
- upsert_website_pipeline_batch

This function will check the remaining git api calls available (if `settings.GITHUB_RATE_LIMIT_CHECK=True`), and if it is below a certain threshold (defined by `settings.GITHUB_RATE_LIMIT_CUTOFF`) then sleep until the rate limit is reset. 

#### How should this be manually tested?
Set the following in your .env file:
```
GITHUB_RATE_LIMIT_CHECK=True
OCW_STUDIO_LOG_LEVEL=DEBUG
```

You can start running the `mass_publish` command (or `sync_unsynced_websites.delay(create_backends=True)` in a shell ) and look at the logs - search for `Remaining github calls`.  Eventually, if the remaining requests drops below 100, execution should pause until the limit is reset.  

If running `mass_publish`, it might be safer to use a larger-than-default chunk size (for instance, 2000 instead of 500).

Related: https://github.com/mitodl/salt-ops/pull/1493