### PR TITLE
add management command markdown_cleanup_baseurl

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
   db:
     image: postgres:12.8
     ports:
-      - "5432"
+      - "5431:5432"
     environment:
       POSTGRES_PASSWORD: postgres
 

--- a/websites/management/commands/markdown_cleanup_baseurl.py
+++ b/websites/management/commands/markdown_cleanup_baseurl.py
@@ -128,11 +128,8 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         self.validate_options(options)
-        self.do_handle(**options)
-
-    @staticmethod
-    def do_handle(commit=False, out=None):
-        """Replace baseurl with resource_link"""
+        commit = options['commit']
+        out = options['out']
 
         with ExitStack() as stack:
             wc_list = WebsiteContent.all_objects.all().only(

--- a/websites/management/commands/markdown_cleanup_baseurl.py
+++ b/websites/management/commands/markdown_cleanup_baseurl.py
@@ -133,7 +133,7 @@ class Command(BaseCommand):
     @staticmethod
     def do_handle(commit=False, out=None):
         """Replace baseurl with resource_link"""
-        print(WebsiteContent.all_objects)
+
         with ExitStack() as stack:
             wc_list = WebsiteContent.all_objects.all().only(
                 "dirpath", "filename", "markdown", "website_id"

--- a/websites/management/commands/markdown_cleanup_baseurl.py
+++ b/websites/management/commands/markdown_cleanup_baseurl.py
@@ -144,17 +144,17 @@ class Command(BaseCommand):
 
             content_lookup = ContentLookup(wc_list)
             replacer = BaseurlReplacer(content_lookup)
-            clear = WebsiteContentMarkdownCleaner(
+            cleaner = WebsiteContentMarkdownCleaner(
                 BaseurlReplacer.baseurl_regex, replacer
             )
 
             wc: WebsiteContent
             for wc in progress_bar(wc_list):
-                clear.update_website_content_markdown(wc)
+                cleaner.update_website_content_markdown(wc)
 
             if commit:
-                wc_list.bulk_update(clear.updated_website_contents, ["markdown"])
+                wc_list.bulk_update(cleaner.updated_website_contents, ["markdown"])
 
         if out is not None:
             outpath = os.path.normpath(os.path.join(os.getcwd(), out))
-            clear.write_matches_to_csv(outpath)
+            cleaner.write_matches_to_csv(outpath)

--- a/websites/management/commands/markdown_cleanup_baseurl.py
+++ b/websites/management/commands/markdown_cleanup_baseurl.py
@@ -1,0 +1,131 @@
+"""Replace baseurl-based links with resource_link shortcodes."""
+import os
+import re
+from contextlib import ExitStack
+from typing import Iterable
+
+from django.core.management import BaseCommand
+from django.core.management.base import CommandParser
+from django.db import transaction
+
+from websites.management.commands.util import (
+    WebsiteContentMarkdownCleaner,
+    progress_bar,
+)
+from websites.models import WebsiteContent
+
+
+class ContentLookup:
+    """
+    Thin wrapper around a dictionary to facilitate looking up WebsiteContent
+    objects by their content-relative URL + website id.
+    """
+
+    def __init__(self, website_contents: Iterable[WebsiteContent]):
+        self.website_contents = {
+            (wc.website_id, wc.dirpath, wc.filename): wc for wc in website_contents
+        }
+
+    def __str__(self):
+        return self.website_contents.__str__()
+
+    def get_content_by_url(self, website_id, content_relative_url: str):
+        """Lookup content by its website_id and content-relative URL.
+
+        Example:
+        =======
+        content_lookup.get_content_by_url('some-uuid', '/resources/graphs/cos')
+        """
+
+        content_relative_dirpath, filename = os.path.split(content_relative_url)
+
+        dirpath = f"content{content_relative_dirpath}"
+
+        return self.website_contents[(website_id, dirpath, filename)]
+
+
+class BaseurlReplacer:
+    """Replacer function for use with WebsiteContentMarkdownCleaner. Replaces
+    baseurl links with < resource_link > shortcodes.
+
+    This is intentially limited in scope for now. Some baseurl links, such as
+    those whose titles are images or include square brackets, are excluded from
+    replacement.
+    """
+
+    baseurl_regex = r"\[(?P<title>[^\[\]\n]*?)\]\({{< baseurl >}}(?P<url>.*?)\)"
+
+    def __init__(self, content_lookup: ContentLookup):
+        self.content_lookup = content_lookup
+
+    def __call__(self, match: re.Match, website_content: WebsiteContent):
+        original_text = match[0]
+        escaped_title = match.group("title").replace('"', '\\"')
+        url = match.group("url")
+
+        try:
+            linked_content = self.content_lookup.get_content_by_url(
+                website_content.website_id, url
+            )
+            return (
+                f'{{{{< resource_link {linked_content.text_id} "{escaped_title}" >}}}}'
+            )
+        except KeyError:
+            return original_text
+
+
+class Command(BaseCommand):
+    """
+    Replaces baseurl-based links in markdown with < resource_link > shortcodes.
+    """
+
+    help = __doc__
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument(
+            "-o",
+            "--out",
+            dest="out",
+            help="If provided, a CSV file of baseurl-based links and their replacements will be written to this path.",
+        )
+        parser.add_argument(
+            "-c",
+            "--commit",
+            dest="commit",
+            help="Whether the changes to markdown should be commited. The default, False, is useful for QA and testing when combined with --out parameter.",
+        )
+        super().add_arguments(parser)
+
+    def validate_options(self, options):
+        """Validate options passed to command."""
+        if not options["commit"] and not options["out"]:
+            raise ValueError("If --commit is falsy, --out should be provided")
+
+    def handle(self, *args, **options):
+        self.validate_options(options)
+        commit = options["commit"]
+
+        with ExitStack() as stack:
+            wc_list = WebsiteContent.all_objects.all().only(
+                "dirpath", "filename", "markdown", "website_id"
+            )
+            if commit:
+                stack.enter_context(transaction.atomic())
+                wc_list.select_for_update()
+
+            content_lookup = ContentLookup(wc_list)
+            replacer = BaseurlReplacer(content_lookup)
+            surgeon = WebsiteContentMarkdownCleaner(
+                BaseurlReplacer.baseurl_regex, replacer
+            )
+
+            wc: WebsiteContent
+            for wc in progress_bar(wc_list):
+                surgeon.update_website_content_markdown(wc)
+
+            if commit:
+                wc_list.bulk_update(surgeon.updated_website_contents, ["markdown"])
+
+        if "out" in options:
+            outpath = os.path.normpath(os.path.join(os.getcwd(), options["out"]))
+            surgeon.write_matches_to_csv(outpath)

--- a/websites/management/commands/markdown_cleanup_baseurl.py
+++ b/websites/management/commands/markdown_cleanup_baseurl.py
@@ -128,8 +128,8 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         self.validate_options(options)
-        commit = options['commit']
-        out = options['out']
+        commit = options["commit"]
+        out = options["out"]
 
         with ExitStack() as stack:
             wc_list = WebsiteContent.all_objects.all().only(

--- a/websites/management/commands/markdown_cleanup_baseurl_test.py
+++ b/websites/management/commands/markdown_cleanup_baseurl_test.py
@@ -1,0 +1,168 @@
+"""Tests for convert_baseurl_links_to_resource_links.py"""
+import pytest
+
+from websites.factories import WebsiteContentFactory, WebsiteFactory
+from websites.management.commands.markdown_cleanup_baseurl import (
+    BaseurlReplacer,
+    ContentLookup,
+    WebsiteContentMarkdownCleaner,
+)
+
+
+def get_markdown_cleaner(website_contents):
+    """Convenience to get baseurl-replacing markdown cleaner"""
+    content_lookup = ContentLookup(website_contents)
+    replacer = BaseurlReplacer(content_lookup)
+    return WebsiteContentMarkdownCleaner(BaseurlReplacer.baseurl_regex, replacer)
+
+
+@pytest.mark.parametrize(
+    "markdown, expected_markdown",
+    [
+        (
+            # standard link on same line as baseurl link
+            R"Cats are on [wikipedia](https://en.wikipedia.org/wiki/Cat). I also have a cat [meow]({{< baseurl >}}/resources/path/to/file1).",
+            R'Cats are on [wikipedia](https://en.wikipedia.org/wiki/Cat). I also have a cat {{< resource_link content-uuid-1 "meow" >}}.',
+        ),
+        (
+            R'This is a link with quote in title: [Cats say "meow"]({{< baseurl >}}/resources/path/to/file1).',
+            R'This is a link with quote in title: {{< resource_link content-uuid-1 "Cats say \"meow\"" >}}.',
+        ),
+        (
+            R"This link should change [text title]({{< baseurl >}}/resources/path/to/file1) cool",
+            R'This link should change {{< resource_link content-uuid-1 "text title" >}} cool',
+        ),
+        (
+            # < resource_link > short code is only for textual titles
+            "This link should not change: [![image](cat.com)]({{< baseurl >}}/resources/path/to/file1) for now",
+            "This link should not change: [![image](cat.com)]({{< baseurl >}}/resources/path/to/file1) for now",
+        ),
+        (
+            # Titles with nested brackets may not be feasible with a regex approach, but they're very rare anyway.
+            "This link should not change: [title has [square] braackets]({{< baseurl >}}/resources/path/to/file1) for now",
+            "This link should not change: [title has [square] braackets]({{< baseurl >}}/resources/path/to/file1) for now",
+        ),
+        (
+            "This link should not change: [title \n has newline]({{< baseurl >}}/resources/path/to/file1) for now",
+            "This link should not change: [title \n has newline]({{< baseurl >}}/resources/path/to/file1) for now",
+        ),
+    ],
+)
+def test_baseurl_replacer_specific_replacements(markdown, expected_markdown):
+    """Test specific replacements"""
+    website_uuid = "website-uuid"
+    target_content = WebsiteContentFactory.build(
+        markdown=markdown, website_id=website_uuid
+    )
+
+    linkables = [
+        WebsiteContentFactory.build(
+            website_id=website_uuid,
+            dirpath="content/resources/path/to",
+            filename=f"file{x}",
+            text_id=f"content-uuid-{x}",
+        )
+        for x in range(3)
+    ]
+
+    cleaner = get_markdown_cleaner(linkables)
+    cleaner.update_website_content_markdown(target_content)
+
+    assert target_content.markdown == expected_markdown
+
+
+def test_baseurl_replacer_replaces_baseurl_links():
+    """replace_baseurl_links should replace multiple links with expected values"""
+
+    markdown = R"""
+    « [Previous]({{< baseurl >}}/pages/reducing-problem) | [Next]({{< baseurl >}}/pages/vibration-analysis) »
+
+    ### Lecture Videos
+
+    *   Watch [Lecture 21: Vibration Isolation]({{< baseurl >}}/resources/lecture-21)
+        *   Video Chapters
+            *   [Demonstration of a vibration isolation system-strobe light and vibrating beam]({{< baseurl >}}/resources/demos/vibration-isolation)
+            * Euler's formula
+
+    Wasn't [the video]({{< baseurl >}}/resources/lecture-21) fun? Yes it was!
+    """
+
+    expected = R"""
+    « {{< resource_link uuid-111 "Previous" >}} | {{< resource_link uuid-222 "Next" >}} »
+
+    ### Lecture Videos
+
+    *   Watch {{< resource_link uuid-333 "Lecture 21: Vibration Isolation" >}}
+        *   Video Chapters
+            *   {{< resource_link uuid-444 "Demonstration of a vibration isolation system-strobe light and vibrating beam" >}}
+            * Euler's formula
+
+    Wasn't {{< resource_link uuid-333 "the video" >}} fun? Yes it was!
+    """
+
+    website = WebsiteFactory.build()
+    target_content = WebsiteContentFactory.build(markdown=markdown, website=website)
+
+    linked_contents = [
+        WebsiteContentFactory.build(website=website, **kwargs)
+        for kwargs in [
+            {
+                "dirpath": "content/pages",
+                "filename": "reducing-problem",
+                "text_id": "uuid-111",
+            },
+            {
+                "dirpath": "content/pages",
+                "filename": "vibration-analysis",
+                "text_id": "uuid-222",
+            },
+            {
+                "dirpath": "content/resources",
+                "filename": "lecture-21",
+                "text_id": "uuid-333",
+            },
+            {
+                "dirpath": "content/resources/demos",
+                "filename": "vibration-isolation",
+                "text_id": "uuid-444",
+            },
+        ]
+    ]
+
+    cleaner = get_markdown_cleaner(linked_contents)
+    cleaner.update_website_content_markdown(target_content)
+    assert target_content.markdown == expected
+
+
+@pytest.mark.parametrize(
+    "website_uuid, should_markdown_change",
+    [("website-uuid-111", True), ("website-uuid-222", False)],
+)
+def test_baseurl_replacer_replaces_content_in_same_course(
+    website_uuid, should_markdown_change
+):
+    """
+    Double check that if the dirpath + filename match multiple times, the
+    content chosen is from the same course as the markdown being edited
+    """
+
+    markdown = R"""
+    Kittens [meow]({{< baseurl >}}/resources/pets/cat) meow.
+    """
+
+    target_content = WebsiteContentFactory.build(
+        markdown=markdown, website_id="website-uuid-111"
+    )
+
+    linkable = WebsiteContentFactory.build(
+        website_id=website_uuid,
+        dirpath="content/resources/pets",
+        filename="cat",
+        text_id="uuid-111",
+    )
+
+    cleaner = get_markdown_cleaner([linkable])
+    cleaner.update_website_content_markdown(target_content)
+
+    is_markdown_changed = target_content.markdown != markdown
+    assert is_markdown_changed == should_markdown_change

--- a/websites/management/commands/util.py
+++ b/websites/management/commands/util.py
@@ -1,0 +1,147 @@
+import csv
+import re
+from collections import namedtuple
+from typing import Callable, Iterable, Match
+
+from websites.models import WebsiteContent
+
+
+def progress_bar(
+    iterable: Iterable,
+    prefix="",
+    suffix="",
+    decimals=1,
+    char_length=100,
+    fill="█",
+    printEnd="\r",
+):
+    """Call in a loop to create a terminal progress bar.
+
+    Args:
+        iterable (iterable): must implement __len__
+        prefix   (str): prefix string
+        suffix   (str): suffix string
+        decimals (int): positive number of decimals in percent complete
+        length   (int): character length of bar
+        fill     (str): bar fill character
+        printEnd (str): end character (e.g. "\r", "\r\n")
+
+    Yields:
+        The same items as `iterable`
+
+    From https://stackoverflow.com/a/34325723/2747370
+    """
+    total = len(iterable)
+    # Progress Bar Printing Function
+
+    def print_progress_bar(iteration):
+        percent = ("{0:." + str(decimals) + "f}").format(
+            100 * (iteration / float(total))
+        )
+        filledLength = int(char_length * iteration // total)
+        progress = fill * filledLength + "-" * (char_length - filledLength)
+        print(f"\r{prefix} |{progress}| {percent}% {suffix}", end=printEnd)
+
+    # Initial Call
+    print_progress_bar(0)
+    # Update Progress Bar
+    for i, item in enumerate(iterable):
+        yield item
+        print_progress_bar(i + 1)
+    # Print New Line on Complete
+    print()
+
+
+class WebsiteContentMarkdownCleaner:
+    """Facilitates regex-based replacements on WebsiteContent markdown.
+
+    Args:
+        pattern (str)       : The pattern to match for when making replacements.
+            If the pattern uses named capturing groups, these groups will be
+            included as csv columns by `write_to_csv()` method.
+        replacer (callable) : A function called for every non-overlapping match
+            of `pattern` and returning the replacement string. This is similar
+            to the `repl` argument of `re.sub`, but is invoked with two
+            arguments: `(match, website_content)`, where `website_content` is
+            `website_content` object whose markdown is currently being edited.
+
+    Note: Internally records all matches and replacement results for subsequent
+    writing to csv
+    """
+
+    ReplacementMatch = namedtuple(
+        "ReplacementMatch",
+        ["match", "replacement", "website_content_uuid", "website_uuid"],
+    )
+    csv_metadata_fieldnames = [
+        "original_text",
+        "replacement",
+        "website_content_uuid",
+        "website_uuid",
+    ]
+
+    def __init__(self, pattern: str, replacer: Callable[[Match, WebsiteContent], str]):
+        self.regex = self.compile_regex(pattern)
+
+        self.text_changes: "list[WebsiteContentMarkdownCleaner.ReplacementMatch]" = []
+        self.updated_website_contents: "list[WebsiteContent]" = []
+
+        def _replacer(match: Match, website_content: WebsiteContent):
+            replacement = replacer(match, website_content)
+            self.text_changes.append(
+                self.ReplacementMatch(
+                    match,
+                    replacement,
+                    website_content.text_id,
+                    website_content.website_id,
+                )
+            )
+            return replacement
+
+        self.replacer = _replacer
+
+    def update_website_content_markdown(self, website_content: WebsiteContent):
+        """
+        Updates website_content's markdown in-place. Does not commit to
+        database.
+        """
+        if not website_content.markdown:
+            return
+
+        new_markdown = self.regex.sub(
+            lambda match: self.replacer(match, website_content),
+            website_content.markdown,
+        )
+        if new_markdown != website_content.markdown:
+            website_content.markdown = new_markdown
+            self.updated_website_contents.append(website_content)
+
+    @classmethod
+    def compile_regex(cls, pattern):
+        """Compile `pattern` and validate that it has no named capturing groups
+        whose name would conflict with csv metadata fieldnames."""
+        compiled = re.compile(pattern)
+        for groupname in cls.csv_metadata_fieldnames:
+            if groupname in compiled.groupindex:
+                raise ValueError(
+                    f"Regex group name {groupname} is reserved for use by {cls.__name__}"
+                )
+        return compiled
+
+    def write_matches_to_csv(self, path: str):
+        """Write matches and replacements to csv."""
+
+        fieldnames = self.text_changes[0].match
+        with open(path, "w", newline="") as csvfile:
+            fieldnames = [*self.csv_metadata_fieldnames, *self.regex.groupindex]
+            writer = csv.DictWriter(csvfile, fieldnames, quoting=csv.QUOTE_ALL)
+            writer.writeheader()
+            for change in self.text_changes:
+                row = {
+                    "website_content_uuid": change.website_content_uuid,
+                    "website_uuid": change.website_uuid,
+                    "original_text": change.match[0],
+                    "replacement": change.replacement,
+                    **change.match.groupdict(),
+                }
+                writer.writerow(row)


### PR DESCRIPTION
Converts baseurl links to resource_link shortcodes. Current version cleans up 90% of the baseurl links.

#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets? #969 

#### What's this PR do?
This PR adds a management command to clean up baseurl links in our markdown and convert them to resource_link shortcodes.

This management command converts about 90% of our current baseurl usage. The remaining 10% falls in two categories:

1. **Links we can convert soon:** baseurl links we can convert soon, but just aren't handled by this command yet. See https://github.com/mitodl/ocw-studio/pull/1002/files#r806218276 for more info.

2. **Links whose conversion to resource_link is blocked:** This includes things like links whose titles are images.

#### How should this be manually tested?

The management command can be invoked via
```
docker-compose run --rm web python manage.py markdown_cleanup_baseurl -o out.csv
```
This will:

1. Run the find-and-replace cleanup on all website content markdown, writing the replacements made as a csv `out.csv`
2. but NOT commit the changes

To commit the changes, add `--commit true`.

To test this locally, I would recommend running this on some courses and inspecting `out.csv`, then running in commit-mode and checking that markdown has changed as you would expect.  _If you want to run the commit multiple times, or restore your original data afterwards, dump your database beforehand and recreate the container a la #923_

For example, you can check the Calendar page in "Uncertainty in Engineering" on rc vs local studio. On rc the calendar links do not show up correctly in CKEditor, but after this management command, they will.

#### How I tested this
My primary concern when testing this was ensuring that it didn't screw up our data. And I found some issues with earlier versions, e.g., an earlier version was capturing way too much text as link title. I tested this pretty thoroughly and am now confident that the converter is correctly converting the stuff it changes.

What I did to test this was
- import all courses from `ocw-to-hugo-output-qa`
- run some queries on our website tables to investigate baseurl usage
- generate the csv of replacements
- imported csv into a psotgres db and did some analysis

The numbers below are based on 2642 courses imported on 2022-02-14:
```
92607 instances of 'baseurl' across 10533 markdown files in 2415 courses
91227 instances of 'baseurl' picked up by markdown_cleanup_baseurl's regex
83966 instances of 'baseurl' converted by markdown_cleanup_baseurl
```
Of the 83966 replacements made, all but 646 involved links whose
    - title was shorter than 80 characters, AND
    - title matched regex `[0-9\.a-zA-z\s]` (alphanumeric + period + space)

The 646 longer or more complicated titles I scanned over briefly. They all look reasonable.

#### Other Notes:
- took about 90 seconds locally on the 2600 courses 
- [CSV output from my testing](https://docs.google.com/spreadsheets/d/1VYMMiVkpY7jTrC6UlmgTFgHOcGCyNjqEoEeWCIaHtk8/edit?usp=sharing)