### PR TITLE
Add user metadata to mediaconvert job for filtering, based on queue name

### DIFF
--- a/app.json
+++ b/app.json
@@ -513,6 +513,10 @@
       "description": "Prefix to be used for S3 keys of files transcoded from AWS MediaConvert",
       "required": false
     },
+    "VIDEO_TRANSCODE_QUEUE": {
+      "description": "Name of MediaConvert queue to use for transcoding",
+      "required": false
+    },
     "YT_ACCESS_TOKEN": {
       "description": "Youtube access token",
       "required": false

--- a/main/settings.py
+++ b/main/settings.py
@@ -490,6 +490,11 @@ VIDEO_S3_TRANSCODE_PREFIX = get_string(
         "Prefix to be used for S3 keys of files transcoded from AWS MediaConvert"
     ),
 )
+VIDEO_TRANSCODE_QUEUE = get_string(
+    name="VIDEO_TRANSCODE_QUEUE",
+    default="Default",
+    description=("Name of MediaConvert queue to use for transcoding"),
+)
 YT_ACCESS_TOKEN = get_string(
     name="YT_ACCESS_TOKEN", default="", description="Youtube access token"
 )

--- a/videos/api.py
+++ b/videos/api.py
@@ -32,9 +32,10 @@ def create_media_convert_job(video: Video, source_prefix=None):
         "r",
     ) as job_template:
         job_dict = json.loads(job_template.read())
+        job_dict["UserMetadata"]["filter"] = settings.VIDEO_TRANSCODE_QUEUE
         job_dict[
             "Queue"
-        ] = f"arn:aws:mediaconvert:{settings.AWS_REGION}:{settings.AWS_ACCOUNT_ID}:queues/Default"
+        ] = f"arn:aws:mediaconvert:{settings.AWS_REGION}:{settings.AWS_ACCOUNT_ID}:queues/{settings.VIDEO_TRANSCODE_QUEUE}"
         job_dict[
             "Role"
         ] = f"arn:aws:iam::{settings.AWS_ACCOUNT_ID}:role/{settings.AWS_ROLE_NAME}"

--- a/videos/api_test.py
+++ b/videos/api_test.py
@@ -16,6 +16,7 @@ pytestmark = pytest.mark.django_db
 
 def test_create_media_convert_job(settings, mocker):
     """create_media_convert_job should send a request to MediaConvert, create a VideoJob object"""
+    settings.VIDEO_TRANSCODE_QUEUE = "test_queue"
     mock_boto = mocker.patch("videos.api.boto3")
     job_id = "abcd123-gh564"
     mock_boto.client.return_value.create_job.return_value = {"Job": {"Id": job_id}}
@@ -26,6 +27,7 @@ def test_create_media_convert_job(settings, mocker):
     assert call_kwargs["Role"] == (
         f"arn:aws:iam::{settings.AWS_ACCOUNT_ID}:role/{settings.AWS_ROLE_NAME}"
     )
+    assert call_kwargs["UserMetadata"]["filter"] == "test_queue"
     destination = call_kwargs["Settings"]["OutputGroups"][0]["OutputGroupSettings"][
         "FileGroupSettings"
     ]["Destination"]


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
Part of #995

#### What's this PR do?
Adds a new setting VIDEO_TRANSCODE_QUEUE, to match the queues specified in ol-infrastructure, and updates the MediaConvert job definition to include it.
Adds a `UserMetadata.filter` key to the MediaConvert job definition, which will be used for SNS event rule filtering on AWS (this will require a change to the ol-infrastructure code).

#### How should this be manually tested?
- Copy RC `AWS_*` settings to your .env file, and set `VIDEO_TRANSCODE_QUEUE=ocw-studio-mediaconvert-queue-qa`
- Create a `Video` object in a shell and then start a mediaconvert job for it.  There should be no errors.
   ```
   from videos.api import *
   video = Video.objects.create(website=<your_website>, source_key="gdrive_uploads/11-382-water-diplomacy-spring-2021/1RxRDvHiKFR-QZ99GgZam2PiXRFCLJTLM/jellie3local1.mp4")
   create_media_convert_job(video)
   ```
- If you change `VIDEO_TRANSCODE_QUEUE=fake_queue`, restart containers, and run `create_media_convert_job(video)` again, you should get an error about an invalid queue.

