### PR TITLE
add GTM_ACCOUNT_ID to OCW site builds

### DIFF
--- a/app.json
+++ b/app.json
@@ -270,6 +270,10 @@
       "description": "The slug of the WebsiteStarter to assign to courses imported from ocw-to-hugo",
       "required": false
     },
+    "OCW_GTM_ACCOUNT_ID": {
+      "description": "The Google Tag Manager account ID to use in OCW site build pipelines",
+      "required": false
+    },
     "OCW_STUDIO_ADMIN_EMAIL": {
       "description": "E-mail to send 500 reports to.",
       "required": false

--- a/content_sync/conftest.py
+++ b/content_sync/conftest.py
@@ -52,3 +52,4 @@ def required_concourse_settings(settings):
     settings.SITE_BASE_URL = "http://test.edu"
     settings.API_BEARER_TOKEN = "abc123"
     settings.SEARCH_API_URL = "http://test.edu/api/v0/search"
+    settings.OCW_GTM_ACCOUNT_ID = "abc123"

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -194,7 +194,7 @@ class SitePipeline(BaseSitePipeline, ConcoursePipeline):
         "GIT_DOMAIN",
         "GIT_ORGANIZATION",
         "GITHUB_WEBHOOK_BRANCH",
-        "OCW_GTM_ACCOUNT_ID"
+        "OCW_GTM_ACCOUNT_ID",
     ]
 
     def __init__(self, website: Website, api: Optional[ConcourseApi] = None):
@@ -313,7 +313,7 @@ class ThemeAssetsPipeline(ConcoursePipeline, BaseThemeAssetsPipeline):
 
     MANDATORY_SETTINGS = MANDATORY_CONCOURSE_SETTINGS + [
         "GITHUB_WEBHOOK_BRANCH",
-        "SEARCH_API_URL"
+        "SEARCH_API_URL",
     ]
 
     def __init__(self, api: Optional[ConcourseApi] = None):
@@ -370,7 +370,7 @@ class MassPublishPipeline(BaseMassPublishPipeline, ConcoursePipeline):
             "GIT_DOMAIN",
             "GIT_ORGANIZATION",
             "GITHUB_WEBHOOK_BRANCH",
-            "OCW_GTM_ACCOUNT_ID"
+            "OCW_GTM_ACCOUNT_ID",
         ]
         super().__init__(api=api)
         self.pipeline_name = "mass_publish"

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -194,6 +194,7 @@ class SitePipeline(BaseSitePipeline, ConcoursePipeline):
         "GIT_DOMAIN",
         "GIT_ORGANIZATION",
         "GITHUB_WEBHOOK_BRANCH",
+        "OCW_GTM_ACCOUNT_ID"
     ]
 
     def __init__(self, website: Website, api: Optional[ConcourseApi] = None):
@@ -259,6 +260,7 @@ class SitePipeline(BaseSitePipeline, ConcoursePipeline):
                     pipeline_config_file.read()
                     .replace("((markdown-uri))", markdown_uri)
                     .replace("((git-private-key-var))", private_key_var)
+                    .replace("((gtm-account-id))", settings.OCW_GTM_ACCOUNT_ID)
                     .replace("((ocw-bucket))", destination_bucket)
                     .replace(
                         "((ocw-hugo-themes-branch))", settings.GITHUB_WEBHOOK_BRANCH
@@ -311,7 +313,7 @@ class ThemeAssetsPipeline(ConcoursePipeline, BaseThemeAssetsPipeline):
 
     MANDATORY_SETTINGS = MANDATORY_CONCOURSE_SETTINGS + [
         "GITHUB_WEBHOOK_BRANCH",
-        "SEARCH_API_URL",
+        "SEARCH_API_URL"
     ]
 
     def __init__(self, api: Optional[ConcourseApi] = None):
@@ -368,6 +370,7 @@ class MassPublishPipeline(BaseMassPublishPipeline, ConcoursePipeline):
             "GIT_DOMAIN",
             "GIT_ORGANIZATION",
             "GITHUB_WEBHOOK_BRANCH",
+            "OCW_GTM_ACCOUNT_ID"
         ]
         super().__init__(api=api)
         self.pipeline_name = "mass_publish"
