### PR TITLE
move pipeline api callbacks to jgriff/http-resource

### DIFF
--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -35,7 +35,6 @@ resources:
         headers:
             Content-Type: "application/json"
             Authorization: "Bearer ((api-token))"
-        text: "{json}"
         out_only: true
 jobs:
   - name: build-ocw-site
@@ -46,7 +45,7 @@ jobs:
           timeout: 5m
           attempts: 3
           params:
-            json: |
+            text: |
               {
                 "version": "((version))",
                 "status": "started"
@@ -58,7 +57,7 @@ jobs:
           try:
             put: ocw-studio-webhook
             params:
-                json: |
+                text: |
                   {
                     "version": "((version))",
                     "status": "errored"
@@ -71,7 +70,7 @@ jobs:
           try:
             put: ocw-studio-webhook
             params:
-                json: |
+                text: |
                   {
                     "version": "((version))",
                     "status": "errored"
@@ -84,7 +83,7 @@ jobs:
           try:
             put: ocw-studio-webhook
             params:
-                json: |
+                text: |
                   {
                     "version": "((version))",
                     "status": "errored"
@@ -97,7 +96,7 @@ jobs:
           try:
             put: ocw-studio-webhook
             params:
-                json: |
+                text: |
                   {
                     "version": "((version))",
                     "status": "errored"
@@ -135,7 +134,7 @@ jobs:
             put: ocw-studio-webhook
             attempts: 3
             params:
-                json: |
+                text: |
                   {
                     "version": "((version))",
                     "status": "errored"
@@ -164,7 +163,7 @@ jobs:
             put: ocw-studio-webhook
             attempts: 3
             params:
-                json: |
+                text: |
                   {
                     "version": "((version))",
                     "status": "errored"
@@ -191,7 +190,7 @@ jobs:
             put: ocw-studio-webhook
             attempts: 3
             params:
-                json: |
+                text: |
                   {
                     "version": "((version))",
                     "status": "succeeded"
@@ -201,7 +200,7 @@ jobs:
             put: ocw-studio-webhook
             attempts: 3
             params:
-                json: |
+                text: |
                   {
                     "version": "((version))",
                     "status": "errored"

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -1,9 +1,9 @@
 ---
 resource_types:
-  - name: http-api
+  - name: http-resource
     type: docker-image
     source:
-      repository: aequitas/http-api-resource
+      repository: jgriff/http-resource
       tag: latest
 resources:
   - name: ocw-hugo-themes
@@ -28,16 +28,15 @@ resources:
       uri: ((ocw-hugo-projects-uri))
       branch: ((ocw-hugo-projects-branch))
   - name: ocw-studio-webhook
-    type: http-api
+    type: http-resource
     source:
-        uri: ((ocw-studio-url))/api/websites/((site-name))/pipeline_status/
+        url: ((ocw-studio-url))/api/websites/((site-name))/pipeline_status/
         method: POST
         headers:
-            Authorization: "Bearer {bearer_token}"
-        json:
-            version: ((version))
-            status: "{status}"
-        bearer_token: ((api-token))
+            Content-Type: "application/json"
+            Authorization: "Bearer ((api-token))"
+        text: "{json}"
+        out_only: true
 jobs:
   - name: build-ocw-site
     serial: true
@@ -47,7 +46,11 @@ jobs:
           timeout: 5m
           attempts: 3
           params:
-            status: "started"
+            json: |
+              {
+                "version": "((version))",
+                "status": "started"
+              }
       - get: ocw-hugo-themes
         trigger: ((theme-created-trigger))
         timeout: 5m
@@ -55,7 +58,11 @@ jobs:
           try:
             put: ocw-studio-webhook
             params:
-                status: "errored"
+                json: |
+                  {
+                    "version": "((version))",
+                    "status": "errored"
+                  }
       - get: ocw-static-version
         trigger: ((theme-deployed-trigger))
         timeout: 5m
@@ -64,7 +71,11 @@ jobs:
           try:
             put: ocw-studio-webhook
             params:
-                status: "errored"
+                json: |
+                  {
+                    "version": "((version))",
+                    "status": "errored"
+                  }
       - get: ocw-hugo-projects
         trigger: true
         timeout: 5m
@@ -73,7 +84,11 @@ jobs:
           try:
             put: ocw-studio-webhook
             params:
-                status: "errored"
+                json: |
+                  {
+                    "version": "((version))",
+                    "status": "errored"
+                  }
       - get: course-markdown
         trigger: false
         timeout: 5m
@@ -82,7 +97,11 @@ jobs:
           try:
             put: ocw-studio-webhook
             params:
-                status: "errored"
+                json: |
+                  {
+                    "version": "((version))",
+                    "status": "errored"
+                  }
       - task: build-course-task
         timeout: 20m
         attempts: 3
@@ -116,7 +135,11 @@ jobs:
             put: ocw-studio-webhook
             attempts: 3
             params:
-                status: "errored"
+                json: |
+                  {
+                    "version": "((version))",
+                    "status": "errored"
+                  }
       - task: copy-s3-buckets
         timeout: 20m
         attempts: 3
@@ -141,7 +164,11 @@ jobs:
             put: ocw-studio-webhook
             attempts: 3
             params:
-                status: "errored"
+                json: |
+                  {
+                    "version": "((version))",
+                    "status": "errored"
+                  }
       - task: clear-cdn-cache
         timeout: 5m
         attempts: 3
@@ -164,10 +191,18 @@ jobs:
             put: ocw-studio-webhook
             attempts: 3
             params:
-                status: "succeeded"
+                json: |
+                  {
+                    "version": "((version))",
+                    "status": "succeeded"
+                  }
         on_failure:
           try:
             put: ocw-studio-webhook
             attempts: 3
             params:
-                status: "errored"
+                json: |
+                  {
+                    "version": "((version))",
+                    "status": "errored"
+                  }


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/936

#### What's this PR do?
Currently, we are using [`aequitas/http-api-resource`](https://github.com/aequitas/concourse-http-api-resource) to form HTTP requests back to the `ocw-studio` API and set the status of a build.  This resource has been problematic, causing massive timeouts.  It uses the Python `requests` library which has to be installed from pip each time the Docker container is re-created, and also doesn't allow you to specify a no-op in the `get` step.  This PR moves over to using [`jgriff/http-resource`](https://github.com/jgriff/http-resource) for the API calls instead, which simply uses `curl` behind the scenes and also allows for a no-op on the `get` step.

#### How should this be manually tested?
 - Spin up your local `ocw-studio` instance on this PR branch using all of the `CONCOURSE_` env variables from the RC instance of `ocw-studio` in Heroku as well as `OCW_STUDIO_BASE_URL=https://ocw-studio-rc.odl.mit.edu`
 - Create a site in [`ocw-studio-rc`](https://ocw-studio-rc.odl.mit.edu/sites) and leave it empty
 - Create a site in your local Concourse instance with the exact same name / short id
 - In a shell, run `docker-compose run --rm web ./manage.py backpopulate_pipelines --filter cpg-test-course-3`, replacing `cpg-test-course-3` with the short id of the course you created
 - Browse to https://cicd-qa.odl.mit.edu and log in, then find your site under the `live` or `draft` folder
 - Trigger a new build and watch the `ocw-studio-webhook` steps carefully, making sure that the pipeline doesn't hang at that step for more than a minute or so.  It should be very quick and definitely not time out
 - Keep in mind that while the webhook requests should succeed, the course build itself will fail because there is no content for it yet.  Browse to your site in [`ocw-studio-rc`](https://ocw-studio-rc.odl.mit.edu/sites) and ensure that you see "failed" in the upper right corner with a red circle.
