### PR TITLE
fix resource_link regex, make non-greedy

### DIFF
--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
@@ -1,7 +1,7 @@
 jest.mock("@ckeditor/ckeditor5-utils/src/version")
 
 import ResourceLink from "@mitodl/ckeditor5-resource-link/src/link"
-import Markdown from "./Markdown"
+import Markdown, { MarkdownDataProcessor } from "./Markdown"
 import { createTestEditor, markdownTest } from "./test_util"
 import { turndownService } from "../turndown"
 
@@ -44,6 +44,25 @@ describe("ResourceLink plugin", () => {
       editor,
       '{{< resource_link asdfasdfasdfasdf "text here" >}}',
       '<p><a class="resource-link" data-uuid="asdfasdfasdfasdf">text here</a></p>'
+    )
+  })
+
+  it("should serialize multiple links to and from markdown", async () => {
+    const editor = await getEditor("")
+    markdownTest(
+      editor,
+      'dogs {{< resource_link uuid1 "woof" >}} cats {{< resource_link uuid2 "meow" >}}, cool',
+      '<p>dogs <a class="resource-link" data-uuid="uuid1">woof</a> cats <a class="resource-link" data-uuid="uuid2">meow</a>, cool</p>'
+    )
+  })
+
+  it("[BUG] does not behave well if link title ends in backslash", async () => {
+    const editor = await getEditor("")
+    const { md2html } = (editor.data
+      .processor as unknown) as MarkdownDataProcessor
+    expect(md2html('{{< resource_link uuid123 "bad \\" >}}')).toBe(
+      // This is wrong. Should not end in &lt;/a&gt;
+      '<p><a class="resource-link" data-uuid="uuid123">bad &lt;/a&gt;</p>'
     )
   })
 })

--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
@@ -10,7 +10,6 @@ import {
   RESOURCE_LINK
 } from "@mitodl/ckeditor5-resource-link/src/constants"
 
-export const RESOURCE_LINK_SHORTCODE_REGEX = /{{< resource_link (\S+) "(.*?)" >}}/g
 /**
  * (\S+) to match and capture the UUID
  * "(.*?)" to match and capture the label text
@@ -19,6 +18,7 @@ export const RESOURCE_LINK_SHORTCODE_REGEX = /{{< resource_link (\S+) "(.*?)" >}
  *   - gets fooled by label texts that include literal `" >}}` values. For
  *     example, < resource_link uuid123 "silly " >}} link" >}}.
  */
+export const RESOURCE_LINK_SHORTCODE_REGEX = /{{< resource_link (\S+) "(.*?)" >}}/g
 
 /**
  * Class for defining Markdown conversion rules for Resource links

--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
@@ -10,6 +10,16 @@ import {
   RESOURCE_LINK
 } from "@mitodl/ckeditor5-resource-link/src/constants"
 
+export const RESOURCE_LINK_SHORTCODE_REGEX = /{{< resource_link (\S+) "(.*?)" >}}/g
+/**
+ * (\S+) to match and capture the UUID
+ * "(.*?)" to match and capture the label text
+ *
+ * Limitations:
+ *   - gets fooled by label texts that include literal `" >}}` values. For
+ *     example, < resource_link uuid123 "silly " >}} link" >}}.
+ */
+
 /**
  * Class for defining Markdown conversion rules for Resource links
  *
@@ -25,17 +35,6 @@ import {
  * The ResourceEmbed plugin itself is provided via our fork of CKEditor's
  * 'link' plugin.
  */
-
-export const RESOURCE_LINK_SHORTCODE_REGEX = /{{< resource_link (\S+) "(.*?)" >}}/g
-/**
- * (\S+) to match and capture the UUID
- * "(.*?)" to match and capture the label text
- *
- * Limitations:
- *   - gets fooled by label texts that include literal `" >}}` values. For
- *     example, < resource_link uuid123 "silly " >}} link" >}}.
- */
-
 export default class ResourceLinkMarkdownSyntax extends MarkdownSyntaxPlugin {
   constructor(editor: editor.Editor) {
     super(editor)

--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
@@ -5,8 +5,6 @@ import { editor } from "@ckeditor/ckeditor5-core"
 import MarkdownSyntaxPlugin from "./MarkdownSyntaxPlugin"
 import { TurndownRule } from "../../../types/ckeditor_markdown"
 
-export const RESOURCE_LINK_SHORTCODE_REGEX = /{{< resource_link (\S+) "(.+)" >}}/g
-
 import {
   RESOURCE_LINK_CKEDITOR_CLASS,
   RESOURCE_LINK
@@ -27,6 +25,17 @@ import {
  * The ResourceEmbed plugin itself is provided via our fork of CKEditor's
  * 'link' plugin.
  */
+
+export const RESOURCE_LINK_SHORTCODE_REGEX = /{{< resource_link (\S+) "(.*?)" >}}/g
+/**
+ * (\S+) to match and capture the UUID
+ * "(.*?)" to match and capture the label text
+ *
+ * Limitations:
+ *   - gets fooled by label texts that include literal `" >}}` values. For
+ *     example, < resource_link uuid123 "silly " >}} link" >}}.
+ */
+
 export default class ResourceLinkMarkdownSyntax extends MarkdownSyntaxPlugin {
   constructor(editor: editor.Editor) {
     super(editor)


### PR DESCRIPTION
Before the regex was greedy so it would not stop at the end of the first resource_link. Two resource links on the same lin would be gobbled up as one.

The new regex is still pretty simple but will be fooled by resource_link titles that include literal `" >}}` values. This is a pretty edgy edge case. We could get around this in the future by escpaing quotations in the link titles and using a different regex (or parsing some other way). But right now the unescaped quotation characters are not causing any problems other than this, so lets keep this fix simple.

#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes https://github.com/mitodl/ocw-studio/issues/917 and https://github.com/mitodl/ocw-studio/issues/903.

#### What's this PR do?
Fixes the regex that was turning resource_link shortcodes into HTM.

#### How should this be manually tested?
- #917 add multiple resource links on the same line; save the page and re-open editor. Verify links look the same.
- #903 add multiple resource links within a table; save the page and re-open editor. Verify table / links look the same.

#### Screenshots (if appropriate)
**Before / After**
<img width="350" alt="Screen Shot 2022-01-24 at 3 05 13 PM" src="https://user-images.githubusercontent.com/9010790/150858379-955f37ad-4ad8-450e-b860-7fea1bc52230.png"> <img width="175" alt="Screen Shot 2022-01-24 at 3 04 54 PM" src="https://user-images.githubusercontent.com/9010790/150858413-f0dcd375-6ed3-416f-8a74-e42cfce777f0.png">

