### PR TITLE
No duplicate entries in ResourceCollection, CourseCollection

### DIFF
--- a/static/js/components/widgets/RelationField.test.tsx
+++ b/static/js/components/widgets/RelationField.test.tsx
@@ -107,8 +107,7 @@ describe("RelationField", () => {
       previous: null
     }
 
-    // @ts-ignore
-    global.fetch.mockResolvedValue({ json: async () => fakeResponse })
+    global.mockFetch.mockResolvedValue({ json: async () => fakeResponse })
     // @ts-ignore
     debouncedFetch.mockResolvedValue({ json: async () => fakeResponse })
 
@@ -125,8 +124,7 @@ describe("RelationField", () => {
 
     // @ts-ignore
     debouncedFetch.mockClear()
-    // @ts-ignore
-    global.fetch.mockClear()
+    global.mockFetch.mockClear()
     // @ts-ignore
     useWebsiteSelectOptions.mockReset()
   })
@@ -433,16 +431,14 @@ describe("RelationField", () => {
   })
 
   it("should display an error message ", async () => {
-    // @ts-ignore
-    global.fetch.mockClear()
+    global.mockFetch.mockClear()
     const fakeResponse = {
       results:  undefined,
       count:    0,
       next:     null,
       previous: null
     }
-    // @ts-ignore
-    global.fetch.mockResolvedValue({ json: async () => fakeResponse })
+    global.mockFetch.mockResolvedValue({ json: async () => fakeResponse })
     const { wrapper } = await render()
     wrapper.update()
     const error = wrapper.find(FormError)
@@ -465,6 +461,26 @@ describe("RelationField", () => {
           title: id
         }))
       )
+    })
+
+    it("should disable already-selected options", async () => {
+      const value = contentListingItems.slice(3).map(item => item.text_id)
+      const options = contentListingItems.map(item => ({
+        value: item.text_id,
+        label: item.title ?? "title"
+      }))
+      const { wrapper } = await render({
+        multiple: true,
+        sortable: true,
+        value
+      })
+
+      const isOptionEnabled = wrapper
+        .find(SortableSelect)
+        .prop("isOptionDisabled")!
+      expect(isOptionEnabled).toBeDefined()
+      const expected = [false, false, false, ...Array(7).fill(true)]
+      expect(options.map(isOptionEnabled)).toEqual(expected)
     })
   })
 })

--- a/static/js/components/widgets/RelationField.tsx
+++ b/static/js/components/widgets/RelationField.tsx
@@ -1,4 +1,10 @@
-import React, { ChangeEvent, useCallback, useEffect, useState } from "react"
+import React, {
+  ChangeEvent,
+  useCallback,
+  useEffect,
+  useState,
+  useMemo
+} from "react"
 import { equals } from "ramda"
 import { uniqBy } from "lodash"
 
