### PR TITLE
type -> ocw_type

### DIFF
--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -182,7 +182,7 @@ def get_learning_resource_types(content_json):
 
     if "Section" in content_json.get("parent_type", ""):
         section_title = content_json.get("parent_title")
-    elif "Section" in content_json.get("type", ""):
+    elif "Section" in content_json.get("ocw_type", ""):
         section_title = content_json.get("title")
     else:
         return []

--- a/ocw_import/api_test.py
+++ b/ocw_import/api_test.py
@@ -425,7 +425,7 @@ def test_update_ocw2hugo_course(mocker, website_exists):
     [
         [
             {
-                "type": "CourseSection",
+                "ocw_type": "CourseSection",
                 "parent_type": "CourseSection",
                 "title": "First Paper Assignment",
                 "parent_title": "Lecture Summaries",
@@ -434,14 +434,14 @@ def test_update_ocw2hugo_course(mocker, website_exists):
         ],
         [
             {
-                "type": "CourseSection",
+                "ocw_type": "CourseSection",
                 "title": "First Paper Assignment",
             },
             [OCW_TYPE_ASSIGNMENTS],
         ],
         [
             {
-                "type": "CourseSection",
+                "ocw_type": "CourseSection",
                 "parent_type": "CourseSection",
                 "title": "First Paper Assignment",
                 "parent_title": "Assignments and Exams",
@@ -450,7 +450,7 @@ def test_update_ocw2hugo_course(mocker, website_exists):
         ],
         [
             {
-                "type": "CourseSection",
+                "ocw_type": "CourseSection",
                 "parent_type": "CourseSection",
                 "title": "First Paper Assignment",
                 "parent_title": OCW_TYPE_LECTURE_NOTES,
@@ -459,7 +459,7 @@ def test_update_ocw2hugo_course(mocker, website_exists):
         ],
         [
             {
-                "type": "CourseSection",
+                "ocw_type": "CourseSection",
                 "title": "Exercises",
             },
             [],

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/pages/assignments.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/pages/assignments.md
@@ -1,7 +1,7 @@
 ---
 uid: 8e344ad5-a553-4368-9048-9e95e736657a
 title: Assignments
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 {{< tableopen >}}

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/pages/calendar.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/pages/calendar.md
@@ -1,7 +1,7 @@
 ---
 uid: ff5e415d-cded-bcfc-d6b2-c4a96377207c
 title: Calendar
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 {{< tableopen >}}

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/pages/lecture-notes.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/pages/lecture-notes.md
@@ -1,7 +1,7 @@
 ---
 uid: dec40ff4-e8ca-636f-c6db-d88880914a96
 title: Lecture Notes
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 A significant portion of this course was taught at the blackboard, so the following lecture notes are not intended to fully capture the content of the course. The lecture notes tend to be more detailed in the second half of the course. Lecture summaries are also available for the first half of the course.

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/pages/related-resources.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/pages/related-resources.md
@@ -1,7 +1,7 @@
 ---
 uid: 4f5c3926-e4d5-6974-7f16-131a6f692568
 title: Related Resources
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 MATLAB® Tutorials

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/pages/syllabus.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/pages/syllabus.md
@@ -1,7 +1,7 @@
 ---
 uid: 96c31e82-69f0-6d67-daee-8272526ac56a
 title: Syllabus
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 Course Meeting Times

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/1-050f07-th.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/1-050f07-th.md
@@ -6,7 +6,7 @@ resourcetype: Image
 file_type: image/jpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/4cdfb4e332fa9fdfa166c337e35fc009_1-050f07-th.jpg
-type: OCWImage
+ocw_type: OCWImage
 image_metadata:
   image-alt: Sketch of the World Trade Center towers and graph showing velocity profiles.
   caption: >-

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/1-050f07.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/1-050f07.md
@@ -9,7 +9,7 @@ resourcetype: Image
 file_type: image/jpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/ba36b42898988e4581d42067ac439546_1-050f07.jpg
-type: OCWImage
+ocw_type: OCWImage
 image_metadata:
   image-alt: Sketch of the World Trade Center towers and graph showing velocity profiles.
   caption: >-

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/assn1.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/assn1.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/aa326bf3aa0fba3bdd1e1739e0d4f5ce_assn1.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Assignments
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/assn10.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/assn10.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/e92039c1a9022b9b7800701a112543e2_assn10.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Assignments
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/assn11.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/assn11.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/f12456a1c7cd33db34cb9e7176f4abbf_assn11.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Assignments
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/assn2.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/assn2.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/44953699b457bb463f41e470ee31673a_assn2.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Assignments
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/assn3.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/assn3.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/5248762c7c1340f201b69511bcc8f03b_assn3.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Assignments
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/assn4.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/assn4.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/6209d23c2b1abb0019fd8f93dbe628e1_assn4.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Assignments
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/assn5.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/assn5.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/3fbcfd921f119af5cc17ef3a34dfe6ee_assn5.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Assignments
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/assn6.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/assn6.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/ae80fa2b35e67473563e2cf8e470efa5_assn6.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Assignments
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/assn7.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/assn7.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/1de6f6177ff0b4ad09f6c4f2797d6cbf_assn7.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Assignments
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/assn8.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/assn8.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/0356dd1609456fc27dfdeedeac534a7d_assn8.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Assignments
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/assn9.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/assn9.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/df86fc3a3ec24865b833f8e4c74aafb9_assn9.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Assignments
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec1.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec1.md
@@ -9,7 +9,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/7f91d52457aaef8093c58a43f10a099b_lec1.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec10.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec10.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/a0431a76b3dace8fd97ceab087512395_lec10.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec11.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec11.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/0b893146c018337e497a76c8f7aaffb6_lec11.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec12.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec12.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/37bf75128b6f9961c0148b6316b19d4a_lec12.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec13.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec13.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/8deeb8fae4ee23f0dbc0331c7bc815a9_lec13.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec14.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec14.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/28c62a7d4fc9416ce49e3f08b3f5b650_lec14.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec15.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec15.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/67c58d499d0a9929cbd638e6e36af58d_lec15.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec16.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec16.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/873a66281579d2a970b69fb51ea1610d_lec16.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec17.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec17.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/bbb169ea17e92da6dab5db04a771e06e_lec17.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec19.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec19.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/a4064fb01c4285ba2c801a8e66000434_lec19.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec2.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec2.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/12add51eb384c9c49d83bac16e954c57_lec2.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec22.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec22.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/e7b029d16e1e2b5374cb8482c3fba57f_lec22.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec23.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec23.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/d5f760fef818de14b55dd70d3878fbbe_lec23.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec24.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec24.md
@@ -10,7 +10,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/07816e0cb4ebc6d3324106e02b58f068_lec24.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec25.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec25.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/5591032a97d3b31dca44e323b3c3fdcf_lec25.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec26.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec26.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/47c2c866a5e0bbcf31251d5c7ec03b77_lec26.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec27.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec27.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/717159d9dc1314e0dab7f5a53b79afe8_lec27.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec28.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec28.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/fcb0c513f4d844b9e2593403f8b6eb47_lec28.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec29.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec29.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/4c3131b7c213fef713f19bfc4e61b8ac_lec29.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec3.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec3.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/1ee8f138ba06d561ffd74486422fd421_lec3.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec30.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec30.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/702704e972fd5a8605b3e4c4a7c41e5c_lec30.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec31.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec31.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/5145526a666205b26e523e60b2447985_lec31.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec32.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec32.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/17dbb6a7318ca4c032d795af353a86a3_lec32.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec32_clapeyron.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec32_clapeyron.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/a772ecdcf16244e8ac8a7e46422ae8dd_lec32_clapeyron.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec33.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec33.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/bd534b246d9216f12720659d93934e6c_lec33.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec34.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec34.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/ec501d2b0af7374520084ee3f20a79bb_lec34.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec34_buckling.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec34_buckling.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/b664aab1195a41b9368950a3bf51c93c_lec34_buckling.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec37_review.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec37_review.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/4721abd8c8e8b8c8181de1d93715aaf7_lec37_review.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec4.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec4.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/cd7abd1e2698c451c57f7b238b45fc57_lec4.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec5.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec5.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/d7060aed8f689a10cb19de0ff86e6766_lec5.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec6.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec6.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/0df283a26a1fc71882705f3938eb3ba3_lec6.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec7.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec7.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/15a836500520ce939db4b1ff292cfebc_lec7.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec8.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec8.md
@@ -9,7 +9,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/68ebacfa8ae36eeb8d8b4e2fb6ef0ad7_lec8.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec9.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/lec9.md
@@ -9,7 +9,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/2e080e7e82663cdcf89f58e157571d96_lec9.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/matlab.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/matlab.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/c8cd93840305bfbb46aea7e7a8229f57_matlab.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Related Resources
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary1.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary1.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/fee09afca9f77fd1982faf1b26ad790a_summary1.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary10.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary10.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/aa0b2c4f452cfd9013a4959015507b30_summary10.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary11.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary11.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/6b47e02132d41461231ad5de61411c86_summary11.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary12.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary12.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/82c7b696e40b8918be63eb19e78646b9_summary12.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary13.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary13.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/45f15a5eac5ac77798cce994f22ba752_summary13.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary14.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary14.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/b5a6a34526b92337938d68aa4976c5dd_summary14.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary16.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary16.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/cf46effb13e876aebd053f609daa8754_summary16.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary17.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary17.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/e64211c8e263b15c89514f0db5b4e569_summary17.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary18.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary18.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/d9c7f7b43df2e3381478b6a46966b7c9_summary18.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary19.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary19.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/2bd7cef30d04750bc0eec1c3c30e4d11_summary19.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary2.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary2.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/fd43440bb9b95859b6c869362a1628b9_summary2.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary3.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary3.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/a124ef9c60ac91f72efc1590735b883c_summary3.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary4.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary4.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/bb39a033fe023ffd7108e380e6e5ecc3_summary4.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary5.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary5.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/deee67ff54621a536b429396258c5d32_summary5.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary6.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary6.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/748001b6bf289636952d0496cf32ce2e_summary6.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary7.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/summary7.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/1ee1b4ab14b57967f6bca59c93656ce1_summary7.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/variables1.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/variables1.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/fceddc7f413aa59ebe8f45c7becd94a1_variables1.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/variables2.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/variables2.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/b5e06f54a37ac451fe00a2cd0a9d6532_variables2.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/variables3.md
+++ b/test_ocw2hugo/1-050-engineering-mechanics-i-fall-2007/content/resources/variables3.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-050-engineering-mechanics-i-fall-2007/35806cc11f73e1ddf902580c83d1566f_variables3.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/pages/assignments.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/pages/assignments.md
@@ -1,7 +1,7 @@
 ---
 uid: 9fcb7d0d-8cfe-f1b0-2f1d-7a69f645464a
 title: Assignments
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 {{< tableopen >}}

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/pages/calendar.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/pages/calendar.md
@@ -1,7 +1,7 @@
 ---
 uid: 54903c0a-c436-795e-6e69-f4d5ac7ff701
 title: Calendar
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 {{< tableopen >}}

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/pages/exams.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/pages/exams.md
@@ -1,7 +1,7 @@
 ---
 uid: d07e7cf7-851b-fa90-9694-67a43405b492
 title: Exams
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 {{< tableopen >}}

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/pages/lecture-notes.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/pages/lecture-notes.md
@@ -1,7 +1,7 @@
 ---
 uid: 94c094b7-b01d-868e-f112-82cef13859cc
 title: Lecture Notes
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 Selected lectures are available below. All guest lectures are courtesy of the person named, and are used with permission.

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/pages/readings.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/pages/readings.md
@@ -1,7 +1,7 @@
 ---
 uid: 306bf4e0-7394-1c59-852a-235dc8dd97d7
 title: Readings
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 The course draws on three primary textbooks, which are listed in the table below with the following abbreviations:

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/pages/syllabus.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/pages/syllabus.md
@@ -1,7 +1,7 @@
 ---
 uid: 4bb2e8f1-277b-1082-11e3-471c42e948f3
 title: Syllabus
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 Course Meeting Times

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/pages/test_no_uid.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/pages/test_no_uid.md
@@ -1,7 +1,7 @@
 ---
 title: No UID
 course_id: 1-201j-transportation-systems-analysis-demand-and-economics-fall-2008
-type: course
+ocw_type: course
 layout: course_section
 ---
 

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/1-201_f08_lec23.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/1-201_f08_lec23.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/04a48a5b9358e4429602c65b26b60a0d_1.201_f08_lec23.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/1-201_f08_lecture22.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/1-201_f08_lecture22.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/6062840fe01898c55f7ae9ffc7759aa1_1.201_f08_lecture22.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/1-201jf08-th.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/1-201jf08-th.md
@@ -8,7 +8,7 @@ resourcetype: Image
 file_type: image/jpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/6d7b103f7ee8600b369f8b7ed69c1519_1-201jf08-th.jpg
-type: OCWImage
+ocw_type: OCWImage
 image_metadata:
   image-alt: Passengers boarding a subway in Madrid.
   caption: >-

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/1-201jf08.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/1-201jf08.md
@@ -8,7 +8,7 @@ resourcetype: Image
 file_type: image/jpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/0c62366c41d2af0b8e1ec4b9dc3748d7_1-201jf08.jpg
-type: OCWImage
+ocw_type: OCWImage
 image_metadata:
   image-alt: Passengers boarding a subway in Madrid.
   caption: >-

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/hw_5.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/hw_5.md
@@ -6,7 +6,7 @@ resourcetype: Other
 file_type: application/msword
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/abbd17c15ff53ba0f81910b66afd6522_hw_5.xls
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Assignments
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_final.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_final.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/08be108a6f0362fa3ef5409203c1956f_MIT1_201JF08_final.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Exams
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_final07.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_final07.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/b234e9a9f28f9f114e4a2df9ccf04722_MIT1_201JF08_final07.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Exams
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_hw_1.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_hw_1.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/275a107cdaf86cfd6b3d59f3534e094a_MIT1_201JF08_hw_1.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Assignments
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_hw_2.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_hw_2.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/39821eb3270ba800d6ef4ce81cf8d5f1_MIT1_201JF08_hw_2.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Assignments
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_hw_3.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_hw_3.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/ac17cea8e12cae7dc70adb967e73b108_MIT1_201JF08_hw_3.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Assignments
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_hw_4.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_hw_4.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/1e8c891662e8ad3942e773db1e2f4eba_MIT1_201JF08_hw_4.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Assignments
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_hw_5.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_hw_5.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/32a3224d398faa84cfa7564042be9a3d_MIT1_201JF08_hw_5.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Assignments
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec01.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec01.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/12e51b7ca0fb18891c74d21d5f7b475f_MIT1_201JF08_lec01.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec02.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec02.md
@@ -9,7 +9,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/0da5d80892d0497c15107f296bfa3a75_MIT1_201JF08_lec02.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec03.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec03.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/9eadd4cccfa491680a5c5bb4233f78ab_MIT1_201JF08_lec03.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec04.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec04.md
@@ -9,7 +9,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/1fe5a6531216e44dbe94543535a1ddd3_MIT1_201JF08_lec04.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec05.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec05.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/a73e9a7cb5edbbd0d0b955ca172c0856_MIT1_201JF08_lec05.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec06.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec06.md
@@ -9,7 +9,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/7c29839f902550fa6800c37f31943bec_MIT1_201JF08_lec06.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec07.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec07.md
@@ -13,7 +13,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/c5ad55d9fbbac5fefca9cf035d9a47a2_MIT1_201JF08_lec07.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec08.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec08.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/5cb4b68ba2862c05be088455242112f4_MIT1_201JF08_lec08.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec09.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec09.md
@@ -9,7 +9,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/f85bad821869fc927af7c2c078f78c01_MIT1_201JF08_lec09.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec10.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec10.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/811d2e2f5bb724df2e3e46ff0c2da6b8_MIT1_201JF08_lec10.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec12.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec12.md
@@ -9,7 +9,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/e7bd11d71c997467d994e11e0e7081a6_MIT1_201JF08_lec12.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec13.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec13.md
@@ -10,7 +10,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/1f95d3f5478db83751911b5617967db4_MIT1_201JF08_lec13.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec16.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec16.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/f4fa5794738819bdbc0ae42508120f21_MIT1_201JF08_lec16.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec17.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec17.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/0fc64f08e8343d2c4b0f2c27bc13690d_MIT1_201JF08_lec17.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec18.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec18.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/973ee77cd644ca7685647313cf892e2d_MIT1_201JF08_lec18.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec19.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec19.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/cde9ee13763469fdce84edc34d217868_MIT1_201JF08_lec19.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec20.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec20.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/a23d95b1e9f7973f03fe6da9f7493fe5_MIT1_201JF08_lec20.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec21.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec21.md
@@ -9,7 +9,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/afc26475c9b2e882dd28af69353a22b0_MIT1_201JF08_lec21.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec24.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec24.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/53ff1622c95cb74b9a8965aae40c1fd5_MIT1_201JF08_lec24.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec26.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_lec26.md
@@ -11,7 +11,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/246ff23f8bd157759243b3fc55c631f0_MIT1_201JF08_lec26.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lecture Notes
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_midterm.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_midterm.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/75f5aad063e2a28e118804b9aee48034_MIT1_201JF08_midterm.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Exams
 ---

--- a/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_pricing_prob.md
+++ b/test_ocw2hugo/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/content/resources/mit1_201jf08_pricing_prob.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/1-201j-transportation-systems-analysis-demand-and-economics-fall-2008/b9e57716c8c766dc2ccc0f76e2fefc1a_MIT1_201JF08_pricing_prob.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Exams
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/calendar.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/calendar.md
@@ -1,7 +1,7 @@
 ---
 uid: 7aa9e941-aeaf-6118-7b6b-140bd04f00c3
 title: Calendar
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 {{< tableopen >}}

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/instructor-insights/_index.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/instructor-insights/_index.md
@@ -2,7 +2,7 @@
 uid: a6e7d634-7a40-6faa-23d0-020703ee7044
 title: Instructor Insights
 layout: instructor_insights
-type: ThisCourseAtMITSection
+ocw_type: ThisCourseAtMITSection
 ---
 
 Course Overview
@@ -58,7 +58,7 @@ The Classroom
     
     Dr. Paola Rebusco shows off the newly redesigned kitchen she used to teach Speak Italian With Your Mouth Full.
     
-    \<style type="text/css"> .pagecontainer {display:none;} \</style> \<div id="atnmsg" style='width: 300px;' class="attention\_message"> \<p>Flash and JavaScript are required for this feature.\</p> \</div>
+    \<style ocw_type="text/css"> .pagecontainer {display:none;} \</style> \<div id="atnmsg" style='width: 300px;' class="attention\_message"> \<p>Flash and JavaScript are required for this feature.\</p> \</div>
     
     [Watch Dr. Rebusco give a guided tour of the ESG common space and classrooms.](#?w=535)
     

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/instructor-insights/developing-the-course.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/instructor-insights/developing-the-course.md
@@ -5,7 +5,7 @@ parent_uid: a6e7d634-7a40-6faa-23d0-020703ee7044
 parent_title: Instructor Insights
 parent_type: ThisCourseAtMITSection
 layout: instructor_insights
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/instructor-insights) | [Next]({{< baseurl >}}/pages/instructor-insights/teaching-italian-and-cooking-together) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/instructor-insights/learning-from-challenges.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/instructor-insights/learning-from-challenges.md
@@ -5,7 +5,7 @@ parent_uid: a6e7d634-7a40-6faa-23d0-020703ee7044
 parent_title: Instructor Insights
 parent_type: ThisCourseAtMITSection
 layout: instructor_insights
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/instructor-insights/using-technology-to-expand-reach) | [Next]({{< baseurl >}}/pages/calendar) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/instructor-insights/teaching-italian-and-cooking-together.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/instructor-insights/teaching-italian-and-cooking-together.md
@@ -5,7 +5,7 @@ parent_uid: a6e7d634-7a40-6faa-23d0-020703ee7044
 parent_title: Instructor Insights
 parent_type: ThisCourseAtMITSection
 layout: instructor_insights
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/instructor-insights/developing-the-course) | [Next]({{< baseurl >}}/pages/instructor-insights/using-technology-to-expand-reach) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/instructor-insights/using-technology-to-expand-reach.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/instructor-insights/using-technology-to-expand-reach.md
@@ -5,7 +5,7 @@ parent_uid: a6e7d634-7a40-6faa-23d0-020703ee7044
 parent_title: Instructor Insights
 parent_type: ThisCourseAtMITSection
 layout: instructor_insights
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/instructor-insights/teaching-italian-and-cooking-together) | [Next]({{< baseurl >}}/pages/instructor-insights/learning-from-challenges) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-1/_index.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-1/_index.md
@@ -1,7 +1,7 @@
 ---
 uid: c4c7fba0-2305-e785-952c-8d8e6bf26fc3
 title: Lesson 1
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 [Next]({{< baseurl >}}/pages/lesson-1/language-instruction) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-1/cooking-instruction.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-1/cooking-instruction.md
@@ -4,7 +4,7 @@ title: Cooking Instruction
 parent_uid: c4c7fba0-2305-e785-952c-8d8e6bf26fc3
 parent_title: Lesson 1
 parent_type: CourseSection
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-1/language-instruction) | [Next]({{< baseurl >}}/pages/lesson-2) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-1/language-instruction.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-1/language-instruction.md
@@ -4,7 +4,7 @@ title: Language Instruction
 parent_uid: c4c7fba0-2305-e785-952c-8d8e6bf26fc3
 parent_title: Lesson 1
 parent_type: CourseSection
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-1) | [Next]({{< baseurl >}}/pages/lesson-1/cooking-instruction) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-10/_index.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-10/_index.md
@@ -1,7 +1,7 @@
 ---
 uid: 246b7204-f562-c6cf-d930-6a51cbf7a049
 title: Lesson 10
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-9/cooking-instruction) | [Next]({{< baseurl >}}/pages/lesson-10/language-instruction) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-10/cooking-instruction.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-10/cooking-instruction.md
@@ -4,7 +4,7 @@ title: Cooking Instruction
 parent_uid: 246b7204-f562-c6cf-d930-6a51cbf7a049
 parent_title: Lesson 10
 parent_type: CourseSection
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-10/language-instruction) | [Next]({{< baseurl >}}/pages/lesson-11) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-10/language-instruction.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-10/language-instruction.md
@@ -4,7 +4,7 @@ title: Language Instruction
 parent_uid: 246b7204-f562-c6cf-d930-6a51cbf7a049
 parent_title: Lesson 10
 parent_type: CourseSection
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-10) | [Next]({{< baseurl >}}/pages/lesson-10/cooking-instruction) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-11/_index.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-11/_index.md
@@ -1,7 +1,7 @@
 ---
 uid: 0b61d31d-8bf7-43a0-6195-1c787115299e
 title: Lesson 11
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-10/cooking-instruction) | [Next]({{< baseurl >}}/pages/lesson-11/language-instruction) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-11/cooking-instruction.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-11/cooking-instruction.md
@@ -4,7 +4,7 @@ title: Cooking Instruction
 parent_uid: 0b61d31d-8bf7-43a0-6195-1c787115299e
 parent_title: Lesson 11
 parent_type: CourseSection
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-11/language-instruction) | [Next]({{< baseurl >}}/pages/lesson-12) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-11/language-instruction.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-11/language-instruction.md
@@ -4,7 +4,7 @@ title: Language Instruction
 parent_uid: 0b61d31d-8bf7-43a0-6195-1c787115299e
 parent_title: Lesson 11
 parent_type: CourseSection
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-11) | [Next]({{< baseurl >}}/pages/lesson-11/cooking-instruction) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-12/_index.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-12/_index.md
@@ -1,7 +1,7 @@
 ---
 uid: f0ae6f59-4c9a-13c9-9b83-75ccf8b3c6ee
 title: Lesson 12
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-11/cooking-instruction) | [Next]({{< baseurl >}}/pages/lesson-12/language-instruction) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-12/cooking-instruction.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-12/cooking-instruction.md
@@ -4,7 +4,7 @@ title: Cooking Instruction
 parent_uid: f0ae6f59-4c9a-13c9-9b83-75ccf8b3c6ee
 parent_title: Lesson 12
 parent_type: CourseSection
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-12/language-instruction) | [Next]({{< baseurl >}}/pages/lesson-13) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-12/language-instruction.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-12/language-instruction.md
@@ -4,7 +4,7 @@ title: Language Instruction
 parent_uid: f0ae6f59-4c9a-13c9-9b83-75ccf8b3c6ee
 parent_title: Lesson 12
 parent_type: CourseSection
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-12) | [Next]({{< baseurl >}}/pages/lesson-12/cooking-instruction) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-13.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-13.md
@@ -1,7 +1,7 @@
 ---
 uid: 47f6cbac-8f7a-d956-625b-ba782046ba03
 title: Lesson 13
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-12/cooking-instruction)

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-2/_index.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-2/_index.md
@@ -1,7 +1,7 @@
 ---
 uid: 463b4c8e-dc1e-e06b-6353-693de4b36524
 title: Lesson 2
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-1/cooking-instruction) | [Next]({{< baseurl >}}/pages/lesson-2/language-instruction) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-2/cooking-instruction.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-2/cooking-instruction.md
@@ -4,7 +4,7 @@ title: Cooking Instruction
 parent_uid: 463b4c8e-dc1e-e06b-6353-693de4b36524
 parent_title: Lesson 2
 parent_type: CourseSection
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-2/language-instruction) | [Next]({{< baseurl >}}/pages/lesson-3) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-2/language-instruction.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-2/language-instruction.md
@@ -4,7 +4,7 @@ title: Language Instruction
 parent_uid: 463b4c8e-dc1e-e06b-6353-693de4b36524
 parent_title: Lesson 2
 parent_type: CourseSection
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-2) | [Next]({{< baseurl >}}/pages/lesson-2/cooking-instruction) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-3/_index.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-3/_index.md
@@ -1,7 +1,7 @@
 ---
 uid: 16b38273-3d02-fca8-e488-1b3e810b1572
 title: Lesson 3
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-2/cooking-instruction) | [Next]({{< baseurl >}}/pages/lesson-3/language-instruction) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-3/cooking-instruction.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-3/cooking-instruction.md
@@ -4,7 +4,7 @@ title: 'Cooking Instruction '
 parent_uid: 16b38273-3d02-fca8-e488-1b3e810b1572
 parent_title: Lesson 3
 parent_type: CourseSection
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-3/language-instruction) | [Next]({{< baseurl >}}/pages/lesson-4) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-3/language-instruction.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-3/language-instruction.md
@@ -4,7 +4,7 @@ title: Language Instruction
 parent_uid: 16b38273-3d02-fca8-e488-1b3e810b1572
 parent_title: Lesson 3
 parent_type: CourseSection
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-3) | [Next]({{< baseurl >}}/pages/lesson-3/cooking-instruction) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-4/_index.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-4/_index.md
@@ -1,7 +1,7 @@
 ---
 uid: 45ae6e3b-7bcf-ebdb-0480-f2b9be5a75b7
 title: Lesson 4
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-3/cooking-instruction) | [Next]({{< baseurl >}}/pages/lesson-4/language-instruction) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-4/cooking-instruction.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-4/cooking-instruction.md
@@ -4,7 +4,7 @@ title: 'Cooking Instruction '
 parent_uid: 45ae6e3b-7bcf-ebdb-0480-f2b9be5a75b7
 parent_title: Lesson 4
 parent_type: CourseSection
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-4/language-instruction) | [Next]({{< baseurl >}}/pages/lesson-5) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-4/language-instruction.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-4/language-instruction.md
@@ -4,7 +4,7 @@ title: Language Instruction
 parent_uid: 45ae6e3b-7bcf-ebdb-0480-f2b9be5a75b7
 parent_title: Lesson 4
 parent_type: CourseSection
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-4) | [Next]({{< baseurl >}}/pages/lesson-4/cooking-instruction) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-5/_index.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-5/_index.md
@@ -1,7 +1,7 @@
 ---
 uid: 56e06732-1e88-3c54-5df6-9d03d3daeb8b
 title: Lesson 5
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-4/cooking-instruction) | [Next]({{< baseurl >}}/pages/lesson-5/language-instruction) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-5/cooking-instruction.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-5/cooking-instruction.md
@@ -4,7 +4,7 @@ title: 'Cooking Instruction '
 parent_uid: 56e06732-1e88-3c54-5df6-9d03d3daeb8b
 parent_title: Lesson 5
 parent_type: CourseSection
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-5/language-instruction) | [Next]({{< baseurl >}}/pages/lesson-6) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-5/language-instruction.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-5/language-instruction.md
@@ -4,7 +4,7 @@ title: Language Instruction
 parent_uid: 56e06732-1e88-3c54-5df6-9d03d3daeb8b
 parent_title: Lesson 5
 parent_type: CourseSection
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-5) | [Next]({{< baseurl >}}/pages/lesson-5/cooking-instruction) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-6/_index.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-6/_index.md
@@ -1,7 +1,7 @@
 ---
 uid: 4295e758-bff2-5514-bf94-945586ed328d
 title: Lesson 6
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-5/cooking-instruction) | [Next]({{< baseurl >}}/pages/lesson-6/language-instruction) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-6/cooking-instruction.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-6/cooking-instruction.md
@@ -4,7 +4,7 @@ title: Cooking Instruction
 parent_uid: 4295e758-bff2-5514-bf94-945586ed328d
 parent_title: Lesson 6
 parent_type: CourseSection
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-6/language-instruction) | [Next]({{< baseurl >}}/pages/lesson-7) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-6/language-instruction.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-6/language-instruction.md
@@ -4,7 +4,7 @@ title: Language Instruction
 parent_uid: 4295e758-bff2-5514-bf94-945586ed328d
 parent_title: Lesson 6
 parent_type: CourseSection
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-6) | [Next]({{< baseurl >}}/pages/lesson-6/cooking-instruction) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-7/_index.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-7/_index.md
@@ -1,7 +1,7 @@
 ---
 uid: 5c721348-1ad2-e19c-b11f-3f348f64d7e5
 title: Lesson 7
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-6/cooking-instruction) | [Next]({{< baseurl >}}/pages/lesson-7/language-instruction) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-7/cooking-instruction.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-7/cooking-instruction.md
@@ -4,7 +4,7 @@ title: Cooking Instruction
 parent_uid: 5c721348-1ad2-e19c-b11f-3f348f64d7e5
 parent_title: Lesson 7
 parent_type: CourseSection
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-7/language-instruction) | [Next]({{< baseurl >}}/pages/lesson-8) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-7/language-instruction.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-7/language-instruction.md
@@ -4,7 +4,7 @@ title: Language Instruction
 parent_uid: 5c721348-1ad2-e19c-b11f-3f348f64d7e5
 parent_title: Lesson 7
 parent_type: CourseSection
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-7) | [Next]({{< baseurl >}}/pages/lesson-7/cooking-instruction) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-8/_index.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-8/_index.md
@@ -1,7 +1,7 @@
 ---
 uid: 31012ed4-66e8-2d99-ed4d-314823b03f20
 title: Lesson 8
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-7/cooking-instruction) | [Next]({{< baseurl >}}/pages/lesson-8/language-instruction) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-8/cooking-instruction.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-8/cooking-instruction.md
@@ -4,7 +4,7 @@ title: Cooking Instruction
 parent_uid: 31012ed4-66e8-2d99-ed4d-314823b03f20
 parent_title: Lesson 8
 parent_type: CourseSection
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-8/language-instruction) | [Next]({{< baseurl >}}/pages/lesson-9) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-8/language-instruction.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-8/language-instruction.md
@@ -4,7 +4,7 @@ title: Language Instruction
 parent_uid: 31012ed4-66e8-2d99-ed4d-314823b03f20
 parent_title: Lesson 8
 parent_type: CourseSection
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-8) | [Next]({{< baseurl >}}/pages/lesson-8/cooking-instruction) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-9/_index.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-9/_index.md
@@ -1,7 +1,7 @@
 ---
 uid: af3c6f3d-fbcc-b159-a0f9-93ffeb5ccf38
 title: Lesson 9
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-8/cooking-instruction) | [Next]({{< baseurl >}}/pages/lesson-9/language-instruction) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-9/cooking-instruction.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-9/cooking-instruction.md
@@ -4,7 +4,7 @@ title: Cooking Instruction
 parent_uid: af3c6f3d-fbcc-b159-a0f9-93ffeb5ccf38
 parent_title: Lesson 9
 parent_type: CourseSection
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-9/language-instruction) | [Next]({{< baseurl >}}/pages/lesson-10) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-9/language-instruction.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/lesson-9/language-instruction.md
@@ -4,7 +4,7 @@ title: Language Instruction
 parent_uid: af3c6f3d-fbcc-b159-a0f9-93ffeb5ccf38
 parent_title: Lesson 9
 parent_type: CourseSection
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 « [Previous]({{< baseurl >}}/pages/lesson-9) | [Next]({{< baseurl >}}/pages/lesson-9/cooking-instruction) »

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/recipes.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/recipes.md
@@ -1,7 +1,7 @@
 ---
 uid: aa2443c8-8a36-13c0-d31a-fda4e1664e48
 title: Recipes
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 {{< tableopen >}}

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/syllabus.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/pages/syllabus.md
@@ -1,7 +1,7 @@
 ---
 uid: 4c9be39e-2e49-82ff-1487-c3a92220fd54
 title: Syllabus
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 Course Meeting Times

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/10-approx.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/10-approx.md
@@ -6,7 +6,7 @@ resourcetype: Image
 file_type: image/png
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/538583d414c417b08c689be22393edfd_10-approx.png
-type: OCWImage
+ocw_type: OCWImage
 parent_type: ThisCourseAtMITSection
 parent_title: Instructor Insights
 image_metadata:

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/artdet.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/artdet.md
@@ -6,7 +6,7 @@ resourcetype: Other
 file_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/476ce7cae5ffc67b75936e67746d5466_artdet.mp3
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/bialetti.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/bialetti.md
@@ -9,7 +9,7 @@ resourcetype: Image
 file_type: image/jpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/ab951a3b4ad4f406f5f4eb1738269ed3_bialetti.jpg
