### PR TITLE
Add open webhook to pipelines

### DIFF
--- a/app.json
+++ b/app.json
@@ -274,6 +274,10 @@
       "description": "The Google Tag Manager account ID to use in OCW site build pipelines",
       "required": false
     },
+    "OCW_NEXT_SEARCH_WEBHOOK_KEY": {
+      "description": "Open discussions webhook key",
+      "required": false
+    },
     "OCW_STUDIO_ADMIN_EMAIL": {
       "description": "E-mail to send 500 reports to.",
       "required": false
@@ -364,6 +368,10 @@
     },
     "OCW_STUDIO_USE_S3": {
       "description": "Use S3 for storage backend (required on Heroku)",
+      "required": false
+    },
+    "OPEN_DISCUSSIONS_URL": {
+      "description": "Open discussions url",
       "required": false
     },
     "PGBOUNCER_DEFAULT_POOL_SIZE": {

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -276,6 +276,10 @@ class SitePipeline(BaseSitePipeline, ConcoursePipeline):
                         "((ocw-import-starter-slug))", settings.OCW_IMPORT_STARTER_SLUG
                     )
                     .replace("((ocw-studio-bucket))", settings.AWS_STORAGE_BUCKET_NAME)
+                    .replace("((open-discussions-url))", settings.OPEN_DISCUSSIONS_URL)
+                    .replace(
+                        "((open-webhook-key))", settings.OCW_NEXT_SEARCH_WEBHOOK_KEY
+                    )
                     .replace("((ocw-site-repo))", self.website.short_id)
                     .replace("((ocw-site-repo-branch))", branch)
                     .replace("((config-slug))", self.website.starter.slug)
@@ -428,6 +432,8 @@ class MassPublishPipeline(BaseMassPublishPipeline, ConcoursePipeline):
                 .replace("((ocw-site-repo-branch))", branch)
                 .replace("((version))", self.version)
                 .replace("((api-token))", settings.API_BEARER_TOKEN or "")
+                .replace("((open-discussions-url))", settings.OPEN_DISCUSSIONS_URL)
+                .replace("((open-webhook-key))", settings.OCW_NEXT_SEARCH_WEBHOOK_KEY)
             )
         log.debug(config_str)
         config = json.dumps(yaml.load(config_str, Loader=yaml.SafeLoader))

--- a/content_sync/pipelines/definitions/concourse/mass-publish.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-publish.yml
@@ -112,6 +112,7 @@ jobs:
                 cd $CURDIR
                 aws s3 sync s3://((ocw-studio-bucket))/$SITE_URL s3://((ocw-bucket))/$SITE_URL --metadata site-id=$NAME || return 1            
                 aws s3 sync $SHORT_ID/public s3://((ocw-bucket))/$BASE_URL --metadata site-id=$NAME || return 1
+                curl -X POST -H 'Content-Type: application/json' --data '{"webhook_key":"((open-webhook-key))","prefix":"'"$SITE_URL"/'","version":"((version))"}' ((open-discussions-url))/api/v0/ocw_next_webhook/
                 curl -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer ((api-token))' --data '{"version":"((version))","status":"succeeded"}' ((ocw-studio-url))/api/websites/$NAME/pipeline_status/
                 rm -rf $SHORT_ID
                 return 0

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -45,6 +45,15 @@ resources:
             Content-Type: "application/json"
             Authorization: "Bearer ((api-token))"
         out_only: true
+  - name: open-discussions-webhook
+    type: http-resource
+    check_every: never
+    source:
+        url: ((open-discussions-url))/api/v0/ocw_next_webhook/
+        method: POST
+        headers:
+          Content-Type: "application/json"
+        out_only: true
 jobs:
   - name: build-ocw-site
     serial: true
@@ -199,15 +208,26 @@ jobs:
               - https://api.fastly.com/service/((fastly.service_id))/((purge-url))
         on_success:
           try:
