### PR TITLE
Upgrade celery

### DIFF
--- a/main/tasks.py
+++ b/main/tasks.py
@@ -1,8 +1,8 @@
 """main tasks"""
-import celery
+from main.celery import app
 
 
-@celery.task
+@app.task
 def chord_finisher(*args, **kwargs):  # pylint:disable=unused-argument
     """
     Dummy task to indicate a chord has finished processing, so the next step(s) can proceed

--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 beautifulsoup4
 django
 boto3==1.18.7
-celery
+celery>=5.2.2
 concoursepy
 dj-database-url
 django-anymail[mailgun]==8.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile
 #
-amqp==2.6.1
+amqp==5.0.9
     # via kombu
 asgiref==3.2.10
     # via django
@@ -16,7 +16,7 @@ beautifulsoup4==4.9.3
     # via
     #   -r requirements.in
     #   mitol-django-mail
-billiard==3.6.3.0
+billiard==3.6.4.0
     # via celery
 boto3==1.18.7
     # via
@@ -30,7 +30,7 @@ cachetools==4.2.2
     # via
     #   google-auth
     #   premailer
-celery==4.4.7
+celery==5.2.2
     # via
     #   -r requirements.in
     #   django-server-status
@@ -45,6 +45,18 @@ cffi==1.14.2
     #   pynacl
 chardet==3.0.4
     # via requests
+click==8.0.3
+    # via
+    #   celery
+    #   click-didyoumean
+    #   click-plugins
+    #   click-repl
+click-didyoumean==0.3.0
+    # via celery
+click-plugins==1.1.1
+    # via celery
+click-repl==0.2.0
+    # via celery
 concoursepy==0.0.20
     # via -r requirements.in
 cryptography==3.3.2
@@ -163,7 +175,7 @@ jmespath==0.10.0
     # via
     #   boto3
     #   botocore
-kombu==4.6.11
+kombu==5.2.3
     # via
     #   celery
     #   django-server-status
@@ -206,7 +218,9 @@ pluggy==0.13.1
 premailer==3.9.0
     # via mitol-django-mail
 prompt-toolkit==3.0.6
-    # via ipython
+    # via
+    #   click-repl
+    #   ipython
 protobuf==3.17.3
     # via
     #   google-api-core
@@ -298,6 +312,7 @@ sentry-sdk==1.4.3
     # via -r requirements.in
 six==1.15.0
     # via
+    #   click-repl
     #   cryptography
     #   django-compat
     #   django-server-status
@@ -348,10 +363,11 @@ urllib3==1.25.10
     #   sentry-sdk
 uwsgi==2.0.19.1
     # via -r requirements.in
-vine==1.3.0
+vine==5.0.0
     # via
     #   amqp
     #   celery
+    #   kombu
 wcwidth==0.2.5
     # via prompt-toolkit
 webencodings==0.5.1


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [ ] Changes have been manually tested


#### What are the relevant tickets?
Replacement for #893
Closes #906 

#### What's this PR do?
Upgrades celery to 5.2.2 and fixes a failing test

#### How should this be manually tested?
Tests should pass.
Run `manage.py import_ocw_course_sites -d True --bucket ocw-to-hugo-output-qa --limit 5`, it should complete without errors