-type: OCWImage
+ocw_type: OCWImage
 parent_type: CourseSection
 parent_title: Language Instruction
 image_metadata:

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/bruschetta.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/bruschetta.md
@@ -6,7 +6,7 @@ resourcetype: Other
 file_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/654ca452e91e7c7319010bad8936b0e6_bruschetta.mp3
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Cooking Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/canzone.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/canzone.md
@@ -6,7 +6,7 @@ resourcetype: Other
 file_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/44f646f15c6c261b5e65217eeac99409_canzone.mp3
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Cooking Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/comestai.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/comestai.md
@@ -6,7 +6,7 @@ resourcetype: Other
 file_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/3e82c7d37f3d1e92d80f286979ae8007_comestai.mp3
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/cosafai.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/cosafai.md
@@ -6,7 +6,7 @@ resourcetype: Other
 file_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/308c242edc90d60292e78307be56f025_cosafai.mp3
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/crossword8.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/crossword8.md
@@ -6,7 +6,7 @@ resourcetype: Other
 file_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/3a03bfdeb7df9f03dc411f4e3b512755_crossword8.mp3
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/crostata.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/crostata.md
@@ -8,7 +8,7 @@ resourcetype: Image
 file_type: image/jpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/70681bfa0ce3478f83ea3f52a0102e14_crostata.jpg
