### PR TITLE
improvements to site search [backend]

### DIFF
--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -386,10 +386,16 @@ def test_website_endpoint_search(drf_client):
     superuser = UserFactory.create(is_superuser=True)
     drf_client.force_login(superuser)
 
-    WebsiteFactory.create(title="BEST")
-    WebsiteFactory.create(title="WORST")
-    resp = drf_client.get(reverse("websites_api-list"), {"search": "BEST"})
-    assert [website["title"] for website in resp.data.get("results")] == ["BEST"]
+    WebsiteFactory.create(title="Apple", name="Bacon", short_id="Cheese").save()
+    WebsiteFactory.create(title="Xylophone", name="Yellow", short_id="Zebra").save()
+    for word in ["Apple", "Bacon", "Cheese"]:
+        resp = drf_client.get(reverse("websites_api-list"), {"search": word})
+        assert [website["title"] for website in resp.data.get("results")] == ["Apple"]
+    for word in ["Xylophone", "Yellow", "Zebra"]:
+        resp = drf_client.get(reverse("websites_api-list"), {"search": word})
+        assert [website["title"] for website in resp.data.get("results")] == [
+            "Xylophone"
+        ]
 
 
 def test_websites_autogenerate_name(mocker, drf_client):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #990 

this is sort of a twin PR to #992 but addresses the backend portion

#### What's this PR do?

This PR changes how we find results when the `search` parameter is passed to the `WebsiteListing` API. Previously we were doing an `icontains` filter on only the `title` field, which resulted in surprising behavior -- for instance, searching for course numbers would not return the relevant courses.

This changes things around a bit so that instead of a more basic filter we instead leverage Django's support for Postgres' built-in full text search. I set it up to search on the `title`, `name`, and `short_id` fields, which should hopefully give us what we need to provide a search that works the way course authors expect.

#### How should this be manually tested?

Check out the course search, and confirm the following:

- if you search for a course number you should get the relevant course back, hopefully as the first result.
- ditto with a fragment of the course's `title` (or the whole title) and
- ditto with the course's `name` 

It hopefully won't return anything unexpected or weird in the result set!

#### screencast

this just shows searching for a course number:

https://user-images.githubusercontent.com/6207644/153464473-116efa1f-3ce6-4951-b908-2355dc5f4928.mov


