### PR TITLE
fix issue with website name not being saved in resource collection

### DIFF
--- a/static/js/components/widgets/RelationField.test.tsx
+++ b/static/js/components/widgets/RelationField.test.tsx
@@ -27,6 +27,7 @@ import {
 import { ReactWrapper } from "enzyme"
 import { FormError } from "../forms/FormError"
 import { formatOptions, useWebsiteSelectOptions } from "../../hooks/websites"
+import SortableSelect from "./SortableSelect"
 
 jest.mock("../../lib/api/util", () => ({
   ...jest.requireActual("../../lib/api/util"),
@@ -249,6 +250,25 @@ describe("RelationField", () => {
           label: item.title
         }))
       )
+
+      await act(async () => {
+        wrapper.find(SortableSelect).prop("onChange")([
+          contentListingItems[0].text_id
+        ])
+        wrapper.update()
+      })
+
+      // this expect call is a regression test for the fix for
+      // https://github.com/mitodl/ocw-studio/issues/940
+      expect(onChange.mock.calls[0][0]).toEqual({
+        target: {
+          name:  "relation_field",
+          value: {
+            website: website.name,
+            content: [[contentListingItems[0].text_id, website.name]]
+          }
+        }
+      })
     })
   })
 

--- a/static/js/components/widgets/RelationField.tsx
+++ b/static/js/components/widgets/RelationField.tsx
@@ -165,6 +165,7 @@ export default function RelationField(props: Props): JSX.Element {
   const fetchOptions = useCallback(
     async (search: string | null, debounce: boolean) => {
       const params = collection ? { type: collection } : { page_content: true }
+      const name = crossSite && focusedWebsite ? focusedWebsite : websiteName
       const url = siteApiContentListingUrl
         .query({
           detailed_list:   true,
@@ -178,7 +179,7 @@ export default function RelationField(props: Props): JSX.Element {
           ...params
         })
         .param({
-          name: crossSite && focusedWebsite ? focusedWebsite : websiteName
+          name
         })
         .toString()
 
@@ -203,6 +204,16 @@ export default function RelationField(props: Props): JSX.Element {
           })
           return newMap
         })
+
+        if (crossSite) {
+          setContentToWebsite(cur => {
+            const update = new Map(cur)
+            results.forEach(websiteContent => {
+              update.set(websiteContent.text_id, name)
+            })
+            return update
+          })
+        }
         setFetchStatus(FetchStatus.Ok)
         return formatOptions(filterContentListing(results), display_field)
       } else {
@@ -220,6 +231,7 @@ export default function RelationField(props: Props): JSX.Element {
       collection,
       filter,
       focusedWebsite,
+      setContentToWebsite,
       crossSite
     ]
   )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

closes #940

#### What's this PR do?

This fixes an issue where the website name wasn't properly being stored in resource collections (aka `cross_site` Relation  fields). We need the website name so that we'll be able to construct a URL to get info about the resource when rendering in ocw-www.

#### How should this be manually tested?

Create a resource collection and inspect the saved markdown. The value for the field should be an array of tuples like

```
[
  [resource-uuid, website-name]
]
```

the issue this fixes was causing the website name to just be `null`.