### PR TITLE
scroll to form errors on submission

### DIFF
--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -17,6 +17,7 @@ import {
   newInitialValues,
   renameNestedFields
 } from "../../lib/site_content"
+import { scrollToElement } from "../../util/dom"
 
 import {
   ConfigField,
@@ -93,8 +94,17 @@ export default function SiteContentForm({
       initialValues={initialValues}
       enableReinitialize={true}
     >
-      {({ isSubmitting, status, values, handleChange }) => (
-        <Form>
+      {({ isSubmitting, status, values, handleChange, handleSubmit }) => (
+        <Form
+          onSubmit={async event => {
+            handleSubmit(event)
+            const { target } = event // get target before the await; https://reactjs.org/docs/legacy-event-pooling.html
+            const errors = await validate(values)
+            if (Object.keys(errors).length > 0) {
+              scrollToElement(target as HTMLElement, ".form-error")
+            }
+          }}
+        >
           <div>
             {renamedFields
               .filter(field => fieldIsVisible(field, values))

--- a/static/js/test_setup.ts
+++ b/static/js/test_setup.ts
@@ -44,6 +44,7 @@ declare global {
 // cleanup after each test run
 // eslint-disable-next-line mocha/no-top-level-hooks
 afterEach(function() {
+  jest.resetAllMocks()
   const node = document.querySelector("#integration_test_div")
   if (node) {
     ReactDOM.unmountComponentAtNode(node)

--- a/static/js/test_util.ts
+++ b/static/js/test_util.ts
@@ -25,3 +25,19 @@ export const wait = async (ms: number): Promise<undefined> => {
     }, ms)
   })
 }
+
+export const mockMatchMedia = () => {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value:    jest.fn().mockImplementation(query => ({
+      matches:             false,
+      media:               query,
+      onchange:            null,
+      addEventListener:    jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent:       jest.fn()
+    }))
+  })
+
+  return window.matchMedia as jest.Mock<any, [string]>
+}

--- a/static/js/util/dom.test.tsx
+++ b/static/js/util/dom.test.tsx
@@ -1,0 +1,116 @@
+import React from "react"
+import ReactDOMServer from "react-dom/server"
+import { mockMatchMedia } from "../test_util"
+import { scrollToElement } from "./dom"
+
+describe("scrollToError", () => {
+  const stringToHtml = (string: string): HTMLElement => {
+    const template = document.createElement("template")
+    template.innerHTML = string.trim()
+    const node = template.content.firstChild
+    if (node instanceof HTMLElement) return node
+    throw new Error("Expected an HTMLElement")
+  }
+  const getTestPage = () => {
+    const page = stringToHtml(
+      ReactDOMServer.renderToStaticMarkup(
+        <div>
+          <form id="form-1">
+            <div id="div-1a"></div>
+            <div id="div-1b" className="form-error"></div>
+            <div id="div-1c" className="form-error meow"></div>
+          </form>
+          <form id="form-2">
+            <div id="div-2a" className="form-error meow"></div>
+            <div id="div-2b" className="form-error"></div>
+            <div id="div-2c"></div>
+          </form>
+        </div>
+      )
+    )
+    const [form1, form2] = ["#form-1", "#form-2"].map(s =>
+      page.querySelector(s)
+    ) as HTMLElement[]
+    const [div1b, div1c, div2a] = ["#div-1b", "#div-1c", "#div-2a"].map(s =>
+      page.querySelector(s)
+    ) as HTMLElement[]
+    const elements = [form1, form2, div1b, div1c, div2a]
+    expect(elements.every(e => e instanceof HTMLElement)).toBe(true)
+
+    // js-dom does not currently implement scrollIntoView
+    div1b.scrollIntoView = jest.fn()
+    div1c.scrollIntoView = jest.fn()
+    div2a.scrollIntoView = jest.fn()
+
+    return {
+      containers: { form1, form2, page },
+      spies:      {
+        div1b: {
+          scrollIntoView: div1b.scrollIntoView,
+          focus:          jest.spyOn(div1b, "focus")
+        },
+        div1c: {
+          scrollIntoView: div1c.scrollIntoView,
+          focus:          jest.spyOn(div1c, "focus")
+        },
+        div2a: {
+          scrollIntoView: div2a.scrollIntoView,
+          focus:          jest.spyOn(div2a, "focus")
+        }
+      }
+    }
+  }
+
+  it("it scrolls to and focuses the first matching div in container", () => {
+    mockMatchMedia()
+    const { containers, spies } = getTestPage()
+
+    scrollToElement(containers.form1, ".form-error")
+    expect(spies.div1b.scrollIntoView).toHaveBeenCalledTimes(1)
+    expect(spies.div1b.focus).toHaveBeenCalledTimes(1)
+
+    scrollToElement(containers.form2, ".form-error")
+    expect(spies.div2a.scrollIntoView).toHaveBeenCalledTimes(1)
+    expect(spies.div2a.focus).toHaveBeenCalledTimes(1)
+
+    scrollToElement(containers.page, ".meow")
+    expect(spies.div1c.scrollIntoView).toHaveBeenCalledTimes(1)
+    expect(spies.div1c.focus).toHaveBeenCalledTimes(1)
+  })
+
+  it("it smoothly scrolls to center by default", () => {
+    mockMatchMedia()
+    const { containers, spies } = getTestPage()
+
+    scrollToElement(containers.form1, ".form-error")
+    expect(spies.div1b.scrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block:    "center"
+    })
+    expect(spies.div1b.focus).toHaveBeenCalledWith({ preventScroll: true })
+  })
+
+  it("it respects (prefers-reduced-motion: reduce)", () => {
+    const matchMedia = mockMatchMedia()
+    const { containers, spies } = getTestPage()
+
+    matchMedia.mockImplementation(() => ({ matches: true }))
+
+    scrollToElement(containers.form1, ".form-error")
+    expect(matchMedia).toHaveBeenCalledWith("(prefers-reduced-motion: reduce)")
+    expect(spies.div1b.scrollIntoView).toHaveBeenCalledWith({
+      behavior: "auto",
+      block:    "center"
+    })
+    expect(spies.div1b.focus).toHaveBeenCalledWith({ preventScroll: true })
+  })
+
+  it("it does not error when no element is found", () => {
+    const matchMedia = mockMatchMedia()
+    const { containers } = getTestPage()
+
+    matchMedia.mockImplementation(() => ({ matches: true }))
+
+    expect(() => scrollToElement(containers.page, ".not-there")).not.toThrow()
+  })
+})

--- a/static/js/util/dom.ts
+++ b/static/js/util/dom.ts
@@ -1,0 +1,14 @@
+export const scrollToElement = (container: HTMLElement, selector: string) => {
+  const errorElement = container.querySelector<HTMLElement>(selector)
+  if (!errorElement) {
+    return
+  }
+  const { matches: prefersReducedMotion } = window.matchMedia(
+    "(prefers-reduced-motion: reduce)"
+  )
+  errorElement.scrollIntoView({
+    behavior: prefersReducedMotion ? "auto" : "smooth",
+    block:    "center"
+  })
+  errorElement.focus({ preventScroll: true })
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets? https://github.com/mitodl/ocw-studio/issues/706

#### What's this PR do?
Adds logic to scroll to form errors upon submission. Should be no other changes.

#### How should this be manually tested?
This should affect all forms using `<SiteContentForm />` that have field validation. The one I am aware of is metadata, but if there are others, feel free to check those, too!

#### Screenshots (if appropriate)

<details open>
<summary>Collapse/expand distracting gif</summary>

![form_scroll_on_errors](https://user-images.githubusercontent.com/9010790/152363103-50c8e7e4-14be-4d26-a0ac-925732927173.gif)


</details>