### PR TITLE
Link to page within course

### DIFF
--- a/static/js/components/widgets/MarkdownEditor.test.tsx
+++ b/static/js/components/widgets/MarkdownEditor.test.tsx
@@ -61,9 +61,16 @@ describe("MarkdownEditor", () => {
     })
   })
 
-  it("should pass attach down to a ResourceEmbedField", () => {
-    const wrapper = render({ attach: "resource" })
-    expect(wrapper.find("ResourcePickerDialog").prop("attach")).toBe("resource")
+  it("should render ResourceEmbedField if attach is provided", () => {
+    const wrapper = render({ attach: "foo" })
+    const diaglogWrapper = wrapper.find("ResourcePickerDialog")
+    expect(diaglogWrapper.length).toBe(1)
+  })
+
+  it("should not render ResourceEmbedField if attach is missing", () => {
+    const wrapper = render()
+    const diaglogWrapper = wrapper.find("ResourcePickerDialog")
+    expect(diaglogWrapper.length).toBe(0)
   })
 
   it("should render resources with using EmbeddedResource", () => {
@@ -113,7 +120,7 @@ describe("MarkdownEditor", () => {
         wrapper
           .find("ResourcePickerDialog")
           .at(0)
-          .prop("state")
+          .prop("mode")
       ).toBe(resourceNodeType)
     })
   })

--- a/static/js/components/widgets/MarkdownEditor.tsx
+++ b/static/js/components/widgets/MarkdownEditor.tsx
@@ -14,8 +14,9 @@ import {
   CKEDITOR_RESOURCE_UTILS,
   RenderResourceFunc,
   ResourceCommandMap,
-  ResourceDialogState,
-  ADD_RESOURCE_EMBED
+  ResourceDialogMode,
+  ADD_RESOURCE_EMBED,
+  RESOURCE_LINK
 } from "../../lib/ckeditor/plugins/constants"
 import ResourcePickerDialog from "./ResourcePickerDialog"
 
@@ -42,9 +43,11 @@ export default function MarkdownEditor(props: Props): JSX.Element {
   const setEditorRef = useCallback(editorInstance => {
     editor.current = editorInstance
   }, [])
-  const [resourcePickerState, setResourcePickerState] = useState<
-    ResourceDialogState
-  >("closed")
+
+  const [resourcePickerMode, setResourcePickerMode] = useState<
+    ResourceDialogMode
+  >(RESOURCE_LINK)
+  const [isResourcePickerOpen, setIsResourcePickerOpen] = useState(false)
 
   const addResourceEmbed = useCallback(
     (uuid: string, title: string, variant: CKEResourceNodeType) => {
@@ -76,9 +79,10 @@ export default function MarkdownEditor(props: Props): JSX.Element {
 
   const openResourcePicker = useCallback(
     (resourceDialogType: CKEResourceNodeType) => {
-      setResourcePickerState(resourceDialogType)
+      setResourcePickerMode(resourceDialogType)
+      setIsResourcePickerOpen(true)
     },
-    [setResourcePickerState]
+    [setResourcePickerMode, setIsResourcePickerOpen]
   )
 
   const hasAttach = attach && attach.length > 0
@@ -129,8 +133,8 @@ export default function MarkdownEditor(props: Props): JSX.Element {
   )
 
   const closeResourcePicker = useCallback(() => {
-    setResourcePickerState("closed")
-  }, [setResourcePickerState])
+    setIsResourcePickerOpen(false)
+  }, [setIsResourcePickerOpen])
 
   return (
     <>
@@ -143,10 +147,10 @@ export default function MarkdownEditor(props: Props): JSX.Element {
       />
       {hasAttach ? (
         <ResourcePickerDialog
-          state={resourcePickerState}
+          isOpen={isResourcePickerOpen}
+          mode={resourcePickerMode}
           closeDialog={closeResourcePicker}
           insertEmbed={addResourceEmbed}
-          attach={attach as string}
         />
       ) : null}
       {renderQueue.map(([uuid, el], idx) => (

--- a/static/js/components/widgets/ResourcePickerListing.tsx
+++ b/static/js/components/widgets/ResourcePickerListing.tsx
@@ -18,16 +18,22 @@ import {
 
 interface Props {
   focusResource: (item: WebsiteContent) => void
-  attach: string
   filter: string | null
-  resourcetype: string
+  resourcetype: string | null
+  contentType: string
   focusedResource: WebsiteContent | null
 }
 
 export default function ResourcePickerListing(
   props: Props
 ): JSX.Element | null {
-  const { focusResource, focusedResource, attach, filter, resourcetype } = props
+  const {
+    focusResource,
+    focusedResource,
+    filter,
+    resourcetype,
+    contentType
+  } = props
   const website = useWebsite()
 
   const listingParams: ContentListingParams = useMemo(
@@ -35,13 +41,13 @@ export default function ResourcePickerListing(
       Object.assign(
         {
           name:   website.name,
-          type:   attach,
+          type:   contentType,
           offset: 0
         },
         resourcetype ? { resourcetype } : null,
         filter ? { search: filter } : null
       ),
-    [website, attach, filter, resourcetype]
+    [website, filter, resourcetype, contentType]
   )
 
   useRequest(websiteContentListingRequest(listingParams, true, false))
@@ -54,10 +60,11 @@ export default function ResourcePickerListing(
     return null
   }
 
-  const className =
-    resourcetype === RESOURCE_TYPE_DOCUMENT ?
-      "resource-picker-listing column-view" :
-      "resource-picker-listing"
+  const useColumnView =
+    contentType === "page" || resourcetype === RESOURCE_TYPE_DOCUMENT
+  const className = useColumnView ?
+    "resource-picker-listing column-view" :
+    "resource-picker-listing"
 
   return (
     <div className={className}>

--- a/static/js/constants.ts
+++ b/static/js/constants.ts
@@ -153,6 +153,9 @@ export const exampleSiteConfigFields: ConfigField[] = uniq(
   ])
 )
 
+export const CONTENT_TYPE_RESOURCE = "resource"
+export const CONTENT_TYPE_PAGE = "page"
+
 // these should match with the values in the ocw-course schema
 export const RESOURCE_TYPE_IMAGE = "Image"
 export const RESOURCE_TYPE_VIDEO = "Video"

--- a/static/js/lib/ckeditor/plugins/ResourcePicker.ts
+++ b/static/js/lib/ckeditor/plugins/ResourcePicker.ts
@@ -28,7 +28,7 @@ export default class ResourcePicker extends Plugin {
       const view = new ButtonView(locale)
 
       view.set({
-        label:    "Link resource",
+        label:    "Add link",
         withText: true
       })
 

--- a/static/js/lib/ckeditor/plugins/constants.ts
+++ b/static/js/lib/ckeditor/plugins/constants.ts
@@ -41,10 +41,7 @@ export interface RenderResourceFunc {
   (uuid: string, el: HTMLElement): void
 }
 
-export type ResourceDialogState =
-  | typeof RESOURCE_LINK
-  | typeof RESOURCE_EMBED
-  | "closed"
+export type ResourceDialogMode = typeof RESOURCE_LINK | typeof RESOURCE_EMBED
 
 export const TABLE_ELS: TurndownService.TagName[] = [
   "table",

--- a/static/js/query-configs/websites.test.ts
+++ b/static/js/query-configs/websites.test.ts
@@ -1,0 +1,18 @@
+import { ContentListingParams } from "../types/websites"
+import { contentListingKey } from "./websites"
+
+describe("contentListingKey", () => {
+  it("uses all param properties to make a key", () => {
+    const contentListingParams: Required<ContentListingParams> = {
+      name:         "0",
+      offset:       1,
+      type:         "2",
+      search:       "3",
+      resourcetype: "4",
+      pageContent:  true
+    }
+    expect(contentListingKey(contentListingParams)).toBe(
+      '["0","2","3",true,1,"4"]'
+    )
+  })
+})

--- a/static/js/query-configs/websites.ts
+++ b/static/js/query-configs/websites.ts
@@ -300,6 +300,8 @@ export const contentListingKey = (
   JSON.stringify([
     listingParams.name,
     listingParams.type,
+    listingParams.search,
+    listingParams.pageContent,
     listingParams.offset,
     listingParams.resourcetype
   ])


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets? https://github.com/mitodl/ocw-studio/issues/902

#### What's this PR do?
This PR enables authors to create links to pages in their course through the markdown editor..
- "Link resource" has been renamed to "Add link". This dialog increases a fourth "Pages" tab.
- "Embed resource" is unchanged (it still has only 3 tabs).

#### How should this be manually tested?
In a course with multiple pages:
1. Edit a page, then "Add link". Select the pages tab. Check filter works. Select a page. Click "Add Link".
2. Check link works in published course. 

#### Where should reviewer start
I suggest starting with `static/js/components/widgets/ResourcePickerDialog.tsx`, and the associated github comments.

#### Out of scope
Pages tab does not have pagination: It shows at most 10 pages. This is consistent with the other tabs (documents, images, videos).

#### Screenshots 
![link_to_page](https://user-images.githubusercontent.com/9010790/150431638-43be62aa-1dc6-4081-afb2-0d7d48f26d65.gif)

