### PR TITLE
Course link clickability

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "autoprefixer": "9",
     "bootstrap": "4",
     "casual": "^1.6.2",
+    "classnames": "^2.3.1",
     "core-js": "^3.16.0",
     "css-loader": "^4.2.1",
     "enzyme": "^3.11.0",

--- a/static/js/components/Card.tsx
+++ b/static/js/components/Card.tsx
@@ -9,7 +9,7 @@ export default function Card(props: Props): JSX.Element {
 
   return (
     <div className="studio-card">
-      <div className="card-contents p-4">{children}</div>
+      <div className="p-4">{children}</div>
     </div>
   )
 }

--- a/static/js/components/StudioList.test.tsx
+++ b/static/js/components/StudioList.test.tsx
@@ -1,0 +1,21 @@
+import React from "react"
+import { shallow } from "enzyme"
+import { StudioListItem } from "./StudioList"
+
+describe("StudioListItem", () => {
+  it("does not have hover-pointer class if onClick not provided", () => {
+    const wrapper = shallow(
+      <StudioListItem title="some-titlle" subtitle="meow" />
+    )
+
+    expect(wrapper.find("li").hasClass("hover-pointer")).toBe(false)
+  })
+
+  it("does have hover-pointer class if onClick is provided", () => {
+    const wrapper = shallow(
+      <StudioListItem title="some-titlle" subtitle="meow" onClick={jest.fn} />
+    )
+
+    expect(wrapper.find("li").hasClass("hover-pointer")).toBe(true)
+  })
+})

--- a/static/js/components/StudioList.tsx
+++ b/static/js/components/StudioList.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from "react"
 import { Link } from "react-router-dom"
 import OutsideClickHandler from "react-outside-click-handler"
+import classNames from "classnames"
 
 import Card from "./Card"
 
@@ -63,10 +64,16 @@ export function StudioListItem(props: ListItemProps): JSX.Element {
   )
 
   return (
-    <li className="my-3" onClick={onClick}>
+    <li
+      className={classNames({
+        "my-3":          true,
+        "hover-pointer": Boolean(onClick)
+      })}
+      onClick={onClick}
+    >
       <Card>
         <div className="d-flex flex-row align-items-center justify-content-between">
-          <div className="d-flex flex-column">
+          <div className="d-flex flex-column flex-grow-1">
             {to ? (
               <Link className="title" to={to}>
                 {title}

--- a/static/js/components/StudioList.tsx
+++ b/static/js/components/StudioList.tsx
@@ -63,7 +63,7 @@ export function StudioListItem(props: ListItemProps): JSX.Element {
   )
 
   return (
-    <li className="py-2" onClick={onClick}>
+    <li className="my-3" onClick={onClick}>
       <Card>
         <div className="d-flex flex-row align-items-center justify-content-between">
           <div className="d-flex flex-column">

--- a/static/scss/common.scss
+++ b/static/scss/common.scss
@@ -35,3 +35,7 @@ a.underline {
 .noflex {
   flex: none;
 }
+
+.hover-pointer:hover {
+  cursor: pointer;
+}

--- a/static/scss/list.scss
+++ b/static/scss/list.scss
@@ -5,11 +5,11 @@
 
   li {
     &:first-child {
-      padding-top: 0 !important;
+      margin-top: 0 !important;
     }
 
     &:last-child {
-      padding-bottom: 0 !important;
+      margin-bottom: 0 !important;
     }
   }
 }

--- a/static/scss/list.scss
+++ b/static/scss/list.scss
@@ -31,8 +31,6 @@ ul.studio-list {
   @include unstyled-list;
 
   li {
-    cursor: pointer;
-
     .title {
       font-size: 18px;
       font-weight: 500;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9399,6 +9399,7 @@ __metadata:
     autoprefixer: 9
     bootstrap: 4
     casual: ^1.6.2
+    classnames: ^2.3.1
     core-js: ^3.16.0
     css-loader: ^4.2.1
     enzyme: ^3.11.0


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots _see comment_
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets? #908 

#### What's this PR do?
This PR makes `<StudioListItems />`'s cursor reflect its clickability better. Previously, all StudioListItems had `cursor:pointer` on hover. Now they only get that css effect if the onClick prop is passed.

In #908 two ideas were presented:
> the pointer should match up with triggering some behavior, so we should either 1) make the whole card an <a> tag which links to the site page or 2) make only the title portion (which is an <a> tag) have cursor: pointer

I went with option (2) but also made the site link area a bit bigger so it's easier to click. 

#### How should this be manually tested?
StudioListItems pointer status should now match the affect that clicking has. So for example:
- collaborator listings should no longer have cursor:pointer
- ...but pages, resources still should
- the site listing should only show pointer for the clickable part