### PR TITLE
copy webpack.json into base-theme instead of into the site's data folder

### DIFF
--- a/content_sync/pipelines/definitions/concourse/mass-publish.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-publish.yml
@@ -104,7 +104,7 @@ jobs:
                 BASE_URL=$(echo $1 | jq -c '.base_url' | tr -d '"')
                 git -c core.sshCommand="ssh $GITKEYSSH -o StrictHostKeyChecking=no" clone -b ((ocw-site-repo-branch)) ((markdown-uri))/$SHORT_ID.git || return 1
                 cd $CURDIR/$SHORT_ID
-                cp ../webpack-json/webpack.json data
+                cp ../webpack-json/webpack.json ../ocw-hugo-themes/base-theme/data
                 hugo --config ../ocw-hugo-projects/$STARTER_SLUG/config.yaml --baseUrl /$BASE_URL --themesDir ../ocw-hugo-themes/  || return 1
                 cd $CURDIR
                 aws s3 sync s3://((ocw-studio-bucket))/$SITE_URL s3://((ocw-bucket))/$SITE_URL --metadata site-id=$NAME || return 1            

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -133,7 +133,7 @@ jobs:
             args:
             - -exc
             - |
-              cp ../webpack-json/webpack.json data
+              cp ../webpack-json/webpack.json ../ocw-hugo-themes/base-theme/data
               hugo --config ../ocw-hugo-projects/((config-slug))/config.yaml --baseUrl /((base-url)) --themesDir ../ocw-hugo-themes/
         on_failure:
           try:


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/976

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/945 and https://github.com/mitodl/ocw-studio/pull/950 we set up site pipelines to use the new theme assets pipeline strategy where we deploy built assets directly to the target environment and only upload the `webpack.json` data file to `ol-eng-artifacts`.  Before the Hugo build, this file was being copied into the `data` folder of the site to be built.  The issue with that is that some sites (like `ocw-www`) don't already have a data folder.  This PR switches this over to a more reliable strategy of copying it into `ocw-hugo-themes/base-theme/data` where a folder is guaranteed to exist.

#### How should this be manually tested?
This really needs to be tested in RC, because it relies on the theme assets build being able to upload content into `ol-eng-artifacts`
