### PR TITLE
Separate celery queues for publish tasks, batch tasks

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bin/start-nginx bin/start-pgbouncer newrelic-admin run-program uwsgi uwsgi.ini
-worker: bin/start-pgbouncer newrelic-admin run-program celery -A main.celery:app worker -B -l $OCW_STUDIO_LOG_LEVEL
-extra_worker: bin/start-pgbouncer newrelic-admin run-program celery -A main.celery:app worker -l $OCW_STUDIO_LOG_LEVEL
+worker: bin/start-pgbouncer newrelic-admin run-program celery -A main.celery:app worker -Q publish,batch,default -B -l $OCW_STUDIO_LOG_LEVEL
+extra_worker: bin/start-pgbouncer newrelic-admin run-program celery -A main.celery:app worker -Q publish,batch,default -l $OCW_STUDIO_LOG_LEVEL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
     command: >
       /bin/bash -c '
       sleep 3;
-      celery -A main.celery:app worker -B -l ${OCW_STUDIO_LOG_LEVEL:-INFO}'
+      celery -A main.celery:app worker -Q publish,batch,default, -B -l ${OCW_STUDIO_LOG_LEVEL:-INFO}'
     links:
       - db
       - redis

--- a/main/celery.py
+++ b/main/celery.py
@@ -14,5 +14,22 @@ app = Celery("ocw_studio")
 
 # Using a string here means the worker will not have to
 # pickle the object when using Windows.
+app.conf.task_default_queue = "default"
 app.config_from_object("django.conf:settings", namespace="CELERY")
 app.autodiscover_tasks()
+
+app.conf.task_routes = {
+    "content_sync.tasks.sync_website_content": {"queue": "publish"},
+    "content_sync.tasks.create_website_backend": {"queue": "publish"},
+    "content_sync.tasks.publish_website_backend_draft": {"queue": "publish"},
+    "content_sync.tasks.publish_website_backend_live": {"queue": "publish"},
+    "content_sync.tasks.check_incomplete_publish_build_statuses": {
+        "queue": "publish"
+    },
+    "content_sync.tasks.upsert_website_publishing_pipeline": {"queue": "publish"},
+    "content_sync.tasks.sync_unsynced_websites": {"queue": "batch"},
+    "content_sync.tasks.upsert_pipelines": {"queue": "batch"},
+    "content_sync.tasks.trigger_mass_publish": {"queue": "batch"},
+    "content_sync.tasks.publish_website_batch": {"queue": "batch"},
+    "content_sync.tasks.publish_websites": {"queue": "batch"},
+}

--- a/main/celery.py
+++ b/main/celery.py
@@ -23,9 +23,7 @@ app.conf.task_routes = {
     "content_sync.tasks.create_website_backend": {"queue": "publish"},
     "content_sync.tasks.publish_website_backend_draft": {"queue": "publish"},
     "content_sync.tasks.publish_website_backend_live": {"queue": "publish"},
-    "content_sync.tasks.check_incomplete_publish_build_statuses": {
-        "queue": "publish"
-    },
+    "content_sync.tasks.check_incomplete_publish_build_statuses": {"queue": "publish"},
     "content_sync.tasks.upsert_website_publishing_pipeline": {"queue": "publish"},
     "content_sync.tasks.sync_unsynced_websites": {"queue": "batch"},
     "content_sync.tasks.upsert_pipelines": {"queue": "batch"},


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes #1010 

#### What's this PR do?
Adds 2 new queues ("publish", "batch").
Assigns individual publish/git tasks to the "publish" queue
Assigns long-running tasks affecting multiple sites to the "batch" queue

#### How should this be manually tested?
Set `CONCOURSE_` vars in your .env to point to your local instance as describe in the README.
Run `docker-compose --profile concourse up`
Run `manage.py mass_publish --filter <filter_matching_some_sites> draft` and make sure it completes successfully (not including the pipeline which will fail).
Publish a site to draft and/or live, make sure that the task to sync to github and trigger the site pipeline runs and completes.

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
