### PR TITLE
Fix short_id assignment for imported ocw sites

### DIFF
--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -282,6 +282,9 @@ def convert_data_to_content(filepath, data, website):
 
 def get_short_id(name: str, metadata: Dict) -> str:
     """ Get a short_id from the metadata"""
+    existing_site = Website.objects.filter(name=name).first()
+    if existing_site and existing_site.short_id:
+        return existing_site.short_id
     course_num = metadata.get("primary_course_number")
     if not course_num:
         raise ValueError("Primary course number is missing")

--- a/ocw_import/api_test.py
+++ b/ocw_import/api_test.py
@@ -320,10 +320,12 @@ def test_get_short_id(course_num, term, year, expected_id):
         assert short_id == expected_id
         for i in range(2, 5):
             name = f"site_name_{i}"
-            website = WebsiteFactory.create(
+            website.short_id = get_short_id(website.name, metadata)
+            new_site = WebsiteFactory.create(
                 name=name, short_id=get_short_id(name, metadata)
             )
-            assert website.short_id == f"{expected_id}-{i}"
+            assert new_site.short_id == f"{expected_id}-{i}"
+            assert website.short_id == expected_id
     else:
         with pytest.raises(ValueError):
             get_short_id("random-name", metadata)

--- a/ocw_import/management/commands/repair_dupe_repos.py
+++ b/ocw_import/management/commands/repair_dupe_repos.py
@@ -1,0 +1,58 @@
+""" Fix sites that have been assigned a new repo on every import """
+from django.core.management import BaseCommand
+from django.db import transaction
+from github import GithubException
+from mitol.common.utils.datetime import now_in_utc
+
+from content_sync.api import get_sync_backend, get_sync_pipeline
+from content_sync.models import ContentSyncState
+from websites.models import Website
+
+
+class Command(BaseCommand):
+    """  Fix sites that have been assigned a new repo on every import"""
+
+    help = __doc__
+
+    def handle(self, *args, **options):
+        self.stdout.write("Fixing repos for imported OCW sites")
+        start = now_in_utc()
+        errors = 0
+        websites = (
+            Website.objects.exclude(short_id__endswith="-2")
+            .filter(source="ocw-import", short_id__regex=r".+\-\d{1,2}$")
+            .order_by("name")
+        )
+        self.stdout.write(f"Repairing repos for {websites.count()} sites")
+        for website in websites:
+            try:
+                with transaction.atomic():
+                    short_id_secs = website.short_id.split("-")
+                    base_repo, idx = ("-".join(short_id_secs[:-1]), short_id_secs[-1])
+                    website.short_id = f"{base_repo}-2"
+                    website.save()
+                    ContentSyncState.objects.filter(content__website=website).update(
+                        synced_checksum=None, data=None
+                    )
+                    backend = get_sync_backend(website)
+                    backend.sync_all_content_to_backend()
+                    get_sync_pipeline(website).upsert_pipeline()
+                    for i in range(3, int(idx) + 1):
+                        try:
+                            backend.api.org.get_repo(f"{base_repo}-{i}").delete()
+                        except GithubException as ge:
+                            if ge.status != 404:
+                                raise
+            except Exception as exc:  # pylint:disable=broad-except
+                self.stderr.write(
+                    f"Error occurred repairing repo for {website.name}: {exc}"
+                )
+                errors += 1
+
+        total_seconds = (now_in_utc() - start).total_seconds()
+        if errors == 0:
+            self.stdout.write(f"Repo repair finished, took {total_seconds} seconds")
+        else:
+            self.stderr.write(
+                f"Repo repair finished with {errors} errors, took {total_seconds} seconds"
+            )


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #979 

#### What's this PR do?
- Adds a management command to find and repair affected sites
- Tweaks the `get_short_id` function to just return the current value for an existing `Website`

#### How should this be manually tested?
- Set up your own github organization as explained in the README
- Set up local concourse integration as described in the README
- On the master branch, run `manage.py import_ocw_course_sites --filter 10-01-ethics-for-engineers` at least twice.
- In django admin, go to the `Websites` section and filter by `10-01-ethics-for-engineers`, there should be two sites, one of them should have a short_id ending with `-<number above 2>` depending on how many times you ran the above step.
- Switch to this branch and run `docker-compose --profile concourse up`
- In a separate terminal run `manage.py repair_dupe_repos`
- Verify that it completes without errors, the above site's short_id ends with `-2`, that repo has been fully updated in github, the site pipeline definition has been updated with the new repo, and any repos of the same name but ending with `-<number above 2>` no longer exist.


This is the list of affected sites:
```
'10-01-ethics-for-engineers-artificial-intelligence-spring-2020'
'24-908-creole-languages-and-caribbean-identities-spring-2017'
'5-72-non-equilibrium-statistical-mechanics-spring-2012'
'res-15-005-healthcare-finance-spring-2019'
 ```