### PR TITLE
refactor the content form dirty logic to use Formik's state

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,8 @@ module.exports = {
       { argsIgnorePattern: "_" }
     ],
     "mocha/no-top-level-hooks": "off",
+    "mocha/no-sibling-hooks": "off",
+    "mocha/no-global-tests": "off",
     "camelcase": [
       "error",
       {

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -1,11 +1,13 @@
-import React, { useCallback, useMemo } from "react"
+import React, { useEffect, useMemo } from "react"
 import {
   Form,
   Formik,
   FormikHelpers,
   FormikValues,
+  FormikProps,
   validateYupSchema,
-  yupToFormErrors
+  yupToFormErrors,
+  FormikErrors
 } from "formik"
 
 import SiteContentField from "./SiteContentField"
@@ -30,7 +32,7 @@ import { SiteFormValues } from "../../types/forms"
 import { getContentSchema } from "./validation"
 import { useWebsite } from "../../context/Website"
 
-interface Props {
+export interface FormProps {
   onSubmit: (
     values: any,
     formikHelpers: FormikHelpers<any>
@@ -41,14 +43,11 @@ interface Props {
   setDirty: (dirty: boolean) => void
 }
 
-export default function SiteContentForm({
-  onSubmit,
-  configItem,
-  content,
-  editorState,
-  setDirty
-}: Props): JSX.Element {
+export default function SiteContentForm(props: FormProps): JSX.Element {
+  const { onSubmit, configItem, content, editorState } = props
+
   const website = useWebsite()
+
   const initialValues: SiteFormValues = useMemo(
     () =>
       editorState.adding() ?
@@ -60,25 +59,12 @@ export default function SiteContentForm({
         ),
     [configItem.fields, editorState, content, website]
   )
-  const contentContext = content?.content_context ?? null
 
-  const renamedFields: ConfigField[] = useMemo(
-    () => renameNestedFields(configItem.fields),
-    [configItem]
-  )
-
-  const markDirtyAndHandleChange = useCallback(
-    (handleChange: (event: React.ChangeEvent<any>) => void) => (
-      event: React.ChangeEvent<any>
-    ) => {
-      handleChange(event)
-      setDirty(true)
-    },
-    [setDirty]
-  )
-
-  const validate = async (values: FormikValues) => {
+  const validate = async (
+    values: FormikValues
+  ): Promise<FormikErrors<SiteFormValues>> => {
     const schema = getContentSchema(configItem, values)
+
     try {
       await validateYupSchema(values, schema)
     } catch (e) {
@@ -94,56 +80,90 @@ export default function SiteContentForm({
       initialValues={initialValues}
       enableReinitialize={true}
     >
-      {({ isSubmitting, status, values, handleChange, handleSubmit }) => (
-        <Form
-          onSubmit={async event => {
-            handleSubmit(event)
-            const { target } = event // get target before the await; https://reactjs.org/docs/legacy-event-pooling.html
-            const errors = await validate(values)
-            if (Object.keys(errors).length > 0) {
-              scrollToElement(target as HTMLElement, ".form-error")
-            }
-          }}
-        >
-          <div>
-            {renamedFields
-              .filter(field => fieldIsVisible(field, values))
-              .map(field =>
-                field.widget === WidgetVariant.Object ? (
-                  <ObjectField
-                    field={field}
-                    key={field.name}
-                    contentContext={contentContext}
-                    values={values}
-                    onChange={markDirtyAndHandleChange(handleChange)}
-                  />
-                ) : SETTINGS.gdrive_enabled &&
-                  content?.type === "resource" &&
-                  field.widget === WidgetVariant.File ? null : (
-                    <SiteContentField
-                      field={field}
-                      key={field.name}
-                      contentContext={contentContext}
-                      onChange={markDirtyAndHandleChange(handleChange)}
-                    />
-                  )
-              )}
-          </div>
-          <div className="form-group d-flex w-100 justify-content-end">
-            <button
-              type="submit"
-              disabled={isSubmitting}
-              className="px-5 btn cyan-button"
-            >
-              Save
-            </button>
-          </div>
-          {status && (
-            // Status is being used to store non-field errors
-            <div className="form-error">{status}</div>
-          )}
-        </Form>
+      {formikProps => (
+        <FormFields validate={validate} {...formikProps} {...props} />
       )}
     </Formik>
+  )
+}
+
+export interface InnerFormProps extends FormikProps<SiteFormValues>, FormProps {
+  validate: (values: FormikValues) => Promise<FormikErrors<SiteFormValues>>
+}
+
+export function FormFields(props: InnerFormProps): JSX.Element {
+  const {
+    isSubmitting,
+    status,
+    values,
+    handleChange,
+    dirty,
+    configItem,
+    content,
+    setDirty,
+    handleSubmit,
+    validate
+  } = props
+
+  const contentContext = content?.content_context ?? null
+
+  const renamedFields: ConfigField[] = useMemo(
+    () => renameNestedFields(configItem.fields),
+    [configItem]
+  )
+
+  useEffect(() => {
+    setDirty(dirty)
+  }, [setDirty, dirty])
+
+  return (
+    <Form
+      onSubmit={async event => {
+        handleSubmit(event)
+        const { target } = event // get target before the await; https://reactjs.org/docs/legacy-event-pooling.html
+        const errors = await validate(values)
+        if (Object.keys(errors).length > 0) {
+          scrollToElement(target as HTMLElement, ".form-error")
+        }
+      }}
+    >
+      <div>
+        {renamedFields
+          .filter(field => fieldIsVisible(field, values))
+          .map(field =>
+            field.widget === WidgetVariant.Object ? (
+              <ObjectField
+                field={field}
+                key={field.name}
+                contentContext={contentContext}
+                values={values}
+                onChange={handleChange}
+              />
+            ) : SETTINGS.gdrive_enabled &&
+              content?.type === "resource" &&
+              field.widget === WidgetVariant.File ? null : (
+                <SiteContentField
+                  field={field}
+                  key={field.name}
+                  contentContext={contentContext}
+                  onChange={handleChange}
+                />
+              )
+          )}
+      </div>
+      <div className="form-group d-flex w-100 justify-content-end">
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="px-5 btn cyan-button"
+        >
+          Save
+        </button>
+      </div>
+      {status && (
+        // Status is being used to store non-field errors
+        <div className="form-error">{status}</div>
+      )}
+    </Form>
   )
 }

--- a/static/js/components/widgets/ObjectField.test.tsx
+++ b/static/js/components/widgets/ObjectField.test.tsx
@@ -26,19 +26,7 @@ describe("ObjectField", () => {
 
   beforeEach(() => {
     field = makeWebsiteConfigField({
-      widget: WidgetVariant.Object,
-      label:  "myobject",
-      fields: [
-        makeWebsiteConfigField({
-          widget: WidgetVariant.String,
-          label:  "mystring"
-        }),
-        makeWebsiteConfigField({
-          widget:   WidgetVariant.Select,
-          multiple: true,
-          label:    "myselect"
-        })
-      ]
+      widget: WidgetVariant.Object
     }) as ObjectConfigField
 
     // @ts-ignore

--- a/static/js/util/factories/websites.ts
+++ b/static/js/util/factories/websites.ts
@@ -46,6 +46,20 @@ export const makeWebsiteConfigField = (
 ): ConfigField => {
   const label = props.label ?? casual.word
 
+  if (props.widget && props.widget === WidgetVariant.Object && !props.fields) {
+    props.fields = [
+      makeWebsiteConfigField({
+        widget: WidgetVariant.String,
+        label:  "mystring"
+      }),
+      makeWebsiteConfigField({
+        widget:   WidgetVariant.Select,
+        multiple: true,
+        label:    "myselect"
+      })
+    ]
+  }
+
   return {
     label,
     name:   label.toLowerCase(),


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

none

#### What's this PR do?

Our existing implementation of setting a dirty variable was basically duplicating Formik's logic. I refactored the `SiteContentForm` to add a `useEffect` hook between `Formik` and our form fields which listens to Formik's `dirty` property and echos that out via a callback.

I also refactored the associated test file to be flat (no nesting) and to not use any mutable shared variables. I think it's much cleaner and easier to figure out where things are coming from, and I think I'd like to write frontend tests like this going forward.

#### How should this be manually tested?

The 'are you sure?' confirmation behavior should work 100% as it did before (i.e. if you go into a site content, type something, and then try to leave without saving it should make you confirm that you want to throw that input out).