### PR TITLE
When resetting sync state, the data field should also be set to None

### DIFF
--- a/content_sync/management/commands/reset_sync_states.py
+++ b/content_sync/management/commands/reset_sync_states.py
@@ -84,7 +84,7 @@ class Command(BaseCommand):
         if source_str:
             content_qset = content_qset.filter(content__website__source=source_str)
 
-        content_qset.update(synced_checksum=None)
+        content_qset.update(synced_checksum=None, data=None)
 
         total_seconds = (now_in_utc() - start).total_seconds()
         self.stdout.write(


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested


#### What are the relevant tickets?
https://sentry.io/organizations/mit-office-of-digital-learning/issues/2813483201/events/82df4ae91fb64c039ad5d0f319c3222c/?environment=production&project=5739976

#### What's this PR do?
When resetting sync state, sets both `synced_checksum` and `data` fields to `None`

#### How should this be manually tested?
Add a new page to a site and verify it's in github.
In a shell:
```
css = ContentSyncState.objects.get(content_id=<WebsiteContent id of your page>)
css.data = {"filepath": "fake/badname.txt"}
css.save()
```

Run `manage.py sync_website_to_backend --website <your_website_name>` - it should fail
Run `manage,py reset_sync_states --filter <your_website_name>`
Run `manage.py sync_website_to_backend --website <your_website_name>` - it should succeed


