### PR TITLE
Codify new mass publish pipeline and api endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ will need to follow some additional steps before it is fully functional.
     CONCOURSE_USERNAME=<Concourse-CI username>
     CONCOURSE_PASSWORD=<Concourse-CI password>
     CONCOURSE_IS_PRIVATE_REPO=<True if repo is private, False otherwise>
+    API_BEARER_TOKEN=<some hard to guess string>
     ```
 - Draft and live pipelines should then be created for every new `Website` based on a `WebsiteStarter` with `source=github` and a valid github `path`.
 - There are also several management commands for Concourse-CI pipelines:

--- a/README.md
+++ b/README.md
@@ -230,12 +230,12 @@ If you wish to use a github app,
 
 
 # Enabling Concourse-CI integration
-You can enable Concourse-CI integration to create and trigger publishing pipelines.
+Concourse-CI integration is enabled by default to create and trigger publishing pipelines, but you
+will need to follow some additional steps before it is fully functional.
 - Set up github integration as described above
 - Set up a Concourse-CI instance with a team, username, and password
 - Add the following to your .env file:
     ``` 
-    CONTENT_SYNC_PIPELINE=content_sync.pipelines.concourse.ConcourseGithubPipeline
     AWS_PREVIEW_BUCKET_NAME=<S3 bucket for draft content>
     AWS_PUBLISH_BUCKET_NAME=<S3 bucket for live content>
     GIT_DOMAIN=<root domain for github repos, ie github.com>
@@ -251,7 +251,8 @@ You can enable Concourse-CI integration to create and trigger publishing pipelin
 - There are also several management commands for Concourse-CI pipelines:
   - `backpopulate_pipelines`: to create/update pipelines for all or some existing `Websites` (filters available)
   - `trigger_pipelines <version>`: to manually trigger the draft or live pipeline for all or some existing `Websites` (filters available)
-  
+- If you wish to disable concourse integration, set `CONTENT_SYNC_PIPELINE_BACKEND=` in your .env file.  
+
 ### Running a Local Concourse Docker Container
   You can run a local concourse instance in a docker container for some light testing.  You will need docker-compose version 1.28.0 or above:
 

--- a/app.json
+++ b/app.json
@@ -103,12 +103,8 @@
       "description": "The backend to sync websites/content with",
       "required": false
     },
-    "CONTENT_SYNC_PIPELINE": {
-      "description": "The pipeline to preview/publish websites with",
-      "required": false
-    },
-    "CONTENT_SYNC_THEME_PIPELINE": {
-      "description": "The pipeline to publish theme assets",
+    "CONTENT_SYNC_PIPELINE_BACKEND": {
+      "description": "The pipeline backend name to preview/publish websites with",
       "required": false
     },
     "CONTENT_SYNC_RETRIES": {
@@ -408,6 +404,10 @@
       "description": "s3 transcripts subfolder",
       "required": false
     },
+    "SEARCH_API_URL": {
+      "description": "The URL to open discussions search to inject into the theme assets build",
+      "required": false
+    },
     "SECRET_KEY": {
       "description": "Django secret key.",
       "generator": "secret",
@@ -575,10 +575,6 @@
     },
     "YT_UPLOAD_LIMIT": {
       "description": "Max Youtube uploads allowed per day",
-      "required": false
-    },
-    "SEARCH_API_URL": {
-      "description": "The URL to open discussions search to inject into the theme assets build",
       "required": false
     }
   },

--- a/content_sync/api.py
+++ b/content_sync/api.py
@@ -56,7 +56,7 @@ def get_mass_publish_pipeline(version: str, api: Optional[object] = None) -> obj
         return import_string(
             f"content_sync.pipelines.{settings.CONTENT_SYNC_PIPELINE_BACKEND}.MassPublishPipeline"
         )(version, api=api)
-    except AttributeError:
+    except ModuleNotFoundError:
         return None
 
 

