### PR TITLE
Only update metadata for youtube videos with associated VideoFile objects

### DIFF
--- a/videos/youtube.py
+++ b/videos/youtube.py
@@ -22,7 +22,7 @@ from videos.constants import DESTINATION_YOUTUBE
 from videos.messages import YouTubeUploadFailureMessage, YouTubeUploadSuccessMessage
 from videos.models import VideoFile
 from websites.api import is_ocw_site
-from websites.constants import RESOURCE_TYPE_VIDEO, WEBSITE_SOURCE_OCW_IMPORT
+from websites.constants import RESOURCE_TYPE_VIDEO
 from websites.models import Website, WebsiteContent
 from websites.utils import get_dict_field, get_dict_query_field
 
@@ -339,14 +339,10 @@ def update_youtube_metadata(website: Website, version=VERSION_DRAFT):
     youtube = YouTubeApi()
     for video_resource in video_resources:
         youtube_id = get_dict_field(video_resource.metadata, settings.YT_FIELD_ID)
-        if (
-            website.source != WEBSITE_SOURCE_OCW_IMPORT
-            or VideoFile.objects.filter(
-                video__website=website, destination_id=youtube_id
-            ).exists()
-            or settings.ENVIRONMENT in ["prod", "production"]
-        ):
-            # do not run this for imported OCW site videos on RC
+        # do not run this for any old imported videos
+        if VideoFile.objects.filter(
+            video__website=website, destination_id=youtube_id
+        ).exists():
             youtube.update_video(
                 video_resource, privacy=("public" if version == VERSION_LIVE else None)
             )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
Only updates metadata for youtube videos if there is a corresponding `VideoFile` object (in other words, a video that has been transcoded and uploaded via Studio).  Any video resources that do not have an associated `VideoFile` will not have their metadata updated on YouTube.

#### How should this be manually tested?
- Copy `YT_*` values from RC to your .env file
- For one of your sites, add a small video to the site's Google Drive folder and sync.
- Once you have a video resource, update its title and description.
- Change the Youtube ID field to `ulPWKn5hJ3w` and save.
- In a shell, run the following:
   ```
    from websites.models import Website
    from videos.youtube import update_youtube_metadata
    website = Website.objects.get(name=<your_site_name>)
    update_youtube_metadata(website)
    ```
- Check the video on youtube, it should NOT match your title/description.
- In a shell, create a `VideoFile` object associated with this youtube id and try again:
   ```
   VideoFile.objects.create(video=Video.objects.create(website=website), destination_id="ulPWKn5hJ3w")
   update_youtube_metadata(website)
   ```
-   Check the video on youtube, it should match your title/description.
