### PR TITLE
fix up eslint camelcase rule disables

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,6 +20,12 @@ module.exports = {
       "error",
       { argsIgnorePattern: "_" }
     ],
-    "mocha/no-top-level-hooks": "off"
+    "mocha/no-top-level-hooks": "off",
+    "camelcase": [
+      "error",
+      {
+        "properties": "never"
+      }
+    ]
   }
 }

--- a/static/js/components/widgets/HierarchicalSelectField.tsx
+++ b/static/js/components/widgets/HierarchicalSelectField.tsx
@@ -14,7 +14,7 @@ type HierarchicalSelection = Array<string | null>
 
 type Props = {
   name: string
-  levels: Level[] // eslint-disable-line camelcase
+  levels: Level[]
   value: HierarchicalSelection[] | null
   onChange: (event: any) => void
   options_map: OptionsMap // eslint-disable-line camelcase

--- a/static/js/components/widgets/RelationField.tsx
+++ b/static/js/components/widgets/RelationField.tsx
@@ -27,10 +27,11 @@ import SortableSelect from "./SortableSelect"
 // the first string is the content UUID, and the second is the website UUID
 type CrossSitePair = [string, string]
 
+/* eslint-disable camelcase */
 interface Props {
   name: string
   collection?: string | string[]
-  display_field: string // eslint-disable-line camelcase
+  display_field: string
   multiple: boolean
   value: string | string[] | CrossSitePair[]
   filter?: RelationFilter
@@ -39,8 +40,9 @@ interface Props {
   sortable?: boolean
   contentContext: WebsiteContent[] | null
   onChange: (event: any) => void
-  cross_site?: boolean // eslint-disable-line camelcase
+  cross_site?: boolean
 }
+/* eslint-enable camelcase */
 
 /**
  * Turn a list of WebsiteContent objects into a list of Options, suitable
@@ -48,10 +50,10 @@ interface Props {
  */
 const formatContentOptions = (
   listing: WebsiteContent[],
-  display_field: string // eslint-disable-line camelcase
+  displayField: string
 ): Option[] =>
   listing.map(entry => ({
-    label: entry[display_field],
+    label: entry[displayField],
     value: entry.text_id
   }))
 
@@ -59,7 +61,7 @@ export default function RelationField(props: Props): JSX.Element {
   const {
     collection,
     contentContext,
-    display_field, // eslint-disable-line camelcase
+    display_field: displayField,
     name,
     multiple,
     value,
@@ -67,11 +69,11 @@ export default function RelationField(props: Props): JSX.Element {
     valuesToOmit,
     onChange,
     sortable,
-    cross_site: crossSite // eslint-disable-line camelcase
+    cross_site: crossSite
   } = props
 
   const [options, setOptions] = useState<Option[]>(
-    contentContext ? formatContentOptions(contentContext, display_field) : []
+    contentContext ? formatContentOptions(contentContext, displayField) : []
   )
   const [defaultOptions, setDefaultOptions] = useState<Option[]>([])
   const [contentMap, setContentMap] = useState<Map<string, WebsiteContent>>(
@@ -221,10 +223,7 @@ export default function RelationField(props: Props): JSX.Element {
           })
         }
         setFetchStatus(FetchStatus.Ok)
-        return formatContentOptions(
-          filterContentListing(results),
-          display_field
-        )
+        return formatContentOptions(filterContentListing(results), displayField)
       } else {
         // there was some error fetching the results
         setFetchStatus(FetchStatus.Error)
@@ -235,8 +234,7 @@ export default function RelationField(props: Props): JSX.Element {
       setFetchStatus,
       filterContentListing,
       websiteName,
-      // eslint-disable-next-line camelcase
-      display_field,
+      displayField,
       collection,
       filter,
       focusedWebsite,

--- a/static/js/types/globals.d.ts
+++ b/static/js/types/globals.d.ts
@@ -1,5 +1,5 @@
 /* eslint-disable */
-//
+
 interface SETTINGS {
   reactGaDebug: string;
   gaTrackingID: string;

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import {
   GoogleDriveSyncStatuses,
   PublishStatus,
@@ -92,7 +93,7 @@ export interface ObjectConfigField extends ConfigFieldBaseProps {
 
 export interface HierarchicalSelectConfigField extends ConfigFieldBaseProps {
   widget: WidgetVariant.HierarchicalSelect
-  options_map: Record<string, any> // eslint-disable-line camelcase
+  options_map: Record<string, any>
   min?: number
   max?: number
 }
@@ -115,21 +116,21 @@ export enum RelationFilterVariant {
  **/
 export interface RelationFilter {
   field: string
-  filter_type: RelationFilterVariant // eslint-disable-line camelcase
+  filter_type: RelationFilterVariant
   value: SiteFormValue
 }
 
 export interface RelationConfigField extends ConfigFieldBaseProps {
   widget: WidgetVariant.Relation
   collection: string
-  display_field: string // eslint-disable-line camelcase
+  display_field: string
   multiple?: boolean
   min?: number
   max?: number
   filter?: RelationFilter
   website?: string
   sortable?: boolean
-  cross_site?: boolean // eslint-disable-line camelcase
+  cross_site?: boolean
 }
 
 export interface MenuConfigField extends ConfigFieldBaseProps {
@@ -159,7 +160,6 @@ export type ConfigField =
 export interface BaseConfigItem {
   name: string
   label: string
-  // eslint-disable-next-line camelcase
   label_singular?: string
 }
 
@@ -186,7 +186,6 @@ export type EditableConfigItem = RepeatableConfigItem | SingletonConfigItem
 export interface ConfigItem {
   name: string
   label: string
-  // eslint-disable-next-line
   label_singular?: string
   category: string
   fields: ConfigField[]
@@ -211,7 +210,7 @@ export interface WebsiteStarter {
 
 export interface NewWebsitePayload {
   title: string
-  short_id: string // eslint-disable-line
+  short_id: string
   starter: number
 }
 
@@ -219,44 +218,44 @@ export interface WebsiteStatus {
   uuid: string
   name: string
   /** ISO 8601 datetime string or null */
-  publish_date: string | null // eslint-disable-line
+  publish_date: string | null
   /** ISO 8601 datetime string or null */
-  draft_publish_date: string | null // eslint-disable-line
-  has_unpublished_draft: boolean // eslint-disable-line
-  has_unpublished_live: boolean // eslint-disable-line
-  live_publish_status: PublishStatus | null // eslint-disable-line
-  live_publish_status_updated_on: string | null // eslint-disable-line
-  draft_publish_status: PublishStatus | null // eslint-disable-line
-  draft_publish_status_updated_on: string | null // eslint-disable-line
-  sync_status: GoogleDriveSyncStatuses | null // eslint-disable-line
-  synced_on: string | null // eslint-disable-line
-  sync_errors: Array<string> | null // eslint-disable-line
+  draft_publish_date: string | null
+  has_unpublished_draft: boolean
+  has_unpublished_live: boolean
+  live_publish_status: PublishStatus | null
+  live_publish_status_updated_on: string | null
+  draft_publish_status: PublishStatus | null
+  draft_publish_status_updated_on: string | null
+  sync_status: GoogleDriveSyncStatuses | null
+  synced_on: string | null
+  sync_errors: Array<string> | null
 }
 
 export type Website = WebsiteStatus & {
   uuid: string
-  created_on: string // eslint-disable-line
-  updated_on: string // eslint-disable-line
+  created_on: string
+  updated_on: string
   name: string
   title: string
-  short_id: string // eslint-disable-line
+  short_id: string
   source: string | null
   starter: WebsiteStarter | null
   metadata?: any
-  is_admin?: boolean // eslint-disable-line
-  draft_url: string // eslint-disable-line
-  live_url: string // eslint-disable-line
-  gdrive_url: string | null // eslint-disable-line
-  has_unpublished_draft: boolean // eslint-disable-line
-  has_unpublished_live: boolean // eslint-disable-line
-  content_warnings?: Array<string> // eslint-disable-line
+  is_admin?: boolean
+  draft_url: string
+  live_url: string
+  gdrive_url: string | null
+  has_unpublished_draft: boolean
+  has_unpublished_live: boolean
+  content_warnings?: Array<string>
 }
 
 type WebsiteRoleEditable = typeof ROLE_ADMIN | typeof ROLE_EDITOR
 type WebsiteRole = typeof ROLE_GLOBAL | typeof ROLE_OWNER | WebsiteRoleEditable
 
 export interface WebsiteCollaborator {
-  user_id: number // eslint-disable-line
+  user_id: number
   role: WebsiteRole
   email: string
   name: string
@@ -268,17 +267,17 @@ export interface WebsiteCollaboratorFormData {
 }
 
 export interface WebsiteContentListItem {
-  text_id: string // eslint-disable-line
+  text_id: string
   title: string | null
   type: string
   /** ISO 8601 formatted datetime string */
-  updated_on: string // eslint-disable-line camelcase
+  updated_on: string
 }
 
 export interface WebsiteContent extends WebsiteContentListItem {
   markdown: string | null
   metadata: null | Record<string, SiteFormValue>
-  content_context: WebsiteContent[] | null // eslint-disable-line camelcase
+  content_context: WebsiteContent[] | null
   file?: string
 }
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

none

#### What's this PR do?

Just a little neatness thing. For `types/websites.ts` we're declaring the values we're getting from the backend, so we're stuck with camelcase stuff there. I went ahead and disabled the `camelcase` rule for the whole file, so we don't have to have a whole bunch of per-line disables.

Then I also made a few small changes to the `RelationField` widget to improve the situation a bit.

#### How should this be manually tested?

tests should pass, etc.