### PR TITLE
fix: youtube video thumbnail 0.jpg replaced with default.jpg (120x90)

### DIFF
--- a/videos/constants.py
+++ b/videos/constants.py
@@ -7,6 +7,8 @@ DESTINATION_ARCHIVE = "archive"
 
 ALL_DESTINATIONS = [DESTINATION_YOUTUBE, DESTINATION_ARCHIVE]
 
+YT_THUMBNAIL_IMG = "https://img.youtube.com/vi/{video_id}/default.jpg"
+
 
 class VideoStatus:
     """Simple class for possible VideoFile statuses"""

--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -17,6 +17,7 @@ from main.constants import STATUS_CREATED
 from videos import threeplay_api
 from videos.constants import (
     DESTINATION_YOUTUBE,
+    YT_THUMBNAIL_IMG,
     VideoFileStatus,
     VideoStatus,
     YouTubeStatus,
@@ -151,7 +152,7 @@ def update_youtube_statuses():
                     set_dict_field(
                         resource.metadata,
                         settings.YT_FIELD_THUMBNAIL,
-                        f"https://img.youtube.com/vi/{video_file.destination_id}/default.jpg",
+                        YT_THUMBNAIL_IMG.format(video_id=video_file.destination_id),
                     )
                     resource.save()
             mail_youtube_upload_success(video_file)

--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -151,7 +151,7 @@ def update_youtube_statuses():
                     set_dict_field(
                         resource.metadata,
                         settings.YT_FIELD_THUMBNAIL,
-                        f"https://img.youtube.com/vi/{video_file.destination_id}/0.jpg",
+                        f"https://img.youtube.com/vi/{video_file.destination_id}/default.jpg",
                     )
                     resource.save()
             mail_youtube_upload_success(video_file)

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -268,7 +268,7 @@ def test_update_youtube_statuses(
                 "resourcetype": "Video",
                 "file_type": video_file.video.drivefile_set.first().mime_type,
                 "video_files": {
-                    "video_thumbnail_file": f"https://img.youtube.com/vi/{video_file.destination_id}/0.jpg"
+                    "video_thumbnail_file": f"https://img.youtube.com/vi/{video_file.destination_id}/default.jpg"
                 },
                 "video_metadata": {"youtube_id": video_file.destination_id},
                 "image": "",

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -18,6 +18,7 @@ from users.factories import UserFactory
 from videos.conftest import MockHttpErrorResponse
 from videos.constants import (
     DESTINATION_YOUTUBE,
+    YT_THUMBNAIL_IMG,
     VideoFileStatus,
     VideoStatus,
     YouTubeStatus,
@@ -268,7 +269,9 @@ def test_update_youtube_statuses(
                 "resourcetype": "Video",
                 "file_type": video_file.video.drivefile_set.first().mime_type,
                 "video_files": {
-                    "video_thumbnail_file": f"https://img.youtube.com/vi/{video_file.destination_id}/default.jpg"
+                    "video_thumbnail_file": YT_THUMBNAIL_IMG.format(
+                        video_id=video_file.destination_id
+                    )
                 },
                 "video_metadata": {"youtube_id": video_file.destination_id},
                 "image": "",

--- a/websites/api.py
+++ b/websites/api.py
@@ -14,6 +14,7 @@ from mitol.mail.api import get_message_sender
 
 from content_sync.constants import VERSION_DRAFT
 from users.models import User
+from videos.constants import YT_THUMBNAIL_IMG
 from websites.constants import (
     CONTENT_FILENAME_MAX_LEN,
     PUBLISH_STATUS_ABORTED,
@@ -193,7 +194,7 @@ def update_youtube_thumbnail(website_id: str, metadata: Dict, overwrite=False):
             set_dict_field(
                 metadata,
                 settings.YT_FIELD_THUMBNAIL,
-                f"https://img.youtube.com/vi/{youtube_id}/default.jpg",
+                YT_THUMBNAIL_IMG.format(video_id=youtube_id),
             )
 
 

--- a/websites/api.py
+++ b/websites/api.py
@@ -193,7 +193,7 @@ def update_youtube_thumbnail(website_id: str, metadata: Dict, overwrite=False):
             set_dict_field(
                 metadata,
                 settings.YT_FIELD_THUMBNAIL,
-                f"https://img.youtube.com/vi/{youtube_id}/0.jpg",
+                f"https://img.youtube.com/vi/{youtube_id}/default.jpg",
             )
 
 

--- a/websites/api_test.py
+++ b/websites/api_test.py
@@ -7,6 +7,7 @@ from mitol.common.utils import now_in_utc
 
 from content_sync.constants import VERSION_DRAFT, VERSION_LIVE
 from users.factories import UserFactory
+from videos.constants import YT_THUMBNAIL_IMG
 from websites.api import (
     detect_mime_type,
     fetch_website,
@@ -191,23 +192,23 @@ def test_is_ocw_site(settings):
     [
         [
             None,
-            "https://img.youtube.com/fake/default.jpg",
+            YT_THUMBNAIL_IMG.format(video_id="fake"),
             True,
-            "https://img.youtube.com/fake/default.jpg",
+            YT_THUMBNAIL_IMG.format(video_id="fake"),
         ],
         [
             "abc123",
-            "https://img.youtube.com/def456/default.jpg",
+            YT_THUMBNAIL_IMG.format(video_id="def456"),
             False,
-            "https://img.youtube.com/def456/default.jpg",
+            YT_THUMBNAIL_IMG.format(video_id="def456"),
         ],
-        ["abc123", "", False, "https://img.youtube.com/vi/abc123/default.jpg"],
-        ["abc123", None, False, "https://img.youtube.com/vi/abc123/default.jpg"],
+        ["abc123", "", False, YT_THUMBNAIL_IMG.format(video_id="abc123")],
+        ["abc123", None, False, YT_THUMBNAIL_IMG.format(video_id="abc123")],
         [
             "abc123",
-            "https://img.youtube.com/def456/default.jpg",
+            YT_THUMBNAIL_IMG.format(video_id="def456"),
             True,
-            "https://img.youtube.com/vi/abc123/default.jpg",
+            YT_THUMBNAIL_IMG.format(video_id="abc123"),
         ],
     ],
 )

--- a/websites/api_test.py
+++ b/websites/api_test.py
@@ -191,23 +191,23 @@ def test_is_ocw_site(settings):
     [
         [
             None,
-            "https://img.youtube.com/fake/0.jpg",
+            "https://img.youtube.com/fake/default.jpg",
             True,
-            "https://img.youtube.com/fake/0.jpg",
+            "https://img.youtube.com/fake/default.jpg",
         ],
         [
             "abc123",
-            "https://img.youtube.com/def456/0.jpg",
+            "https://img.youtube.com/def456/default.jpg",
             False,
-            "https://img.youtube.com/def456/0.jpg",
+            "https://img.youtube.com/def456/default.jpg",
         ],
-        ["abc123", "", False, "https://img.youtube.com/vi/abc123/0.jpg"],
-        ["abc123", None, False, "https://img.youtube.com/vi/abc123/0.jpg"],
+        ["abc123", "", False, "https://img.youtube.com/vi/abc123/default.jpg"],
+        ["abc123", None, False, "https://img.youtube.com/vi/abc123/default.jpg"],
         [
             "abc123",
-            "https://img.youtube.com/def456/0.jpg",
+            "https://img.youtube.com/def456/default.jpg",
             True,
-            "https://img.youtube.com/vi/abc123/0.jpg",
+            "https://img.youtube.com/vi/abc123/default.jpg",
         ],
     ],
 )

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -272,7 +272,7 @@ def test_website_content_detail_serializer_youtube_ocw(settings, is_resource):
             assert content.metadata["video_metadata"]["youtube_id"] == youtube_id
             assert (
                 content.metadata["video_files"]["video_thumbnail_file"]
-                == f"https://img.youtube.com/vi/{youtube_id}/0.jpg"
+                == f"https://img.youtube.com/vi/{youtube_id}/default.jpg"
             )
         else:
             assert content.metadata["body"] == "text"

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -33,6 +33,7 @@ from websites.serializers import (
 )
 from websites.site_config_api import SiteConfig
 
+
 pytestmark = pytest.mark.django_db
 
 

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -7,6 +7,7 @@ from django.db.models import CharField, Value
 from main.constants import ISO_8601_FORMAT
 from users.factories import UserFactory
 from users.models import User
+from videos.constants import YT_THUMBNAIL_IMG
 from websites.constants import (
     CONTENT_TYPE_RESOURCE,
     ROLE_EDITOR,
@@ -31,7 +32,6 @@ from websites.serializers import (
     WebsiteStatusSerializer,
 )
 from websites.site_config_api import SiteConfig
-
 
 pytestmark = pytest.mark.django_db
 
@@ -270,10 +270,9 @@ def test_website_content_detail_serializer_youtube_ocw(settings, is_resource):
     for content in [existing_content, new_content]:
         if is_resource:
             assert content.metadata["video_metadata"]["youtube_id"] == youtube_id
-            assert (
-                content.metadata["video_files"]["video_thumbnail_file"]
-                == f"https://img.youtube.com/vi/{youtube_id}/default.jpg"
-            )
+            assert content.metadata["video_files"][
+                "video_thumbnail_file"
+            ] == YT_THUMBNAIL_IMG.format(video_id=youtube_id)
         else:
             assert content.metadata["body"] == "text"
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
  - [ ] Desktop screenshots
  - [ ] Mobile width screenshots
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/419

#### What's this PR do?
- Youtube generates multiple thumbnail images, so the image URL can be either:
    - `https://img.youtube.com/vi/<youtube-video-id>/0.jpg ` or  `.../1.jpg`, `.../2.jpg`, `.../3.jpg`, ...
    - The default thumbnail image of size 120x90 is `.../default.jpg`.  
- This PR replaces `.../0.jpg` with `.../default.jpg` so every time, default thumbnail (120x90 size) is pulled.   

#### How should this be manually tested?
- Go to studio
- Add new content/resource with youtube video(s) or update an existing one.
- Publish the course and ensure the thumbnail URL is with  `.../default.jpg not `.../0.jpg`
- Go to the course page -> videos/resources and ensure that the thumbnail images size is uniform and appropriate. ([For example](https://ocwnext-rc.odl.mit.edu/courses/18-06-linear-algebra-spring-2010/video_galleries/video-lectures/))