### PR TITLE
convert baseurl links w/ fragments

### DIFF
--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
@@ -6,7 +6,9 @@ import { createTestEditor, markdownTest } from "./test_util"
 import { turndownService } from "../turndown"
 
 import { RESOURCE_LINK } from "@mitodl/ckeditor5-resource-link/src/constants"
-import ResourceLinkMarkdownSyntax from "./ResourceLinkMarkdownSyntax"
+import ResourceLinkMarkdownSyntax, {
+  encodeShortcodeArgs as encode
+} from "./ResourceLinkMarkdownSyntax"
 import Paragraph from "@ckeditor/ckeditor5-paragraph/src/paragraph"
 
 const getEditor = createTestEditor([
@@ -45,8 +47,9 @@ describe("ResourceLink plugin", () => {
     markdownTest(
       editor,
       '{{< resource_link 1234-5678 "link text" "#some-header-id" >}}',
-      `<p><a class="resource-link" data-uuid="${encodeURIComponent(
-        JSON.stringify(["1234-5678", "#some-header-id"])
+      `<p><a class="resource-link" data-uuid="${encode(
+        "1234-5678",
+        "#some-header-id"
       )}">link text</a></p>`
     )
   })
@@ -56,7 +59,9 @@ describe("ResourceLink plugin", () => {
     markdownTest(
       editor,
       '{{< resource_link asdfasdfasdfasdf "text here" >}}',
-      '<p><a class="resource-link" data-uuid="asdfasdfasdfasdf">text here</a></p>'
+      `<p><a class="resource-link" data-uuid="${encode(
+        "asdfasdfasdfasdf"
+      )}">text here</a></p>`
     )
   })
 
@@ -65,7 +70,11 @@ describe("ResourceLink plugin", () => {
     markdownTest(
       editor,
       'dogs {{< resource_link uuid1 "woof" >}} cats {{< resource_link uuid2 "meow" >}}, cool',
-      '<p>dogs <a class="resource-link" data-uuid="uuid1">woof</a> cats <a class="resource-link" data-uuid="uuid2">meow</a>, cool</p>'
+      `<p>dogs <a class="resource-link" data-uuid="${encode(
+        "uuid1"
+      )}">woof</a> cats <a class="resource-link" data-uuid="${encode(
+        "uuid2"
+      )}">meow</a>, cool</p>`
     )
   })
 
@@ -75,7 +84,9 @@ describe("ResourceLink plugin", () => {
       .processor as unknown) as MarkdownDataProcessor
     expect(md2html('{{< resource_link uuid123 "bad \\" >}}')).toBe(
       // This is wrong. Should not end in &lt;/a&gt;
-      '<p><a class="resource-link" data-uuid="uuid123">bad &lt;/a&gt;</p>'
+      `<p><a class="resource-link" data-uuid="${encode(
+        "uuid123"
+      )}">bad &lt;/a&gt;</p>`
     )
   })
 })

--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
@@ -44,9 +44,9 @@ describe("ResourceLink plugin", () => {
 
     markdownTest(
       editor,
-      '{{< resource_link 1234-5678 "link text" "some-header-id" >}}',
+      '{{< resource_link 1234-5678 "link text" "#some-header-id" >}}',
       `<p><a class="resource-link" data-uuid="${encodeURIComponent(
-        "1234-5678#some-header-id"
+        JSON.stringify(["1234-5678", "#some-header-id"])
       )}">link text</a></p>`
     )
   })

--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
@@ -10,6 +10,12 @@ import {
   RESOURCE_LINK
 } from "@mitodl/ckeditor5-resource-link/src/constants"
 
