### PR TITLE
pass the --buildDrafts argument to Hugo if building a preview

### DIFF
--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -251,6 +251,8 @@ class SitePipeline(BaseSitePipeline, ConcoursePipeline):
             else:
                 markdown_uri = f"https://{settings.GIT_DOMAIN}/{settings.GIT_ORGANIZATION}/{self.website.short_id}.git"
                 private_key_var = ""
+            build_drafts = "--buildDrafts" if pipeline_name == VERSION_DRAFT else ""
+
             with open(
                 os.path.join(
                     os.path.dirname(__file__), "definitions/concourse/site-pipeline.yml"
@@ -292,6 +294,7 @@ class SitePipeline(BaseSitePipeline, ConcoursePipeline):
                     .replace("((api-token))", settings.API_BEARER_TOKEN or "")
                     .replace("((theme-deployed-trigger))", theme_deployed_trigger)
                     .replace("((theme-created-trigger))", theme_created_trigger)
+                    .replace("((build-drafts))", build_drafts)
                 )
             config = json.dumps(yaml.load(config_str, Loader=yaml.SafeLoader))
             log.debug(config)
@@ -406,6 +409,7 @@ class MassPublishPipeline(BaseMassPublishPipeline, ConcoursePipeline):
             branch = settings.GIT_BRANCH_RELEASE
             destination_bucket = settings.AWS_PUBLISH_BUCKET_NAME
             static_api_url = settings.OCW_STUDIO_LIVE_URL
+        build_drafts = "--buildDrafts" if self.version == VERSION_DRAFT else ""
 
         with open(
             os.path.join(
@@ -434,6 +438,7 @@ class MassPublishPipeline(BaseMassPublishPipeline, ConcoursePipeline):
                 .replace("((api-token))", settings.API_BEARER_TOKEN or "")
                 .replace("((open-discussions-url))", settings.OPEN_DISCUSSIONS_URL)
                 .replace("((open-webhook-key))", settings.OCW_NEXT_SEARCH_WEBHOOK_KEY)
+                .replace("((build-drafts))", build_drafts)
             )
         log.debug(config_str)
         config = json.dumps(yaml.load(config_str, Loader=yaml.SafeLoader))

--- a/content_sync/pipelines/definitions/concourse/mass-publish.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-publish.yml
@@ -108,7 +108,7 @@ jobs:
                 git -c core.sshCommand="ssh $GITKEYSSH -o StrictHostKeyChecking=no" clone -b ((ocw-site-repo-branch)) ((markdown-uri))/$SHORT_ID.git || return 1
                 cd $CURDIR/$SHORT_ID
                 cp ../webpack-json/webpack.json ../ocw-hugo-themes/base-theme/data
-                hugo --config ../ocw-hugo-projects/$STARTER_SLUG/config.yaml --baseUrl /$BASE_URL --themesDir ../ocw-hugo-themes/  || return 1
+                hugo --config ../ocw-hugo-projects/$STARTER_SLUG/config.yaml --baseUrl /$BASE_URL --themesDir ../ocw-hugo-themes/ ((build-drafts))  || return 1
                 cd $CURDIR
                 aws s3 sync s3://((ocw-studio-bucket))/$SITE_URL s3://((ocw-bucket))/$SITE_URL --metadata site-id=$NAME || return 1            
                 aws s3 sync $SHORT_ID/public s3://((ocw-bucket))/$BASE_URL --metadata site-id=$NAME || return 1

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -149,7 +149,7 @@ jobs:
             - -exc
             - |
               cp ../webpack-json/webpack.json ../ocw-hugo-themes/base-theme/data
-              hugo --config ../ocw-hugo-projects/((config-slug))/config.yaml --baseUrl /((base-url)) --themesDir ../ocw-hugo-themes/
+              hugo --config ../ocw-hugo-projects/((config-slug))/config.yaml --baseUrl /((base-url)) --themesDir ../ocw-hugo-themes/ ((build-drafts))
         on_failure:
           try:
             put: ocw-studio-webhook


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1058

#### What's this PR do?
Once https://github.com/mitodl/ocw-hugo-projects/pull/125 merges and is released, content will able to be marked with `draft: true` in `ocw-studio`.  This PR passes `--buildDrafts` to the `hugo` command executed during draft builds, but not production builds, ensuring what when a user previews their site, drafts will be included.

#### How should this be manually tested?
 - Spin up your local instance of `ocw-studio` with local Concourse support by running `docker-compose --profile concourse up`
 - Create a test site or make sure you have an existing one and know the ID
 - Run `docker-compose run --rm web ./manage.py backpopulate_pipelines <site_id>`
 - Using the [`fly` CLI](https://concourse-ci.org/fly.html), run `fly -t local get-pipeline -p draft/site:<side_id>` and verify that you see `--buildDrafts` in the `hugo` command
 - Run `fly -t local get-pipeline -p live/site:<side_id>` and verify that you *do not* see `--buildDrafts` in the `hugo` command