-            put: ocw-studio-webhook
-            timeout: 1m
-            attempts: 3
-            params:
-                text: |
-                  {
-                    "version": "((pipeline_name))",
-                    "status": "succeeded"
-                  }
+            do:
+              - put: open-discussions-webhook
+                timeout: 1m
+                attempts: 3
+                params:
+                  text: |
+                    {
+                      "webhook_key": "((open-webhook-key))",
+                      "prefix": "((site-url))/",
+                      "version": "((pipeline_name))"
+                    }
+              - put: ocw-studio-webhook
+                timeout: 1m
+                attempts: 3
+                params:
+                  text: |
+                    {
+                      "version": "((pipeline_name))",
+                      "status": "succeeded"
+                    }
         on_failure:
           try:
             put: ocw-studio-webhook

--- a/main/settings.py
+++ b/main/settings.py
@@ -483,6 +483,18 @@ DRIVE_UPLOADS_PARENT_FOLDER_ID = get_string(
     description="Gdrive folder for video uploads",
     required=False,
 )
+OCW_NEXT_SEARCH_WEBHOOK_KEY = get_string(
+    name="OCW_NEXT_SEARCH_WEBHOOK_KEY",
+    default="",
+    description="Open discussions webhook key",
+    required=False,
+)
+OPEN_DISCUSSIONS_URL = get_string(
+    name="OPEN_DISCUSSIONS_URL",
+    default="",
+    description="Open discussions url",
+    required=False,
+)
 VIDEO_S3_TRANSCODE_PREFIX = get_string(
     name="VIDEO_S3_TRANSCODE_PREFIX",
     default="aws_mediaconvert_transcodes",


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable
  - [x] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
https://github.com/mitodl/ocw-studio/issues/1005

#### What's this PR do?
This pr adds a call to open-discussions to update indexes at the end of the site-pipeline and mass-publish pipelines

#### How should this be manually tested?
To test the site-publish functionality:
Checkout https://github.com/mitodl/open-discussions/pull/3510 in open-discussions

Set OPEN_DISCUSSIONS_WEBHOOK_KEY=key here and OCW_NEXT_WEBHOOK_KEY=key in open-discussions. Set up ngrok. Run open-discussions locally with ngrok pointed to it. Set OPEN_DISCUSSIONS_URL to the ngrok url.

Set CONTENT_SYNC_PIPELINE, GITHUB_ and CONCOURSE_ variables to the values on RC. 

Get or create a site.  Run `docker-compose run web ./manage.py backpopulate_pipelines --filter <your-site-name>` to update your site.

Publish the site to draft and live via your local ui. Verify that you see requests to open-discussions in the ngrok up and open-discussions. The requests should return 200 and have body
```
{
    "webhook_key": "key",
    "prefix": <your-course-name>,
    "version": <live or draft>
}
```

When you publish to live you should also see `course_catalog.tasks.get_ocw_next_courses` in the open-discussion celery logs.

If your test site exists on ocw-studio-rc, set the pipelines back by running `manage.py backpopulate_pipelines --filter <your-site-name>` on heroku rc

To test the mass-publish functionality:
Keep the .env updates you just made.
Set OCW_STUDIO_BASE_URL=https://ocw-studio-rc.odl.mit.edu/ and API_BEARER_TOKEN to the value from ocw-studio-rc on heroku

### **Check with the team to make sure that no one is planning to run a mass publish on rc**

Run `docker-compose run web ./manage.py upsert_mass_publish_pipeline` locally to update the mass publish pipeline on rc.

Go to the concourse UI https://cicd-qa.odl.mit.edu/?search=team%3A%22ocw%22%20group%3A%22mass-publish%22.
Start a draft mass-publish. Verify that you are seeing requests to open-discussions in the open-discussions logs and ngrok. The requests in ngrok should have body

 ```
{
    "webhook_key": "key",
    "prefix": <course-name>,
    "version": "draft.
}
```
and 200 responses.  You should not see `course_catalog.tasks.get_ocw_next_courses` in the open-discussion celery log.

Stop the pipeline run from the concourse UI once you start seeing the requests.

Start a live mass-publish. Again, you should see requests to open-discussions with body
 ```
{
    "webhook_key": "key",
    "prefix": <course-name>,
    "version": "live"
}
```
and 200 responses. This time you will see `course_catalog.tasks.get_ocw_next_courses` in the open-discussion celery log.   Once you see some requests you can cancel the rest of the pipeline.

### ****Run `manage.py upsert_mass_publish_pipeline` through heroku in rc to set the mass publish pipeline back to how it was**** 