@@ -410,6 +413,7 @@ class MassPublishPipeline(BaseMassPublishPipeline, ConcoursePipeline):
                 pipeline_config_file.read()
                 .replace("((markdown-uri))", markdown_uri)
                 .replace("((git-private-key-var))", private_key_var)
+                .replace("((gtm-account-id))", settings.OCW_GTM_ACCOUNT_ID)
                 .replace("((ocw-bucket))", destination_bucket)
                 .replace("((ocw-hugo-themes-branch))", settings.GITHUB_WEBHOOK_BRANCH)
                 .replace("((ocw-hugo-themes-uri))", OCW_HUGO_THEMES_GIT)

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -173,6 +173,7 @@ def test_upsert_website_pipelines(
     config_str = json.dumps(kwargs)
 
     assert f"{hugo_projects_path}.git" in config_str
+    assert settings.OCW_GTM_ACCOUNT_ID in config_str
     assert settings.OCW_IMPORT_STARTER_SLUG in config_str
     assert api_url in config_str
     if home_page:
@@ -420,6 +421,7 @@ def test_upsert_mass_publish_pipeline(
         bucket = settings.AWS_PUBLISH_BUCKET_NAME
         api_url = settings.OCW_STUDIO_LIVE_URL
     config_str = json.dumps(kwargs)
+    assert settings.OCW_GTM_ACCOUNT_ID in config_str
     assert bucket in config_str
     assert version in config_str
     assert f"{hugo_projects_path}.git" in config_str

--- a/content_sync/pipelines/definitions/concourse/mass-publish.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-publish.yml
@@ -65,6 +65,7 @@ jobs:
     attempts: 3
     timeout: 300m
     params:
+      GTM_ACCOUNT_ID: ((gtm-account-id))
       OCW_IMPORT_STARTER_SLUG: ((ocw-import-starter-slug))
       OCW_STUDIO_BASE_URL: ((ocw-studio-url))
       STATIC_API_BASE_URL: ((static-api-base-url))

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -116,6 +116,7 @@ jobs:
         timeout: 20m
         attempts: 3
         params:
+          GTM_ACCOUNT_ID: ((gtm-account-id))
           OCW_STUDIO_BASE_URL: ((ocw-studio-url))
           STATIC_API_BASE_URL: ((static-api-base-url))
           OCW_IMPORT_STARTER_SLUG: ((ocw-import-starter-slug))

--- a/main/settings.py
+++ b/main/settings.py
@@ -957,6 +957,11 @@ OCW_IMPORT_STARTER_SLUG = get_string(
     description="The slug of the WebsiteStarter to assign to courses imported from ocw-to-hugo",
     required=False,
 )
+OCW_GTM_ACCOUNT_ID = get_string(
+    name="OCW_GTM_ACCOUNT_ID",
+    default=None,
+    description="The Google Tag Manager account ID to use in OCW site build pipelines",
+)
 OCW_STUDIO_SITE_CONFIG_FILE = get_string(
     name="OCW_STUDIO_SITE_CONFIG_FILE",
     default="ocw-studio.yaml",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [ ] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable
  - [x] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/446

#### What's this PR do?
This PR adds the `GTM_ACCOUNT_ID` env variable to the individual site pipelines as well as the mass publish pipeline, based on `OCW_GTM_ACCOUNT_ID`, added in [this PR](https://github.com/mitodl/salt-ops/pull/1505).  It will set the env variable in the Concourse build environments so that it is properly templated onto the sites and Google analytics starts working again.

#### How should this be manually tested?
 - Spin up `ocw-studio` with local Concourse support by using `docker-compose --profile concourse up`
 - Make sure you have at least one site made with the `ocw-course` starter in your local `ocw-studio` instance
 - Run `docker-compose run web ./manage.py backpopulate_pipelines`
 - Make sure you have the Concourse `fly` CLI set up and add your local instance as a target] with [`fly login`](https://concourse-ci.org/fly.html#fly-login)
 - Query your site pipeline with [`fly get-pipeline`](https://concourse-ci.org/managing-pipelines.html#fly-get-pipeline) and make sure that `GTM_ACCOUNT_ID` is set on the pipeline
 - Run `docker-compose run web ./manage.py upsert_mass_publish_pipeline`
 - Repeat the process above but for the mass publish pipeline and verify that the same env variable is set
