### PR TITLE
Update website publish status immediately on errors (and handle youtube errors)

### DIFF
--- a/content_sync/api_test.py
+++ b/content_sync/api_test.py
@@ -8,7 +8,7 @@ from mitol.common.utils import now_in_utc
 
 from content_sync import api
 from content_sync.constants import VERSION_DRAFT, VERSION_LIVE
-from websites.constants import PUBLISH_STATUS_NOT_STARTED
+from websites.constants import PUBLISH_STATUS_ERRORED, PUBLISH_STATUS_NOT_STARTED
 from websites.factories import WebsiteContentFactory, WebsiteFactory
 
 
@@ -283,7 +283,9 @@ def test_publish_website_error(mock_api_funcs, settings):
     website = WebsiteFactory.create()
     with pytest.raises(Exception):
         api.publish_website(website.name, VERSION_LIVE)
+    website.refresh_from_db()
     mock_api_funcs.mock_get_backend.assert_not_called()
+    assert website.live_publish_status == PUBLISH_STATUS_ERRORED
 
 
 def test_get_mass_publish_pipeline_no_backend(settings):

--- a/videos/youtube.py
+++ b/videos/youtube.py
@@ -347,6 +347,13 @@ def update_youtube_metadata(website: Website, version=VERSION_DRAFT):
         if VideoFile.objects.filter(
             video__website=website, destination_id=youtube_id
         ).exists():
-            youtube.update_video(
-                video_resource, privacy=("public" if version == VERSION_LIVE else None)
-            )
+            try:
+                youtube.update_video(
+                    video_resource,
+                    privacy=("public" if version == VERSION_LIVE else None),
+                )
+            except:  # pylint:disable=bare-except
+                log.exception(
+                    "Unexpected error updating metadata for video resource %d",
+                    video_resource.id,
+                )


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #733 
Closes #1000

#### What's this PR do?
- If any kind of error happens within the `content_sync.api.publish_website` function, change the website's publish status to "errored"
- If an error occurs when trying to update youtube metadata, log the exception and carry on.

#### How should this be manually tested?
- Temporarily modify the `content_sync.tasks.publish_website` function to always raise an exception somewhere within the try-catch block
- Publish one of your sites.  The publish status should almost immediately appear as "Failed" on the front-end, and you should be able to try publishing again.
- Undo your temporary change to `publish_website`

- Copy all the `YT_*`  settings from RC to your .env file
- Set `PREPUBLISH_ACTIONS=videos.youtube.update_youtube_metadata`
- If you haven't imported `res-2-005-girls-who-build-make-your-own-wearables-workshop-spring-2015`, do so now with `manage.py import_ocw_course_sites --bucket ocw-to-hugo-output-qa --filter res-2-005-girls-who-build-make-your-own-wearables-workshop-spring-2015`
- Go to django admin and change the source of the site to "studio"
- Publish that site.  Check the logs, you should see an info statement about an HttpError (`HttpError trying to update metadata for video resource <id>`)but the publish task should not fail because of that (though it may fail for other reasons).