-type: OCWImage
+ocw_type: OCWImage
 parent_type: CourseSection
 parent_title: Cooking Instruction
 image_metadata:

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/cucino.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/cucino.md
@@ -6,7 +6,7 @@ resourcetype: Other
 file_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/54451fe5f143a70b9d9fb22a4b5fc8e3_cucino.mp3
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lesson 1
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/dadove.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/dadove.md
@@ -6,7 +6,7 @@ resourcetype: Other
 file_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/fa3d4d4d982e944cbd994eabf3c10d47_dadove.mp3
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/demonstrative.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/demonstrative.md
@@ -6,7 +6,7 @@ resourcetype: Other
 file_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/2fc74a00c6b08b7b3b25968d8d2964ae_demonstrative.mp3
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/dettato2.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/dettato2.md
@@ -6,7 +6,7 @@ resourcetype: Other
 file_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/1f84fb8ce75fedcf3f88f094026beb2d_dettato2.mp3
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/dettato_1.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/dettato_1.md
@@ -6,7 +6,7 @@ resourcetype: Other
 file_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/9a0ae51da4c4bf4c9210a4673c653112_dettato_1.mp3
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lesson 1
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/domande.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/domande.md
@@ -6,7 +6,7 @@ resourcetype: Other
 file_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/299d6fe7f5adeb2cc7b5d77f2afe64c2_domande.mp3
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/donne.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/donne.md
@@ -6,7 +6,7 @@ resourcetype: Other
 file_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/97df80f2b8cdcb189251348c044cb4a0_donne.mp3
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/es-s41_classroom-1.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/es-s41_classroom-1.md
@@ -6,7 +6,7 @@ resourcetype: Image
 file_type: image/png
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/b9f0393a4bf681d44061a196a29739a7_ES-S41_classroom-1.png
-type: OCWImage
+ocw_type: OCWImage
 parent_type: ThisCourseAtMITSection
 parent_title: Instructor Insights
 image_metadata:

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/es-s41_classroom-2.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/es-s41_classroom-2.md
@@ -6,7 +6,7 @@ resourcetype: Image
 file_type: image/png
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/e36b5812ddd99f8fbc1b73e567d69113_ES-S41_classroom-2.png
-type: OCWImage
+ocw_type: OCWImage
 parent_type: ThisCourseAtMITSection
 parent_title: Instructor Insights
 image_metadata:

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/es-s41s12-th.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/es-s41s12-th.md
@@ -8,7 +8,7 @@ resourcetype: Image
 file_type: image/jpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/317de1a21f8ff8599c548edb446eae6a_es-s41s12-th.jpg
