### PR TITLE
Enforce youtube length limits when uploading/updating title, description

### DIFF
--- a/main/utils.py
+++ b/main/utils.py
@@ -4,7 +4,7 @@ import hmac
 import re
 from enum import Flag, auto
 from pathlib import Path
-from typing import Tuple, Optional
+from typing import Optional, Tuple
 from uuid import UUID, uuid4
 
 from django.http import HttpRequest

--- a/main/utils.py
+++ b/main/utils.py
@@ -4,7 +4,7 @@ import hmac
 import re
 from enum import Flag, auto
 from pathlib import Path
-from typing import Tuple
+from typing import Tuple, Optional
 from uuid import UUID, uuid4
 
 from django.http import HttpRequest
@@ -109,3 +109,11 @@ def valid_key(key: str, request: HttpRequest) -> bool:
     digest = hmac.new(key.encode("utf-8"), request.body, hashlib.sha1).hexdigest()
     sig_parts = request.headers["X-Hub-Signature"].split("=", 1)
     return hmac.compare_digest(sig_parts[1], digest)
+
+
+def truncate_words(content: str, length: int, suffix: Optional[str] = "...") -> str:
+    """Truncate text to < length chars, keeping words intact"""
+    if len(content) <= length:
+        return content
+    else:
+        return content[: (length - len(suffix))].rsplit(" ", 1)[0] + suffix

--- a/main/utils_test.py
+++ b/main/utils_test.py
@@ -8,6 +8,7 @@ from main.utils import (
     is_valid_uuid,
     remove_trailing_slashes,
     valid_key,
+    truncate_words,
 )
 
 
@@ -95,3 +96,11 @@ def test_valid_key(mocker, key, is_valid):
         headers={"X-Hub-Signature": "sha1=6a4e7673fa9c3afbb2860ae03ac2082958313a9c"},
     )
     assert valid_key(key, mock_request) is is_valid
+
+
+@pytest.mark.parametrize(
+    "text, truncated", [["Hello world", "Hello___"], ["HelloWorld", "HelloW___"]]
+)
+def test_truncate_words(text, truncated):
+    """ truncate_words returns expected result"""
+    assert truncate_words(text, 9, suffix="___") == truncated

--- a/main/utils_test.py
+++ b/main/utils_test.py
@@ -7,8 +7,8 @@ from main.utils import (
     get_file_extension,
     is_valid_uuid,
     remove_trailing_slashes,
-    valid_key,
     truncate_words,
+    valid_key,
 )
 
 

