### PR TITLE
Update ContentSyncState checksums when bulk updating WebsiteContent

### DIFF
--- a/websites/management/commands/markdown_cleaning/cleaner.py
+++ b/websites/management/commands/markdown_cleaning/cleaner.py
@@ -45,6 +45,7 @@ class WebsiteContentMarkdownCleaner:
 
         self.text_changes: "list[WebsiteContentMarkdownCleaner.ReplacementMatch]" = []
         self.updated_website_contents: "list[WebsiteContent]" = []
+        self.updated_sync_states: "list[ContentSyncState]" = []
 
         def _replacer(match: re.Match, website_content: WebsiteContent):
             replacement = rule(match, website_content)
@@ -75,6 +76,19 @@ class WebsiteContentMarkdownCleaner:
         if new_markdown != website_content.markdown:
             website_content.markdown = new_markdown
             self.updated_website_contents.append(website_content)
+
+    def update_website_content_checksum(self, website_content: WebsiteContent):
+        """
+        Updates website_content's sync state checksum in-place. Does not commit to database.
+        """
+        sync_state = website_content.content_sync_state
+        if not sync_state:
+            return
+
+        new_checksum = website_content.calculate_checksum()
+        if new_checksum != sync_state.current_checksum:
+            sync_state.current_checksum = new_checksum
+            self.updated_sync_states.append(sync_state)
 
     @classmethod
     def compile_regex(cls, pattern):

--- a/websites/management/commands/markdown_cleaning/cleaner.py
+++ b/websites/management/commands/markdown_cleaning/cleaner.py
@@ -63,7 +63,7 @@ class WebsiteContentMarkdownCleaner:
 
     def update_website_content_markdown(self, website_content: WebsiteContent):
         """
-        Updates website_content's markdown in-place. Does not commit to
+        Updates website_content's markdown and checksums in-place. Does not commit to
         database.
         """
         if not website_content.markdown:
@@ -77,18 +77,14 @@ class WebsiteContentMarkdownCleaner:
             website_content.markdown = new_markdown
             self.updated_website_contents.append(website_content)
 
-    def update_website_content_checksum(self, website_content: WebsiteContent):
-        """
-        Updates website_content's sync state checksum in-place. Does not commit to database.
-        """
-        sync_state = website_content.content_sync_state
-        if not sync_state:
-            return
+            sync_state = website_content.content_sync_state
+            if not sync_state:
+                return
 
-        new_checksum = website_content.calculate_checksum()
-        if new_checksum != sync_state.current_checksum:
-            sync_state.current_checksum = new_checksum
-            self.updated_sync_states.append(sync_state)
+            new_checksum = website_content.calculate_checksum()
+            if new_checksum != sync_state.current_checksum:
+                sync_state.current_checksum = new_checksum
+                self.updated_sync_states.append(sync_state)
 
     @classmethod
     def compile_regex(cls, pattern):

--- a/websites/management/commands/markdown_cleaning/legacy_shortcodes_data_fix_test.py
+++ b/websites/management/commands/markdown_cleaning/legacy_shortcodes_data_fix_test.py
@@ -1,6 +1,7 @@
 """Tests for convert_baseurl_links_to_resource_links.py"""
 import pytest
 