-type: OCWImage
+ocw_type: OCWImage
 image_metadata:
   image-alt: >-
     A woman poses in a kitchen with various items like olive oil, garlic and

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/es-s41s12.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/es-s41s12.md
@@ -8,7 +8,7 @@ resourcetype: Image
 file_type: image/jpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/d0dde8482e079ce6210132b295d34fa3_es-s41s12.jpg
-type: OCWImage
+ocw_type: OCWImage
 image_metadata:
   image-alt: >-
     A woman poses in a kitchen with various items like olive oil, garlic and

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/essere.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/essere.md
@@ -6,7 +6,7 @@ resourcetype: Other
 file_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/82ca41e84087149080b6dcd81c4da7e1_essere.mp3
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/incucina.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/incucina.md
@@ -6,7 +6,7 @@ resourcetype: Other
 file_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/990339c3155169918889ff00999d1eef_incucina.mp3
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/ingredienti2.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/ingredienti2.md
@@ -6,7 +6,7 @@ resourcetype: Other
 file_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/e1d0c900c718ec527386df8ceb4a1315_ingredienti2.mp3
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Cooking Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/ingredienti4.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/ingredienti4.md
@@ -6,7 +6,7 @@ resourcetype: Other
 file_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/5f8fb78fd36b1ab3b105e34d386a3967_ingredienti4.mp3
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/ingredienti5-1.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/ingredienti5-1.md
@@ -6,7 +6,7 @@ resourcetype: Other
 file_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/a347ca798ee274e64e109a7eb8ffabd7_ingredienti5.mp3
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: 'Cooking Instruction '
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/ingredienti5.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/ingredienti5.md
@@ -6,7 +6,7 @@ resourcetype: Other
 file_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/32689eb067548f38df5ad842e81973f8_ingredienti5.mp3
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/lesson1.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/lesson1.md
@@ -6,7 +6,7 @@ resourcetype: Image
 file_type: image/jpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/b0b26ac51e9af71e5ad4feb8217b9a9c_Lesson1.jpg
