### PR TITLE
add markdown cleanup rule for legacy data fix

### DIFF
--- a/websites/management/commands/markdown_cleaning/legacy_shortcodes_data_fix.py
+++ b/websites/management/commands/markdown_cleaning/legacy_shortcodes_data_fix.py
@@ -1,0 +1,52 @@
+"""
+These rules are intended to help fix data after the legacy shortocde incident.
+Prior to https://github.com/mitodl/ocw-studio/pull/1013, "legacy" shortcodes
+like {{< baseurl >}} would become corrupted in studio during editing. The editor:
+    - displayed the shortcodes as raw text in studio edit
+    - then escaped special characters like "[" and "<" when saving (only if edits were made)
+
+This rule selectively unescapes content.
+"""
+import re
+
+from websites.management.commands.markdown_cleaning.cleanup_rule import (
+    MarkdownCleanupRule,
+)
+
+
+LINK_WITHOUT_IMAGE = r"\\\[[^\[\]]*\\\]\({{\\<"
+LINK_WITH_IMAGE = r"\\\[!\\\[[^\[\]]*\][^\[\]]*\\\]\({{\\<"
+
+
+class LegacyShortcodeFixOne(MarkdownCleanupRule):
+    """
+    Use this BEFORE LegacyShortcodeTwo because this matches against "{{\\<" for
+    increased selectivity.
+    """
+
+    regex = f"{LINK_WITH_IMAGE}|{LINK_WITHOUT_IMAGE}"
+
+    alias = "legacy_shortcode_datafix_1_of_2"
+
+    def __call__(self, match: re.Match, _website_content):
+        original_text = match[0]
+        fixed = (
+            original_text.replace("\\[", "[").replace("\\]", "]").replace("\\_", "_")
+        )
+        return fixed
+
+
+class LegacyShortcodeFixTwo(MarkdownCleanupRule):
+    """
+    Use this AFTER LegacyShortcodeFixOne, which matches against the data fixed
+    by this rule.
+    """
+
+    regex = r"{{\\< .*?>}}"
+
+    alias = "legacy_shortcode_datafix_2_of_2"
+
+    def __call__(self, match: re.Match, _website_content):
+        original_text = match[0]
+        fixed = original_text.replace("\\<", "<").replace("\\_", "_")
+        return fixed

--- a/websites/management/commands/markdown_cleaning/legacy_shortcodes_data_fix.py
+++ b/websites/management/commands/markdown_cleaning/legacy_shortcodes_data_fix.py
@@ -6,6 +6,19 @@ like {{< baseurl >}} would become corrupted in studio during editing. The editor
     - then escaped special characters like "[" and "<" when saving (only if edits were made)
 
 This rule selectively unescapes content.
