### PR TITLE
improvements to site search [frontend]

### DIFF
--- a/static/js/hooks/state.ts
+++ b/static/js/hooks/state.ts
@@ -41,7 +41,9 @@ type TextInputRetProps = [string, (e: ChangeEvent<HTMLInputElement>) => void]
  * A little utility hook for the boilerplate you need to hold the state
  * for a single text input.
  */
-export function useTextInputState(initialValue = ""): TextInputRetProps {
+export function useTextInputState(
+  initialValue: string | (() => string) = ""
+): TextInputRetProps {
   const [inputState, setInputState] = useState<string>(initialValue)
 
   const setSearchInputCB = useCallback(

--- a/static/js/pages/SitesDashboard.test.tsx
+++ b/static/js/pages/SitesDashboard.test.tsx
@@ -8,7 +8,7 @@ import {
   sitesBaseUrl
 } from "../lib/urls"
 import { WebsiteListingResponse } from "../query-configs/websites"
-import { isIf, wait } from "../test_util"
+import { wait } from "../test_util"
 import {
   makeWebsiteListing,
   makeWebsiteDetail
@@ -66,7 +66,7 @@ describe("SitesDashboard", () => {
     helper.cleanup()
   })
 
-  it("lists a page", async () => {
+  test("lists a page", async () => {
     const { wrapper } = await render()
     let idx = 0
     for (const website of websites) {
@@ -80,7 +80,7 @@ describe("SitesDashboard", () => {
     }
   })
 
-  it("lets the user filter the sites", async () => {
+  test("lets the user filter the sites", async () => {
     const { wrapper } = await render()
     const filterInput = wrapper.find(".site-search-input")
     const event = {
@@ -90,12 +90,10 @@ describe("SitesDashboard", () => {
     } as React.ChangeEvent<HTMLInputElement>
     filterInput.simulate("change", event)
     await wait(800)
-    expect(helper.browserHistory.location.search).toBe(
-      "offset=0&q=my-search-string"
-    )
+    expect(helper.browserHistory.location.search).toBe("?q=my-search-string")
   })
 
-  it("should issue a request based on the 'q' param", async () => {
+  test("should issue a request based on the 'q' param", async () => {
     helper.browserHistory.replace({
       pathname: "/",
       search:   "q=searchfilter"
@@ -120,74 +118,73 @@ describe("SitesDashboard", () => {
     ])
   })
 
-  it("sets the page title", async () => {
+  test("sets the page title", async () => {
     const { wrapper } = await render()
     expect(wrapper.find("DocumentTitle").prop("title")).toBe(
       "OCW Studio | Sites"
     )
   })
 
-  it("has an add link to the new site page", async () => {
+  test("has an add link to the new site page", async () => {
     const { wrapper } = await render()
     expect(wrapper.find(`Link.add-new`).prop("to")).toBe(newSiteUrl.toString())
   })
 
-  //
-  ;[true, false].forEach(hasPrevLink => {
-    [true, false].forEach(hasNextLink => {
-      it(`shows the right links when there ${isIf(
-        hasPrevLink
-      )} a previous link and ${isIf(hasNextLink)} a next link`, async () => {
-        response.next = hasNextLink ? "next" : null
-        response.previous = hasPrevLink ? "prev" : null
-        const startingOffset = 20
-        helper.mockGetRequest(
-          siteApiListingUrl.query({ offset: startingOffset }).toString(),
-          response
-        )
-        helper.browserHistory.replace({
-          pathname: "/path/to/page",
-          search:   `offset=${startingOffset}`
-        })
-        const { wrapper } = await render()
-
-        const prevWrapper = wrapper.find(".pagination Link.previous")
-        expect(prevWrapper.exists()).toBe(hasPrevLink)
-        if (hasPrevLink) {
-          expect(prevWrapper.prop("to")).toBe(
-            sitesBaseUrl
-              .query({ offset: startingOffset - WEBSITES_PAGE_SIZE })
-              .toString()
-          )
-        }
-
-        const nextWrapper = wrapper.find(".pagination Link.next")
-        expect(nextWrapper.exists()).toBe(hasNextLink)
-        if (hasNextLink) {
-          expect(nextWrapper.prop("to")).toBe(
-            sitesBaseUrl
-              .query({ offset: startingOffset + WEBSITES_PAGE_SIZE })
-              .toString()
-          )
-        }
+  test.each([
+    [true, true],
+    [true, false],
+    [false, true],
+    [false, false]
+  ])(
+    "shows the right links when hasPrevLink=%P and hasNextLink=%p",
+    async (hasPrevLink, hasNextLink) => {
+      response.next = hasNextLink ? "next" : null
+      response.previous = hasPrevLink ? "prev" : null
+      const startingOffset = 20
+      helper.mockGetRequest(
+        siteApiListingUrl.query({ offset: startingOffset }).toString(),
+        response
+      )
+      helper.browserHistory.replace({
+        pathname: "/path/to/page",
+        search:   `offset=${startingOffset}`
       })
-    })
+      const { wrapper } = await render()
+
+      const prevWrapper = wrapper.find(".pagination Link.previous")
+      expect(prevWrapper.exists()).toBe(hasPrevLink)
+      if (hasPrevLink) {
+        expect(prevWrapper.prop("to")).toBe(
+          sitesBaseUrl
+            .query({ offset: startingOffset - WEBSITES_PAGE_SIZE })
+            .toString()
+        )
+      }
+
+      const nextWrapper = wrapper.find(".pagination Link.next")
+      expect(nextWrapper.exists()).toBe(hasNextLink)
+      if (hasNextLink) {
+        expect(nextWrapper.prop("to")).toBe(
+          sitesBaseUrl
+            .query({ offset: startingOffset + WEBSITES_PAGE_SIZE })
+            .toString()
+        )
+      }
+    }
+  )
+
+  test("makes description text for a site with metadata", () => {
+    const site = {
+      ...makeWebsiteDetail(),
+      metadata: null
+    }
+    expect(siteDescription(site)).toBe(null)
   })
 
-  describe("siteDescription", () => {
-    it("makes description text for a site with metadata", () => {
-      const site = {
-        ...makeWebsiteDetail(),
-        metadata: null
-      }
-      expect(siteDescription(site)).toBe(null)
-    })
-
-    it("makes description text for a site without metadata", () => {
-      const site = makeWebsiteDetail()
-      expect(siteDescription(site)).toBe(
-        `${site.metadata.course_numbers[0]} - ${site.metadata.term}`
-      )
-    })
+  test("makes description text for a site without metadata", () => {
+    const site = makeWebsiteDetail()
+    expect(siteDescription(site)).toBe(
+      `${site.metadata.course_numbers[0]} - ${site.metadata.term}`
+    )
   })
 })


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #963 

this is sort of a twin PR to #993 but just addresses the frontend part.

#### What's this PR do?

This fixes a few issues on the site search (the little box on `/sites`). In particular, previously a full page refresh (well, actually a react-router reboot of the whole route) was triggered when the search changed. now the search results are updated, the search box retains focus, and the UI around the results doesn't go away.

#### How should this be manually tested?

Verify that the site search has a few properties:

- if you type in a new search string (like `ocw-www`) after a short debounce (600ms) there should be a brief loading indicator and then results relevant to your query should appear. the rest of the UI should now refresh.
- if you load the page with a search query param (`?q=foobar`) the value of the search param should show up in the search box, and the results shown should be relevant to that search (e.g. at `/sites/?q=ocw-www` you should see ocw-www)
- pagination should work as normal. in particular:
    - without a search param it should just work as you'd expect
    - and _with_ a search param it should just work as you'd expect :)
    - if you have paginated into the result set and you change the search param, then it should take you to the _first page_ of result for that search parameter, rather than retaining the `offset` parameter when the search input changes.

This PR does not address #990 (changing the search to match on more fields).


#### Screenshots (if appropriate)

This showcases some of the changes in behavior (compare with the video on the linked issue):

https://user-images.githubusercontent.com/6207644/153459788-fdd8efcd-9f27-4421-a5c8-0bbf7f6536ed.mov

