### PR TITLE
add content filtering to the website content listing page

### DIFF
--- a/static/js/hooks/search.ts
+++ b/static/js/hooks/search.ts
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react"
+import { useHistory, useLocation } from "react-router"
+import { useDebouncedEffect } from "./effect"
+import { useTextInputState } from "./state"
+
+interface URLParamFilterReturnValue<ParamType> {
+  searchInput: string
+  setSearchInput: React.ChangeEventHandler<HTMLInputElement>
+  listingParams: ParamType
+}
+
+interface ListingParamsMinimum {
+  search?: string | null | undefined
+}
+
+/**
+ * Simple, URL-param search support
+ *
+ * Search text is echoed to the `q` URL parameter.
+ */
+export function useURLParamFilter<LParams extends ListingParamsMinimum>(
+  getListingParams: (search: string) => LParams
+): URLParamFilterReturnValue<LParams> {
+  const { search } = useLocation()
+  const history = useHistory()
+
+  const [listingParams, setListingParams] = useState<LParams>(() =>
+    getListingParams(search)
+  )
+
+  const [searchInput, setSearchInput] = useTextInputState(
+    listingParams.search ?? ""
+  )
+
+  /**
+   * This debounced effect listens on the search input and, when it is
+   * different from the value current set on `listingParams`, will format a new
+   * query string (with offset reset to zero) and push that onto the history
+   * stack.
+   *
+   * We are using the URL and the browser's history mechanism as our source of
+   * truth for when we are going to re-run the search and whatnot. So in this
+   * call we're just concerned with debouncing user input (on the text input)
+   * and then basically echoing it up to the URL bar every so often. Below we
+   * listen to the `search` param and regenerate `listingParams` when it
+   * changes.
+   */
+  useDebouncedEffect(
+    () => {
+      const currentSearch = listingParams.search ?? ""
+      if (searchInput !== currentSearch) {
+        const newParams = new URLSearchParams()
+        if (searchInput) {
+          newParams.set("q", searchInput)
+        }
+        const newSearch = newParams.toString()
+        history.push(`?${newSearch}`)
+      }
+    },
+    [searchInput, listingParams],
+    600
+  )
+
+  /**
+   * Whenever the search params in the URL change we want to generate a new
+   * value for `listingParams`. This will in turn trigger the request to re-run
+   * and fetch new results.
+   */
+  useEffect(() => {
+    setListingParams(getListingParams(search))
+  }, [search, setListingParams, getListingParams])
+
+  return {
+    searchInput,
+    setSearchInput,
+    listingParams
+  }
+}

--- a/static/js/pages/SitesDashboard.tsx
+++ b/static/js/pages/SitesDashboard.tsx
@@ -1,7 +1,7 @@
-import React, { useEffect, useState } from "react"
+import React from "react"
 import { useSelector } from "react-redux"
 import { useRequest } from "redux-query-react"
-import { Link, useHistory, useLocation } from "react-router-dom"
+import { Link } from "react-router-dom"
 
 import PaginationControls from "../components/PaginationControls"
 
@@ -16,8 +16,7 @@ import { WEBSITES_PAGE_SIZE } from "../constants"
 import { Website } from "../types/websites"
 import DocumentTitle, { formatTitle } from "../components/DocumentTitle"
 import { StudioList, StudioListItem } from "../components/StudioList"
-import { useTextInputState } from "../hooks/state"
-import { useDebouncedEffect } from "../hooks/effect"
+import { useURLParamFilter } from "../hooks/search"
 
 export function siteDescription(site: Website): string | null {
   const courseNumber = (site.metadata?.course_numbers ?? [])[0]
@@ -38,54 +37,9 @@ function getListingParams(search: string): WebsiteListingParams {
 }
 
 export default function SitesDashboard(): JSX.Element {
-  const { search } = useLocation()
-  const history = useHistory()
-
-  const [listingParams, setListingParams] = useState<WebsiteListingParams>(() =>
-    getListingParams(search)
+  const { listingParams, searchInput, setSearchInput } = useURLParamFilter(
+    getListingParams
   )
-
-  const [searchInput, setSearchInput] = useTextInputState(
-    listingParams.search ?? ""
-  )
-
-  /**
-   * This debounced effect listens on the search input and, when it is
-   * different from the value current set on `listingParams`, will format a new
-   * query string (with offset reset to zero) and push that onto the history
-   * stack.
-   *
-   * We are using the URL and the browser's history mechanism as our source of
-   * truth for when we are going to re-run the search and whatnot. So in this
-   * call we're just concerned with debouncing user input (on the text input)
-   * and then basically echoing it up to the URL bar every so often. Below we
-   * listen to the `search` param and regenerate `listingParams` when it
-   * changes.
-   */
-  useDebouncedEffect(
-    () => {
-      const currentSearch = listingParams.search ?? ""
-      if (searchInput !== currentSearch) {
-        const newParams = new URLSearchParams()
-        if (searchInput) {
-          newParams.set("q", searchInput)
-        }
-        const newSearch = newParams.toString()
-        history.push(`?${newSearch}`)
-      }
-    },
-    [searchInput, listingParams],
-    600
-  )
-
-  /**
-   * Whenever the search params in the URL change we want to generate a new
-   * value for `listingParams`. This will in turn trigger the request to re-run
-   * and fetch new results.
-   */
-  useEffect(() => {
-    setListingParams(getListingParams(search))
-  }, [search, setListingParams])
 
   useRequest(websiteListingRequest(listingParams))
 

--- a/static/js/test_util.ts
+++ b/static/js/test_util.ts
@@ -41,3 +41,10 @@ export const mockMatchMedia = () => {
 
   return window.matchMedia as jest.Mock<any, [string]>
 }
+
+export const twoBooleanTestMatrix = [
+  [true, true],
+  [true, false],
+  [false, true],
+  [false, false]
+]


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

for  #1020

#### What's this PR do?

this PR implements a basic sort UI on the content listing pages. I pulled out the logic I wrote for the same type of sort on the `/sites` page into a hook and then added it to the content page, so it works the same way.

#### How should this be manually tested?

go to a content page like `/sites/$SITENAME/type/page` and try it out!

#### Screenshots (if appropriate)

<img width="1914" alt="Screen Shot 2022-02-22 at 11 50 09 AM" src="https://user-images.githubusercontent.com/6207644/155179520-5df08c8a-2625-4521-91ca-c0fb2a2c3a3f.png">