-type: OCWImage
+ocw_type: OCWImage
 parent_type: CourseSection
 parent_title: Lesson 1
 image_metadata:

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/lesson10.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/lesson10.md
@@ -8,7 +8,7 @@ resourcetype: Image
 file_type: image/jpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/28bae3a747f7b30910596aa0afeb7534_Lesson10.jpg
-type: OCWImage
+ocw_type: OCWImage
 parent_type: CourseSection
 parent_title: Lesson 10
 image_metadata:

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/lesson11.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/lesson11.md
@@ -6,7 +6,7 @@ resourcetype: Image
 file_type: image/jpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/8ddb59bc97d2d2e915cc548370390ed6_Lesson11.jpg
-type: OCWImage
+ocw_type: OCWImage
 parent_type: CourseSection
 parent_title: Lesson 11
 image_metadata:

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/lesson12.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/lesson12.md
@@ -8,7 +8,7 @@ resourcetype: Image
 file_type: image/jpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/998c3315e64cb0a66ad44ef1a53f853b_Lesson12.jpg
-type: OCWImage
+ocw_type: OCWImage
 parent_type: CourseSection
 parent_title: Lesson 12
 image_metadata:

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/lesson13.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/lesson13.md
@@ -8,7 +8,7 @@ resourcetype: Image
 file_type: image/jpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/457aa75e8c977201fe6d391f8bb8a2c4_Lesson13.jpg
