### PR TITLE
add support for resource link anchor tag thingies

### DIFF
--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
@@ -28,13 +28,26 @@ describe("ResourceLink plugin", () => {
   })
 
   it("should take in and return 'resource' shortcode", async () => {
-    const editor = await getEditor(
-      '{{< resource_link 1234567890 "link text" >}}'
-    )
+    const md = '{{< resource_link 1234567890 "link text" >}}'
+    const editor = await getEditor(md)
 
     // @ts-ignore
-    expect(editor.getData()).toBe(
-      '{{< resource_link 1234567890 "link text" >}}'
+    expect(editor.getData()).toBe(md)
+  })
+
+  it("should not mash an anchor hash thingy", async () => {
+    const md =
+      '{{< resource_link 1234-5678 "link text" "some-header-id" >}}{{< resource_link link-this-here-uuid "Title of the Link" "some-heading-id" >}}'
+    const editor = await getEditor(md)
+    // @ts-ignore
+    expect(editor.getData()).toBe(md)
+
+    markdownTest(
+      editor,
+      '{{< resource_link 1234-5678 "link text" "some-header-id" >}}',
+      `<p><a class="resource-link" data-uuid="${encodeURIComponent(
+        "1234-5678#some-header-id"
+      )}">link text</a></p>`
     )
   })
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

none

#### What's this PR do?

We recently added support for an ID param on resource links (https://github.com/mitodl/ocw-hugo-themes/pull/444) in the course theme. We don't yet have these in prod or anywhere, but soon we'll be converting some `{{< baseurl >}}`-based (haha) links over to this format, so we want to have support for it in CKEditor ready to go.

#### How should this be manually tested?

You can edit the markdown on a piece of content manually and add something like this:

```
{{< resource_link link-this-here-uuid "Title of the Link" "some-heading-id" >}}
```

if you then open that content in CKEditor and then save it it should be unchanged. 

