### PR TITLE
use alternate s3 resource type for webpack-json

### DIFF
--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -5,9 +5,14 @@ resource_types:
     source:
       repository: jgriff/http-resource
       tag: latest
+  - name: s3-resource-iam
+    type: docker-image
+    source:
+      repository: governmentpaas/s3-resource
+      tag: latest
 resources:
   - name: webpack-json
-    type: s3
+    type: s3-resource-iam
     source:
       bucket: ol-eng-artifacts
       versioned_file: ocw-hugo-themes/((ocw-hugo-themes-branch))/webpack.json


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Follow up PR for https://github.com/mitodl/ocw-studio/pull/945

#### What's this PR do?
In testing on RC, it was found that the `webpack.json` check added to `site-pipeline.yml` was getting `AccessDenied` errors.  Devops found that this was due to the stock Concourse S3 resource not being able to authenticate using an IAM profile.  This PR swaps out the stock S3 resource for a [forked version](https://github.com/alphagov/paas-s3-resource) that includes IAM support.

#### How should this be manually tested?
 - Spin up your local `ocw-studio` instance with the environment from `ocw-studio-rc`
 - Create a test site if you don't have one, and upsert it to RC Concourse using `./manage.py backpopulate_pipelines --filter <your course id here>`
 - Browse to https://cicd-qa.odl.mit.edu/ and find your site's pipeline and trigger a build
 - Watch the `webpack.json` check and ensure it does not fail