-type: OCWImage
+ocw_type: OCWImage
 parent_type: CourseSection
 parent_title: Lesson 13
 image_metadata:

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/lesson2.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/lesson2.md
@@ -8,7 +8,7 @@ resourcetype: Image
 file_type: image/jpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/35e81c71eb7a8eee6aa284b3e38ef095_Lesson2.jpg
-type: OCWImage
+ocw_type: OCWImage
 parent_type: CourseSection
 parent_title: Lesson 2
 image_metadata:

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/lesson3.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/lesson3.md
@@ -8,7 +8,7 @@ resourcetype: Image
 file_type: image/jpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/33c93bbd7da68feccf4b043b6d42a4cd_Lesson3.jpg
-type: OCWImage
+ocw_type: OCWImage
 parent_type: CourseSection
 parent_title: Lesson 3
 image_metadata:

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/lesson4.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/lesson4.md
@@ -8,7 +8,7 @@ resourcetype: Image
 file_type: image/jpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/970f8c937ff788acd1b6a2e0e87d54ab_Lesson4.jpg
-type: OCWImage
+ocw_type: OCWImage
 parent_type: CourseSection
 parent_title: Lesson 4
 image_metadata:

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/lesson5.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/lesson5.md
@@ -8,7 +8,7 @@ resourcetype: Image
 file_type: image/jpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/d91360fb2bbf5611b989e4654ec228fd_Lesson5.jpg
-type: OCWImage
+ocw_type: OCWImage
 parent_type: CourseSection
 parent_title: Lesson 5
 image_metadata:

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/lesson6.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/lesson6.md
@@ -8,7 +8,7 @@ resourcetype: Image
 file_type: image/jpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/1356ee4ce6a0ccb399723c407aeb3acb_Lesson6.jpg
-type: OCWImage
+ocw_type: OCWImage
 parent_type: CourseSection
 parent_title: Lesson 6
 image_metadata:

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/lesson7.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/lesson7.md
@@ -8,7 +8,7 @@ resourcetype: Image
 file_type: image/jpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/d38d54015192a07a2a36b6643f6c9f28_Lesson7.jpg
-type: OCWImage
+ocw_type: OCWImage
 parent_type: CourseSection
 parent_title: Lesson 7
 image_metadata:

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/lesson8.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/lesson8.md
@@ -9,7 +9,7 @@ resourcetype: Image
 file_type: image/jpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/103848ae41da7ef945eae9eaf3aa902d_Lesson8.jpg
-type: OCWImage
+ocw_type: OCWImage
 parent_type: CourseSection
 parent_title: Lesson 8
 image_metadata:

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/lesson9.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/lesson9.md
@@ -8,7 +8,7 @@ resourcetype: Image
 file_type: image/jpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/f805ea3dfb2d31497c3e1aeeff9e1df4_Lesson9.jpg
-type: OCWImage
+ocw_type: OCWImage
 parent_type: CourseSection
 parent_title: Lesson 9
 image_metadata:

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/meal_structure.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/meal_structure.md
@@ -6,7 +6,7 @@ resourcetype: Other
 file_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/e5f176efb653d9d9b1dfa960189504e9_meal_structure.mp3
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/meals.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/meals.md
@@ -6,7 +6,7 @@ resourcetype: Other
 file_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/768d93fe3d45275c94adec8c6467a521_meals.mp3
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mi_chiamo.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mi_chiamo.md
@@ -6,7 +6,7 @@ resourcetype: Other
 file_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/f8a45ada7f7aecf2fbdf6d3e601dccaa_mi_chiamo.mp3
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lesson 1
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mipiace.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mipiace.md
@@ -6,7 +6,7 @@ resourcetype: Other
 file_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/27e08e48433c97b866b7d9e1b2008d52_mipiace.mp3
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_beefstwrecip.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_beefstwrecip.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/88c30dd6a966e0022603fb80d3ab1986_MITES_S41S12_BeefStwRecip.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Cooking Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_brschtarecip.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_brschtarecip.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/55660d5dc421a90a58517eb16808d833_MITES_S41S12_brschtaRecip.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Cooking Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_compiti_1.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_compiti_1.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/dfacc78b54ce17876c54d421c46fc5f6_MITES_S41S12_compiti_1.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_compiti_2.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_compiti_2.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/ae709ed8a8fcd05a8237fe340e61b453_MITES_S41S12_compiti_2.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_compiti_3.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_compiti_3.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/efaf3ee3669f5f5e355165241c54a717_MITES_S41S12_compiti_3.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_compiti_4.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_compiti_4.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/85f412795336eae299c1bdf4bad5561b_MITES_S41S12_compiti_4.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_compiti_5.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_compiti_5.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/ad81fad5139f72e29ffebbdbedfb19e9_MITES_S41S12_compiti_5.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_compiti_6.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_compiti_6.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/983ce2d4eed96d5785e5b2e634e40edb_MITES_S41S12_compiti_6.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_dietlectures.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_dietlectures.md
@@ -8,7 +8,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/c8869aba4da4ed9b6600d63e110cc249_MITES_S41S12_DietLectures.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_dough_recipe.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_dough_recipe.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/570e5ed612d8e8fac953692ac2fbc8e6_MITES_S41S12_dough_recipe.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Cooking Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_eggplantparm.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_eggplantparm.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/602e508c6b9bab09ffd3bdd3c0f72e27_MITES_S41S12_EggplantParm.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Cooking Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_esercizi10.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_esercizi10.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/67f74482a2fab954ec1ea2475305d512_MITES_S41S12_Esercizi10.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_esercizi11.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_esercizi11.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/ab52820017c7940e011748fdb57d4ab1_MITES_S41S12_Esercizi11.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_esercizi9.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_esercizi9.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/9a75c2c08b3cbd499460516c2a08e58c_MITES_S41S12_Esercizi9.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_lesson3exerci.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_lesson3exerci.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/b8909e0058fac355ab26abc13bcb93a6_MITES_S41S12_Lesson3Exerci.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_lesson4exerci.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_lesson4exerci.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/d7cc05f8343273c058f91c4c9b36c398_MITES_S41S12_lesson4Exerci.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_pastrycreamrcp.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_pastrycreamrcp.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/26b307a4c8fc9d3e0aae882b2c385175_MITES_S41S12_PastryCreamRcp.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Cooking Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_1.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_1.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/585b00847c73209d6a833baae34e26b5_MITES_S41S12_recipe_1.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Recipes
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_10.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_10.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/889b255d64eb5cdd6e457c9be0ccaaf8_MITES_S41S12_recipe_10.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Recipes
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_11.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_11.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/f1462f5fea6b2e7f0c3bc516f334723d_MITES_S41S12_recipe_11.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Recipes
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_12a.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_12a.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/a8c32855b3f310d2820e9bc005258a0f_MITES_S41S12_recipe_12a.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Recipes
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_12b.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_12b.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/3201c17742e0019f3d428e536c8cac5e_MITES_S41S12_recipe_12b.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Recipes
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_13a.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_13a.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/7e9a3bed7349f74b4781f91677f8e004_MITES_S41S12_recipe_13a.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Recipes
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_13b.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_13b.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/3446dbf3efdd83af705ed8eb2b6bd334_MITES_S41S12_recipe_13b.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Recipes
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_13c.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_13c.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/7647c0a633afc8673656ec52be277cec_MITES_S41S12_recipe_13c.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Recipes
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_1a.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_1a.md
@@ -6,7 +6,7 @@ resourcetype: Document
 file_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/f91459b0e02a7d5ea0b71277e29e0c8a_MITES_S41S12_recipe_1a.pdf
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Recipes
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_2.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_2.md
@@ -3,10 +3,10 @@ title: Risotto Recipe
 description: This resource contains information regarding Risotto Recipe.
 uid: a0a4dfc6-272b-6b61-e33b-6732816b7cfc
 resourcetype: Document