--- a/static/js/components/PublishDrawer.tsx
+++ b/static/js/components/PublishDrawer.tsx
@@ -149,8 +149,7 @@ export default function PublishDrawer(props: Props): JSX.Element {
         {website.content_warnings && !isEmpty(website.content_warnings) ? (
           <div className="publish-warnings pt-2">
             <strong className="text-danger">
-              This site is missing information that could affect publishing
-              output.
+              This site has issues that could affect publishing output.
             </strong>
             <ul className="text-danger">
               {website.content_warnings.map((warning: string, idx: number) => (

--- a/videos/constants.py
+++ b/videos/constants.py
@@ -8,6 +8,8 @@ DESTINATION_ARCHIVE = "archive"
 ALL_DESTINATIONS = [DESTINATION_YOUTUBE, DESTINATION_ARCHIVE]
 
 YT_THUMBNAIL_IMG = "https://img.youtube.com/vi/{video_id}/default.jpg"
+YT_MAX_LENGTH_TITLE = 100
+YT_MAX_LENGTH_DESCRIPTION = 5000
 
 
 class VideoStatus:

--- a/videos/youtube.py
+++ b/videos/youtube.py
@@ -19,7 +19,11 @@ from smart_open.s3 import Reader
 
 from content_sync.constants import VERSION_DRAFT, VERSION_LIVE
 from main.utils import truncate_words
-from videos.constants import DESTINATION_YOUTUBE
+from videos.constants import (
+    DESTINATION_YOUTUBE,
+    YT_MAX_LENGTH_DESCRIPTION,
+    YT_MAX_LENGTH_TITLE,
+)
 from videos.messages import YouTubeUploadFailureMessage, YouTubeUploadSuccessMessage
 from videos.models import VideoFile
 from websites.api import is_ocw_site
@@ -33,8 +37,6 @@ log = logging.getLogger(__name__)
 # Quota errors should contain the following
 API_QUOTA_ERROR_MSG = "quota"
 CAPTION_UPLOAD_NAME = "ocw_captions_upload"
-MAX_LENGTH_TITLE = 100
-MAX_LENGTH_DESCRIPTION = 5000
 
 
 class YouTubeUploadException(Exception):
@@ -212,7 +214,9 @@ class YouTubeApi:
         original_name = videofile.video.source_key.split("/")[-1]
         request_body = dict(
             snippet=dict(
-                title=truncate_words(strip_bad_chars(original_name), MAX_LENGTH_TITLE),
+                title=truncate_words(
+                    strip_bad_chars(original_name), YT_MAX_LENGTH_TITLE
+                ),
                 description="",
                 categoryId=settings.YT_CATEGORY_ID,
             ),
@@ -308,10 +312,10 @@ class YouTubeApi:
                 "id": youtube_id,
                 "snippet": {
                     "title": truncate_words(
-                        strip_bad_chars(resource.title), MAX_LENGTH_TITLE
+                        strip_bad_chars(resource.title), YT_MAX_LENGTH_TITLE
                     ),
                     "description": truncate_words(
-                        strip_bad_chars(description), MAX_LENGTH_DESCRIPTION
+                        strip_bad_chars(description), YT_MAX_LENGTH_DESCRIPTION
                     ),
                     "tags": get_dict_field(metadata, settings.YT_FIELD_TAGS),
                     "categoryId": settings.YT_CATEGORY_ID,

--- a/videos/youtube.py
+++ b/videos/youtube.py
@@ -212,7 +212,7 @@ class YouTubeApi:
         original_name = videofile.video.source_key.split("/")[-1]
         request_body = dict(
             snippet=dict(
-                title=truncate_words(strip_bad_chars(original_name), 100),
+                title=truncate_words(strip_bad_chars(original_name), MAX_LENGTH_TITLE),
                 description="",
                 categoryId=settings.YT_CATEGORY_ID,
             ),

--- a/videos/youtube_test.py
+++ b/videos/youtube_test.py
@@ -10,7 +10,6 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from googleapiclient.errors import HttpError
 
 from content_sync.constants import VERSION_DRAFT, VERSION_LIVE
-from main.utils import truncate_words
 from users.factories import UserFactory
 from videos.conftest import MockHttpErrorResponse
 from videos.constants import DESTINATION_YOUTUBE

--- a/videos/youtube_test.py
+++ b/videos/youtube_test.py
@@ -12,13 +12,15 @@ from googleapiclient.errors import HttpError
 from content_sync.constants import VERSION_DRAFT, VERSION_LIVE
 from users.factories import UserFactory
 from videos.conftest import MockHttpErrorResponse
-from videos.constants import DESTINATION_YOUTUBE
+from videos.constants import (
+    DESTINATION_YOUTUBE,
+    YT_MAX_LENGTH_DESCRIPTION,
+    YT_MAX_LENGTH_TITLE,
+)
 from videos.factories import VideoFactory, VideoFileFactory
 from videos.messages import YouTubeUploadFailureMessage, YouTubeUploadSuccessMessage
 from videos.youtube import (
     CAPTION_UPLOAD_NAME,
-    MAX_LENGTH_DESCRIPTION,
-    MAX_LENGTH_TITLE,
     YouTubeApi,
     YouTubeUploadException,
     mail_youtube_upload_failure,
@@ -212,10 +214,10 @@ def test_update_video(settings, mocker, youtube_mocker, privacy):
     expected_title = f'{" ".join([title.replace(">", "") for _ in range(9)])}...'
     expected_desc = f'{" ".join([description.replace(">", "") for _ in range(499)])}...'
 
-    assert len(content.title) > MAX_LENGTH_TITLE
-    assert len(content.metadata["description"]) > MAX_LENGTH_DESCRIPTION
-    assert len(expected_title) <= MAX_LENGTH_TITLE
-    assert len(expected_desc) <= MAX_LENGTH_DESCRIPTION
+    assert len(content.title) > YT_MAX_LENGTH_TITLE
+    assert len(content.metadata["description"]) > YT_MAX_LENGTH_DESCRIPTION
+    assert len(expected_title) <= YT_MAX_LENGTH_TITLE
+    assert len(expected_desc) <= YT_MAX_LENGTH_DESCRIPTION
 
     mock_update_caption = mocker.patch("videos.youtube.YouTubeApi.update_captions")
 

--- a/videos/youtube_test.py
+++ b/videos/youtube_test.py
@@ -10,6 +10,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from googleapiclient.errors import HttpError
 
 from content_sync.constants import VERSION_DRAFT, VERSION_LIVE
+from main.utils import truncate_words
 from users.factories import UserFactory
 from videos.conftest import MockHttpErrorResponse
 from videos.constants import DESTINATION_YOUTUBE
@@ -17,6 +18,8 @@ from videos.factories import VideoFactory, VideoFileFactory
 from videos.messages import YouTubeUploadFailureMessage, YouTubeUploadSuccessMessage
 from videos.youtube import (
     CAPTION_UPLOAD_NAME,
+    MAX_LENGTH_DESCRIPTION,
+    MAX_LENGTH_TITLE,
     YouTubeApi,
     YouTubeUploadException,
     mail_youtube_upload_failure,
@@ -174,7 +177,7 @@ def test_upload_video_long_fields(mocker, youtube_mocker):
     mock_upload = youtube_mocker().videos.return_value.insert
     YouTubeApi().upload_video(video_file)
     called_args, called_kwargs = mock_upload.call_args
-    assert called_kwargs["body"]["snippet"]["title"] == name[:100]
+    assert called_kwargs["body"]["snippet"]["title"] == f"{name[:97]}..."
 
 
 def test_delete_video(youtube_mocker):
@@ -191,19 +194,29 @@ def test_update_video(settings, mocker, youtube_mocker, privacy):
     """update_video should send the correct data in a request to update youtube metadata"""
     speakers = "speaker1, speaker2"
     tags = "tag1, tag2"
-    youtube_id = "abc123"
-    description = "video test description"
+    youtube_id = "test video description"
+    title = "TitleLngt>"
+    description = "DescLngth>"
     content = WebsiteContentFactory.create(
+        title=" ".join([title for i in range(11)]),
         metadata={
             "resourcetype": RESOURCE_TYPE_VIDEO,
-            "description": description,
+            "description": " ".join([description for _ in range(501)]),
             "video_metadata": {
                 "youtube_id": youtube_id,
                 "video_tags": tags,
                 "video_speakers": speakers,
             },
-        }
+        },
     )
+
+    expected_title = f'{" ".join([title.replace(">", "") for _ in range(9)])}...'
+    expected_desc = f'{" ".join([description.replace(">", "") for _ in range(499)])}...'
+
+    assert len(content.title) > MAX_LENGTH_TITLE
+    assert len(content.metadata["description"]) > MAX_LENGTH_DESCRIPTION
+    assert len(expected_title) <= MAX_LENGTH_TITLE
+    assert len(expected_desc) <= MAX_LENGTH_DESCRIPTION
 
     mock_update_caption = mocker.patch("videos.youtube.YouTubeApi.update_captions")
 
@@ -213,8 +226,8 @@ def test_update_video(settings, mocker, youtube_mocker, privacy):
         body={
             "id": youtube_id,
             "snippet": {
-                "title": content.title,
-                "description": f"{description}\n\nSpeakers: {speakers}",
+                "title": expected_title,
+                "description": expected_desc,
                 "tags": tags,
                 "categoryId": settings.YT_CATEGORY_ID,
             },


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1008 
Closes #1011 

#### What's this PR do?
Truncates title and description if they exceed the Youtube length limit when uploading/updating.
Shows a warning on the publish drawer if any videos for the site will be truncated on Youtube.

#### How should this be manually tested?
- Copy `YT_*` values from RC to your .env file
- For one of your sites (with starter ocw-course), add a small video to the site's Google Drive folder and sync.
- Once you have a video resource, update its title to be over 100 chars and its description to be over 5000 chars.
- Change the Youtube ID field to `ulPWKn5hJ3w` and save.
- In a shell, run the following:
   ```
    from websites.models import *
    from videos.models import *
    from videos.youtube import *
    website = Website.objects.get(name=<your_website_name>)
    VideoFile.objects.create(video=Video.objects.create(website=website), destination_id="ulPWKn5hJ3w")
    update_youtube_metadata(website)
    ```
- Go to https://www.youtube.com/watch?v=ulPWKn5hJ3w, your title should be truncated to <= 100 chars and your description to <= 5000 chars.

#### Screenshots
<img width="564" alt="Screen Shot 2022-02-16 at 9 39 55 AM" src="https://user-images.githubusercontent.com/187676/154290056-ab7c0126-aecf-4f7e-a54b-8e53123e2946.png">

