### PR TITLE
baseurl replacement improvements

### DIFF
--- a/websites/management/commands/markdown_cleaning/baseurl_rule.py
+++ b/websites/management/commands/markdown_cleaning/baseurl_rule.py
@@ -76,7 +76,12 @@ class BaseurlReplacementRule(MarkdownCleanupRule):
     replacement.
     """
 
-    regex = r"\[(?P<title>[^\[\]\n]*?)\]\({{< baseurl >}}(?P<url>.*?)\)"
+    regex = (
+        r"\\?\[(?P<title>[^\[\]\n]*?)\\?\]"
+        + r"\({{< baseurl >}}(?P<url>.*?)"
+        + r"(/?#(?P<fragment>.*?))?"
+        + r"\)"
+    )
 
     alias = "baseurl"
 
@@ -88,6 +93,13 @@ class BaseurlReplacementRule(MarkdownCleanupRule):
         original_text = match[0]
         escaped_title = match.group("title").replace('"', '\\"')
         url = match.group("url")
+        fragment = match.group("fragment")
+        if fragment is not None:
+            return original_text
+
+        # This is probably a link with image as title, where the image is a < resource >
+        if R"{{<" in match.group("title"):
+            return original_text
 
         try:
             linked_content = self.content_lookup.get_content_by_url(

--- a/websites/management/commands/markdown_cleaning/baseurl_rule_test.py
+++ b/websites/management/commands/markdown_cleaning/baseurl_rule_test.py
@@ -35,14 +35,31 @@ def get_markdown_cleaner(website_contents):
             R'This is a link with quote in title: [Cats say "meow"]({{< baseurl >}}/resources/path/to/file1).',
             R'This is a link with quote in title: {{< resource_link content-uuid-1 "Cats say \"meow\"" >}}.',
         ),
+        (  # Ignores backslashes around the title brackets
+            R'This is a link with quote in title: \[Cats say "meow"\]({{< baseurl >}}/resources/path/to/file1).',
+            R'This is a link with quote in title: {{< resource_link content-uuid-1 "Cats say \"meow\"" >}}.',
+        ),
         (
             R"This link should change [text title]({{< baseurl >}}/resources/path/to/file1) cool",
             R'This link should change {{< resource_link content-uuid-1 "text title" >}} cool',
+        ),
+        (  # should not touch fragments
+            R"This link includes a fragment [text title]({{< baseurl >}}/resources/path/to/file1#some-fragment) cool",
+            R"This link includes a fragment [text title]({{< baseurl >}}/resources/path/to/file1#some-fragment) cool",
+        ),
+        (  # should not touch fragments with / before #
+            R"This link includes a fragment with slash first [text title]({{< baseurl >}}/resources/path/to/file1/#some-fragment) cool",
+            R"This link includes a fragment with slash first [text title]({{< baseurl >}}/resources/path/to/file1/#some-fragment) cool",
         ),
         (
             # < resource_link > short code is only for textual titles
             "This link should not change: [![image](cat.com)]({{< baseurl >}}/resources/path/to/file1) for now",
             "This link should not change: [![image](cat.com)]({{< baseurl >}}/resources/path/to/file1) for now",
+        ),
+        (
+            # < resource_link > short code is only for textual titles
+            R"This should not change [{{< resource uuid1 >}}]({{< baseurl >}}/resources/mit18_02sc_l20brds_5)",
+            R"This should not change [{{< resource uuid1 >}}]({{< baseurl >}}/resources/mit18_02sc_l20brds_5)",
         ),
         (
             # Titles with nested brackets may not be feasible with a regex approach, but they're very rare anyway.


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets? 
Related to #1024 #1012  

#### What's this PR do?
This PR improves the baseurl --> resource_link replacement rule to:
1. treat `[title]` and `\[title\]` the same
2. do not permit shortcodes in the baseurl link title
3. Also modifies the regex to handle fragments, but does not do replacements on urls with fragments.

#### How should this be manually tested?
Run:
```
# To generate csv of replacements only
docker-compose exec web python manage.py markdown_cleanup baseurl -o meow2.csv
# to commit changes to database
docker-compose exec web python manage.py markdown_cleanup baseurl --commit
```
Inspect csv to ensure replacements look reasonable.