-file_type: application/pdf
+file_ocw_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/a0a4dfc6272b6b61e33b6732816b7cfc_MITES_S41S12_recipe_2.pdf
-type: OCWFile
-parent_type: CourseSection
+ocw_type: OCWFile
+parent_ocw_type: CourseSection
 parent_title: Recipes
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_3.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_3.md
@@ -3,10 +3,10 @@ title: Quick Pizza Recipe
 description: This resource contains information regarding Quick Pizza Recipe.
 uid: a8c84c75-ea23-f774-acfd-d14397db2426
 resourcetype: Document
-file_type: application/pdf
+file_ocw_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/a8c84c75ea23f774acfdd14397db2426_MITES_S41S12_recipe_3.pdf
-type: OCWFile
-parent_type: CourseSection
+ocw_type: OCWFile
+parent_ocw_type: CourseSection
 parent_title: Recipes
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_4.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_4.md
@@ -3,10 +3,10 @@ title: Potato Gnocchi Recipe
 description: This resource contains information regarding Potato Gnocchi Recipe.
 uid: d9553af4-0c99-2254-8666-8438367d7671
 resourcetype: Document
-file_type: application/pdf
+file_ocw_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/d9553af40c99225486668438367d7671_MITES_S41S12_recipe_4.pdf
-type: OCWFile
-parent_type: CourseSection
+ocw_type: OCWFile
+parent_ocw_type: CourseSection
 parent_title: Recipes
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_5.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_5.md
@@ -5,10 +5,10 @@ description: >-
   recipes.
 uid: 97dc0dc2-5eff-be4e-cbcc-bca9c1fba173
 resourcetype: Document
-file_type: application/pdf
+file_ocw_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/97dc0dc25effbe4ecbccbca9c1fba173_MITES_S41S12_recipe_5.pdf
-type: OCWFile
-parent_type: CourseSection
+ocw_type: OCWFile
+parent_ocw_type: CourseSection
 parent_title: Recipes
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_6a.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_6a.md
@@ -3,10 +3,10 @@ title: Eggplant parmesan
 description: This resource contains information regarding Eggplant parmesan.
 uid: 5ce3bd84-eb9b-15b3-f705-e16853b2fd88
 resourcetype: Document
-file_type: application/pdf
+file_ocw_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/5ce3bd84eb9b15b3f705e16853b2fd88_MITES_S41S12_recipe_6a.pdf
-type: OCWFile
-parent_type: CourseSection
+ocw_type: OCWFile
+parent_ocw_type: CourseSection
 parent_title: Recipes
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_6b.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_6b.md
@@ -3,10 +3,10 @@ title: Beef stew
 description: This resource contains information regarding Beef stew.
 uid: f2c9afc6-858e-2a05-0860-573a41d004af
 resourcetype: Document
-file_type: application/pdf
+file_ocw_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/f2c9afc6858e2a050860573a41d004af_MITES_S41S12_recipe_6b.pdf
-type: OCWFile
-parent_type: CourseSection
+ocw_type: OCWFile
+parent_ocw_type: CourseSection
 parent_title: Recipes
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_6c.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_6c.md
@@ -3,10 +3,10 @@ title: Bruschetta
 description: This resource contains information regarding Bruschetta.
 uid: dc18aa1c-efd5-a07a-aee1-3fb83bbf7e31
 resourcetype: Document
-file_type: application/pdf
+file_ocw_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/dc18aa1cefd5a07aaee13fb83bbf7e31_MITES_S41S12_recipe_6c.pdf
-type: OCWFile
-parent_type: CourseSection
+ocw_type: OCWFile
+parent_ocw_type: CourseSection
 parent_title: Recipes
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_7.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_7.md
@@ -3,10 +3,10 @@ title: Spinach Crepe recipe
 description: This resource contains information regarding Spinach Crepe recipe.
 uid: df2bb85c-aa96-f30b-3aba-8a14ff53502f
 resourcetype: Document
-file_type: application/pdf
+file_ocw_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/df2bb85caa96f30b3aba8a14ff53502f_MITES_S41S12_recipe_7.pdf
-type: OCWFile
-parent_type: CourseSection
+ocw_type: OCWFile
+parent_ocw_type: CourseSection
 parent_title: Recipes
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_8a.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_8a.md
@@ -3,10 +3,10 @@ title: Potato and Fennel in Milk Recipe
 description: This resource contains information regarding Potato and Fennel in Milk Recipe.
 uid: ecaf2b07-5d54-c05d-4506-0b250ebfd8d8
 resourcetype: Document
-file_type: application/pdf
+file_ocw_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/ecaf2b075d54c05d45060b250ebfd8d8_MITES_S41S12_recipe_8a.pdf
-type: OCWFile
-parent_type: CourseSection
+ocw_type: OCWFile
+parent_ocw_type: CourseSection
 parent_title: Recipes
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_8b.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_8b.md
@@ -3,10 +3,10 @@ title: Chicken Roll Ups Recipe
 description: This resource contains information regarding Chicken Roll Ups Recipe.
 uid: f7d1fdb0-792c-3f29-4b8a-e855699540ec
 resourcetype: Document
-file_type: application/pdf
+file_ocw_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/f7d1fdb0792c3f294b8ae855699540ec_MITES_S41S12_recipe_8b.pdf
-type: OCWFile
-parent_type: CourseSection
+ocw_type: OCWFile
+parent_ocw_type: CourseSection
 parent_title: Recipes
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_9.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_recipe_9.md
@@ -3,10 +3,10 @@ title: Tiramisu recipe
 description: This resource contains information regarding Tiramisu recipe.
 uid: d8dda8af-f5ec-4387-610b-a78bbe25886f
 resourcetype: Document
