### PR TITLE
add OCW_IMPORT_STARTER_SLUG to the mass publish pipeline definition code

### DIFF
--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -415,6 +415,9 @@ class MassPublishPipeline(BaseMassPublishPipeline, ConcoursePipeline):
                 .replace("((ocw-hugo-themes-uri))", OCW_HUGO_THEMES_GIT)
                 .replace("((ocw-hugo-projects-branch))", settings.GITHUB_WEBHOOK_BRANCH)
                 .replace("((ocw-hugo-projects-uri))", hugo_projects_url)
+                .replace(
+                    "((ocw-import-starter-slug))", settings.OCW_IMPORT_STARTER_SLUG
+                )
                 .replace("((ocw-studio-url))", settings.SITE_BASE_URL)
                 .replace("((static-api-base-url))", static_api_url)
                 .replace("((ocw-studio-bucket))", settings.AWS_STORAGE_BUCKET_NAME)

--- a/content_sync/pipelines/definitions/concourse/mass-publish.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-publish.yml
@@ -64,6 +64,7 @@ jobs:
     attempts: 3
     timeout: 300m
     params:
+      OCW_IMPORT_STARTER_SLUG: ((ocw-import-starter-slug))
       OCW_STUDIO_BASE_URL: ((ocw-studio-url))
       STATIC_API_BASE_URL: ((static-api-base-url))
       GIT_KEY: ((git-private-key-var))


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/983

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/950, we added a pipeline definition to create a single mass publish pipeline in Concourse for publishing all sites at once.  This PR was missing one env variable, `OCW_IMPORT_STARTER_SLUG` which is used to create the query string the API is hit with when requesting new courses. as well as news items.  This PR adds the environment variable to the pipeline definition with the proper value in each environment.

#### How should this be manually tested?
This should be tested in RC by upserting the mass publish pipeline definition with `./manage.py upsert_mass_publish_pipeline` followed by triggering the live pipeline.  After the run is complete, inspect https://ocwnext-rc.odl.mit.edu and make sure that the error "OCW Studio URL not configured" is not displayed.
