### PR TITLE
change resource_link delimiters to % instead of < >

### DIFF
--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
@@ -30,7 +30,7 @@ describe("ResourceLink plugin", () => {
   })
 
   it("should take in and return 'resource' shortcode", async () => {
-    const md = '{{< resource_link 1234567890 "link text" >}}'
+    const md = '{{% resource_link 1234567890 "link text" %}}'
     const editor = await getEditor(md)
 
     // @ts-ignore
@@ -39,14 +39,14 @@ describe("ResourceLink plugin", () => {
 
   it("should not mash an anchor hash thingy", async () => {
     const md =
-      '{{< resource_link 1234-5678 "link text" "some-header-id" >}}{{< resource_link link-this-here-uuid "Title of the Link" "some-heading-id" >}}'
+      '{{% resource_link 1234-5678 "link text" "some-header-id" %}}{{% resource_link link-this-here-uuid "Title of the Link" "some-heading-id" %}}'
     const editor = await getEditor(md)
     // @ts-ignore
     expect(editor.getData()).toBe(md)
 
     markdownTest(
       editor,
-      '{{< resource_link 1234-5678 "link text" "#some-header-id" >}}',
+      '{{% resource_link 1234-5678 "link text" "#some-header-id" %}}',
       `<p><a class="resource-link" data-uuid="${encode(
         "1234-5678",
         "#some-header-id"
@@ -58,7 +58,7 @@ describe("ResourceLink plugin", () => {
     const editor = await getEditor("")
     markdownTest(
       editor,
-      '{{< resource_link asdfasdfasdfasdf "text here" >}}',
+      '{{% resource_link asdfasdfasdfasdf "text here" %}}',
       `<p><a class="resource-link" data-uuid="${encode(
         "asdfasdfasdfasdf"
       )}">text here</a></p>`
@@ -69,7 +69,7 @@ describe("ResourceLink plugin", () => {
     const editor = await getEditor("")
     markdownTest(
       editor,
-      'dogs {{< resource_link uuid1 "woof" >}} cats {{< resource_link uuid2 "meow" >}}, cool',
+      'dogs {{% resource_link uuid1 "woof" %}} cats {{% resource_link uuid2 "meow" %}}, cool',
       `<p>dogs <a class="resource-link" data-uuid="${encode(
         "uuid1"
       )}">woof</a> cats <a class="resource-link" data-uuid="${encode(
@@ -82,7 +82,7 @@ describe("ResourceLink plugin", () => {
     const editor = await getEditor("")
     const { md2html } = (editor.data
       .processor as unknown) as MarkdownDataProcessor
-    expect(md2html('{{< resource_link uuid123 "bad \\" >}}')).toBe(
+    expect(md2html('{{% resource_link uuid123 "bad \\" %}}')).toBe(
       // This is wrong. Should not end in &lt;/a&gt;
       `<p><a class="resource-link" data-uuid="${encode(
         "uuid123"

--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
@@ -22,10 +22,10 @@ const decodeShortcodeArgs = (encoded: string) =>
  * (?: "(.*?)")? to match the optional anchor ID param
  *
  * Limitations:
- *   - gets fooled by label texts that include literal `" >}}` values. For
- *     example, < resource_link uuid123 "silly " >}} link" >}}.
+ *   - gets fooled by label texts that include literal `" %}}` values. For
+ *     example, < resource_link uuid123 "silly " %}} link" %}}.
  */
-export const RESOURCE_LINK_SHORTCODE_REGEX = /{{< resource_link (\S+) "(.*?)"(?: "(.*?)")? >}}/g
+export const RESOURCE_LINK_SHORTCODE_REGEX = /{{% resource_link (\S+) "(.*?)"(?: "(.*?)")? %}}/g
 
 /**
  * Class for defining Markdown conversion rules for Resource links
@@ -33,7 +33,7 @@ export const RESOURCE_LINK_SHORTCODE_REGEX = /{{< resource_link (\S+) "(.*?)"(?:
  * These are stored in Markdown like this:
  *
  * ```md
- * {{< resource_link AUUIDUNLIKEANYOTHER "Here's a link to my resource" >}}
+ * {{% resource_link AUUIDUNLIKEANYOTHER "Here's a link to my resource" %}}
  * ```
  *
  * The first argument is the uuid of the resource to which we're linking, and
@@ -90,9 +90,9 @@ export default class ResourceLinkMarkdownSyntax extends MarkdownSyntaxPlugin {
             )
 
             if (anchor) {
-              return `{{< resource_link ${uuid} "${node.textContent}" "${anchor}" >}}`
+              return `{{% resource_link ${uuid} "${node.textContent}" "${anchor}" %}}`
             } else {
-              return `{{< resource_link ${uuid} "${node.textContent}" >}}`
+              return `{{% resource_link ${uuid} "${node.textContent}" %}}`
             }
           }
         }

--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
@@ -23,7 +23,7 @@ const decodeShortcodeArgs = (encoded: string) =>
  *
  * Limitations:
  *   - gets fooled by label texts that include literal `" %}}` values. For
- *     example, < resource_link uuid123 "silly " %}} link" %}}.
+ *     example, % resource_link uuid123 "silly " %}} link" %}}.
  */
 export const RESOURCE_LINK_SHORTCODE_REGEX = /{{% resource_link (\S+) "(.*?)"(?: "(.*?)")? %}}/g
 

--- a/websites/management/commands/markdown_cleaning/baseurl_rule.py
+++ b/websites/management/commands/markdown_cleaning/baseurl_rule.py
@@ -69,7 +69,7 @@ def get_all_website_content():
 
 class BaseurlReplacementRule(MarkdownCleanupRule):
     """Replacement rule for use with WebsiteContentMarkdownCleaner. Replaces
-    baseurl links with < resource_link > shortcodes.
+    baseurl links with % resource_link % shortcodes.
 
     This is intentially limited in scope for now. Some baseurl links, such as
     those whose titles are images or include square brackets, are excluded from
@@ -104,6 +104,6 @@ class BaseurlReplacementRule(MarkdownCleanupRule):
                 website_content.website_id, url
             )
             fragment_arg = f' "{fragment}"' if fragment is not None else ""
-            return f'{{{{< resource_link {linked_content.text_id} "{escaped_title}"{fragment_arg} >}}}}'
+            return f'{{{{% resource_link {linked_content.text_id} "{escaped_title}"{fragment_arg} %}}}}'
         except KeyError:
             return original_text

--- a/websites/management/commands/markdown_cleaning/baseurl_rule_test.py
+++ b/websites/management/commands/markdown_cleaning/baseurl_rule_test.py
@@ -30,35 +30,35 @@ def get_markdown_cleaner(website_contents):
         (
             # standard link on same line as baseurl link
             R"Cats are on [wikipedia](https://en.wikipedia.org/wiki/Cat). I also have a cat [meow]({{< baseurl >}}/resources/path/to/file1).",
-            R'Cats are on [wikipedia](https://en.wikipedia.org/wiki/Cat). I also have a cat {{< resource_link content-uuid-1 "meow" >}}.',
+            R'Cats are on [wikipedia](https://en.wikipedia.org/wiki/Cat). I also have a cat {{% resource_link content-uuid-1 "meow" %}}.',
         ),
         (
             R'This is a link with quote in title: [Cats say "meow"]({{< baseurl >}}/resources/path/to/file1).',
-            R'This is a link with quote in title: {{< resource_link content-uuid-1 "Cats say \"meow\"" >}}.',
+            R'This is a link with quote in title: {{% resource_link content-uuid-1 "Cats say \"meow\"" %}}.',
         ),
         (  # Ignores backslashes around the title brackets
             R'This is a link with quote in title: \[Cats say "meow"\]({{< baseurl >}}/resources/path/to/file1).',
-            R'This is a link with quote in title: {{< resource_link content-uuid-1 "Cats say \"meow\"" >}}.',
+            R'This is a link with quote in title: {{% resource_link content-uuid-1 "Cats say \"meow\"" %}}.',
         ),
         (
             R"This link should change [text title]({{< baseurl >}}/resources/path/to/file1) cool",
-            R'This link should change {{< resource_link content-uuid-1 "text title" >}} cool',
+            R'This link should change {{% resource_link content-uuid-1 "text title" %}} cool',
         ),
         (
             R"This link includes a fragment [text title]({{< baseurl >}}/resources/path/to/file1#some-fragment) cool",
-            R'This link includes a fragment {{< resource_link content-uuid-1 "text title" "#some-fragment" >}} cool',
+            R'This link includes a fragment {{% resource_link content-uuid-1 "text title" "#some-fragment" %}} cool',
         ),
         (
             R"This link includes a fragment with slash first [text title]({{< baseurl >}}/resources/path/to/file1/#some-fragment) cool",
-            R'This link includes a fragment with slash first {{< resource_link content-uuid-1 "text title" "#some-fragment" >}} cool',
+            R'This link includes a fragment with slash first {{% resource_link content-uuid-1 "text title" "#some-fragment" %}} cool',
         ),
         (
-            # < resource_link > short code is only for textual titles
+            # % resource_link % short code is only for textual titles
             "This link should not change: [![image](cat.com)]({{< baseurl >}}/resources/path/to/file1) for now",
             "This link should not change: [![image](cat.com)]({{< baseurl >}}/resources/path/to/file1) for now",
         ),
         (
-            # < resource_link > short code is only for textual titles
+            # % resource_link % short code is only for textual titles
             R"This should not change [{{< resource uuid1 >}}]({{< baseurl >}}/resources/mit18_02sc_l20brds_5)",
             R"This should not change [{{< resource uuid1 >}}]({{< baseurl >}}/resources/mit18_02sc_l20brds_5)",
         ),
@@ -117,7 +117,7 @@ def test_baseurl_replacer_handle_specific_url_replacements(
     """Test specific replacements"""
     website_uuid = "website-uuid"
     markdown = f"my [pets]({{{{< baseurl >}}}}{url}) are legion"
-    expected_markdown = 'my {{< resource_link content-uuid "pets" >}} are legion'
+    expected_markdown = 'my {{% resource_link content-uuid "pets" %}} are legion'
     target_content = WebsiteContentFactory.build(
         markdown=markdown, website_id=website_uuid
     )
@@ -141,7 +141,7 @@ def test_baseurl_replacer_handles_index_files():
     """Test specific replacements"""
     website_uuid = "website-uuid"
     markdown = R"my [pets]({{< baseurl >}}/pages/cute/pets) are legion"
-    expected_markdown = R'my {{< resource_link content-uuid "pets" >}} are legion'
+    expected_markdown = R'my {{% resource_link content-uuid "pets" %}} are legion'
     target_content = WebsiteContentFactory.build(
         markdown=markdown, website_id=website_uuid
     )
@@ -179,16 +179,16 @@ def test_baseurl_replacer_replaces_baseurl_links():
     """
 
     expected = R"""
-    « {{< resource_link uuid-111 "Previous" >}} | {{< resource_link uuid-222 "Next" >}} »
+    « {{% resource_link uuid-111 "Previous" >}} | {{% resource_link uuid-222 "Next" %}} »
 
     ### Lecture Videos
 
-    *   Watch {{< resource_link uuid-333 "Lecture 21: Vibration Isolation" >}}
+    *   Watch {{% resource_link uuid-333 "Lecture 21: Vibration Isolation" %}}
         *   Video Chapters
-            *   {{< resource_link uuid-444 "Demonstration of a vibration isolation system-strobe light and vibrating beam" >}}
+            *   {{% resource_link uuid-444 "Demonstration of a vibration isolation system-strobe light and vibrating beam" %}}
             * Euler's formula
 
-    Wasn't {{< resource_link uuid-333 "the video" >}} fun? Yes it was!
+    Wasn't {{% resource_link uuid-333 "the video" %}} fun? Yes it was!
     """
 
     website = WebsiteFactory.build()

--- a/websites/management/commands/markdown_cleaning/baseurl_rule_test.py
+++ b/websites/management/commands/markdown_cleaning/baseurl_rule_test.py
@@ -179,7 +179,7 @@ def test_baseurl_replacer_replaces_baseurl_links():
     """
 
     expected = R"""
-    « {{% resource_link uuid-111 "Previous" >}} | {{% resource_link uuid-222 "Next" %}} »
+    « {{% resource_link uuid-111 "Previous" %}} | {{% resource_link uuid-222 "Next" %}} »
 
     ### Lecture Videos
 

--- a/websites/management/commands/markdown_cleaning/resource_link_delimiters.py
+++ b/websites/management/commands/markdown_cleaning/resource_link_delimiters.py
@@ -16,11 +16,10 @@ from websites.models import WebsiteContent
 class ResourceLinkDelimitersReplacementRule(MarkdownCleanupRule):
     """Replacement rule for use with WebsiteContentMarkdownCleaner."""
 
-    regex = r"{{<\sresource_link\s(?P<resource_uuid>[a-z0-9\-]*)\s(?P<link_text>\".*?\")\s>}}"
+    regex = r"{{<\sresource_link\s(?P<args>.*?)\s>}}"
 
     alias = "resource_link_delimiter_swap"
 
     def __call__(self, match: re.Match, website_content: WebsiteContent):
-        escaped_title = match.group("resource_uuid")
-        link_text = match.group("link_text")
-        return f"{{{{% resource_link {escaped_title} {link_text} %}}}}"
+        args = match.group("args")
+        return f"{{{{% resource_link {args} %}}}}"

--- a/websites/management/commands/markdown_cleaning/resource_link_delimiters.py
+++ b/websites/management/commands/markdown_cleaning/resource_link_delimiters.py
@@ -1,0 +1,26 @@
+"""
+WebsiteContentMarkdownCleaner rule to convert
+
+{{< resource_link 8c8f3d8e-da91-817b-219e-e6671b2456a6 "Link Text" >}}
+to
+{{% resource_link 8c8f3d8e-da91-817b-219e-e6671b2456a6 "Link Text" %}}
+"""
+import re
+
+from websites.management.commands.markdown_cleaning.cleanup_rule import (
+    MarkdownCleanupRule,
+)
+from websites.models import WebsiteContent
+
+
+class ResourceLinkDelimitersReplacementRule(MarkdownCleanupRule):
+    """Replacement rule for use with WebsiteContentMarkdownCleaner."""
+
+    regex = r"{{<\sresource_link\s(?P<resource_uuid>[a-z0-9\-]*)\s(?P<link_text>\".*?\")\s>}}"
+
+    alias = "resource_link_delimiter_swap"
+
+    def __call__(self, match: re.Match, website_content: WebsiteContent):
+        escaped_title = match.group("resource_uuid")
+        link_text = match.group("link_text")
+        return f"{{{{% resource_link {escaped_title} {link_text} %}}}}"

--- a/websites/management/commands/markdown_cleaning/resource_link_delimiters_test.py
+++ b/websites/management/commands/markdown_cleaning/resource_link_delimiters_test.py
@@ -1,0 +1,47 @@
+"""Tests for convert_baseurl_links_to_resource_links.py"""
+from content_sync.factories import ContentSyncStateFactory
+from websites.factories import WebsiteContentFactory
+from websites.management.commands.markdown_cleaning.cleaner import (
+    WebsiteContentMarkdownCleaner,
+)
+from websites.management.commands.markdown_cleaning.resource_link_delimiters import (
+    ResourceLinkDelimitersReplacementRule,
+)
+
+
+def get_markdown_cleaner():
+    """Convenience to get rule-specific markdown cleaner"""
+    rule = ResourceLinkDelimitersReplacementRule()
+    return WebsiteContentMarkdownCleaner(rule)
+
+
+def test_resource_file_replacer():
+    """Check that it replaces resource_file links as expected"""
+    website_uuid = "website-uuid"
+    markdown = R"""
+    {{< resource_link uuid-1 "this is a link to a resource" >}}
+
+    {{< resource_link uuid-2 "this is a link to another resource" >}}
+
+    nice.
+    """
+    expected_markdown = R"""
+    {{% resource_link uuid-1 "this is a link to a resource" %}}
+
+    {{% resource_link uuid-2 "this is a link to another resource" %}}
+
+    nice.
+    """
+    target_content = WebsiteContentFactory.build(
+        markdown=markdown, website_id=website_uuid
+    )
+    ContentSyncStateFactory.build(content=target_content)
+
+    cleaner = get_markdown_cleaner()
+    cleaner.update_website_content_markdown(target_content)
+
+    assert target_content.markdown == expected_markdown
+    assert (
+        target_content.content_sync_state.current_checksum
+        == target_content.calculate_checksum()
+    )

--- a/websites/management/commands/markdown_cleanup.py
+++ b/websites/management/commands/markdown_cleanup.py
@@ -24,6 +24,9 @@ from websites.management.commands.markdown_cleaning.legacy_shortcodes_data_fix i
 from websites.management.commands.markdown_cleaning.resource_file_rule import (
     ResourceFileReplacementRule,
 )
+from websites.management.commands.markdown_cleaning.resource_link_delimiters import (
+    ResourceLinkDelimitersReplacementRule,
+)
 from websites.models import WebsiteContent
 
 
@@ -39,6 +42,7 @@ class Command(BaseCommand):
         ResourceFileReplacementRule,
         LegacyShortcodeFixOne,
         LegacyShortcodeFixTwo,
+        ResourceLinkDelimitersReplacementRule,
     ]
 
     def add_arguments(self, parser: CommandParser) -> None:


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1066

#### What's this PR do?
The Hugo documentation doesn't really explain this very well, but there are two types of delimiters you can use when calling shortcodes.  The standard method of `{{< shortcode >}}`, using the `< >` syntax, expects that the shortcode will return HTML, and therefore the shortcode template should be HTML.  When you use `{{% shortcode %}}`, Hugo expects that the shortcode will return markdown.  So, in your shortcode template definition you write markdown instead of HTML to be rendered.  This PR changes `resource_link` to be called with `%` delimiters so it is interpreted as markdown.  This way, when Hugo sees actual markdown links with line breaks on either side, it will properly preserve that structure when rendering HTML.

#### How should this be manually tested?

 - Spin up a local instance of `ocw-studio`, making sure you follow the directions in the readme and are set up to publish courses to a test Github Organization.  It's okay to use RC's Google Drive credentials, and you will need them to test this PR
 - Create a test site and verify that a repo has been created in your test org
 - Add a resource to your site in Google Drive and sync
 - Add a page to your site and create multiple resource links (doesn't matter if it's to the same resource or different ones) with line breaks in between them
 - Publish your site and inspect the output, you should see your resource links with `%` delimiters
 - Clone `ocw-hugo-themes` on the branch from [this PR](https://github.com/mitodl/ocw-hugo-themes/pull/485)
 - Clone your test site's repo from your test org and configure `ocw-hugo-themes` to point at it by setting `COURSE_CONTENT_PATH=/path/to/test-org` and `OCW_TEST_COURSE=your-test-course`, replacing with your values
 - Spin up the site with `npm run start:course`
 - Visit http://localhost:3000 and browse to your test page
 - Verify that all of the links are displayed on their own line

Finally, check the new `markdown_cleanup` strategy to verify results on your local database:
 - Make sure you have at least one page saved with `resource_link` shortcodes
 - Run `docker-compose run --rm web ./manage.py markdown_cleanup resource_link_delimiter_swap -o resource_link_delimiters.csv`
 - Inspect the output and make sure your `resource_link` shortcodes are now properly delimited with `%` instead of `< >`