--- a/content_sync/api.py
+++ b/content_sync/api.py
@@ -119,7 +119,7 @@ def publish_website(  # pylint: disable=too-many-arguments
     else:
         backend.merge_backend_live()
 
-    if trigger_pipeline:
+    if trigger_pipeline and settings.CONTENT_SYNC_PIPELINE_BACKEND:
         pipeline = get_sync_pipeline(website, api=pipeline_api)
         pipeline.unpause_pipeline(version)
         build_id = pipeline.trigger_pipeline_build(version)

--- a/content_sync/api.py
+++ b/content_sync/api.py
@@ -45,19 +45,18 @@ def get_sync_pipeline(website: Website, api: Optional[object] = None) -> BasePip
 
 def get_theme_assets_pipeline(api: Optional[object] = None) -> BasePipeline:
     """ Get the configured theme asset pipeline """
-    return import_string(
-        f"content_sync.pipelines.{settings.CONTENT_SYNC_PIPELINE_BACKEND}.ThemeAssetsPipeline"
-    )(api=api)
+    if settings.CONTENT_SYNC_PIPELINE_BACKEND:
+        return import_string(
+            f"content_sync.pipelines.{settings.CONTENT_SYNC_PIPELINE_BACKEND}.ThemeAssetsPipeline"
+        )(api=api)
 
 
 def get_mass_publish_pipeline(version: str, api: Optional[object] = None) -> object:
     """Get a mass publishing pipeline if the backend has one"""
-    try:
+    if settings.CONTENT_SYNC_PIPELINE_BACKEND:
         return import_string(
             f"content_sync.pipelines.{settings.CONTENT_SYNC_PIPELINE_BACKEND}.MassPublishPipeline"
         )(version, api=api)
-    except ModuleNotFoundError:
-        return None
 
 
 @is_sync_enabled

--- a/content_sync/api.py
+++ b/content_sync/api.py
@@ -35,28 +35,28 @@ def get_sync_backend(website: Website) -> BaseSyncBackend:
     return import_string(settings.CONTENT_SYNC_BACKEND)(website)
 
 
+@is_publish_pipeline_enabled
 def get_sync_pipeline(website: Website, api: Optional[object] = None) -> BasePipeline:
     """ Get the configured sync publishing pipeline """
-    if settings.CONTENT_SYNC_PIPELINE_BACKEND:
-        return import_string(
-            f"content_sync.pipelines.{settings.CONTENT_SYNC_PIPELINE_BACKEND}.SitePipeline"
-        )(website, api=api)
+    return import_string(
+        f"content_sync.pipelines.{settings.CONTENT_SYNC_PIPELINE_BACKEND}.SitePipeline"
+    )(website, api=api)
 
 
+@is_publish_pipeline_enabled
 def get_theme_assets_pipeline(api: Optional[object] = None) -> BasePipeline:
     """ Get the configured theme asset pipeline """
-    if settings.CONTENT_SYNC_PIPELINE_BACKEND:
-        return import_string(
-            f"content_sync.pipelines.{settings.CONTENT_SYNC_PIPELINE_BACKEND}.ThemeAssetsPipeline"
-        )(api=api)
+    return import_string(
+        f"content_sync.pipelines.{settings.CONTENT_SYNC_PIPELINE_BACKEND}.ThemeAssetsPipeline"
+    )(api=api)
 
 
+@is_publish_pipeline_enabled
 def get_mass_publish_pipeline(version: str, api: Optional[object] = None) -> object:
     """Get a mass publishing pipeline if the backend has one"""
-    if settings.CONTENT_SYNC_PIPELINE_BACKEND:
-        return import_string(
-            f"content_sync.pipelines.{settings.CONTENT_SYNC_PIPELINE_BACKEND}.MassPublishPipeline"
-        )(version, api=api)
+    return import_string(
+        f"content_sync.pipelines.{settings.CONTENT_SYNC_PIPELINE_BACKEND}.MassPublishPipeline"
+    )(version, api=api)
 
 
 @is_sync_enabled

--- a/content_sync/api_test.py
+++ b/content_sync/api_test.py
@@ -270,3 +270,9 @@ def test_publish_website_error(mock_api_funcs, settings):
     with pytest.raises(Exception):
         api.publish_website(website.name, VERSION_LIVE)
     mock_api_funcs.mock_get_backend.assert_not_called()
+
+
+def test_get_mass_publish_pipeline(settings):
+    """get_mass_publish_pipeline should return None if no backend is specified"""
+    settings.CONTENT_SYNC_PIPELINE_BACKEND = None
+    assert api.get_mass_publish_pipeline(VERSION_DRAFT) is None

--- a/content_sync/api_test.py
+++ b/content_sync/api_test.py
@@ -272,7 +272,19 @@ def test_publish_website_error(mock_api_funcs, settings):
     mock_api_funcs.mock_get_backend.assert_not_called()
 
 
-def test_get_mass_publish_pipeline(settings):
+def test_get_mass_publish_pipeline_no_backend(settings):
     """get_mass_publish_pipeline should return None if no backend is specified"""
     settings.CONTENT_SYNC_PIPELINE_BACKEND = None
     assert api.get_mass_publish_pipeline(VERSION_DRAFT) is None
+
+
+def test_get_theme_assets_pipeline_no_backend(settings):
+    """get_theme_assets_pipeline should return None if no backend is specified"""
+    settings.CONTENT_SYNC_PIPELINE_BACKEND = None
+    assert api.get_theme_assets_pipeline() is None
+
+
+def test_get_sync_pipeline_no_backend(settings):
+    """get_sync_pipeline should return None if no backend is specified"""
+    settings.CONTENT_SYNC_PIPELINE_BACKEND = None
+    assert api.get_sync_pipeline(WebsiteFactory.create()) is None

--- a/content_sync/decorators.py
+++ b/content_sync/decorators.py
@@ -51,7 +51,7 @@ def is_publish_pipeline_enabled(func: Callable) -> Callable:
     """ Returns True if the publishing pipeline is enabled """
 
     def wrapper(*args, **kwargs):
-        if settings.CONTENT_SYNC_PIPELINE:
+        if settings.CONTENT_SYNC_PIPELINE_BACKEND:
             return func(*args, **kwargs)
         return None
 

--- a/content_sync/management/commands/backpopulate_pipelines.py
+++ b/content_sync/management/commands/backpopulate_pipelines.py
@@ -59,7 +59,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
 
-        if not settings.CONTENT_SYNC_PIPELINE:
+        if not settings.CONTENT_SYNC_PIPELINE_BACKEND:
             self.stderr.write("Pipeline backend is not configured")
             return
 

--- a/content_sync/management/commands/mass_publish.py
+++ b/content_sync/management/commands/mass_publish.py
@@ -58,7 +58,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
 
-        if not settings.CONTENT_SYNC_PIPELINE:
+        if not settings.CONTENT_SYNC_PIPELINE_BACKEND:
             self.stderr.write("Pipeline backend is not configured for publishing")
             return
 
@@ -86,9 +86,13 @@ class Command(BaseCommand):
             if source_str != WEBSITE_SOURCE_OCW_IMPORT:
                 # do not publish any unpublished sites
                 if version == VERSION_DRAFT:
-                    website_qset = website_qset.exclude(draft_publish_date__isnull=True)
+                    website_qset = website_qset.exclude(
+                        draft_publish_status__isnull=True
+                    )
                 else:
-                    website_qset = website_qset.exclude(publish_date__isnull=True)
+                    website_qset = website_qset.exclude(
+                        live_publish_status__isnull=True
+                    )
 
         website_names = list(website_qset.values_list("name", flat=True))
 

--- a/content_sync/pipelines/base.py
+++ b/content_sync/pipelines/base.py
@@ -22,6 +22,13 @@ class BasePipeline(abc.ABC):
         ...
 
     @abc.abstractmethod
+    def upsert_pipeline(self):  # pragma: no cover
+        """
+        Called to create/update the pipeline.
+        """
+        ...
+
+    @abc.abstractmethod
     def trigger_pipeline_build(self, pipeline_name: str) -> int:
         """
         Called to trigger the website pipeline.
@@ -34,3 +41,19 @@ class BasePipeline(abc.ABC):
         Called to unpause a website pipeline.
         """
         ...
+
+
+class BaseSitePipeline(BasePipeline):
+    """ Base class for site-specific publishing """
+
+
+class BaseMassPublishPipeline(BasePipeline):
+    """ Base class for mass publishing """
+
+    PIPELINE_NAME = "mass-publish"
+
+
+class BaseThemeAssetsPipeline(BasePipeline):
+    """ Base class for theme asset publishing """
+
+    PIPELINE_NAME = "ocw-theme-assets"

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -166,14 +166,14 @@ class ConcoursePipeline(BasePipeline):
         return self.api.abort_build(build_id)
 
     def unpause(self):
-        """ Use self.pipeline_name as input to the parent function"""
+        """ Use self.PIPELINE_NAME as input to the unpause_pipeline function"""
         if self.PIPELINE_NAME:
             self.unpause_pipeline(self.PIPELINE_NAME)
         else:
             raise ValueError("No default name specified for this pipeline")
 
     def trigger(self) -> int:
-        """ Use self.pipeline_name as input to the parent function"""
+        """ Use self.PIPELINE_NAME as input to the trigger_pipeline_build function"""
         if self.PIPELINE_NAME:
             return self.trigger_pipeline_build(self.PIPELINE_NAME)
         else:

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -112,12 +112,14 @@ class ConcoursePipeline(BasePipeline):
     MANDATORY_SETTINGS = MANDATORY_CONCOURSE_SETTINGS
     PIPELINE_NAME = None
 
-    def __init__(self, *args, **kwargs):  # pylint:disable=unused-argument
+    def __init__(
+        self, *args, api: Optional[object] = None, **kwargs
+    ):  # pylint:disable=unused-argument
         """Initialize the pipeline API instance"""
         if self.MANDATORY_SETTINGS:
             check_mandatory_settings(self.MANDATORY_SETTINGS)
         self.instance_vars = ""
-        self.api = kwargs.get("api", None) or self.get_api()
+        self.api = api or self.get_api()
 
     @staticmethod
     def get_api():

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -19,7 +19,12 @@ from requests import HTTPError
 
 from content_sync.constants import VERSION_DRAFT, VERSION_LIVE
 from content_sync.decorators import retry_on_failure
-from content_sync.pipelines.base import BasePipeline
+from content_sync.pipelines.base import (
+    BaseMassPublishPipeline,
+    BasePipeline,
+    BaseSitePipeline,
+    BaseThemeAssetsPipeline,
+)
 from content_sync.utils import check_mandatory_settings
 from websites.constants import OCW_HUGO_THEMES_GIT, STARTER_SOURCE_GITHUB
 from websites.models import Website
@@ -104,14 +109,15 @@ class ConcourseApi(BaseConcourseApi):
 class ConcoursePipeline(BasePipeline):
     """ Base class for a Concourse pipeline """
 
-    MANDATORY_SETTINGS = []
+    MANDATORY_SETTINGS = MANDATORY_CONCOURSE_SETTINGS
+    PIPELINE_NAME = None
 
-    def __init__(self, api: Optional[object] = None, website: Optional[Website] = None):
+    def __init__(self, *args, **kwargs):  # pylint:disable=unused-argument
+        """Initialize the pipeline API instance"""
         if self.MANDATORY_SETTINGS:
             check_mandatory_settings(self.MANDATORY_SETTINGS)
-        if website:
-            self.website = website
-        self.api = api or self.get_api()
+        self.instance_vars = ""
+        self.api = kwargs.get("api", None) or self.get_api()
 
     @staticmethod
     def get_api():
@@ -125,19 +131,19 @@ class ConcoursePipeline(BasePipeline):
 
     def _make_builds_url(self, pipeline_name: str, job_name: str):
         """Make URL for fetching builds information"""
-        return f"/api/v1/teams/{settings.CONCOURSE_TEAM}/pipelines/{pipeline_name}/jobs/{job_name}/builds?vars={self.instance_vars}"
+        return f"/api/v1/teams/{settings.CONCOURSE_TEAM}/pipelines/{pipeline_name}/jobs/{job_name}/builds{self.instance_vars}"
 
     def _make_pipeline_config_url(self, pipeline_name: str):
         """Make URL for fetching pipeline info"""
-        return f"/api/v1/teams/{settings.CONCOURSE_TEAM}/pipelines/{pipeline_name}/config?vars={self.instance_vars}"
+        return f"/api/v1/teams/{settings.CONCOURSE_TEAM}/pipelines/{pipeline_name}/config{self.instance_vars}"
 
     def _make_job_url(self, pipeline_name: str, job_name: str):
         """Make URL for fetching job info"""
-        return f"/api/v1/teams/{settings.CONCOURSE_TEAM}/pipelines/{pipeline_name}/jobs/{job_name}?vars={self.instance_vars}"
+        return f"/api/v1/teams/{settings.CONCOURSE_TEAM}/pipelines/{pipeline_name}/jobs/{job_name}{self.instance_vars}"
 
     def _make_pipeline_unpause_url(self, pipeline_name: str):
         """Make URL for unpausing a pipeline"""
-        return f"/api/v1/teams/{settings.CONCOURSE_TEAM}/pipelines/{pipeline_name}/unpause?vars={self.instance_vars}"
+        return f"/api/v1/teams/{settings.CONCOURSE_TEAM}/pipelines/{pipeline_name}/unpause{self.instance_vars}"
 
     def trigger_pipeline_build(self, pipeline_name: str) -> int:
         """Trigger a pipeline build"""
@@ -157,10 +163,24 @@ class ConcoursePipeline(BasePipeline):
         """Abort a build"""
         return self.api.abort_build(build_id)
 
+    def unpause(self):
+        """ Use self.pipeline_name as input to the parent function"""
+        if self.PIPELINE_NAME:
+            self.unpause_pipeline(self.PIPELINE_NAME)
+        else:
+            raise ValueError("No default name specified for this pipeline")
 
-class ConcourseGithubPipeline(ConcoursePipeline):
+    def trigger(self) -> int:
+        """ Use self.pipeline_name as input to the parent function"""
+        if self.PIPELINE_NAME:
+            return self.trigger_pipeline_build(self.PIPELINE_NAME)
+        else:
+            raise ValueError("No default name specified for this pipeline")
+
+
+class SitePipeline(BaseSitePipeline, ConcoursePipeline):
     """
-    Concourse-CI publishing pipeline, dependent on a Github backend
+    Concourse-CI publishing pipeline, dependent on a Github backend, for individual sites
     """
 
     MANDATORY_SETTINGS = MANDATORY_CONCOURSE_SETTINGS + [
@@ -173,15 +193,14 @@ class ConcourseGithubPipeline(ConcoursePipeline):
         "GIT_ORGANIZATION",
         "GITHUB_WEBHOOK_BRANCH",
     ]
-    VERSION_LIVE = VERSION_LIVE
-    VERSION_DRAFT = VERSION_DRAFT
 
     def __init__(self, website: Website, api: Optional[ConcourseApi] = None):
         """Initialize the pipeline API instance"""
-        super().__init__(website=website, api=api)
-        self.instance_vars = quote(json.dumps({"site": self.website.name}))
+        super().__init__(api=api)
+        self.website = website
+        self.instance_vars = f'?vars={quote(json.dumps({"site": self.website.name}))}'
 
-    def upsert_website_pipeline(self):  # pylint:disable=too-many-locals
+    def upsert_pipeline(self):  # pylint:disable=too-many-locals
         """
         Create or update a concourse pipeline for the given Website
         """
@@ -216,11 +235,11 @@ class ConcourseGithubPipeline(ConcoursePipeline):
 
         for branch in [settings.GIT_BRANCH_PREVIEW, settings.GIT_BRANCH_RELEASE]:
             if branch == settings.GIT_BRANCH_PREVIEW:
-                pipeline_name = self.VERSION_DRAFT
+                pipeline_name = VERSION_DRAFT
                 destination_bucket = settings.AWS_PREVIEW_BUCKET_NAME
                 static_api_url = settings.OCW_STUDIO_DRAFT_URL
             else:
-                pipeline_name = self.VERSION_LIVE
+                pipeline_name = VERSION_LIVE
                 destination_bucket = settings.AWS_PUBLISH_BUCKET_NAME
                 static_api_url = settings.OCW_STUDIO_LIVE_URL
             if settings.CONCOURSE_IS_PRIVATE_REPO:
@@ -281,12 +300,13 @@ class ConcourseGithubPipeline(ConcoursePipeline):
             self.api.put_with_headers(url_path, data=config, headers=version_headers)
 
 
-class ThemeAssetsPipeline(ConcoursePipeline):
+class ThemeAssetsPipeline(ConcoursePipeline, BaseThemeAssetsPipeline):
     """
     Concourse-CI pipeline for publishing theme assets
     """
 
-    PIPELINE_NAME = "ocw-theme-assets"
+    PIPELINE_NAME = BaseThemeAssetsPipeline.PIPELINE_NAME
+
     MANDATORY_SETTINGS = MANDATORY_CONCOURSE_SETTINGS + [
         "GITHUB_WEBHOOK_BRANCH",
         "SEARCH_API_URL",
@@ -295,11 +315,11 @@ class ThemeAssetsPipeline(ConcoursePipeline):
     def __init__(self, api: Optional[ConcourseApi] = None):
         """Initialize the pipeline API instance"""
         super().__init__(api=api)
-        self.instance_vars = quote(
-            json.dumps({"branch": settings.GITHUB_WEBHOOK_BRANCH})
+        self.instance_vars = (
+            f'?vars={quote(json.dumps({"branch": settings.GITHUB_WEBHOOK_BRANCH}))}'
         )
 
-    def upsert_theme_assets_pipeline(self):
+    def upsert_pipeline(self):
         """Upsert the theme assets pipeline"""
         with open(
             os.path.join(
@@ -328,3 +348,88 @@ class ThemeAssetsPipeline(ConcoursePipeline):
             except HTTPError:
                 version_headers = None
             self.api.put_with_headers(url_path, data=config, headers=version_headers)
+
+
+class MassPublishPipeline(BaseMassPublishPipeline, ConcoursePipeline):
+    """Specialized concourse pipeline for mass publishing multiple sites"""
+
+    PIPELINE_NAME = BaseMassPublishPipeline.PIPELINE_NAME
+
+    def __init__(self, version, api: Optional[ConcourseApi] = None):
+        """Initialize the pipeline instance"""
+        self.MANDATORY_SETTINGS = MANDATORY_CONCOURSE_SETTINGS + [
+            "AWS_PREVIEW_BUCKET_NAME",
+            "AWS_PUBLISH_BUCKET_NAME",
+            "AWS_STORAGE_BUCKET_NAME",
+            "GIT_BRANCH_PREVIEW",
+            "GIT_BRANCH_RELEASE",
+            "GIT_DOMAIN",
+            "GIT_ORGANIZATION",
+            "GITHUB_WEBHOOK_BRANCH",
+        ]
+        super().__init__(api=api)
+        self.pipeline_name = "mass_publish"
+        self.version = version
+        self.instance_vars = f'?vars={quote(json.dumps({"version": version}))}'
+
+    def upsert_pipeline(self):  # pylint:disable=too-many-locals
+        """
+        Create or update the concourse pipeline
+        """
+        starter = Website.objects.get(name=settings.ROOT_WEBSITE_NAME).starter
+        starter_path_url = urlparse(starter.path)
+        hugo_projects_url = urljoin(
+            f"{starter_path_url.scheme}://{starter_path_url.netloc}",
+            f"{'/'.join(starter_path_url.path.strip('/').split('/')[:2])}.git",  # /<org>/<repo>.git
+        )
+        if settings.CONCOURSE_IS_PRIVATE_REPO:
+            markdown_uri = f"git@{settings.GIT_DOMAIN}:{settings.GIT_ORGANIZATION}"
+            private_key_var = "((git-private-key))"
+        else:
+            markdown_uri = f"git://{settings.GIT_DOMAIN}/{settings.GIT_ORGANIZATION}"
+            private_key_var = ""
+
+        if self.version == VERSION_DRAFT:
+            branch = settings.GIT_BRANCH_PREVIEW
+            destination_bucket = settings.AWS_PREVIEW_BUCKET_NAME
+            static_api_url = settings.OCW_STUDIO_DRAFT_URL
+        else:
+            branch = settings.GIT_BRANCH_RELEASE
+            destination_bucket = settings.AWS_PUBLISH_BUCKET_NAME
+            static_api_url = settings.OCW_STUDIO_LIVE_URL
+
+        with open(
+            os.path.join(
+                os.path.dirname(__file__),
+                "definitions/concourse/mass-publish.yml",
+            )
+        ) as pipeline_config_file:
+            config_str = (
+                pipeline_config_file.read()
+                .replace("((markdown-uri))", markdown_uri)
+                .replace("((git-private-key-var))", private_key_var)
+                .replace("((ocw-bucket))", destination_bucket)
+                .replace("((ocw-hugo-themes-branch))", settings.GITHUB_WEBHOOK_BRANCH)
+                .replace("((ocw-hugo-themes-uri))", OCW_HUGO_THEMES_GIT)
+                .replace("((ocw-hugo-projects-branch))", settings.GITHUB_WEBHOOK_BRANCH)
+                .replace("((ocw-hugo-projects-uri))", hugo_projects_url)
+                .replace("((ocw-studio-url))", settings.SITE_BASE_URL)
+                .replace("((static-api-base-url))", static_api_url)
+                .replace("((ocw-studio-bucket))", settings.AWS_STORAGE_BUCKET_NAME)
+                .replace("((ocw-site-repo-branch))", branch)
+                .replace("((version))", self.version)
+                .replace("((api-token))", settings.API_BEARER_TOKEN or "")
+            )
+        log.debug(config_str)
+        config = json.dumps(yaml.load(config_str, Loader=yaml.SafeLoader))
+        # Try to get the version of the pipeline if it already exists, because it will be
+        # necessary to update an existing pipeline.
+        url_path = self._make_pipeline_config_url(self.PIPELINE_NAME)
+        try:
+            _, headers = self.api.get_with_headers(url_path)
+            version_headers = {
+                "X-Concourse-Config-Version": headers["X-Concourse-Config-Version"]
+            }
+        except HTTPError:
+            version_headers = None
+        self.api.put_with_headers(url_path, data=config, headers=version_headers)

--- a/content_sync/pipelines/definitions/concourse/mass-publish.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-publish.yml
@@ -102,7 +102,7 @@ jobs:
                 STARTER_SLUG=$(echo $1| jq -c '.starter_slug' | tr -d '"')
                 SITE_URL=$(echo $1 | jq -c '.site_url' | tr -d '"')
                 BASE_URL=$(echo $1 | jq -c '.base_url' | tr -d '"')
-                git -c core.sshCommand="ssh $GITKEYSSH -o StrictHostKeyChecking=no" clone -b ((version)) ((markdown-uri))/$SHORT_ID.git || return 1
+                git -c core.sshCommand="ssh $GITKEYSSH -o StrictHostKeyChecking=no" clone -b ((ocw-site-repo-branch)) ((markdown-uri))/$SHORT_ID.git || return 1
                 cd $CURDIR/$SHORT_ID
                 cp ../webpack-json/ocw-hugo-themes/((ocw-hugo-themes-branch))/webpack.json data
                 hugo --config ../ocw-hugo-projects/$STARTER_SLUG/config.yaml --baseUrl /$BASE_URL --themesDir ../ocw-hugo-themes/  || return 1

--- a/content_sync/pipelines/definitions/concourse/mass-publish.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-publish.yml
@@ -104,7 +104,7 @@ jobs:
                 BASE_URL=$(echo $1 | jq -c '.base_url' | tr -d '"')
                 git -c core.sshCommand="ssh $GITKEYSSH -o StrictHostKeyChecking=no" clone -b ((ocw-site-repo-branch)) ((markdown-uri))/$SHORT_ID.git || return 1
                 cd $CURDIR/$SHORT_ID
-                cp ../webpack-json/ocw-hugo-themes/((ocw-hugo-themes-branch))/webpack.json data
+                cp ../webpack-json/webpack.json data
                 hugo --config ../ocw-hugo-projects/$STARTER_SLUG/config.yaml --baseUrl /$BASE_URL --themesDir ../ocw-hugo-themes/  || return 1
                 cd $CURDIR
                 aws s3 sync s3://((ocw-studio-bucket))/$SITE_URL s3://((ocw-bucket))/$SITE_URL --metadata site-id=$NAME || return 1            

--- a/content_sync/pipelines/definitions/concourse/mass-publish.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-publish.yml
@@ -90,7 +90,7 @@ jobs:
                 STARTER_SLUG=$(echo $1| jq -c '.starter_slug' | tr -d '"')
                 SITE_URL=$(echo $1 | jq -c '.site_url' | tr -d '"')
                 BASE_URL=$(echo $1 | jq -c '.base_url' | tr -d '"')
-                git -c core.sshCommand="ssh $GITKEYSSH -o StrictHostKeyChecking=no" clone -b release ((markdown-uri))/$SHORT_ID.git || return 1
+                git -c core.sshCommand="ssh $GITKEYSSH -o StrictHostKeyChecking=no" clone -b ((version)) ((markdown-uri))/$SHORT_ID.git || return 1
                 cd $CURDIR/$SHORT_ID
                 cp ../webpack-json/ocw-hugo-themes/((ocw-hugo-themes-branch))/webpack.json data
                 hugo --config ../ocw-hugo-projects/$STARTER_SLUG/config.yaml --baseUrl /$BASE_URL --themesDir ../ocw-hugo-themes/  || return 1

--- a/content_sync/pipelines/definitions/concourse/mass-publish.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-publish.yml
@@ -1,3 +1,15 @@
+---
+resource_types:
+  - name: http-resource
+    type: docker-image
+    source:
+      repository: jgriff/http-resource
+      tag: latest
+  - name: s3-resource-iam
+    type: docker-image
+    source:
+      repository: governmentpaas/s3-resource
+      tag: latest
 resources:
   - name: ocw-hugo-themes
     type: git
@@ -10,7 +22,7 @@ resources:
       uri: ((ocw-hugo-projects-uri))
       branch: ((ocw-hugo-projects-branch))
   - name: webpack-json
-    type: s3
+    type: s3-resource-iam
     source:
       bucket: ol-eng-artifacts
       versioned_file: ocw-hugo-themes/((ocw-hugo-themes-branch))/webpack.json
@@ -95,8 +107,8 @@ jobs:
                 cp ../webpack-json/ocw-hugo-themes/((ocw-hugo-themes-branch))/webpack.json data
                 hugo --config ../ocw-hugo-projects/$STARTER_SLUG/config.yaml --baseUrl /$BASE_URL --themesDir ../ocw-hugo-themes/  || return 1
                 cd $CURDIR
+                aws s3 sync s3://((ocw-studio-bucket))/$SITE_URL s3://((ocw-bucket))/$SITE_URL --metadata site-id=$NAME || return 1            
                 aws s3 sync $SHORT_ID/public s3://((ocw-bucket))/$BASE_URL --metadata site-id=$NAME || return 1
-                aws s3 sync s3://((ocw-studio-bucket))/$SITE_URL s3://((ocw-bucket))/$SITE_URL --metadata site-id=$NAME || return 1
                 curl -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer ((api-token))' --data '{"version":"((version))","status":"succeeded"}' ((ocw-studio-url))/api/websites/$NAME/pipeline_status/
                 rm -rf $SHORT_ID
                 return 0

--- a/content_sync/pipelines/definitions/concourse/mass-publish.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-publish.yml
@@ -1,0 +1,135 @@
+resources:
+  - name: ocw-hugo-themes
+    type: git
+    source:
+      uri: ((ocw-hugo-themes-uri))
+      branch: ((ocw-hugo-themes-branch))
+  - name: ocw-hugo-projects
+    type: git
+    source:
+      uri: ((ocw-hugo-projects-uri))
+      branch: ((ocw-hugo-projects-branch))
+  - name: webpack-json
+    type: s3
+    source:
+      bucket: ol-eng-artifacts
+      versioned_file: ocw-hugo-themes/((ocw-hugo-themes-branch))/webpack.json
+task-config: &webhook-config
+  platform: linux
+  image_resource:
+    type: docker-image
+    source: {repository: curlimages/curl}
+jobs:
+- name: mass-publish
+  plan:
+  - get: ocw-hugo-themes
+    timeout: 1m
+    attempts: 3
+    trigger: false
+  - get: webpack-json
+    trigger: true
+  - get: ocw-hugo-projects
+    timeout: 1m
+    attempts: 3
+    trigger: true
+  - task: get-sites
+    timeout: 2m
+    attempts: 3
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source: {repository: bash, tag: latest}
+      outputs:
+        - name: publishable_sites
+      run:
+        path: sh
+        args:
+        - -exc
+        - |
+          wget -O publishable_sites/sites.json --header="Authorization: Bearer ((api-token))" "((ocw-studio-url))/api/publish/?version=((version))"
+  - task: get-repo-build-course-publish-course
+    attempts: 3
+    timeout: 300m
+    params:
+      OCW_STUDIO_BASE_URL: ((ocw-studio-url))
+      STATIC_API_BASE_URL: ((static-api-base-url))
+      GIT_KEY: ((git-private-key-var))
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source: {repository: ardiea/ocw-course-publisher, tag: latest}
+      inputs:
+        - name: publishable_sites
+        - name: ocw-hugo-projects
+        - name: ocw-hugo-themes
+        - name: webpack-json
+      run:
+        path: bash
+        args:
+          - -exc
+          - |
+            CURDIR=$(pwd)
+            if [[ "$GIT_KEY" != "" ]]
+            then
+              echo $GIT_KEY > $CURDIR/git.key
+              sed -i -E "s/(-----BEGIN[^-]+-----)(.+)(-----END[^-]+-----)/-----BEGINSSHKEY-----\2\-----ENDSSHKEY-----/" git.key  
+              sed -i -E "s/\s/\n/g" git.key
+              sed -i -E "s/SSHKEY/ OPENSSH PRIVATE KEY/g" git.key
+              chmod 400 $CURDIR/git.key
+              GITKEYSSH="-i $CURDIR/git.key"
+            else
+              GITKEYSSH=""
+            fi
+            process_site()
+            {
+                cd $CURDIR
+                NAME=$(echo $1 | jq -c '.name' | tr -d '"')
+                SHORT_ID=$(echo $1 | jq -c '.short_id' | tr -d '"')
+                STARTER_SLUG=$(echo $1| jq -c '.starter_slug' | tr -d '"')
+                SITE_URL=$(echo $1 | jq -c '.site_url' | tr -d '"')
+                BASE_URL=$(echo $1 | jq -c '.base_url' | tr -d '"')
+                git -c core.sshCommand="ssh $GITKEYSSH -o StrictHostKeyChecking=no" clone -b release ((markdown-uri))/$SHORT_ID.git || return 1
+                cd $CURDIR/$SHORT_ID
+                cp ../webpack-json/webpack.json data
+                hugo --config ../ocw-hugo-projects/$STARTER_SLUG/config.yaml --baseUrl /$BASE_URL --themesDir ../ocw-hugo-themes/  || return 1
+                cd $CURDIR
+                aws s3 sync $SHORT_ID/public s3://((ocw-bucket))/$BASE_URL --metadata site-id=$NAME || return 1
+                aws s3 sync s3://((ocw-studio-bucket))/$SITE_URL s3://((ocw-bucket))/$SITE_URL --metadata site-id=$NAME || return 1
+                curl -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer ((api-token))' --data '{"version":"((version))","status":"succeeded"}' ((ocw-studio-url))/api/websites/$NAME/pipeline_status/
+                rm -rf $SHORT_ID
+                return 0
+            }
+            fail_site()
+            {
+                NAME=$(echo $1 | jq -c '.name' | tr -d '"')
+                curl -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer ((api-token))' --data '{"version":"((version))","status":"errored"}' ((ocw-studio-url))/api/websites/$NAME/pipeline_status/
+            }
+            jq -c '.sites[]' publishable_sites/sites.json | while read i; do
+                 result=$(process_site $i) || result=1
+                 echo "RESULT IS $result"
+                 if [[ $result == 1 ]]
+                 then
+                   fail_site $i
+                 fi
+            done
+  - task: clear-cdn-cache
+    timeout: 1m
+    attempts: 3
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source: {repository: curlimages/curl}
+      run:
+        path: curl
+        args:
+          - -f
+          - -X
+          - POST
+          - -H
+          - 'Fastly-Key: ((fastly.api_token))'
+          - -H
+          - 'Fastly-Soft-Purge: 1'
+          - https://api.fastly.com/service/((fastly.service_id))/purge_all

--- a/content_sync/pipelines/definitions/concourse/mass-publish.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-publish.yml
@@ -92,7 +92,7 @@ jobs:
                 BASE_URL=$(echo $1 | jq -c '.base_url' | tr -d '"')
                 git -c core.sshCommand="ssh $GITKEYSSH -o StrictHostKeyChecking=no" clone -b release ((markdown-uri))/$SHORT_ID.git || return 1
                 cd $CURDIR/$SHORT_ID
-                cp ../webpack-json/webpack.json data
+                cp ../webpack-json/ocw-hugo-themes/((ocw-hugo-themes-branch))/webpack.json data
                 hugo --config ../ocw-hugo-projects/$STARTER_SLUG/config.yaml --baseUrl /$BASE_URL --themesDir ../ocw-hugo-themes/  || return 1
                 cd $CURDIR
                 aws s3 sync $SHORT_ID/public s3://((ocw-bucket))/$BASE_URL --metadata site-id=$NAME || return 1

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -133,7 +133,7 @@ jobs:
             args:
             - -exc
             - |
-              cp ../webpack-json/ocw-hugo-themes/((ocw-hugo-themes-branch))/webpack.json data
+              cp ../webpack-json/webpack.json data
               hugo --config ../ocw-hugo-projects/((config-slug))/config.yaml --baseUrl /((base-url)) --themesDir ../ocw-hugo-themes/
         on_failure:
           try:

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -161,8 +161,8 @@ jobs:
             args:
             - -exc
             - |
+              aws s3 sync s3://((ocw-studio-bucket))/((site-url)) s3://((ocw-bucket))/((site-url)) --metadata site-id=((site-name))              
               aws s3 sync course-markdown/public s3://((ocw-bucket))/((base-url)) --metadata site-id=((site-name))
-              aws s3 sync s3://((ocw-studio-bucket))/((site-url)) s3://((ocw-bucket))/((site-url)) --metadata site-id=((site-name))
         on_failure:
           try:
             put: ocw-studio-webhook

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -55,7 +55,7 @@ jobs:
                 "status": "started"
               }
       - get: webpack-json
-        trigger: true
+        trigger: false
         on_failure:
           try:
             put: ocw-studio-webhook
@@ -80,7 +80,7 @@ jobs:
                     "status": "errored"
                   }
       - get: ocw-hugo-projects
-        trigger: true
+        trigger: false
         timeout: 5m
         attempts: 3
         on_failure:

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -232,9 +232,12 @@ def publish_website_batch(
 ) -> bool:
     """ Call api.publish_website for a batch of websites"""
     result = True
-    pipeline_api = import_string(
-        f"content_sync.pipelines.{settings.CONTENT_SYNC_PIPELINE_BACKEND}.SitePipeline"
-    ).get_api()
+    if trigger_pipeline and settings.CONTENT_SYNC_PIPELINE_BACKEND:
+        pipeline_api = import_string(
+            f"content_sync.pipelines.{settings.CONTENT_SYNC_PIPELINE_BACKEND}.SitePipeline"
+        ).get_api()
+    else:
+        pipeline_api = None
     for name in website_names:
         try:
             backend = import_string(settings.CONTENT_SYNC_BACKEND)(

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -16,11 +16,8 @@ from content_sync.apis import github
 from content_sync.constants import VERSION_DRAFT, VERSION_LIVE
 from content_sync.decorators import single_task
 from content_sync.models import ContentSyncState
-from content_sync.pipelines.concourse import (
-    ConcourseGithubPipeline,
-    ThemeAssetsPipeline,
-)
 from main.celery import app
+from main.tasks import chord_finisher
 from websites.api import reset_publishing_fields, update_website_status
 from websites.constants import (
     PUBLISH_STATUS_ABORTED,
@@ -111,7 +108,7 @@ def upsert_website_publishing_pipeline(website_name: str):
         )
     else:
         pipeline = api.get_sync_pipeline(website)
-        pipeline.upsert_website_pipeline()
+        pipeline.upsert_pipeline()
 
 
 @app.task(acks_late=True)
@@ -131,11 +128,11 @@ def upsert_website_pipeline_batch(
         if not api_instance:
             # Keep using the same api instance to minimize multiple authentication calls
             api_instance = pipeline.api
-        pipeline.upsert_website_pipeline()
+        pipeline.upsert_pipeline()
         if unpause:
             for version in [
-                ConcourseGithubPipeline.VERSION_LIVE,
-                ConcourseGithubPipeline.VERSION_DRAFT,
+                VERSION_LIVE,
+                VERSION_DRAFT,
             ]:
                 pipeline.unpause_pipeline(version)
     return True
@@ -160,12 +157,22 @@ def upsert_pipelines(
 
 
 @app.task(acks_late=True)
-def upsert_theme_assets_pipeline(unpause=False):
+def upsert_theme_assets_pipeline(unpause=False) -> bool:
     """ Upsert the theme assets pipeline """
     pipeline = api.get_theme_assets_pipeline()
-    pipeline.upsert_theme_assets_pipeline()
+    pipeline.upsert_pipeline()
     if unpause:
-        pipeline.unpause_pipeline(ThemeAssetsPipeline.PIPELINE_NAME)
+        pipeline.unpause()
+    return True
+
+
+@app.task(acks_late=True)
+def trigger_mass_publish(version: str) -> bool:
+    """Trigger the mass publish pipeline for the specified version"""
+    if settings.CONTENT_SYNC_PIPELINE_BACKEND:
+        pipeline = api.get_mass_publish_pipeline(version)
+        pipeline.unpause()
+        pipeline.trigger()
     return True
 
 
@@ -218,11 +225,16 @@ def publish_website_backend_live(website_name: str):
 
 @app.task()
 def publish_website_batch(
-    website_names: List[str], version: str, prepublish: Optional[bool] = False
+    website_names: List[str],
+    version: str,
+    prepublish: Optional[bool] = False,
+    trigger_pipeline: Optional[bool] = True,
 ) -> bool:
     """ Call api.publish_website for a batch of websites"""
     result = True
-    pipeline_api = import_string(settings.CONTENT_SYNC_PIPELINE).get_api()
+    pipeline_api = import_string(
+        f"content_sync.pipelines.{settings.CONTENT_SYNC_PIPELINE_BACKEND}.SitePipeline"
+    ).get_api()
     for name in website_names:
         try:
             backend = import_string(settings.CONTENT_SYNC_BACKEND)(
@@ -234,6 +246,7 @@ def publish_website_batch(
                 version,
                 pipeline_api=pipeline_api,
                 prepublish=prepublish,
+                trigger_pipeline=trigger_pipeline,
             )
         except:  # pylint:disable=bare-except
             log.exception("Error publishing %s website %s", version, name)
@@ -250,14 +263,24 @@ def publish_websites(
     prepublish: Optional[bool] = False,
 ):
     """Publish live or draft versions of multiple websites in parallel batches"""
-    if not settings.CONTENT_SYNC_BACKEND or not settings.CONTENT_SYNC_PIPELINE:
+    if not settings.CONTENT_SYNC_BACKEND or not settings.CONTENT_SYNC_PIPELINE_BACKEND:
         return
-
-    tasks = [
-        publish_website_batch.s(name_subset, version, prepublish=prepublish)
+    no_mass_publish = api.get_mass_publish_pipeline(version) is None
+    site_tasks = [
+        publish_website_batch.s(
+            name_subset,
+            version,
+            prepublish=prepublish,
+            trigger_pipeline=no_mass_publish,
+        )
         for name_subset in chunks(sorted(website_names), chunk_size=chunk_size)
     ]
-    raise self.replace(celery.group(tasks))
+    site_steps = celery.chord(celery.group(site_tasks), chord_finisher.si())
+    pipeline_step = celery.group(
+        [] if no_mass_publish else [trigger_mass_publish.si(version)]
+    )
+    workflow = celery.chain(site_steps, pipeline_step)
+    raise self.replace(celery.group(workflow))
 
 
 @app.task(acks_late=True)
@@ -273,7 +296,7 @@ def check_incomplete_publish_build_statuses():
     """
     Check statuses of concourse builds that have not been updated in a reasonable amount of time
     """
-    if not settings.CONTENT_SYNC_PIPELINE:
+    if not settings.CONTENT_SYNC_PIPELINE_BACKEND:
         return
     now = now_in_utc()
     wait_dt = now - timedelta(seconds=settings.PUBLISH_STATUS_WAIT_TIME)

--- a/content_sync/tasks_test.py
+++ b/content_sync/tasks_test.py
@@ -12,7 +12,7 @@ from requests import HTTPError
 from content_sync import tasks
 from content_sync.constants import VERSION_DRAFT, VERSION_LIVE
 from content_sync.factories import ContentSyncStateFactory
-from content_sync.pipelines.concourse import ThemeAssetsPipeline
+from content_sync.pipelines.base import BaseMassPublishPipeline, BaseThemeAssetsPipeline
 from websites.constants import (
     PUBLISH_STATUS_ABORTED,
     PUBLISH_STATUS_ERRORED,
@@ -32,7 +32,7 @@ pytestmark = pytest.mark.django_db
 def api_mock(mocker, settings):
     """Return a mocked content_sync.tasks.api, and set the backend"""
     settings.CONTENT_SYNC_BACKEND = "content_sync.backends.TestBackend"
-    settings.CONTENT_SYNC_PIPELINE = "content_sync.pipelines.TestPipeline"
+    settings.CONTENT_SYNC_PIPELINE_BACKEND = "concourse"
     return mocker.patch("content_sync.tasks.api")
 
 
@@ -299,20 +299,25 @@ def test_upsert_pipelines(  # pylint:disable=too-many-arguments, unused-argument
 
 @pytest.mark.parametrize("unpause", [True, False])
 def test_upsert_theme_assets_pipeline(  # pylint:disable=unused-argument
-    mocker, mocked_celery, unpause
+    settings, mocker, mocked_celery, unpause
 ):
     """calls upsert_theme_assets_pipeline and unpauses if asked"""
-    mock_get_pipeline = mocker.patch("content_sync.tasks.api.get_theme_assets_pipeline")
+    settings.CONTENT_SYNC_PIPELINE_BACKEND = "concourse"
+    mocker.patch("content_sync.pipelines.concourse.BaseConcourseApi.auth")
+    mock_pipeline_unpause = mocker.patch(
+        "content_sync.pipelines.concourse.ThemeAssetsPipeline.unpause_pipeline"
+    )
+    mock_upsert_pipeline = mocker.patch(
+        "content_sync.pipelines.concourse.ThemeAssetsPipeline.upsert_pipeline",
+    )
     tasks.upsert_theme_assets_pipeline(unpause=unpause)
-    mock_get_pipeline.assert_called_once()
-    mock_pipeline = mock_get_pipeline.return_value
-    mock_pipeline.upsert_theme_assets_pipeline.assert_called_once()
+    mock_upsert_pipeline.assert_called_once()
     if unpause:
-        mock_pipeline.unpause_pipeline.assert_called_once_with(
-            ThemeAssetsPipeline.PIPELINE_NAME
+        mock_pipeline_unpause.assert_called_once_with(
+            BaseThemeAssetsPipeline.PIPELINE_NAME
         )
     else:
-        mock_pipeline.unpause_pipeline.assert_not_called()
+        mock_pipeline_unpause.assert_not_called()
 
 
 @pytest.mark.parametrize("create_backend", [True, False])
@@ -343,7 +348,7 @@ def test_upsert_website_pipeline_batch(
     else:
         mock_get_backend.assert_not_called()
     mock_pipeline = mock_get_pipeline.return_value
-    assert mock_pipeline.upsert_website_pipeline.call_count == 2
+    assert mock_pipeline.upsert_pipeline.call_count == 2
     if unpause:
         mock_pipeline.unpause_pipeline.assert_any_call(VERSION_DRAFT)
         mock_pipeline.unpause_pipeline.assert_any_call(VERSION_LIVE)
@@ -354,41 +359,68 @@ def test_upsert_website_pipeline_batch(
 @pytest.mark.parametrize("prepublish", [True, False])
 @pytest.mark.parametrize("version", [VERSION_DRAFT, VERSION_LIVE])
 @pytest.mark.parametrize("chunk_size, chunks", [[3, 1], [2, 2]])
+@pytest.mark.parametrize("has_mass_publish", [True, False])
 def test_publish_websites(  # pylint:disable=unused-argument,too-many-arguments
-    mocker, mocked_celery, api_mock, version, chunk_size, chunks, prepublish
+    mocker,
+    mocked_celery,
+    api_mock,
+    version,
+    chunk_size,
+    chunks,
+    prepublish,
+    has_mass_publish,
 ):
     """publish_websites calls upsert_pipeline_batch with correct arguments"""
     websites = WebsiteFactory.create_batch(3)
     website_names = sorted([website.name for website in websites])
     mock_batch = mocker.patch("content_sync.tasks.publish_website_batch.s")
+    mocker.patch(
+        "content_sync.tasks.api.get_mass_publish_pipeline",
+        return_value=(mocker.Mock() if has_mass_publish else None),
+    )
+    mock_mass_pub = mocker.patch("content_sync.tasks.trigger_mass_publish.si")
     with pytest.raises(TabError):
         tasks.publish_websites.delay(
             website_names, version, chunk_size=chunk_size, prepublish=prepublish
         )
     mock_batch.assert_any_call(
-        website_names[0:chunk_size], version, prepublish=prepublish
+        website_names[0:chunk_size],
+        version,
+        prepublish=prepublish,
+        trigger_pipeline=not has_mass_publish,
     )
     if chunks > 1:
         mock_batch.assert_any_call(
-            website_names[chunk_size:], version, prepublish=prepublish
+            website_names[chunk_size:],
+            version,
+            prepublish=prepublish,
+            trigger_pipeline=not has_mass_publish,
         )
+    if has_mass_publish:
+        mock_mass_pub.assert_called_once_with(version)
+    else:
+        mock_mass_pub.assert_not_called()
 
 
 @pytest.mark.parametrize("prepublish", [True, False])
+@pytest.mark.parametrize("trigger", [True, False])
 @pytest.mark.parametrize("version", [VERSION_DRAFT, VERSION_LIVE])
-def test_publish_website_batch(mocker, version, prepublish):
+def test_publish_website_batch(mocker, version, prepublish, trigger):
     """publish_website_batch should make the expected function calls"""
     mock_import_string = mocker.patch("content_sync.tasks.import_string")
     mock_publish_website = mocker.patch("content_sync.api.publish_website")
     mock_throttle = mocker.patch("content_sync.tasks.api.throttle_git_backend_calls")
     website_names = sorted([website.name for website in WebsiteFactory.create_batch(3)])
-    tasks.publish_website_batch(website_names, version, prepublish=prepublish)
+    tasks.publish_website_batch(
+        website_names, version, prepublish=prepublish, trigger_pipeline=trigger
+    )
     for name in website_names:
         mock_publish_website.assert_any_call(
             name,
             version,
             pipeline_api=mock_import_string.return_value.get_api.return_value,
             prepublish=prepublish,
+            trigger_pipeline=trigger,
         )
     assert mock_throttle.call_count == len(website_names)
 
@@ -401,9 +433,7 @@ def test_publish_website_batch(mocker, version, prepublish):
         [PUBLISH_STATUS_NOT_STARTED, PUBLISH_STATUS_NOT_STARTED, True, False],
     ],
 )
-@pytest.mark.parametrize(
-    "pipeline", [None, "content_sync.pipelines.concourse.ConcourseGithubPipeline"]
-)
+@pytest.mark.parametrize("pipeline", [None, "concourse"])
 def test_check_incomplete_publish_build_statuses(
     settings,
     mocker,
@@ -415,7 +445,7 @@ def test_check_incomplete_publish_build_statuses(
     pipeline,
 ):  # pylint:disable=too-many-arguments,too-many-locals
     """check_incomplete_publish_build_statuses should update statuses of pipeline builds"""
-    settings.CONTENT_SYNC_PIPELINE = pipeline
+    settings.CONTENT_SYNC_PIPELINE_BACKEND = pipeline
     mock_update_status = mocker.patch("content_sync.tasks.update_website_status")
     now = now_in_utc()
     draft_site_in_query = WebsiteFactory.create(
@@ -489,8 +519,8 @@ def test_check_incomplete_publish_build_statuses(
 
 
 def test_check_incomplete_publish_build_statuses_no_setting(settings, api_mock):
-    """Pipeline apis should not be called if settings.CONTENT_SYNC_PIPELINE is not set"""
-    settings.CONTENT_SYNC_PIPELINE = None
+    """Pipeline apis should not be called if settings.CONTENT_SYNC_PIPELINE_BACKEND is not set"""
+    settings.CONTENT_SYNC_PIPELINE_BACKEND = None
     stuck_website = WebsiteFactory.create(
         draft_publish_status_updated_on=now_in_utc()
         - timedelta(seconds=settings.PUBLISH_STATUS_CUTOFF + 5),
@@ -566,3 +596,25 @@ def test_check_incomplete_publish_build_statuses_500(settings, mocker, api_mock)
     )
     website.refresh_from_db()
     assert website.live_publish_status == PUBLISH_STATUS_NOT_STARTED
+
+
+@pytest.mark.parametrize("version", [VERSION_DRAFT, VERSION_LIVE])
+@pytest.mark.parametrize("backend", ["concourse", None])
+def test_trigger_mass_publish(settings, mocker, backend, version):
+    """trigger_mass_publish should call if enabled"""
+    settings.CONTENT_SYNC_PIPELINE_BACKEND = backend
+    mocker.patch("content_sync.pipelines.concourse.BaseConcourseApi.auth")
+    mock_pipeline_unpause = mocker.patch(
+        "content_sync.pipelines.concourse.ConcoursePipeline.unpause_pipeline"
+    )
+    mock_pipeline_trigger = mocker.patch(
+        "content_sync.pipelines.concourse.ConcoursePipeline.trigger_pipeline_build"
+    )
+    pipeline_name = BaseMassPublishPipeline.PIPELINE_NAME
+    tasks.trigger_mass_publish.delay(version)
+    if backend == "concourse":
+        mock_pipeline_unpause.assert_called_once_with(pipeline_name)
+        mock_pipeline_trigger.assert_called_once_with(pipeline_name)
+    else:
+        mock_pipeline_trigger.assert_not_called()
+        mock_pipeline_unpause.assert_not_called()

--- a/main/settings.py
+++ b/main/settings.py
@@ -805,16 +805,10 @@ CONTENT_SYNC_RETRIES = get_int(
     description="Number of times to retry backend sync attempts",
     required=False,
 )
-CONTENT_SYNC_PIPELINE = get_string(
-    name="CONTENT_SYNC_PIPELINE",
-    default=None,
-    description="The pipeline to preview/publish websites with",
-    required=False,
-)
-CONTENT_SYNC_THEME_PIPELINE = get_string(
-    name="CONTENT_SYNC_THEME_PIPELINE",
-    default=None,
-    description="The pipeline to publish theme assets",
+CONTENT_SYNC_PIPELINE_BACKEND = get_string(
+    name="CONTENT_SYNC_PIPELINE_BACKEND",
+    default="concourse",
+    description="The pipeline backend name to preview/publish websites with",
     required=False,
 )
 

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -24,11 +24,13 @@ from websites.serializers import (
     WebsiteContentDetailSerializer,
     WebsiteContentSerializer,
     WebsiteDetailSerializer,
+    WebsitePublishSerializer,
     WebsiteSerializer,
     WebsiteStarterDetailSerializer,
     WebsiteStarterSerializer,
     WebsiteStatusSerializer,
 )
+from websites.site_config_api import SiteConfig
 
 
 pytestmark = pytest.mark.django_db
@@ -483,4 +485,16 @@ def test_website_content_create_serializer(mocker, add_context_data):
     )
     assert content.filename == (
         "myfile" if not add_context_data else override_context_data["filename"]
+    )
+
+
+@pytest.mark.parametrize("is_root_site", [True, False])
+def test_website_publish_serializer_base_url(settings, is_root_site):
+    """ The WebsitePublishSerializer should return the correct base_url value """
+    site = WebsiteFactory.create()
+    site_config = SiteConfig(site.starter.config)
+    settings.ROOT_WEBSITE_NAME = site.name if is_root_site else "some_other_root_name"
+    serializer = WebsitePublishSerializer(site)
+    assert serializer.data["base_url"] == (
+        "" if is_root_site else f"{site_config.root_url_path}/{site.name}".strip("/")
     )

--- a/websites/urls.py
+++ b/websites/urls.py
@@ -12,6 +12,9 @@ router = SimpleRouter()
 website_route = router.register(
     r"websites", views.WebsiteViewSet, basename="websites_api"
 )
+publish_route = router.register(
+    r"publish", views.WebsitePublishViewSet, basename="publish_api"
+)
 website_route.register(
     r"collaborators",
     views.WebsiteCollaboratorViewSet,

--- a/websites/views.py
+++ b/websites/views.py
@@ -12,6 +12,7 @@ from guardian.shortcuts import get_groups_with_perms, get_objects_for_user
 from mitol.common.utils.datetime import now_in_utc
 from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action
+from rest_framework.exceptions import ValidationError
 from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 from rest_framework_extensions.mixins import NestedViewSetMixin
@@ -53,6 +54,7 @@ from websites.serializers import (
     WebsiteContentDetailSerializer,
     WebsiteContentSerializer,
     WebsiteDetailSerializer,
+    WebsitePublishSerializer,
     WebsiteSerializer,
     WebsiteStarterDetailSerializer,
     WebsiteStarterSerializer,
@@ -126,6 +128,8 @@ class WebsiteViewSet(
 
     def get_serializer_class(self):
         if self.action == "list":
+            if self.request.query_params.get("pipeline", None):
+                return WebsitePublishSerializer
             return WebsiteSerializer
         elif self.action == "create":
             return WebsiteWriteSerializer
@@ -204,6 +208,31 @@ class WebsiteViewSet(
         publish_status = data.get("status")
         update_website_status(website, version, publish_status, now_in_utc())
         return Response(status=200)
+
+
+class WebsitePublishViewSet(viewsets.ViewSet):
+    """Return a list of sites that should be published, with the info required by the pipeline"""
+
+    serializer_class = WebsitePublishSerializer
+    permission_classes = (BearerTokenPermission,)
+
+    def list(self, request):
+        """Return a list of websites that should be published, per version"""
+        version = self.request.query_params.get("version")
+        if version not in (VERSION_LIVE, VERSION_DRAFT):
+            raise ValidationError("Invalid version")
+
+        # Get all sites, minus any never-published sites created in studio (for specified version)
+        sites = (
+            Website.objects.exclude(
+                Q(**{f"{version}_publish_status": None})
+                & Q(**{"source": constants.WEBSITE_SOURCE_STUDIO})
+            )
+            .prefetch_related("starter")
+            .order_by("name")
+        )
+        serializer = WebsitePublishSerializer(instance=sites, many=True)
+        return Response({"sites": serializer.data})
 
 
 class WebsiteStarterViewSet(

--- a/websites/views.py
+++ b/websites/views.py
@@ -128,8 +128,6 @@ class WebsiteViewSet(
 
     def get_serializer_class(self):
         if self.action == "list":
-            if self.request.query_params.get("pipeline", None):
-                return WebsitePublishSerializer
             return WebsiteSerializer
         elif self.action == "create":
             return WebsiteWriteSerializer


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable


#### What's this PR do?
Closes #926

#### How should this be manually tested?
Start containers with `docker-compose --profile concourse up` (make sure you have the required settings values in .env as detailed in the README).
Run `manage.py upsert_mass_publish_pipeline`, it should work and there should be `mass-publish/version:live` and `mass-publish/version:draft` pipelines in concourse
Run `manage.py upsert_theme_assets_pipeline`, it should still work
Run `manage.py mass_publish <with optional filters> draft`, it should work, the publish statuses for the filtered sites should be set to 'not started', and there should be one job triggered for  "mass-publish/version:draft" 

Using curl or postman, you can go to `http://localhost:8043/api/publish/?version=<draft or live>` with an authorization header of `Bearer <settings.API_BEARER_TOKEN>` to see what sites are being supplied to the pipeline.

Create a new site, make some content, and publish.  There should be a pipeline created for it (live and draft) and the appropriate version-specific one should be triggered when you publish.

