### PR TITLE
set serial: true on the mass publish job

### DIFF
--- a/content_sync/pipelines/definitions/concourse/mass-publish.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-publish.yml
@@ -33,6 +33,7 @@ task-config: &webhook-config
     source: {repository: curlimages/curl}
 jobs:
 - name: mass-publish
+  serial: true
   plan:
   - get: ocw-hugo-themes
     timeout: 1m


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/986

#### What's this PR do?
This PR sets `serial: true` on the mass publish pipeline job definition to prevent multiple builds from kicking off simultaneously

#### How should this be manually tested?
 - Start `ocw-studio` locally with Concourse support, read the readme for more info
 - Upsert the mass publish pipeline to your local Concourse with `./manage.py upsert_mass_publish_pipeline`
 - Find the pipeline in the Concourse UI and click the plus sign multiple times
 - Verify that only one build runs at a time and that the others stay pending