+from content_sync.factories import ContentSyncStateFactory
 from websites.factories import WebsiteContentFactory
 from websites.management.commands.markdown_cleaning.cleaner import (
     WebsiteContentMarkdownCleaner as Cleaner,
@@ -68,3 +69,24 @@ def test_baseurl_replacer_specific_title_replacements(markdown, expected_markdow
     cleaner.update_website_content_markdown(target_content)
 
     assert target_content.markdown == expected_markdown
+
+
+def test_update_checksums():
+    """ContentSyncState.current_checksum should be updated"""
+    website_uuid = "website-uuid"
+    target_content = WebsiteContentFactory.build(
+        markdown="test_markdown", website_id=website_uuid
+    )
+    ContentSyncStateFactory.build(content=target_content)
+    assert (
+        target_content.content_sync_state.current_checksum
+        != target_content.calculate_checksum()
+    )
+
+    cleaner = Cleaner(LegacyShortcodeFixTwo())
+    cleaner.update_website_content_checksum(target_content)
+
+    assert (
+        target_content.content_sync_state.current_checksum
+        == target_content.calculate_checksum()
+    )

--- a/websites/management/commands/markdown_cleaning/legacy_shortcodes_data_fix_test.py
+++ b/websites/management/commands/markdown_cleaning/legacy_shortcodes_data_fix_test.py
@@ -33,10 +33,12 @@ def test_baseurl_replacer_specific_title_replacements(markdown, expected_markdow
     target_content = WebsiteContentFactory.build(
         markdown=markdown, website_id=website_uuid
     )
+    target_sync_state = ContentSyncStateFactory.build(content=target_content)
 
     cleaner = Cleaner(LegacyShortcodeFixOne())
     cleaner.update_website_content_markdown(target_content)
     assert target_content.markdown == expected_markdown
+    assert target_sync_state.current_checksum == target_content.calculate_checksum()
 
 
 @pytest.mark.parametrize(
@@ -64,28 +66,12 @@ def test_baseurl_replacer_specific_title_replacements(markdown, expected_markdow
     target_content = WebsiteContentFactory.build(
         markdown=markdown, website_id=website_uuid
     )
+    ContentSyncStateFactory.build(content=target_content)
 
     cleaner = Cleaner(LegacyShortcodeFixTwo())
     cleaner.update_website_content_markdown(target_content)
 
     assert target_content.markdown == expected_markdown
-
-
-def test_update_checksums():
-    """ContentSyncState.current_checksum should be updated"""
-    website_uuid = "website-uuid"
-    target_content = WebsiteContentFactory.build(
-        markdown="test_markdown", website_id=website_uuid
-    )
-    ContentSyncStateFactory.build(content=target_content)
-    assert (
-        target_content.content_sync_state.current_checksum
-        != target_content.calculate_checksum()
-    )
-
-    cleaner = Cleaner(LegacyShortcodeFixTwo())
-    cleaner.update_website_content_checksum(target_content)
-
     assert (
         target_content.content_sync_state.current_checksum
         == target_content.calculate_checksum()

--- a/websites/management/commands/markdown_cleaning/resource_file_rule_test.py
+++ b/websites/management/commands/markdown_cleaning/resource_file_rule_test.py
@@ -1,5 +1,5 @@
 """Tests for convert_baseurl_links_to_resource_links.py"""
-
+from content_sync.factories import ContentSyncStateFactory
 from websites.factories import WebsiteContentFactory
 from websites.management.commands.markdown_cleaning.cleaner import (
     WebsiteContentMarkdownCleaner,
@@ -20,14 +20,14 @@ def test_resource_file_replacer():
     website_uuid = "website-uuid"
     markdown = R"""
     Look an image ![Some alt text here]({{< resource_file uuid-1 >}}) cool.
-    
+
     And here is another one: ![more alt text]({{< resource_file uuid-2 >}})
 
     nice.
     """
     expected_markdown = R"""
     Look an image {{< resource uuid-1 >}} cool.
-    
+
     And here is another one: {{< resource uuid-2 >}}
 
     nice.
@@ -35,8 +35,13 @@ def test_resource_file_replacer():
     target_content = WebsiteContentFactory.build(
         markdown=markdown, website_id=website_uuid
     )
+    ContentSyncStateFactory.build(content=target_content)
 
     cleaner = get_markdown_cleaner()
     cleaner.update_website_content_markdown(target_content)
 
     assert target_content.markdown == expected_markdown
+    assert (
+        target_content.content_sync_state.current_checksum
+        == target_content.calculate_checksum()
+    )

--- a/websites/management/commands/markdown_cleanup.py
+++ b/websites/management/commands/markdown_cleanup.py
@@ -98,13 +98,12 @@ class Command(BaseCommand):
             wc: WebsiteContent
             for wc in tqdm(all_wc):
                 cleaner.update_website_content_markdown(wc)
-                cleaner.update_website_content_checksum(wc)
 
             if commit:
                 all_wc.bulk_update(cleaner.updated_website_contents, ["markdown"])
-                ContentSyncState.objects.all().only(
-                    "id", "current_checksum"
-                ).bulk_update(cleaner.updated_sync_states, ["current_checksum"])
+                ContentSyncState.objects.bulk_update(
+                    cleaner.updated_sync_states, ["current_checksum"]
+                )
 
         if out is not None:
             outpath = os.path.normpath(os.path.join(os.getcwd(), out))

--- a/websites/management/commands/markdown_cleanup.py
+++ b/websites/management/commands/markdown_cleanup.py
@@ -2,12 +2,15 @@
 import os
 from contextlib import ExitStack
 
+from django.conf import settings
 from django.core.management import BaseCommand
 from django.core.management.base import CommandParser
 from django.db import transaction
+from mitol.common.utils import now_in_utc
 from tqdm import tqdm
 
 from content_sync.models import ContentSyncState
+from content_sync.tasks import sync_unsynced_websites
 from websites.management.commands.markdown_cleaning.baseurl_rule import (
     BaseurlReplacementRule,
 )
@@ -59,6 +62,14 @@ class Command(BaseCommand):
             default=False,
             help="Whether the changes to markdown should be commited. The default, False, is useful for QA and testing when combined with --out parameter.",
         )
+        parser.add_argument(
+            "-ss",
+            "--skip-sync",
+            dest="skip_sync",
+            action="store_true",
+            default=False,
+            help="Whether to skip running the sync_unsynced_websites task",
+        )
 
     @classmethod
     def validate_options(cls, options):
@@ -78,6 +89,21 @@ class Command(BaseCommand):
         self.do_handle(
             commit=options["commit"], alias=options["alias"], out=options["out"]
         )
+
+        if (
+            settings.CONTENT_SYNC_BACKEND
+            and options["commit"]
+            and not options["skip_sync"]
+        ):
+            self.stdout.write("Syncing all unsynced websites to the designated backend")
+            start = now_in_utc()
+            task = sync_unsynced_websites.delay(create_backends=True)
+            self.stdout.write(f"Starting task {task}...")
+            task.get()
+            total_seconds = (now_in_utc() - start).total_seconds()
+            self.stdout.write(
+                "Backend sync finished, took {} seconds".format(total_seconds)
+            )
 
     @classmethod
     def do_handle(cls, alias, commit, out):


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Fixes #1040 

#### What's this PR do?
Bulk updates `ContentSyncState.current_checksum` values, while running the `markdown_cleanup` management command.

#### How should this be manually tested?

In a shell, pick a site, save a page's markdown to a corrupted value, and set checksums for `WebsiteContent` objects with markdown to the wrong value:
```
from content_sync.models import *
from websites.models import *
content = WebsiteContent.objects.filter(type="page").first()
content.markdown = '\[!\[Small groups of students talking at tables in a classroom. In the foreground, an instructor stands near a pair of students talking to each other.\]({{\< resource\
    ...: _file 68aab975-18a3-39e4-91a6-bd54c8f35356 >}})\]({{\<'
content.save()
sync_state = content.content_sync_state
sync_state.current_checksum = "wrong"
sync_state.save()
ContentSyncState.objects.filter(current_checksum="wrong").count()
```

Run `docker-compose exec web python manage.py markdown_cleanup legacy_shortcode_datafix_1_of_2 -o one.csv -c`

Check that the checksum values are no longer "wrong".
```
ContentSyncState.objects.filter(current_checksum="wrong").count()
```