### PR TITLE
When syncing from git to db, `file` value should only include the path, not domain

### DIFF
--- a/content_sync/serializers.py
+++ b/content_sync/serializers.py
@@ -1,7 +1,6 @@
 """Serialization/deserialization logic for transforming database content into file content and vice versa"""
 import abc
 import json
-import logging
 import re
 from typing import Dict, Optional
 from urllib.parse import urlparse

--- a/content_sync/serializers.py
+++ b/content_sync/serializers.py
@@ -1,8 +1,10 @@
 """Serialization/deserialization logic for transforming database content into file content and vice versa"""
 import abc
 import json
+import logging
 import re
 from typing import Dict, Optional
+from urllib.parse import urlparse
 
 import yaml
 from mitol.common.utils import dict_without_keys
@@ -111,6 +113,8 @@ class HugoMarkdownFileSerializer(BaseContentFileSerializer):
             if file_field:
                 omitted_keys.append(file_field["name"])
                 file_url = front_matter_data.get(file_field["name"], None)
+                if file_url is not None:
+                    file_url = urlparse(file_url).path.lstrip("/")
 
         base_defaults = {
             "metadata": dict_without_keys(front_matter_data, *omitted_keys),
@@ -296,7 +300,7 @@ class ContentFileSerializerFactory:
     @staticmethod
     def for_file(site_config: SiteConfig, filepath: str) -> BaseContentFileSerializer:
         """
-        Given the path of a file in a storage backend, returns the a serializer object of the correct type for
+        Given the path of a file in a storage backend, returns a serializer object of the correct type for
         deserializing the file as a WebsiteContent object.
         """
         file_ext = get_file_extension(filepath)

--- a/content_sync/serializers_test.py
+++ b/content_sync/serializers_test.py
@@ -217,8 +217,9 @@ def test_hugo_menu_yaml_deserialize(omnibus_config):
 
 
 @pytest.mark.django_db
-def test_hugo_file_deserialize_with_file():
+def test_hugo_file_deserialize_with_file(settings):
     """HugoMarkdownFileSerializer.deserialize should create the expected content object from some file contents"""
+    settings.DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
     website = WebsiteFactory.create()
     site_config = SiteConfig(website.starter.config)
     website_content = HugoMarkdownFileSerializer(site_config).deserialize(
@@ -226,8 +227,13 @@ def test_hugo_file_deserialize_with_file():
         filepath="/test/file.md",
         file_contents=EXAMPLE_HUGO_MARKDOWN_WITH_FILE,
     )
+    path = "courses/website_name/image.png"
     assert "image" not in website_content.metadata.keys()
-    assert website_content.file == "courses/website_name/image.png"
+    assert website_content.file == path
+    assert (
+        website_content.file.url
+        == f"https://s3.amazonaws.com/{settings.AWS_STORAGE_BUCKET_NAME}/{path}"
+    )
 
 
 @pytest.mark.django_db

--- a/content_sync/serializers_test.py
+++ b/content_sync/serializers_test.py
@@ -4,6 +4,7 @@ import re
 
 import pytest
 import yaml
+from moto import mock_s3
 
 from content_sync.serializers import (
     BaseContentFileSerializer,
@@ -216,6 +217,7 @@ def test_hugo_menu_yaml_deserialize(omnibus_config):
     }
 
 
+@mock_s3
 @pytest.mark.django_db
 def test_hugo_file_deserialize_with_file(settings):
     """HugoMarkdownFileSerializer.deserialize should create the expected content object from some file contents"""

--- a/content_sync/serializers_test.py
+++ b/content_sync/serializers_test.py
@@ -42,7 +42,7 @@ EXAMPLE_HUGO_MARKDOWN_WITH_FILE = """---
 title: Example File
 content_type: resource
 uid: abcdefg
-image: https://test.edu/image.png
+image: https://test.edu/courses/website_name/image.png
 ---
 # My markdown
 - abc
@@ -227,7 +227,7 @@ def test_hugo_file_deserialize_with_file():
         file_contents=EXAMPLE_HUGO_MARKDOWN_WITH_FILE,
     )
     assert "image" not in website_content.metadata.keys()
-    assert website_content.file == "https://test.edu/image.png"
+    assert website_content.file == "courses/website_name/image.png"
 
 
 @pytest.mark.django_db
@@ -259,6 +259,7 @@ def test_hugo_file_deserialize_dirpath(
         file_contents=EXAMPLE_HUGO_MARKDOWN,
     )
     assert website_content.dirpath == exp_content_dirpath
+    assert bool(website_content.file) is False
     patched_find_item.assert_any_call("page")
 
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1049 

#### What's this PR do?
When syncing resources from github to the database, if there is a file url, only save the path portion to the `WebsiteContent.file` field

#### How should this be manually tested?
- In your .env file, set `OCW_STUDIO_USE_S3=True` and use the same `AWS_` settings as rc.
- Pick an existing site with resources, or create one.  Check via shell or django admin that the `WebsiteContent.file` fields for those are just paths like `gdrive_uploads/11-382-water-diplomacy-spring-2021/.../somefile.jpg` or `courses/11-382-water-diplomacy-spring-2021/paper.pdf`.
- Check that the `file` value in github for the site repo is a full url like `https://ol-ocw-studio-app-qa.s3.amazonaws.com/courses/11-382-water-diplomacy-spring-2021/paper.pdf`
- Run `manage.py sync_backend_to_db --website <your_website_name>`
- Check that the `WebsiteContent.file` field values for the site are still just paths.  If you try this on master they will be full urls matching what is in the git repo.
- Run `manage.py sync_website_to_backend --website <your_website_name>`, check that the file value in git is still a full and valid url.
