### PR TITLE
update docker postgres to 12.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ x-environment:
   NODE_ENV: 'production'
   DEV_ENV: 'True'  # necessary to have nginx connect to web container
   SECRET_KEY: local_unsafe_key
-  DATABASE_URL: postgres://postgres@db:5432/postgres
+  DATABASE_URL: postgres://postgres:postgres@db:5432/postgres
   OCW_STUDIO_SECURE_SSL_REDIRECT: 'False'
   OCW_STUDIO_DB_DISABLE_SSL: 'True'
   CELERY_TASK_ALWAYS_EAGER: 'False'
@@ -19,9 +19,11 @@ x-environment:
 
 services:
   db:
-    image: postgres:11.6
+    image: postgres:12.8
     ports:
       - "5432"
+    environment:
+      POSTGRES_PASSWORD: postgres
 
   redis:
     image: redis:6.0.10


### PR DESCRIPTION
## Manual migration steps
If you upgrade the postgres container from 11 to 12 without migrating the database files, you'll get an error along the lines of
```
ocw-studio-db-1      | 2022-01-26 21:52:44.993 UTC [1] FATAL:  database files are incompatible with server
ocw-studio-db-1      | 2022-01-26 21:52:44.993 UTC [1] DETAIL:  The data directory was initialized by PostgreSQL version 11, which is not compatible with this version 12.8 (Debian 12.8-1.pgdg110+1).
```
Destroying the pg-11 database seemed like easiest upgrade path. So to keep your local data intact, we'll dump the data, then upgrade, then restore the data.

⚠️  Alert! Do not just dump these all into a shell script. If you do, step 6 will run before the database server starts in step 5, and then the data import will fail.

```sh
# 1. Using your old 11.6 database:
# (If you've already upgraded, just change the docker-compose file back to 11.6 for this step.)
docker-compose exec -T db pg_dumpall -h db -U postgres > dump.sql
# 2. stop all containers
docker-compose stop
# 3 destroy the old database container
docker-compose rm -sv db
# 4. build+start the new database container
docker-compose up db -d
# 5. restore the database from backup
docker-compose exec -T -e PGPASSWORD=postgres db psql -h db -U postgres < dump.sql
# 6. start the remaining containers
docker-compose up
# 7 verify postgres 12 is in use:
docker-compose exec -e PGPASSWORD=postgres db psql -h db -U postgres
```


#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets? https://github.com/mitodl/ocw-studio/issues/455

#### What's this PR do?
Update local postgres to version 12.8 in `db` container only. Does not update concourse-db postgres.

#### How should this be manually tested?
Follow migration steps at top of PR, then try using ocw-studio and observe that it works as expected.

### Notes
- Again, this does not update concourse-db postgres
- The original issue (https://github.com/mitodl/ocw-studio/issues/455) described 4 steps to upgrade. As far as I can tell, only steps 1 and 2 are currently unnecessary
- I am fairly new to docker, so hopefully the above is a reasonable way to do this...