@@ -111,7 +117,7 @@ export default function RelationField(props: Props): JSX.Element {
   const {
     options: websiteOptions,
     loadOptions: loadWebsiteOptions
-  } = useWebsiteSelectOptions("name", crossSite ?? false)
+  } = useWebsiteSelectOptions("name")
   const [focusedWebsite, setFocusedWebsite] = useState<string | null>(null)
   const setFocusedWebsiteCB = useCallback(
     (event: ChangeEvent<HTMLSelectElement>) => {
@@ -318,6 +324,23 @@ export default function RelationField(props: Props): JSX.Element {
     [onChangeShim]
   )
 
+  const selectedIds = useMemo(
+    () =>
+      crossSite ?
+        (value as CrossSitePair[]).map(pair => pair[0]) :
+        multiple ?
+          (value as string[]) :
+          [value as string],
+    [multiple, value, crossSite]
+  )
+
+  const isOptionDisabled = useCallback(
+    (option: Option) => {
+      return selectedIds.includes(option.value)
+    },
+    [selectedIds]
+  )
+
   return (
     <>
       {crossSite ? (
@@ -338,10 +361,8 @@ export default function RelationField(props: Props): JSX.Element {
           options={options}
           loadOptions={loadOptions}
           defaultOptions={defaultOptions}
-          value={(crossSite ?
-            (value as CrossSitePair[]).map(pair => pair[0]) :
-            (value as string[])
-          ).map(id => {
+          isOptionDisabled={isOptionDisabled}
+          value={selectedIds.map(id => {
             const content = contentMap.get(id)
             const title = content ? content.title ?? id : id
 
@@ -354,7 +375,7 @@ export default function RelationField(props: Props): JSX.Element {
       ) : (
         <SelectField
           name={name}
-          value={value}
+          value={value as string | string[]}
           onChange={handleChange}
           options={options}
           loadOptions={loadOptions}

--- a/static/js/components/widgets/SelectField.test.tsx
+++ b/static/js/components/widgets/SelectField.test.tsx
@@ -32,7 +32,7 @@ describe("SelectField", () => {
     sandbox.restore()
   })
 
-  const render = (props: any) =>
+  const render = (props: any = {}) =>
     mount(
       <SelectField
         onChange={onChangeStub}
@@ -59,6 +59,20 @@ describe("SelectField", () => {
       loadOptions:    () => null
     })
     expect(wrapper.find(AsyncSelect).prop("defaultOptions")).toBe("options")
+  })
+
+  it("should pass isOptionDisabled down to the Select", async () => {
+    const isOptionDisabled = jest.fn()
+    const wrapper = await render({ isOptionDisabled })
+    expect(wrapper.find(Select).prop("isOptionDisabled")).toBe(isOptionDisabled)
+  })
+
+  it("should pass isOptionDisabled down to the Async Select", async () => {
+    const isOptionDisabled = jest.fn()
+    const wrapper = await render({ isOptionDisabled, loadOptions: jest.fn() })
+    expect(wrapper.find(AsyncSelect).prop("isOptionDisabled")).toBe(
+      isOptionDisabled
+    )
   })
 
   it("should use AsyncSelect if a loadOptions callback is supplied", () => {

--- a/static/js/components/widgets/SelectField.tsx
+++ b/static/js/components/widgets/SelectField.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, ChangeEvent } from "react"
 import Select from "react-select"
 import AsyncSelect from "react-select/async"
-import { is, isNil } from "ramda"
+import { isNil } from "ramda"
 
 export interface Option {
   label: string
@@ -10,13 +10,14 @@ export interface Option {
 
 interface Props {
   name: string
-  value: any
+  value: null | undefined | string | string[]
   onChange: (event: ChangeEvent<HTMLSelectElement>) => void
   multiple?: boolean
   options: Array<string | Option>
   loadOptions?: (s: string, cb: (options: Option[]) => void) => void
   placeholder?: string
   defaultOptions?: Option[]
+  isOptionDisabled?: (option: Option) => boolean
 }
 
 export default function SelectField(props: Props): JSX.Element {
@@ -27,11 +28,12 @@ export default function SelectField(props: Props): JSX.Element {
     options,
     loadOptions,
     defaultOptions,
-    placeholder
+    placeholder,
+    isOptionDisabled
   } = props
   const multiple = props.multiple ?? false
-  const selectOptions = options.map((option: any) =>
-    is(String, option) ? { label: option, value: option } : option
+  const selectOptions = options.map(option =>
+    typeof option === "string" ? { label: option, value: option } : option
   )
 
   const changeHandler = useCallback(
@@ -66,6 +68,9 @@ export default function SelectField(props: Props): JSX.Element {
       selected = value.map(option => getSelectOption(option))
     }
   } else {
+    if (Array.isArray(value)) {
+      throw new Error("Array values should specify multiple=true")
+    }
     selected = isNil(value) ? null : getSelectOption(value)
   }
 
@@ -82,7 +87,8 @@ export default function SelectField(props: Props): JSX.Element {
         border:    0,
         boxShadow: "none"
       })
-    }
+    },
+    isOptionDisabled
   }
 
   return loadOptions ? (

--- a/static/js/components/widgets/SortableSelect.test.tsx
+++ b/static/js/components/widgets/SortableSelect.test.tsx
@@ -10,6 +10,7 @@ import { Option } from "./SelectField"
 import { zip } from "ramda"
 import { default as SortableItemComponent } from "../SortableItem"
 import { triggerSortableSelect } from "./test_util"
+import SelectField from "./SelectField"
 
 const createFakeOptions = (times: number): Option[] =>
   Array(times)
@@ -49,6 +50,14 @@ describe("SortableSelect", () => {
   it("should pass options down to the SelectField", async () => {
     const { wrapper } = await render()
     expect(wrapper.find("SelectField").prop("options")).toStrictEqual(options)
+  })
+
+  it("should pass isOptionDisabled down to the SelectField", async () => {
+    const isOptionDisabled = jest.fn()
+    const { wrapper } = await render({ isOptionDisabled })
+    expect(wrapper.find(SelectField).prop("isOptionDisabled")).toBe(
+      isOptionDisabled
+    )
   })
 
   it("should render sortable items for the current value", async () => {

--- a/static/js/components/widgets/SortableSelect.tsx
+++ b/static/js/components/widgets/SortableSelect.tsx
@@ -28,10 +28,19 @@ interface Props {
     inputValue: string,
     callback: (options: Option[]) => void
   ) => void
+  isOptionDisabled?: (option: Option) => boolean
 }
 
 export default function SortableSelect(props: Props) {
-  const { options, loadOptions, defaultOptions, value, onChange, name } = props
+  const {
+    options,
+    loadOptions,
+    defaultOptions,
+    value,
+    onChange,
+    name,
+    isOptionDisabled
+  } = props
 
   const [focusedContent, setFocusedContent] = useState<string | undefined>(
     undefined
@@ -101,6 +110,7 @@ export default function SortableSelect(props: Props) {
           options={options}
           loadOptions={loadOptions}
           defaultOptions={defaultOptions}
+          isOptionDisabled={isOptionDisabled}
         />
         <button
           className="px-4 ml-3 btn cyan-button"

--- a/static/js/components/widgets/WebsiteCollectionField.test.tsx
+++ b/static/js/components/widgets/WebsiteCollectionField.test.tsx
@@ -11,6 +11,7 @@ import { Website } from "../../types/websites"
 import { makeWebsiteListing } from "../../util/factories/websites"
 import { triggerSortableSelect } from "./test_util"
 import { Option } from "./SelectField"
+import SortableSelect from "./SortableSelect"
 
 jest.mock("../../hooks/websites", () => ({
   ...jest.requireActual("../../hooks/websites"),
@@ -47,7 +48,7 @@ describe("WebsiteCollectionField", () => {
 
   it("should pass published=true to the useWebsiteSelectOptions", async () => {
     await render()
-    expect(useWebsiteSelectOptions).toBeCalledWith("name", true, true)
+    expect(useWebsiteSelectOptions).toBeCalledWith("name", true)
   })
 
   it("should pass things down to SortableSelect", async () => {
@@ -59,7 +60,7 @@ describe("WebsiteCollectionField", () => {
     const { wrapper } = await render({
       value
     })
-    const sortableSelect = wrapper.find("SortableSelect")
+    const sortableSelect = wrapper.find(SortableSelect)
     expect(sortableSelect.prop("value")).toStrictEqual(value)
     expect(sortableSelect.prop("options")).toStrictEqual(websiteOptions)
     expect(sortableSelect.prop("defaultOptions")).toStrictEqual(websiteOptions)
@@ -68,7 +69,7 @@ describe("WebsiteCollectionField", () => {
   it("should let the user add a website, with UUID and title", async () => {
     const { wrapper } = await render()
     wrapper.update()
-    await triggerSortableSelect(wrapper, [websites[0].name])
+    await triggerSortableSelect(wrapper, websites[0].name)
     expect(onChange).toBeCalledWith({
       target: {
         name:  "test-site-collection",
@@ -80,5 +81,20 @@ describe("WebsiteCollectionField", () => {
         ]
       }
     })
+  })
+
+  it("should disable website options that have already been selected", async () => {
+    expect(websites.length).toBeGreaterThan(2)
+    const value = websites.slice(2).map(website => ({
+      id:    website.name,
+      title: website.title
+    }))
+    const { wrapper } = await render({ value })
+    const isOptionEnabled = wrapper
+      .find(SortableSelect)
+      .prop("isOptionDisabled")!
+    expect(isOptionEnabled).toBeDefined()
+    const expected = [false, false, ...Array(8).fill(true)]
+    expect(websiteOptions.map(isOptionEnabled)).toEqual(expected)
   })
 })

--- a/static/js/components/widgets/WebsiteCollectionField.tsx
+++ b/static/js/components/widgets/WebsiteCollectionField.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from "react"
 
 import SortableSelect, { SortableItem } from "./SortableSelect"
+import { Option } from "./SelectField"
 import { useWebsiteSelectOptions } from "../../hooks/websites"
 
 interface Props {
@@ -35,7 +36,7 @@ export default function WebsiteCollectionField(props: Props): JSX.Element {
     [onChange, websiteMap, name]
   )
 
-  const { options, loadOptions } = useWebsiteSelectOptions("name", true, true)
+  const { options, loadOptions } = useWebsiteSelectOptions("name", true)
 
   useEffect(() => {
     setWebsiteMap(cur => {
@@ -47,6 +48,13 @@ export default function WebsiteCollectionField(props: Props): JSX.Element {
     })
   }, [options, setWebsiteMap])
 
+  const isOptionDisabled = useCallback(
+    (option: Option) => {
+      return value.some(v => v.id === option.value)
+    },
+    [value]
+  )
+
   return (
     <SortableSelect
       name={name}
@@ -55,6 +63,7 @@ export default function WebsiteCollectionField(props: Props): JSX.Element {
       options={options}
       defaultOptions={options}
       loadOptions={loadOptions}
+      isOptionDisabled={isOptionDisabled}
     />
   )
 }

--- a/static/js/hooks/websites.test.ts
+++ b/static/js/hooks/websites.test.ts
@@ -21,8 +21,7 @@ describe("website hooks", () => {
       debouncedFetch.mockReturnValue({
         json: () => ({ results: websites })
       })
-      // @ts-ignore
-      global.fetch.mockReturnValue({
+      global.mockFetch.mockReturnValue({
         json: () => ({ results: websites })
       })
     })
@@ -49,18 +48,13 @@ describe("website hooks", () => {
       )
     })
 
-    it("should skip fetching options on startup if argument set", async () => {
-      renderHook(() => useWebsiteSelectOptions("uuid", false))
-      expect(debouncedFetch).toBeCalledTimes(0)
-    })
-
     //
     ;[true, false].forEach(published => {
       it(`should set published=${String(
         published
       )} if you pass the option`, async () => {
         const { waitForNextUpdate } = renderHook(() =>
-          useWebsiteSelectOptions("uuid", true, published)
+          useWebsiteSelectOptions("uuid", published)
         )
         await act(async () => {
           await waitForNextUpdate()

--- a/static/js/hooks/websites.ts
+++ b/static/js/hooks/websites.ts
@@ -79,7 +79,6 @@ interface ReturnProps {
  */
 export function useWebsiteSelectOptions(
   valueField = "uuid",
-  fetchOnStartup = true,
   published: boolean | undefined = undefined
 ): ReturnProps {
   const [options, setOptions] = useState<Option[]>([])
@@ -126,7 +125,7 @@ export function useWebsiteSelectOptions(
   // be set on SelectField components which consume the output from this hook
   useEffect(() => {
     let mounted = true
-    if (mounted && fetchOnStartup) {
+    if (mounted) {
       loadOptions("")
     }
     return () => {

--- a/static/js/lib/api/util.test.ts
+++ b/static/js/lib/api/util.test.ts
@@ -22,16 +22,32 @@ describe("api utility functions", () => {
   })
 
   it("debounces and fetches", async () => {
+    global.fetch = jest.fn()
+
     await Promise.all([
       debouncedFetch("key", 30, "url1", { credentials: "include" }),
       debouncedFetch("key", 30, "url2", { credentials: "omit" }),
-      debouncedFetch("key", 30, "url3", { credentials: "same-origin" })
+      debouncedFetch("key", 30, "url3", { credentials: "same-origin" }),
+      debouncedFetch("key", 30, "url3", { credentials: "omit" })
     ])
 
     expect(global.fetch).toBeCalledTimes(1)
     // only the last set of arguments should be passed to fetch
     expect(global.fetch).toHaveBeenCalledWith("url3", {
-      credentials: "same-origin"
+      credentials: "omit"
     })
+  })
+
+  it("resolves the most recent call to fetch result", async () => {
+    global.mockFetch.mockResolvedValue("meow")
+
+    const results = await Promise.all([
+      debouncedFetch("key", 30, "url1", { credentials: "include" }),
+      debouncedFetch("key", 30, "url2", { credentials: "omit" }),
+      debouncedFetch("key", 30, "url3", { credentials: "same-origin" }),
+      debouncedFetch("key", 30, "url3", { credentials: "omit" })
+    ])
+
+    expect(results).toEqual([null, null, null, "meow"])
   })
 })

--- a/static/js/lib/api/util.ts
+++ b/static/js/lib/api/util.ts
@@ -66,10 +66,11 @@ export const debouncedFetch = async (
   init: RequestInit
 ): Promise<Response | null> => {
   // if the function gets called multiple times, store the latest version of the args
-  latestDebouncedFetchArgs[key] = [info, init]
+  const args: [RequestInfo, RequestInit] = [info, init]
+  latestDebouncedFetchArgs[key] = args
   await sharedWait(key, delayMillis)
   const latestArgs = latestDebouncedFetchArgs[key]
-  if (latestArgs && latestArgs[0] !== info) {
+  if (latestArgs && latestArgs !== args) {
     return null
   }
   delete latestDebouncedFetchArgs[key]

--- a/static/js/test_setup.ts
+++ b/static/js/test_setup.ts
@@ -27,8 +27,19 @@ global.SETTINGS = _createSettings()
 global._testing = true
 
 beforeEach(() => {
-  global.fetch = jest.fn()
+  /**
+   * We can't make ts aware that global.fetch is always a mock (the best we
+   * could do is merge the mock + native declarations). So instead add a
+   * separate mockFetch property and tell ts that it is always a mock.
+   */
+  global.mockFetch = jest.fn()
+  global.fetch = global.mockFetch
 })
+
+declare global {
+  // eslint-disable-next-line no-var
+  var mockFetch: jest.Mock<any, Parameters<typeof fetch>>
+}
 
 // cleanup after each test run
 // eslint-disable-next-line mocha/no-top-level-hooks


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets? #395

#### What's this PR do?
Disables already-selected values in Relation and WebsiteCollection fields.  

#### How should this be manually tested?
Check that allowed in
- resource collections
- video galleries
- website collections

Any other Relation/WebsiteCollection fields you can think of. (_Aside: Duplicate entries were already filtered out in RelationFields with multi-true, since that seems to be the default behavior of react-select in the multi scenario._)

#### Screenshots (if appropriate)
<img width="547" alt="Screen Shot 2022-02-01 at 2 08 42 PM" src="https://user-images.githubusercontent.com/9010790/152038831-3bf2de45-2074-4298-b3bf-0546f648ba80.png">
