### PR TITLE
add webpack-json as an input to the build-course-task pipeline step

### DIFF
--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -26,6 +26,8 @@ resources:
     source:
       uri: ((ocw-hugo-projects-uri))
       branch: ((ocw-hugo-projects-branch))
+      paths:
+        - ((ocw-import-starter-slug))/config.yaml
   - name: ocw-studio-webhook
     type: http-resource
     source:
@@ -118,6 +120,7 @@ jobs:
             - name: ocw-hugo-themes
             - name: course-markdown
             - name: ocw-hugo-projects
+            - name: webpack-json
           outputs:
             - name: course-markdown
             - name: ocw-hugo-themes

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -130,7 +130,7 @@ jobs:
             args:
             - -exc
             - |
-              cp ../webpack-json/webpack.json data
+              cp ../webpack-json/ocw-hugo-themes/((ocw-hugo-themes-branch))/webpack.json data
               hugo --config ../ocw-hugo-projects/((config-slug))/config.yaml --baseUrl /((base-url)) --themesDir ../ocw-hugo-themes/
         on_failure:
           try:

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -26,8 +26,6 @@ resources:
     source:
       uri: ((ocw-hugo-projects-uri))
       branch: ((ocw-hugo-projects-branch))
-      paths:
-        - ((ocw-import-starter-slug))/config.yaml
   - name: ocw-studio-webhook
     type: http-resource
     source:


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Hotfix for https://github.com/mitodl/ocw-studio/issues/938

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/945, we reconfigured the site pipeline to be triggered off of the theme assets pipeline uploading the `webpack.json` file created during the theme's webpack build.  A line was missed that adds the webpack-json Concourse resource as an input to the `build-course-task` step.  This PR adds it in.

#### How should this be manually tested?
Needs to be tested on RC, but you should be able to run `backpopulate_pipelines --filter <your course id here>` without error locally as long as you are running local Concourse
