### PR TITLE
improve baseurl replacement + more flexible resource_link

### DIFF
--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
@@ -56,6 +56,15 @@ describe("ResourceLink plugin", () => {
     )
   })
 
+  it("should serialize fragment arg to and from markdown", async () => {
+    const editor = await getEditor("")
+    markdownTest(
+      editor,
+      '{{< resource_link asdfasdfasdfasdf "text here" "some-fragment-id" >}}',
+      '<p><a class="resource-link" data-uuid="asdfasdfasdfasdf" data-fragment="some-fragment-id">text here</a></p>'
+    )
+  })
+
   it("[BUG] does not behave well if link title ends in backslash", async () => {
     const editor = await getEditor("")
     const { md2html } = (editor.data

--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
@@ -18,7 +18,7 @@ import {
  *   - gets fooled by label texts that include literal `" >}}` values. For
  *     example, < resource_link uuid123 "silly " >}} link" >}}.
  */
-export const RESOURCE_LINK_SHORTCODE_REGEX = /{{< resource_link (\S+) "(.*?)" >}}/g
+export const RESOURCE_LINK_SHORTCODE_REGEX = /{{< resource_link (\S+) "(.*?)"(?: "(.*?)")? >}}/g
 
 /**
  * Class for defining Markdown conversion rules for Resource links
@@ -50,8 +50,14 @@ export default class ResourceLinkMarkdownSyntax extends MarkdownSyntaxPlugin {
         {
           type:    "lang",
           regex:   RESOURCE_LINK_SHORTCODE_REGEX,
-          replace: (_s: string, uuid: string, linkText: string) => {
-            return `<a class="${RESOURCE_LINK_CKEDITOR_CLASS}" data-uuid="${uuid}">${linkText}</a>`
+          replace: (
+            _s: string,
+            uuid: string,
+            linkText: string,
+            fragment?: string
+          ) => {
+            const fragmentText = fragment ? ` data-fragment="${fragment}"` : ""
+            return `<a class="${RESOURCE_LINK_CKEDITOR_CLASS}" data-uuid="${uuid}"${fragmentText}>${linkText}</a>`
           }
         }
       ]
@@ -72,7 +78,10 @@ export default class ResourceLinkMarkdownSyntax extends MarkdownSyntaxPlugin {
           replacement: (_content: string, node: Turndown.Node): string => {
             // @ts-ignore
             const uuid = node.getAttribute("data-uuid")
-            return `{{< resource_link ${uuid} "${node.textContent}" >}}`
+            // @ts-ignore
+            const fragment = node.getAttribute("data-fragment")
+            const framgmentText = fragment ? `"${fragment}" ` : ""
+            return `{{< resource_link ${uuid} "${node.textContent}" ${framgmentText}>}}`
           }
         }
       }

--- a/websites/management/commands/markdown_cleaning/baseurl_rule_test.py
+++ b/websites/management/commands/markdown_cleaning/baseurl_rule_test.py
@@ -35,14 +35,31 @@ def get_markdown_cleaner(website_contents):
             R'This is a link with quote in title: [Cats say "meow"]({{< baseurl >}}/resources/path/to/file1).',
             R'This is a link with quote in title: {{< resource_link content-uuid-1 "Cats say \"meow\"" >}}.',
         ),
+        (  # Ignores backslashes around the title brackets
+            R'This is a link with quote in title: \[Cats say "meow"\]({{< baseurl >}}/resources/path/to/file1).',
+            R'This is a link with quote in title: {{< resource_link content-uuid-1 "Cats say \"meow\"" >}}.',
+        ),
         (
             R"This link should change [text title]({{< baseurl >}}/resources/path/to/file1) cool",
             R'This link should change {{< resource_link content-uuid-1 "text title" >}} cool',
         ),
         (
+            R"This link includes a fragment [text title]({{< baseurl >}}/resources/path/to/file1#some-fragment) cool",
+            R'This link includes a fragment {{< resource_link content-uuid-1 "text title" "some-fragment" >}} cool',
+        ),
+        (
+            R"This link includes a fragment with slash first [text title]({{< baseurl >}}/resources/path/to/file1/#some-fragment) cool",
+            R'This link includes a fragment with slash first {{< resource_link content-uuid-1 "text title" "some-fragment" >}} cool',
+        ),
+        (
             # < resource_link > short code is only for textual titles
             "This link should not change: [![image](cat.com)]({{< baseurl >}}/resources/path/to/file1) for now",
             "This link should not change: [![image](cat.com)]({{< baseurl >}}/resources/path/to/file1) for now",
+        ),
+        (
+            # < resource_link > short code is only for textual titles
+            R"This should not change [{{< resource uuid1 >}}]({{< baseurl >}}/resources/mit18_02sc_l20brds_5)",
+            R"This should not change [{{< resource uuid1 >}}]({{< baseurl >}}/resources/mit18_02sc_l20brds_5)",
         ),
         (
             # Titles with nested brackets may not be feasible with a regex approach, but they're very rare anyway.


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets? #1015

Related: #1024 #1012  

#### What's this PR do?
This PR improves the baseurl --> resource_link replacement rule to:
1. handle fragments (i.e., `[Entregar os exercícios #2]({{< baseurl >}}/pages/assignments#HW_2)` becomes `{{< resource_link a5bbe7e5-0f66-f74a-26fc-7b59875ac05a "Entregar os exercícios #2" "HW_2" >}}`
2. treat `[title]` and `\[title\]` the same
3. do not permit shortcodes in the baseurl link title

#### How should this be manually tested?
Run:
```
# To generate csv of replacements only
docker-compose exec web python manage.py markdown_cleanup baseurl -o meow2.csv
# to commit changes to database
docker-compose exec web python manage.py markdown_cleanup baseurl --commit
```
Inspect csv to ensure replacements look reasonable.

**Also:** Check that the markdown
```
cat < resource_link uuid "title" "fragment" > meow
# and
cat < resource_link uuid "title" > meow
```
render the same in CKEditor and that saving changes in markdown preserves the fragment in database.