### PR TITLE
reconcile ckedidtor, showdown multiline list items

### DIFF
--- a/static/js/lib/ckeditor/CKEditor.ts
+++ b/static/js/lib/ckeditor/CKEditor.ts
@@ -23,6 +23,7 @@ import ResourceLink from "@mitodl/ckeditor5-resource-link/src/link"
 import ResourceLinkMarkdownSyntax from "./plugins/ResourceLinkMarkdownSyntax"
 import DisallowNestedTables from "./plugins/DisallowNestedTables"
 import TableMarkdownSyntax from "./plugins/TableMarkdownSyntax"
+import MarkdownListSyntax from "./plugins/MarkdownListSyntax"
 
 export const FullEditorConfig = {
   plugins: [
@@ -47,6 +48,7 @@ export const FullEditorConfig = {
     ResourceLink,
     ResourceLinkMarkdownSyntax,
     TableMarkdownSyntax,
+    MarkdownListSyntax,
     Markdown,
     DisallowNestedTables
   ],
@@ -89,6 +91,7 @@ export const MinimalEditorConfig = {
     LinkPlugin,
     ListPlugin,
     ParagraphPlugin,
+    MarkdownListSyntax,
     Markdown
   ],
   toolbar: {

--- a/static/js/lib/ckeditor/plugins/MarkdownListSyntax.test.ts
+++ b/static/js/lib/ckeditor/plugins/MarkdownListSyntax.test.ts
@@ -1,0 +1,75 @@
+import Markdown from "./Markdown"
+import { createTestEditor, markdownTest } from "./test_util"
+import ParagraphPlugin from "@ckeditor/ckeditor5-paragraph/src/paragraph"
+import MarkdownListSyntax from "./MarkdownListSyntax"
+
+const getEditor = createTestEditor([
+  ParagraphPlugin,
+  MarkdownListSyntax,
+  Markdown
+])
+
+describe("list conversion to and from html", () => {
+  it("should not add paragraphs inside lists", async () => {
+    const editor = await getEditor("")
+
+    const markdown = `
+- aardvark
+- see [SO Question](https://meta.stackexchange.com/a/40978/394026) for info re trailing double spaces
+- beaver  
+      
+    bear  
+      
+    battletoad
+- chickadee
+    `.trim()
+    const html = `
+<ul>
+    <li>aardvark</li>
+    <li>see <a href="https://meta.stackexchange.com/a/40978/394026">SO Question</a> for info re trailing double spaces</li>
+    <li>beaver  <br><br>
+        bear  <br><br>
+        battletoad</li>
+    <li>chickadee</li>
+</ul>
+    `
+
+    markdownTest(editor, markdown, html)
+  })
+
+  it("should not add paragraphs inside lists, even when nested", async () => {
+    const editor = await getEditor("")
+
+    const markdown = `
+- item 1  
+      
+    detail 1
+- item 2:  
+      
+    [detail 2](ocw.mit.edu) is a link  
+      
+    - item 2a  
+          
+        detail 2a
+    - item 2b
+- item 3
+    `.trim()
+    const html = `
+<ul>
+    <li>item 1 <br><br>
+        detail 1</li>
+    <li>item 2: <br><br>
+        <a href="ocw.mit.edu">detail 2</a> is a link <br><br>
+        <ul>
+            <li>item 2a <br><br>
+                detail 2a</li>
+            <li>item 2b</li>
+        </ul>
+    </li>
+    <li>item 3</li>
+</ul>
+    `
+
+    markdownTest(editor, markdown, html)
+  })
+})

--- a/static/js/lib/ckeditor/plugins/MarkdownListSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/MarkdownListSyntax.ts
@@ -1,0 +1,47 @@
+import { ShowdownExtension } from "showdown"
+import { TurndownRule } from "../../../types/ckeditor_markdown"
+import MarkdownSyntaxPlugin from "./MarkdownSyntaxPlugin"
+
+/**
+ * This "extension" is addresses an incompatibility between
+ *  - the HTML that showdown produces for lists
+ *  - the HTML that CKEditor expects for lists
+ *
+ * When a markdown list item contains multiple lines, showdown puts <p> tags
+ * around all list items (and multiple <p> tags for the multi-line list item).
+ * See https://github.com/showdownjs/showdown/wiki/Showdown's-Markdown-syntax#known-differences-and-gotchas.
+ *
+ * CKEditor, on the other hand, forbids paragraphs inside list items. Both are
+ * "block" elements in its schema; see https://ckeditor.com/docs/ckeditor5/latest/framework/guides/deep-dive/schema.html#defining-additional-semantics
+ * and block elements cannot contain other block elements. (There is discussion
+ * of having a list variant that can contain block elements; see
+ * https://github.com/ckeditor/ckeditor5/issues/2973 for more.)
+ *
+ * So here we add a Showdown rule to replace list item paragraph tags with
+ * linebreaks, the same as CKEditor produces.
+ *
+ */
+export default class MarkdownListSyntax extends MarkdownSyntaxPlugin {
+  get showdownExtension(): () => ShowdownExtension[] {
+    return () => [
+      {
+        type:   "output",
+        filter: htmlString => {
+          const container = document.createElement("div")
+          container.innerHTML = htmlString
+
+          container.querySelectorAll("li > p").forEach(node => {
+            const suffix = node.nextSibling === null ? "" : " <br><br>"
+            node.outerHTML = `${node.innerHTML}${suffix}`
+          })
+
+          return container.innerHTML
+        }
+      }
+    ]
+  }
+
+  get turndownRules(): TurndownRule[] {
+    return []
+  }
+}

--- a/static/js/lib/ckeditor/plugins/MarkdownSyntaxPlugin.ts
+++ b/static/js/lib/ckeditor/plugins/MarkdownSyntaxPlugin.ts
@@ -29,12 +29,12 @@ export default abstract class MarkdownSyntaxPlugin extends MarkdownConfigPlugin 
         ...currentConfig.showdownExtensions,
         this.showdownExtension
       ],
-      turndownRules: [...currentConfig.turndownRules, this.turndownRule]
+      turndownRules: [...currentConfig.turndownRules, ...this.turndownRules]
     }
     this.setMarkdownConfig(newConfig)
   }
 
   abstract get showdownExtension(): () => Showdown.ShowdownExtension[]
 
