### PR TITLE
small rename of two functions for clarity

### DIFF
--- a/static/js/components/widgets/RelationField.test.tsx
+++ b/static/js/components/widgets/RelationField.test.tsx
@@ -26,7 +26,10 @@ import {
 } from "../../types/websites"
 import { ReactWrapper } from "enzyme"
 import { FormError } from "../forms/FormError"
-import { formatOptions, useWebsiteSelectOptions } from "../../hooks/websites"
+import {
+  formatWebsiteOptions,
+  useWebsiteSelectOptions
+} from "../../hooks/websites"
 import SortableSelect from "./SortableSelect"
 
 jest.mock("../../lib/api/util", () => ({
@@ -112,7 +115,7 @@ describe("RelationField", () => {
     websites = makeWebsiteListing()
     // @ts-ignore
     useWebsiteSelectOptions.mockReturnValue({
-      options:     formatOptions(websites, "name"),
+      options:     formatWebsiteOptions(websites, "name"),
       loadOptions: jest.fn()
     })
   })
@@ -204,7 +207,7 @@ describe("RelationField", () => {
           .find("SelectField")
           .at(0)
           .prop("defaultOptions")
-      ).toEqual(formatOptions(websites, "name"))
+      ).toEqual(formatWebsiteOptions(websites, "name"))
     })
 
     it("should let the user pick a website and then content within that website", async () => {

--- a/static/js/components/widgets/RelationField.tsx
+++ b/static/js/components/widgets/RelationField.tsx
@@ -40,7 +40,7 @@ interface Props {
  * Turn a list of WebsiteContent objects into a list of Options, suitable
  * for use in a SelectField.
  */
-const formatOptions = (
+const formatContentOptions = (
   listing: WebsiteContent[],
   display_field: string // eslint-disable-line camelcase
 ): Option[] =>
@@ -65,7 +65,7 @@ export default function RelationField(props: Props): JSX.Element {
   } = props
 
   const [options, setOptions] = useState<Option[]>(
-    contentContext ? formatOptions(contentContext, display_field) : []
+    contentContext ? formatContentOptions(contentContext, display_field) : []
   )
   const [defaultOptions, setDefaultOptions] = useState<Option[]>([])
   const [contentMap, setContentMap] = useState<Map<string, WebsiteContent>>(
@@ -215,7 +215,10 @@ export default function RelationField(props: Props): JSX.Element {
           })
         }
         setFetchStatus(FetchStatus.Ok)
-        return formatOptions(filterContentListing(results), display_field)
+        return formatContentOptions(
+          filterContentListing(results),
+          display_field
+        )
       } else {
         // there was some error fetching the results
         setFetchStatus(FetchStatus.Error)

--- a/static/js/components/widgets/WebsiteCollectionField.test.tsx
+++ b/static/js/components/widgets/WebsiteCollectionField.test.tsx
@@ -3,7 +3,10 @@ import IntegrationTestHelper, {
 } from "../../util/integration_test_helper"
 import WebsiteCollectionField from "./WebsiteCollectionField"
 
-import { formatOptions, useWebsiteSelectOptions } from "../../hooks/websites"
+import {
+  formatWebsiteOptions,
+  useWebsiteSelectOptions
+} from "../../hooks/websites"
 import { Website } from "../../types/websites"
 import { makeWebsiteListing } from "../../util/factories/websites"
 import { triggerSortableSelect } from "./test_util"
@@ -30,7 +33,7 @@ describe("WebsiteCollectionField", () => {
       value: []
     })
     websites = makeWebsiteListing()
-    websiteOptions = formatOptions(websites, "name")
+    websiteOptions = formatWebsiteOptions(websites, "name")
     // @ts-ignore
     useWebsiteSelectOptions.mockReturnValue({
       options:     websiteOptions,

--- a/static/js/hooks/websites.test.ts
+++ b/static/js/hooks/websites.test.ts
@@ -2,7 +2,7 @@ import { act, renderHook } from "@testing-library/react-hooks"
 
 import { Website } from "../types/websites"
 import { makeWebsiteListing } from "../util/factories/websites"
-import { formatOptions, useWebsiteSelectOptions } from "./websites"
+import { formatWebsiteOptions, useWebsiteSelectOptions } from "./websites"
 import { debouncedFetch } from "../lib/api/util"
 import { siteApiListingUrl } from "../lib/urls"
 
@@ -44,7 +44,9 @@ describe("website hooks", () => {
           .toString(),
         { credentials: "include" }
       )
-      expect(result.current.options).toEqual(formatOptions(websites, "uuid"))
+      expect(result.current.options).toEqual(
+        formatWebsiteOptions(websites, "uuid")
+      )
     })
 
     it("should skip fetching options on startup if argument set", async () => {
@@ -90,7 +92,7 @@ describe("website hooks", () => {
           .toString(),
         { credentials: "include" }
       )
-      expect(cb).toBeCalledWith(formatOptions(websites, "uuid"))
+      expect(cb).toBeCalledWith(formatWebsiteOptions(websites, "uuid"))
     })
   })
 })

--- a/static/js/hooks/websites.ts
+++ b/static/js/hooks/websites.ts
@@ -44,7 +44,14 @@ export function useWebsiteContent(uuid: string): WebsiteContent | null {
   return resource
 }
 
-export const formatOptions = (
+/**
+ * Format an array of Website objects into an array of Option
+ * objects, which can be passed to a Select field.
+ *
+ * The `valueField` argument indicates what field on the Website
+ * you'd like to use for a user-readable label.
+ */
+export const formatWebsiteOptions = (
   websites: Website[],
   valueField: string
 ): Option[] =>
@@ -104,7 +111,7 @@ export function useWebsiteSelectOptions(
       }
       const json: WebsiteListingResponse = await response.json()
       const { results } = json
-      const options = formatOptions(results, valueField)
+      const options = formatWebsiteOptions(results, valueField)
       setOptions(current =>
         uniqBy(option => option.value, [...current, ...options])
       )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

no ticket

#### What's this PR do?

Just noticed while reviewing #951 that we had two functions named `formatOptions` hanging around in the frontend codebase, so I thought I'd go ahead and rename them to be more specific about what they do.

#### How should this be manually tested?

test should pass, select fields and whatnot should work.