-file_type: application/pdf
+file_ocw_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/d8dda8aff5ec4387610ba78bbe25886f_MITES_S41S12_recipe_9.pdf
-type: OCWFile
-parent_type: CourseSection
+ocw_type: OCWFile
+parent_ocw_type: CourseSection
 parent_title: Recipes
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_verbconjugati.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/mites_s41s12_verbconjugati.md
@@ -3,10 +3,10 @@ title: 'Conjugation of avere, mangiare, ridere, dormire'
 description: This resource contains information regarding list of verbs to conjugate.
 uid: b7a7545f-a715-0807-99e5-b191a6440259
 resourcetype: Document
-file_type: application/pdf
+file_ocw_type: application/pdf
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/b7a7545fa715080799e5b191a6440259_MITES_S41S12_verbConjugati.pdf
-type: OCWFile
-parent_type: CourseSection
+ocw_type: OCWFile
+parent_ocw_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/preparing-for-the-course.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/preparing-for-the-course.md
@@ -11,7 +11,7 @@ video_files:
   video_transcript_file: null
   archive_url: >-
     http://www.archive.org/download/MITES.S41S12/MITES_S41S12_Teaching03_300k.mp4
-parent_type: CourseSection
+parent_ocw_type: CourseSection
 parent_title: Developing the Course
 ---
 

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/presente.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/presente.md
@@ -3,10 +3,10 @@ title: presente.mp3
 description: ''
 uid: 6e55be6a-6f71-e542-672d-1bb55b7fd1f9
 resourcetype: Other
-file_type: audio/mpeg
+file_ocw_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/6e55be6a6f71e542672d1bb55b7fd1f9_presente.mp3
-type: OCWFile
-parent_type: CourseSection
+ocw_type: OCWFile
+parent_ocw_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/pronuncia_1.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/pronuncia_1.md
@@ -3,10 +3,10 @@ title: pronuncia_1.mp3
 description: ''
 uid: 1e9fb442-0a10-8bbc-f2ba-8198b986d577
 resourcetype: Other
-file_type: audio/mpeg
+file_ocw_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/1e9fb4420a108bbcf2ba8198b986d577_pronuncia_1.mp3
-type: OCWFile
-parent_type: CourseSection
+ocw_type: OCWFile
+parent_ocw_type: CourseSection
 parent_title: Lesson 1
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/routine.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/routine.md
@@ -3,10 +3,10 @@ title: routine.mp3
 description: ''
 uid: 7f161b8f-201d-8b0b-c3ff-58774b26d3e0
 resourcetype: Other
-file_type: audio/mpeg
+file_ocw_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/7f161b8f201d8b0bc3ff58774b26d3e0_routine.mp3
-type: OCWFile
-parent_type: CourseSection
+ocw_type: OCWFile
+parent_ocw_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/screenshot.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/screenshot.md
@@ -5,11 +5,11 @@ description: >-
   Gordon Ramsay.
 uid: eefaab45-dadf-d5f9-b12a-4cb8f36e4b66
 resourcetype: Image
-file_type: image/jpeg
+file_ocw_type: image/jpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/eefaab45dadfd5f9b12a4cb8f36e4b66_Screenshot.jpg
-type: OCWImage
-parent_type: CourseSection
+ocw_type: OCWImage
+parent_ocw_type: CourseSection
 parent_title: Using Technology to Expand Reach
 image_metadata:
   image-alt: A screenshot of the class blog.

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/selecting-the-correct-language-level.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/selecting-the-correct-language-level.md
@@ -11,7 +11,7 @@ video_files:
   video_transcript_file: null
   archive_url: >-
     http://www.archive.org/download/MITES.S41S12/MITES_S41S12_Teaching06_300k.mp4
-parent_type: CourseSection
+parent_ocw_type: CourseSection
 parent_title: Teaching Italian and Cooking Together
 ---
 

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/structure-of-a-typical-class.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/structure-of-a-typical-class.md
@@ -11,7 +11,7 @@ video_files:
   video_transcript_file: null
   archive_url: >-
     http://www.archive.org/download/MITES.S41S12/MITES_S41S12_Teaching05_300k.mp4
-parent_type: CourseSection
+parent_ocw_type: CourseSection
 parent_title: Teaching Italian and Cooking Together
 ---
 

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/teaching-italian-grammar.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/teaching-italian-grammar.md
@@ -11,7 +11,7 @@ video_files:
   video_transcript_file: null
   archive_url: >-
     http://www.archive.org/download/MITES.S41S12/MITES_S41S12_Teaching10_300k.mp4
-parent_type: CourseSection
+parent_ocw_type: CourseSection
 parent_title: Learning From Challenges
 ---
 

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/time-management-students-energy-levels.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/time-management-students-energy-levels.md
@@ -11,7 +11,7 @@ video_files:
   video_transcript_file: null
   archive_url: >-
     http://www.archive.org/download/MITES.S41S12/MITES_S41S12_Teaching09_300k.mp4
-parent_type: CourseSection
+parent_ocw_type: CourseSection
 parent_title: Learning From Challenges
 ---
 

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/tour-the-experimental-study-group-area.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/tour-the-experimental-study-group-area.md
@@ -10,6 +10,6 @@ video_files:
   video_captions_file: null
   video_transcript_file: null
   archive_url: 'http://archive.org/download/MITES.S41S12/MITES_S41S12_Teaching12_300k.mp4'
-parent_type: ThisCourseAtMITSection
+parent_ocw_type: ThisCourseAtMITSection
 parent_title: Instructor Insights
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/using-cooking-to-teach-italian.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/using-cooking-to-teach-italian.md
@@ -11,7 +11,7 @@ video_files:
   video_transcript_file: null
   archive_url: >-
     http://www.archive.org/download/MITES.S41S12/MITES_S41S12_Teaching08_300k.mp4
-parent_type: CourseSection
+parent_ocw_type: CourseSection
 parent_title: Teaching Italian and Cooking Together
 ---
 

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/vocabolario6.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/vocabolario6.md
@@ -6,7 +6,7 @@ resourcetype: Other
 file_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/6b4328bd79c421fabf251a80f0b8bcfc_vocabolario6.mp3
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Language Instruction
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/vocali.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/resources/vocali.md
@@ -6,7 +6,7 @@ resourcetype: Other
 file_type: audio/mpeg
 file: >-
   https://open-learning-course-data-rc.s3.amazonaws.com/es-s41-speak-italian-with-your-mouth-full-spring-2012/5a51687e05c0820cd260bca18be33d68_vocali.mp3
-type: OCWFile
+ocw_type: OCWFile
 parent_type: CourseSection
 parent_title: Lesson 1
 ---

--- a/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/video_galleries/video-lectures.md
+++ b/test_ocw2hugo/es-s41-speak-italian-with-your-mouth-full-spring-2012/content/video_galleries/video-lectures.md
@@ -44,7 +44,7 @@ videos:
     - 5cdffd62-b8e6-2842-7da1-4bb5fa6254e2
     - 51caf3d5-a138-cd61-69e1-89ef35dbd4f0
   website: es-s41-speak-italian-with-your-mouth-full-spring-2012
-type: CourseSection
+ocw_type: CourseSection
 ---
 
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested


#### What are the relevant tickets?
None

#### What's this PR do?
We had to update `type` to `ocw_type` in ocw-to-hugo output since type is a reserved keyword.

#### How should this be manually tested?
Currently this can't be tested since the pipeline to update `ocw-to-hugo-output-qa` is running. Once that's done

Run
`docker-compose run web ./manage.py overwrite_ocw_course_content --bucket ocw-to-hugo-output-qa --filter 6-007-electromagnetic-energy-from-motors-to-lasers-spring-2011 --content-field metadata.ocw_type`

Run
`docker-compose run web ./manage.py overwrite_ocw_course_content --bucket ocw-to-hugo-output-qa --filter 6-007-electromagnetic-energy-from-motors-to-lasers-spring-2011 --content-field metadata. learning_resource_types `

Verify that both work fine