+
+### Strategy
+In general, there there are two data corruptions we're trying to fix. Consider
+the texts
+
+    blah \[Some Tile\]{{\< resource\_file uuid >}} blah
+    blah blah {{\< sup 2 >}} blah
+
+We will make two rules:
+1. Fix the stuff BEFORE the shortcode, namely link/image title (line 1)
+2. Fix the shortcode itself and its contents
+
+The `\<` in the first line will be caught by the second rule.
 """
 import re
 
@@ -30,6 +43,7 @@ class LegacyShortcodeFixOne(MarkdownCleanupRule):
 
     def __call__(self, match: re.Match, _website_content):
         original_text = match[0]
+        # Intentially not converting {{\< to {{< ... that will be fixed by Rule Two
         fixed = (
             original_text.replace("\\[", "[").replace("\\]", "]").replace("\\_", "_")
         )

--- a/websites/management/commands/markdown_cleaning/legacy_shortcodes_data_fix_test.py
+++ b/websites/management/commands/markdown_cleaning/legacy_shortcodes_data_fix_test.py
@@ -1,0 +1,70 @@
+"""Tests for convert_baseurl_links_to_resource_links.py"""
+import pytest
+
+from websites.factories import WebsiteContentFactory
+from websites.management.commands.markdown_cleaning.cleaner import (
+    WebsiteContentMarkdownCleaner as Cleaner,
+)
+from websites.management.commands.markdown_cleaning.legacy_shortcodes_data_fix import (
+    LegacyShortcodeFixOne,
+    LegacyShortcodeFixTwo,
+)
+
+
+@pytest.mark.parametrize(
+    ["markdown", "expected_markdown"],
+    [
+        (
+            # images inside links
+            R"cats \[!\[ Image description.\]({{\< resource\_file uuid1 >}})\]({{\< meow",
+            R"cats [![ Image description.]({{\< resource_file uuid1 >}})]({{\< meow",
+        ),
+        (
+            # two on same line
+            R"\[post-class assignments\]({{\< some_shortcode >}}) woof \[post-class assignments\]({{\< woof",
+            R"[post-class assignments]({{\< some_shortcode >}}) woof [post-class assignments]({{\< woof",
+        ),
+    ],
+)
+def test_baseurl_replacer_specific_title_replacements(markdown, expected_markdown):
+    """Test specific replacements"""
+    website_uuid = "website-uuid"
+    target_content = WebsiteContentFactory.build(
+        markdown=markdown, website_id=website_uuid
+    )
+
+    cleaner = Cleaner(LegacyShortcodeFixOne())
+    cleaner.update_website_content_markdown(target_content)
+    assert target_content.markdown == expected_markdown
+
+
+@pytest.mark.parametrize(
+    ["markdown", "expected_markdown"],
+    [
+        (
+            R"cats [![ Image description.]({{\< resource_file uuid1 >}})]({{\< meow >}} cool",
+            R"cats [![ Image description.]({{< resource_file uuid1 >}})]({{< meow >}} cool",
+        ),
+        (
+            # without space on closing shortcode
+            R'{{\< div-with-class "reveal1">}}',
+            R'{{< div-with-class "reveal1">}}',
+        ),
+        (
+            # with space
+            R'{{\< div-with-class "reveal1" >}}',
+            R'{{< div-with-class "reveal1" >}}',
+        ),
+    ],
+)
+def test_baseurl_replacer_specific_title_replacements(markdown, expected_markdown):
+    """Test specific replacements"""
+    website_uuid = "website-uuid"
+    target_content = WebsiteContentFactory.build(
+        markdown=markdown, website_id=website_uuid
+    )
+
+    cleaner = Cleaner(LegacyShortcodeFixTwo())
+    cleaner.update_website_content_markdown(target_content)
+
+    assert target_content.markdown == expected_markdown

--- a/websites/management/commands/markdown_cleanup.py
+++ b/websites/management/commands/markdown_cleanup.py
@@ -13,6 +13,10 @@ from websites.management.commands.markdown_cleaning.baseurl_rule import (
 from websites.management.commands.markdown_cleaning.cleaner import (
     WebsiteContentMarkdownCleaner,
 )
+from websites.management.commands.markdown_cleaning.legacy_shortcodes_data_fix import (
+    LegacyShortcodeFixOne,
+    LegacyShortcodeFixTwo,
+)
 from websites.management.commands.markdown_cleaning.resource_file_rule import (
     ResourceFileReplacementRule,
 )
@@ -26,7 +30,12 @@ class Command(BaseCommand):
 
     help = __doc__
 
-    Rules = [BaseurlReplacementRule, ResourceFileReplacementRule]
+    Rules = [
+        BaseurlReplacementRule,
+        ResourceFileReplacementRule,
+        LegacyShortcodeFixOne,
+        LegacyShortcodeFixTwo,
+    ]
 
     def add_arguments(self, parser: CommandParser) -> None:
         aliases = [R.alias for R in self.Rules]


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets? #1025 

#### What's this PR do?
This PR fixes extra escapes caused by the legacy-shortcode editing issue.

#### How should this be manually tested?
I suggest:

Run
```
docker-compose exec web python manage.py markdown_cleanup legacy_shortcode_datafix_1_of_2 -o one.csv
docker-compose exec web python manage.py markdown_cleanup legacy_shortcode_datafix_2_of_2 -o two.csv
```
against a database with some corrupted shortcodes. For example, 
```
\[!\[Small groups of students talking at tables in a classroom. In the foreground, an instructor stands near a pair of students talking to each other.\]({{\< resource\_file 68aab975-18a3-39e4-91a6-bd54c8f35356 >}})\]({{\<
```

Or if you want to test it against production backup:

```
docker-compose stop
docker-compose rm -sv db
docker-compose up db -d
docker-compose exec -T -e PGPASSWORD=postgres db psql -h db -U postgres < prod_dump.sql
```