+export const encodeShortcodeArgs = (...args: (string | undefined)[]) =>
+  encodeURIComponent(JSON.stringify(args))
+
+const decodeShortcodeArgs = (encoded: string) =>
+  JSON.parse(decodeURIComponent(encoded))
+
 /**
  * (\S+) to match and capture the UUID
  * "(.*?)" to match and capture the label text
@@ -57,9 +63,10 @@ export default class ResourceLinkMarkdownSyntax extends MarkdownSyntaxPlugin {
             linkText: string,
             fragment?: string
           ) => {
-            return `<a class="${RESOURCE_LINK_CKEDITOR_CLASS}" data-uuid="${encodeURIComponent(
-              JSON.stringify([uuid, fragment])
-            )}">${linkText}</a>`
+            const encoded = fragment ?
+              encodeShortcodeArgs(uuid, fragment) :
+              encodeShortcodeArgs(uuid)
+            return `<a class="${RESOURCE_LINK_CKEDITOR_CLASS}" data-uuid="${encoded}">${linkText}</a>`
           }
         }
       ]
@@ -78,10 +85,8 @@ export default class ResourceLinkMarkdownSyntax extends MarkdownSyntaxPlugin {
             )
           },
           replacement: (_content: string, node: Turndown.Node): string => {
-            const [uuid, anchor] = JSON.parse(
-              decodeURIComponent(
-                (node as any).getAttribute("data-uuid") as string
-              )
+            const [uuid, anchor] = decodeShortcodeArgs(
+              (node as any).getAttribute("data-uuid") as string
             )
 
             if (anchor) {

--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
@@ -57,9 +57,8 @@ export default class ResourceLinkMarkdownSyntax extends MarkdownSyntaxPlugin {
             linkText: string,
             fragment?: string
           ) => {
-            const formattedUUID = fragment ? `${uuid}#${fragment}` : uuid
             return `<a class="${RESOURCE_LINK_CKEDITOR_CLASS}" data-uuid="${encodeURIComponent(
-              formattedUUID
+              JSON.stringify([uuid, fragment])
             )}">${linkText}</a>`
           }
         }
@@ -79,9 +78,11 @@ export default class ResourceLinkMarkdownSyntax extends MarkdownSyntaxPlugin {
             )
           },
           replacement: (_content: string, node: Turndown.Node): string => {
-            const [uuid, anchor] = decodeURIComponent(
-              (node as any).getAttribute("data-uuid") as string
-            ).split("#")
+            const [uuid, anchor] = JSON.parse(
+              decodeURIComponent(
+                (node as any).getAttribute("data-uuid") as string
+              )
+            )
 
             if (anchor) {
               return `{{< resource_link ${uuid} "${node.textContent}" "${anchor}" >}}`

--- a/websites/management/commands/markdown_cleaning/baseurl_rule.py
+++ b/websites/management/commands/markdown_cleaning/baseurl_rule.py
@@ -94,8 +94,6 @@ class BaseurlReplacementRule(MarkdownCleanupRule):
         escaped_title = match.group("title").replace('"', '\\"')
         url = match.group("url")
         fragment = match.group("fragment")
-        if fragment is not None:
-            return original_text
 
         # This is probably a link with image as title, where the image is a < resource >
         if R"{{<" in match.group("title"):
@@ -105,8 +103,7 @@ class BaseurlReplacementRule(MarkdownCleanupRule):
             linked_content = self.content_lookup.get_content_by_url(
                 website_content.website_id, url
             )
-            return (
-                f'{{{{< resource_link {linked_content.text_id} "{escaped_title}" >}}}}'
-            )
+            fragment_arg = f' "{fragment}"' if fragment is not None else ""
+            return f'{{{{< resource_link {linked_content.text_id} "{escaped_title}"{fragment_arg} >}}}}'
         except KeyError:
             return original_text

--- a/websites/management/commands/markdown_cleaning/baseurl_rule.py
+++ b/websites/management/commands/markdown_cleaning/baseurl_rule.py
@@ -79,7 +79,7 @@ class BaseurlReplacementRule(MarkdownCleanupRule):
     regex = (
         r"\\?\[(?P<title>[^\[\]\n]*?)\\?\]"
         + r"\({{< baseurl >}}(?P<url>.*?)"
-        + r"(/?#(?P<fragment>.*?))?"
+        + r"(/?(?P<fragment>#.*?))?"
         + r"\)"
     )
 

--- a/websites/management/commands/markdown_cleaning/baseurl_rule_test.py
+++ b/websites/management/commands/markdown_cleaning/baseurl_rule_test.py
@@ -43,13 +43,13 @@ def get_markdown_cleaner(website_contents):
             R"This link should change [text title]({{< baseurl >}}/resources/path/to/file1) cool",
             R'This link should change {{< resource_link content-uuid-1 "text title" >}} cool',
         ),
-        (  # should not touch fragments
+        (
             R"This link includes a fragment [text title]({{< baseurl >}}/resources/path/to/file1#some-fragment) cool",
-            R"This link includes a fragment [text title]({{< baseurl >}}/resources/path/to/file1#some-fragment) cool",
+            R'This link includes a fragment {{< resource_link content-uuid-1 "text title" "some-fragment" >}} cool',
         ),
-        (  # should not touch fragments with / before #
+        (
             R"This link includes a fragment with slash first [text title]({{< baseurl >}}/resources/path/to/file1/#some-fragment) cool",
-            R"This link includes a fragment with slash first [text title]({{< baseurl >}}/resources/path/to/file1/#some-fragment) cool",
+            R'This link includes a fragment with slash first {{< resource_link content-uuid-1 "text title" "some-fragment" >}} cool',
         ),
         (
             # < resource_link > short code is only for textual titles

--- a/websites/management/commands/markdown_cleaning/baseurl_rule_test.py
+++ b/websites/management/commands/markdown_cleaning/baseurl_rule_test.py
@@ -45,11 +45,11 @@ def get_markdown_cleaner(website_contents):
         ),
         (
             R"This link includes a fragment [text title]({{< baseurl >}}/resources/path/to/file1#some-fragment) cool",
-            R'This link includes a fragment {{< resource_link content-uuid-1 "text title" "some-fragment" >}} cool',
+            R'This link includes a fragment {{< resource_link content-uuid-1 "text title" "#some-fragment" >}} cool',
         ),
         (
             R"This link includes a fragment with slash first [text title]({{< baseurl >}}/resources/path/to/file1/#some-fragment) cool",
-            R'This link includes a fragment with slash first {{< resource_link content-uuid-1 "text title" "some-fragment" >}} cool',
+            R'This link includes a fragment with slash first {{< resource_link content-uuid-1 "text title" "#some-fragment" >}} cool',
         ),
         (
             # < resource_link > short code is only for textual titles


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets? #1015 

#### What's this PR do?
Add markdown_cleanup rule to convert baseurl links with fragments `[title]({{< baseurl >}}/pages/whatever/file#some-heading)` to resource_links `< resource_link uuid "title" "some-heading" >`.

Includes changes to our CKeditor so that these resource_links **display** properly. But DOES NOT support saving these links. Currently saving markdown like `< resource_link uuid "title" "some-heading" >` results in the `some-heading` portion being lost. (@alicewriteswrongs is working on the necessary change to our CKEditor ResourceLink plugin.)

#### How should this be manually tested?
Run
```
# To generate csv of replacements only
docker-compose exec web python manage.py markdown_cleanup baseurl -o meow2.csv
# to commit changes to database
docker-compose exec web python manage.py markdown_cleanup baseurl --commit
```
and view the changes in Studio editor.

Some pages that would be affected:
```
b7cc5225-96b8-bb67-252f-d5048c2b43f4
    course: The Biology of Aging: Age-Related Diseases and Interventions
    page: Readings
df5e63ff-8c3f-cf7e-32cd-20fae4ed96c7
    course: Design of Electromechanical Robotic Systems
    page: Calendar
db02fb8f-2784-8eb9-d53c-72fe22be0540
    Immune Cell Migration: On the Move in Response to Pathogens and Cancer Immunotherapy
    Readings
```

