### PR TITLE
Explicitly specify embeddable=true when updating youtube video visibility

### DIFF
--- a/videos/youtube.py
+++ b/videos/youtube.py
@@ -231,7 +231,11 @@ class YouTubeApi:
     def update_privacy(self, youtube_id: str, privacy: str):
         """Update the privacy level of a video"""
         self.client.videos().update(
-            part="status", body={"id": youtube_id, "status": {"privacyStatus": privacy}}
+            part="status",
+            body={
+                "id": youtube_id,
+                "status": {"privacyStatus": privacy, "embeddable": True},
+            },
         ).execute()
 
     def update_captions(self, resource: WebsiteContent, youtube_id: str):

--- a/videos/youtube_test.py
+++ b/videos/youtube_test.py
@@ -199,7 +199,11 @@ def test_update_video(settings, mocker, youtube_mocker, privacy):
     )
     if privacy is not None:
         youtube_mocker().videos.return_value.update.assert_any_call(
-            part="status", body={"id": youtube_id, "status": {"privacyStatus": privacy}}
+            part="status",
+            body={
+                "id": youtube_id,
+                "status": {"privacyStatus": privacy, "embeddable": True},
+            },
         )
 
     mock_update_caption.assert_called_once_with(content, youtube_id)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #1021 

#### What's this PR do?
Specifies `embeddable=True` when updating youtube metadata status so that it won't be reverted.

#### How should this be manually tested?
- Copy `YT_*` values from RC to your .env file
- For one of your sites (with starter=ocw-course), add a small video to the site's Google Drive folder and sync.
- Once you have a video resource, update its title and description.
- Change the Youtube ID field to `ulPWKn5hJ3w` and save.
- In a shell, create a `VideoFile` object associated with this youtube id and then update metadata with version "live":
   ```
   video = VideoFile.objects.create(video=Video.objects.create(website=<your_website>), destination_id="ulPWKn5hJ3w")
   update_youtube_metadata(website, version="live")
   ```
- Check that the youtube video is still embeddable with public visibility (I can check for you on the test channel)
