### PR TITLE
support non-destructive editing of content w/ legacy shortcodes

### DIFF
--- a/static/js/lib/ckeditor/CKEditor.ts
+++ b/static/js/lib/ckeditor/CKEditor.ts
@@ -24,6 +24,7 @@ import ResourceLinkMarkdownSyntax from "./plugins/ResourceLinkMarkdownSyntax"
 import DisallowNestedTables from "./plugins/DisallowNestedTables"
 import TableMarkdownSyntax from "./plugins/TableMarkdownSyntax"
 import MarkdownListSyntax from "./plugins/MarkdownListSyntax"
+import LegacyShortcodes from "./plugins/LegacyShortcodes"
 
 export const FullEditorConfig = {
   plugins: [
@@ -49,6 +50,7 @@ export const FullEditorConfig = {
     ResourceLinkMarkdownSyntax,
     TableMarkdownSyntax,
     MarkdownListSyntax,
+    LegacyShortcodes,
     Markdown,
     DisallowNestedTables
   ],

--- a/static/js/lib/ckeditor/plugins/LegacyShortcodes.test.ts
+++ b/static/js/lib/ckeditor/plugins/LegacyShortcodes.test.ts
@@ -1,0 +1,56 @@
+import Markdown from "./Markdown"
+import { createTestEditor } from "./test_util"
+import { turndownService } from "../turndown"
+import LegacyShortcodes from "./LegacyShortcodes"
+import { LEGACY_SHORTCODES } from "./constants"
+import Paragraph from "@ckeditor/ckeditor5-paragraph/src/paragraph"
+
+const quizTestMD = `{{< quiz_multiple_choice questionId="Q1_div" >}}{{< quiz_choices >}}{{< quiz_choice isCorrect="false" >}}sound, satisfiable{{< /quiz_choice >}}{{< quiz_choice isCorrect="false" >}}valid, satisfiable{{< /quiz_choice >}}{{< quiz_choice isCorrect="true" >}}sound, valid{{< /quiz_choice >}}{{< quiz_choice isCorrect="false" >}}valid, true{{< /quiz_choice >}}{{< /quiz_choices >}}{{< quiz_solution / >}}{{< /quiz_multiple_choice >}}`
+
+const getEditor = createTestEditor([Paragraph, LegacyShortcodes, Markdown])
+
+describe("ResourceEmbed plugin", () => {
+  afterEach(() => {
+    turndownService.rules.array = turndownService.rules.array.filter(
+      (rule: any) => !/LegacyShortcodeSyntax/.test(rule.name)
+    )
+    // @ts-ignore
+    turndownService._customRulesSet = undefined
+  })
+
+  test.each(LEGACY_SHORTCODES)(
+    "should take in and return %p shortcode",
+    async shortcode => {
+      const md = `{{< ${shortcode} >}}`
+      const editor = await getEditor(md)
+      // @ts-ignore
+      expect(editor.getData()).toBe(md)
+    }
+  )
+
+  test.each(LEGACY_SHORTCODES)(
+    "should take in and return %p closing shortcode",
+    async shortcode => {
+      const md = `{{< /${shortcode} >}}`
+      const editor = await getEditor(md)
+      // @ts-ignore
+      expect(editor.getData()).toBe(md)
+    }
+  )
+
+  test.each(LEGACY_SHORTCODES)(
+    "should take in and return %p shortcode with arguments",
+    async shortcode => {
+      const md = `{{< ${shortcode} arguments foo=123 html=<for some reason/> >}}`
+      const editor = await getEditor(md)
+      // @ts-ignore
+      expect(editor.getData()).toBe(md)
+    }
+  )
+
+  test("should support a quiz example", async () => {
+    const editor = await getEditor(quizTestMD)
+    // @ts-ignore
+    expect(editor.getData()).toBe(quizTestMD)
+  })
+})

--- a/static/js/lib/ckeditor/plugins/LegacyShortcodes.ts
+++ b/static/js/lib/ckeditor/plugins/LegacyShortcodes.ts
@@ -1,0 +1,194 @@
+import { ShowdownExtension } from "showdown"
+import Plugin from "@ckeditor/ckeditor5-core/src/plugin"
+import { editor } from "@ckeditor/ckeditor5-core"
+
+import MarkdownSyntaxPlugin from "./MarkdownSyntaxPlugin"
+import { TurndownRule } from "../../../types/ckeditor_markdown"
+import { LEGACY_SHORTCODES } from "./constants"
+
+const shortcodeClass = (shortcode: string) => `legacy-shortcode-${shortcode}`
+
+const DATA_ISCLOSING = "data-isclosing"
+const DATA_ARGUMENTS = "data-arguments"
+
+class LegacyShortcodeSyntax extends MarkdownSyntaxPlugin {
+  static get pluginName(): string {
+    return "LegacyShortcodeSyntax"
+  }
+
+  get showdownExtension() {
+    return function legacyShortcodeExtension(): ShowdownExtension[] {
+      return LEGACY_SHORTCODES.map(
+        (shortcode: string): ShowdownExtension => {
+          const shortcodeRegex = new RegExp(`{{< /?${shortcode} (.*?)>}}`, "g")
+          const closingShortcodeRegex = new RegExp(
+            `{{< /${shortcode} (.*?)>}}`,
+            "g"
+          )
+
+          return {
+            type:    "lang",
+            regex:   shortcodeRegex,
+            replace: (stringMatch: string, shortcodeArgs: string | null) => {
+              const isClosing = JSON.stringify(
+                closingShortcodeRegex.test(stringMatch)
+              )
+
+              const tag = `<span ${DATA_ISCLOSING}="${isClosing}" ${
+                shortcodeArgs ?
+                  `${DATA_ARGUMENTS}="${encodeURIComponent(shortcodeArgs)}"` :
+                  ""
+              } class="${shortcodeClass(shortcode)}"></span>`
+
+              return tag
+            }
+          }
+        }
+      )
+    }
+  }
+
+  get turndownRules(): TurndownRule[] {
+    return LEGACY_SHORTCODES.map(shortcode => ({
+      name: `LegacyShortcodeSyntax-${shortcode}`,
+      rule: {
+        filter: node => {
+          return (
+            node.nodeName === "SPAN" &&
+            node.className === shortcodeClass(shortcode)
+          )
+        },
+        replacement: (_content: string, node: any): string => {
+          const isClosingTag = JSON.parse(node.getAttribute(DATA_ISCLOSING))
+          const rawShortcodeArgs = node.getAttribute(DATA_ARGUMENTS)
+
+          return `{{< ${isClosingTag ? "/" : ""}${shortcode} ${
+            rawShortcodeArgs !== undefined && rawShortcodeArgs !== null ?
+              decodeURIComponent(rawShortcodeArgs) :
+              ""
+          }>}}`
+        }
+      }
+    }))
+  }
+}
+
+const shortcodeModelName = (shortcode: string) =>
+  `legacy-shortcode-${shortcode}`
+
+class LegacyShortcodeEditing extends Plugin {
+  static get pluginName(): string {
+    return "LegacyShortcodeEditing"
+  }
+
+  constructor(editor: editor.Editor) {
+    super(editor)
+  }
+
+  init() {
+    this._defineSchema()
+    this._defineConverters()
+  }
+
+  _defineSchema() {
+    const schema = this.editor.model.schema
+
+    LEGACY_SHORTCODES.map(shortcode => {
+      schema.register(`legacy-shortcode-${shortcode}`, {
+        isInline:        true,
+        allowWhere:      "$text",
+        isObject:        true,
+        allowAttributes: ["isClosing", "arguments"]
+      })
+    })
+  }
+
+  _defineConverters() {
+    const conversion = this.editor.conversion
+
+    LEGACY_SHORTCODES.map(shortcode => {
+      /**
+       * convert HTML string to a view element (i.e. ckeditor
+       * internal state, *not* to a DOM element)
+       */
+      conversion.for("upcast").elementToElement({
+        view: {
+          name:    "span",
+          classes: [shortcodeClass(shortcode)]
+        },
+        model: (viewElement: any, { writer: modelWriter }: any) => {
+          const attrs: any = {
+            isClosing: viewElement.getAttribute(DATA_ISCLOSING)
+          }
+
+          const dataArguments = viewElement.getAttribute(DATA_ARGUMENTS)
+          if (dataArguments) {
+            attrs.arguments = dataArguments
+          }
+
+          return modelWriter.createElement(shortcodeModelName(shortcode), attrs)
+        }
+      })
+
+      /**
+       * converts view element to HTML element for data output
+       */
+      conversion.for("dataDowncast").elementToElement({
+        model: shortcodeModelName(shortcode),
+        view:  (modelElement: any, { writer: viewWriter }: any) => {
+          const attrs: any = {
+            [DATA_ISCLOSING]: modelElement.getAttribute("isClosing"),
+            class:            shortcodeClass(shortcode)
+          }
+
+          const dataArguments = modelElement.getAttribute("arguments")
+          if (dataArguments) {
+            attrs[DATA_ARGUMENTS] = dataArguments
+          }
+
+          return viewWriter.createRawElement("span", attrs, function(
+            el: HTMLElement
+          ) {
+            el.innerHTML = shortcode
+          })
+        }
+      })
+
+      /**
+       * editingDowncast converts a view element to HTML which is actually shown
+       * in the editor for WYSIWYG purposes
+       */
+      conversion.for("editingDowncast").elementToElement({
+        model: shortcodeModelName(shortcode),
+
+        view: (modelElement: any, { writer: viewWriter }: any) => {
+          const isClosing = modelElement.getAttribute("isClosing")
+
+          const el = viewWriter.createRawElement(
+            "span",
+            {
+              class: `${shortcodeClass(shortcode)} legacy-shortcode`
+            },
+            function(el: HTMLElement) {
+              el.innerHTML =
+                isClosing.trim() === "true" ? `/${shortcode}` : `${shortcode}`
+            }
+          )
+
+          return el
+        }
+      })
+    })
+  }
+}
+
+export default class LegacyShortcodes extends Plugin {
+  static get requires(): Plugin[] {
+    return [
+      // @ts-ignore
+      LegacyShortcodeEditing,
+      // @ts-ignore
+      LegacyShortcodeSyntax
+    ]
+  }
+}

--- a/static/js/lib/ckeditor/plugins/ResourceEmbed.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceEmbed.ts
@@ -150,7 +150,6 @@ class ResourceEmbedEditing extends Plugin {
     /**
      * editingDowncast converts a view element to HTML which is actually shown
      * in the editor for WYSIWYG purposes
-     * (for the youtube embed this is an iframe)
      */
     conversion.for("editingDowncast").elementToElement({
       model: RESOURCE_EMBED,

--- a/static/js/lib/ckeditor/plugins/TableMarkdownSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/TableMarkdownSyntax.ts
@@ -15,7 +15,7 @@ export default class TableMarkdownSyntax extends MarkdownSyntaxPlugin {
   }
 
   get showdownExtension() {
-    return function resourceExtension(): Showdown.ShowdownExtension[] {
+    return function tableExtension(): Showdown.ShowdownExtension[] {
       return TABLE_ELS.map(el => {
         const shortcodeRegex = new RegExp(`{{< ${el}(open|close).*? >}}`, "g")
 

--- a/static/js/lib/ckeditor/plugins/constants.ts
+++ b/static/js/lib/ckeditor/plugins/constants.ts
@@ -64,3 +64,26 @@ export const TABLE_ALLOWED_ATTRS: string[] = ["colspan", "rowspan"]
  * with a double quote and captures anything in between the quotes.
  */
 export const ATTRIBUTE_REGEX = /(\S+)=["']?((?:.(?!["']?\s+(?:\S+)=|\s*\/?[>"']))+.)["']?/g
+
+export const LEGACY_SHORTCODES = [
+  "quiz_choice",
+  "quiz_choices",
+  "quiz_multiple_choice",
+  "quiz_solution",
+  "resource_file",
+  "video-gallery",
+  "youtube",
+  "anchor",
+  "approx-students",
+  "br",
+  "div-with-class",
+  "fullwidth-cell",
+  "h",
+  "image-gallery-item",
+  "image-gallery",
+  "quote",
+  "simplecast",
+  "sub",
+  "sup",
+  "baseurl"
+]

--- a/static/scss/ckeditor.scss
+++ b/static/scss/ckeditor.scss
@@ -13,4 +13,8 @@
       font-style: initial;
     }
   }
+
+  .legacy-shortcode {
+    border: 1px solid $studio-text-gray;
+  }
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
(Required)

#### What's this PR do?

This implements support for nondestructively editing markdown files which have 'legacy' shortcodes in them (these are shortcodes inserted into converted content by ocw-to-hugo to support a series of things which aren't supported in plain markdown).

#### How should this be manually tested?

You'll need to get some shortcode-filled markdown into one of your pages and then test out that it displays like in the little video below.

- Arguments to shortcodes should be retained between saves
- shortcode opening / closing state should be saved

etc

This is a little snippet that you might want to try:

```
Soundness and Validity
----------------------
  
{{< quiz_multiple_choice questionId="Q1_div" >}}{{< quiz_choices >}}{{< quiz_choice isCorrect="false" >}}&nbsp; sound, satisfiable &nbsp;{{< /quiz_choice >}}
{{< quiz_choice isCorrect="false" >}}&nbsp; valid, satisfiable &nbsp;{{< /quiz_choice >}}
{{< quiz_choice isCorrect="true" >}}&nbsp; sound, valid &nbsp;{{< /quiz_choice >}}
{{< quiz_choice isCorrect="false" >}}&nbsp; valid, true &nbsp;{{< /quiz_choice >}}{{< /quiz_choices >}}
{{< quiz_solution / >}}{{< /quiz_multiple_choice >}}
```

it's an example of a quiz, which uses a whole bunch of shortcodes, opening and closing ones, with arguments, etc.

#### Screenshots (if appropriate)


https://user-images.githubusercontent.com/6207644/154374070-73180ec2-fd79-4cff-858b-d756c3a452b4.mov