-  abstract get turndownRule(): TurndownRule
+  abstract get turndownRules(): TurndownRule[]
 }

--- a/static/js/lib/ckeditor/plugins/ResourceEmbed.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceEmbed.ts
@@ -38,18 +38,20 @@ class ResourceMarkdownSyntax extends MarkdownSyntaxPlugin {
     }
   }
 
-  get turndownRule(): TurndownRule {
-    return {
-      name: "resourceEmbed",
-      rule: {
-        filter:      "section",
-        replacement: (_content: string, node: Turndown.Node): string => {
-          // @ts-ignore
-          const uuid = node.getAttribute("data-uuid")
-          return `{{< resource ${uuid} >}}\n`
+  get turndownRules(): TurndownRule[] {
+    return [
+      {
+        name: "resourceEmbed",
+        rule: {
+          filter:      "section",
+          replacement: (_content: string, node: Turndown.Node): string => {
+            // @ts-ignore
+            const uuid = node.getAttribute("data-uuid")
+            return `{{< resource ${uuid} >}}\n`
+          }
         }
       }
-    }
+    ]
   }
 }
 

--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
@@ -58,22 +58,24 @@ export default class ResourceLinkMarkdownSyntax extends MarkdownSyntaxPlugin {
     }
   }
 
-  get turndownRule(): TurndownRule {
-    return {
-      name: RESOURCE_LINK,
-      rule: {
-        filter: function(node) {
-          return (
-            node.nodeName === "A" &&
-            node.className === RESOURCE_LINK_CKEDITOR_CLASS
-          )
-        },
-        replacement: (_content: string, node: Turndown.Node): string => {
-          // @ts-ignore
-          const uuid = node.getAttribute("data-uuid")
-          return `{{< resource_link ${uuid} "${node.textContent}" >}}`
+  get turndownRules(): TurndownRule[] {
+    return [
+      {
+        name: RESOURCE_LINK,
+        rule: {
+          filter: function(node) {
+            return (
+              node.nodeName === "A" &&
+              node.className === RESOURCE_LINK_CKEDITOR_CLASS
+            )
+          },
+          replacement: (_content: string, node: Turndown.Node): string => {
+            // @ts-ignore
+            const uuid = node.getAttribute("data-uuid")
+            return `{{< resource_link ${uuid} "${node.textContent}" >}}`
+          }
         }
       }
-    }
+    ]
   }
 }

--- a/static/js/lib/ckeditor/plugins/TableMarkdownSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/TableMarkdownSyntax.ts
@@ -33,27 +33,29 @@ export default class TableMarkdownSyntax extends MarkdownSyntaxPlugin {
     }
   }
 
-  get turndownRule(): TurndownRule {
-    return {
-      name: "TableMarkdownSyntax",
-      rule: {
-        filter:      TABLE_ELS,
-        replacement: (content: string, node: Turndown.Node): string => {
-          const name = node.nodeName.toLowerCase()
-          const normalizedContent = content.replace("\n\n", "\n")
-          //@ts-ignore
-          const attributes = node.hasAttributes() ?
-            buildAttrsString(
-              //@ts-ignore
-              Array.from(node.attributes).map(
+  get turndownRules(): TurndownRule[] {
+    return [
+      {
+        name: "TableMarkdownSyntax",
+        rule: {
+          filter:      TABLE_ELS,
+          replacement: (content: string, node: Turndown.Node): string => {
+            const name = node.nodeName.toLowerCase()
+            const normalizedContent = content.replace("\n\n", "\n")
+            //@ts-ignore
+            const attributes = node.hasAttributes() ?
+              buildAttrsString(
                 //@ts-ignore
-                attr => `${attr.name}="${attr.value}"`
-              )
-            ) :
-            ""
-          return `{{< ${name}open${attributes} >}}${normalizedContent}{{< ${name}close >}}`
+                Array.from(node.attributes).map(
+                  //@ts-ignore
+                  attr => `${attr.name}="${attr.value}"`
+                )
+              ) :
+              ""
+            return `{{< ${name}open${attributes} >}}${normalizedContent}{{< ${name}close >}}`
+          }
         }
       }
-    }
+    ]
   }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets? #935 

#### What's this PR do?
Adds a markdown "extension" that addresses an incompatibility between
 - the HTML that showdown produces for lists
 - the HTML that CKEditor expects for lists

When a markdown list item contains multiple lines, showdown puts `<p>` tags around all list items (and multipple `<p>` tags for the multi-line list item). See https://github.com/showdownjs/showdown/wiki/Showdown's-Markdown-syntax#known-differences-and-gotchas.

CKEditor, on the other hand, forbids paragraphs inside list items. Both are "block" elements in its schema; see https://ckeditor.com/docs/ckeditor5/latest/framework/guides/deep-dive/schema.html#defining-additional-semantics and block elements cannot contain other block elements. (There is discussion of having a list variant that can contain block elements; see https://github.com/ckeditor/ckeditor5/issues/2973 for more.)

So here we add a Showdown rule to replace list item paragraph tags with linebreaks, the same as CKEditor produces.


#### How should this be manually tested?
Create a page with list items where the list item contains line breaks (shift+enter). Save the page and re-open. It should look the same as it did before you saved it.

_Except it won't look the same if you insert multiple consecutive line breaks. They'll get collapsed into one. That's a separate issue, and not related to list items. And it seems like a less serious issue than #935_

#### Screenshots (if appropriate)
![list_items_with_new_lines](https://user-images.githubusercontent.com/9010790/151449284-61927af4-6e82-447e-ba98-a2634a8b187b.gif)

