### PR TITLE
Option to add new content, support nested metadata for overwrite_ocw_course_content command

### DIFF
--- a/ocw_import/management/commands/import_ocw_course_sites.py
+++ b/ocw_import/management/commands/import_ocw_course_sites.py
@@ -95,7 +95,7 @@ class Command(BaseCommand):
         if options["list"] is True:
             course_paths = list(
                 fetch_ocw2hugo_course_paths(
-                    bucket_name, prefix=prefix, filter_str=filter_str
+                    bucket_name, prefix=prefix, filter_list=[filter_str]
                 )
             )
             pydoc.pager("\n".join(course_paths))

--- a/ocw_import/management/commands/overwrite_ocw_course_content.py
+++ b/ocw_import/management/commands/overwrite_ocw_course_content.py
@@ -1,4 +1,6 @@
 """ Update OCW course sites and content via update_ocw_resource_data """
+import json
+
 from django.core.management import BaseCommand
 from mitol.common.utils.datetime import now_in_utc
 
@@ -21,7 +23,7 @@ class Command(BaseCommand):
         parser.add_argument(
             "--content-field",
             dest="content_field",
-            required=True,
+            required=False,
             help="WebsiteContent field that needs to be updated. Metadata fields can be entered as metadata.<field name>",
         )
         parser.add_argument(
@@ -42,8 +44,14 @@ class Command(BaseCommand):
         parser.add_argument(
             "--filter",
             dest="filter",
-            default="",
-            help="If specified, only import courses that contain this filter text",
+            default=None,
+            help="If specified, only import courses that contain these comma-delimited site names",
+        )
+        parser.add_argument(
+            "--filter-json",
+            dest="filter-json",
+            default=None,
+            help="If specified, only import courses that contain comma-delimited site names specified in a JSON file",
         )
         parser.add_argument(
             "--limit",
@@ -51,6 +59,12 @@ class Command(BaseCommand):
             default=None,
             type=int,
             help="If specified, limits the overall number of course sites imported",
+        )
+        parser.add_argument(
+            "--create-new",
+            dest="create_new",
+            action="store_true",
+            help="Create any new content if it doesn't exist",
         )
         super().add_arguments(parser)
 
@@ -60,18 +74,30 @@ class Command(BaseCommand):
             # make sure it ends with a '/'
             prefix = prefix.rstrip("/") + "/"
         bucket_name = options["bucket"]
-        filter_str = options["filter"]
+        filter_json = options["filter-json"]
         limit = options["limit"]
+        create_new = options["create_new"]
+        content_field = options["content_field"]
+
+        if filter_json:
+            with open(filter_json) as input_file:
+                filter_list = json.load(input_file)
+        else:
+            filter_list = options["filter"]
+
+        if not create_new and not content_field:
+            self.stderr.write("Either --content-field or --create-new is required")
 
         self.stdout.write(f"Updating OCW courses from '{bucket_name}' bucket")
         start = now_in_utc()
         task = update_ocw_resource_data.delay(
             bucket_name=bucket_name,
             prefix=prefix,
-            filter_str=filter_str,
+            filter_list=filter_list,
             limit=limit,
             chunk_size=options["chunks"],
             content_field=options["content_field"],
+            create_new_content=create_new,
         )
         self.stdout.write(f"Starting task {task}...")
         task.get()

--- a/ocw_import/tasks.py
+++ b/ocw_import/tasks.py
@@ -44,7 +44,9 @@ def import_ocw2hugo_course_paths(paths=None, bucket_name=None, prefix=None):
 
 
 @app.task()
-def update_ocw2hugo_course_paths(paths, bucket_name, prefix, content_field):
+def update_ocw2hugo_course_paths(
+    paths, bucket_name, prefix, content_field, create_new_content=False
+):
     """
     Import all ocw2hugo courses & content
 
@@ -58,7 +60,13 @@ def update_ocw2hugo_course_paths(paths, bucket_name, prefix, content_field):
 
     for path in paths:
         log.info("Importing course: '%s'", path)
-        update_ocw2hugo_course(bucket_name, prefix, path, content_field)
+        update_ocw2hugo_course(
+            bucket_name,
+            prefix,
+            path,
+            content_field,
+            create_new_content=create_new_content,
+        )
 
 
 @app.task()
@@ -141,10 +149,11 @@ def update_ocw_resource_data(
     self,
     bucket_name=None,
     prefix=None,
-    filter_str=None,
+    filter_list=None,
     limit=None,
     chunk_size=100,
     content_field=None,
+    create_new_content=False,
 ):  # pylint:disable=too-many-arguments
     """
     Import all ocw2hugo courses & content
@@ -152,7 +161,7 @@ def update_ocw_resource_data(
     Args:
         bucket_name (str): S3 bucket name
         prefix (str): (Optional) S3 prefix before start of course_id path
-        filter_str (str): (Optional) If specified, only yield course paths containing this string
+        filter_list (List of str): (Optional) If specified, only yield course paths in this list of strings
         limit (int or None): (Optional) If specified, limits the number of courses imported
         chunk_size (int): Number of courses to process per task
         content_field(str): WebsiteContent field that should be updated
@@ -160,11 +169,11 @@ def update_ocw_resource_data(
     if not bucket_name:
         raise TypeError("Bucket name must be specified")
 
-    if not content_field:
-        raise TypeError("Update field must be specified")
-    course_paths = list(fetch_ocw2hugo_course_paths(bucket_name, prefix=prefix))
-    if filter_str is not None:
-        course_paths = [path for path in course_paths if filter_str in path]
+    if not content_field and not create_new_content:
+        raise TypeError("Update field must be specified if create_new_content is False")
+    course_paths = list(
+        fetch_ocw2hugo_course_paths(bucket_name, prefix=prefix, filter_list=filter_list)
+    )
     if limit is not None:
         course_paths = course_paths[:limit]
     course_tasks = [
@@ -173,6 +182,7 @@ def update_ocw_resource_data(
             bucket_name=bucket_name,
             prefix=prefix,
             content_field=content_field,
+            create_new_content=create_new_content,
         )
         for paths in chunks(course_paths, chunk_size=chunk_size)
     ]

--- a/ocw_import/tasks_test.py
+++ b/ocw_import/tasks_test.py
@@ -58,11 +58,16 @@ def test_import_ocw2hugo_course_paths(mocker, paths, course_starter, settings):
 @pytest.mark.parametrize(
     "paths", [["1-050-mechanical-engineering", "3-34-transportation-systems"], [], None]
 )
-def test_update_ocw2hugo_course_paths(mocker, paths):
+@pytest.mark.parametrize("create_new_content", [True, False])
+def test_update_ocw2hugo_course_paths(mocker, paths, create_new_content):
     """ update_ocw2hugo_course should be called from task with correct kwargs """
     mock_update_course = mocker.patch("ocw_import.tasks.update_ocw2hugo_course")
     update_ocw2hugo_course_paths.delay(
-        paths, MOCK_BUCKET_NAME, TEST_OCW2HUGO_PREFIX, "title"
+        paths,
+        MOCK_BUCKET_NAME,
+        TEST_OCW2HUGO_PREFIX,
+        "title",
+        create_new_content=create_new_content,
     )
     if not paths:
         mock_update_course.assert_not_called()
@@ -73,6 +78,7 @@ def test_update_ocw2hugo_course_paths(mocker, paths):
                 TEST_OCW2HUGO_PREFIX,
                 path,
                 "title",
+                create_new_content=create_new_content,
             )
 
 
@@ -186,11 +192,24 @@ def test_import_ocw2hugo_courses_delete_unpublished_false(
 
 @mock_s3
 @pytest.mark.parametrize(
-    "chunk_size, filter_str, limit, call_count",
-    [[1, None, None, 4], [1, "1-050", None, 1], [2, None, None, 2], [1, None, 1, 1]],
+    "chunk_size, filter_list, limit, call_count",
+    [
+        [1, None, None, 4],
+        [1, ["1-050-engineering-mechanics-i-fall-2007"], None, 1],
+        [2, None, None, 2],
+        [1, None, 1, 1],
+    ],
 )
+@pytest.mark.parametrize("create_new_content", [True, False])
 def test_update_ocw_resource_data(
-    settings, mocked_celery, mocker, filter_str, chunk_size, limit, call_count
+    settings,
+    mocked_celery,
+    mocker,
+    filter_list,
+    chunk_size,
+    limit,
+    call_count,
+    create_new_content,
 ):
     """
     update_ocw2hugo_course_paths should be called correct # times for given chunk size, limit, filter, and # of paths
@@ -202,9 +221,10 @@ def test_update_ocw_resource_data(
             bucket_name=MOCK_BUCKET_NAME,
             prefix=TEST_OCW2HUGO_PREFIX,
             chunk_size=chunk_size,
-            filter_str=filter_str,
+            filter_list=filter_list,
             limit=limit,
             content_field="title",
+            create_new_content=create_new_content,
         )
     assert mock_update_paths.call_count == call_count
 


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
#1070 
Related to https://github.com/mitodl/ocw-to-hugo/issues/478, https://github.com/mitodl/ocw-to-hugo/issues/459

#### What's this PR do?
- Supports nested metadata fields for the `--content-field` option
- Creates new/missing content if the `--create-new` option is specified
- Adds new options to the overwrite_ocw_course_content command to accept a list of site names or a json file containing site names

#### How should this be manually tested?
- Import `11-382-water-diplomacy-spring-2021` if you don't already have it.
- Hard-delete its `WebsiteContent` object for "The Past, Present and Future of the Columbia River Treaty: A Case for Modernization":
```python
from websites.models import WebsiteContent
from safedelete.models import HARD_DELETE
WebsiteContent.objects.get(
    title="The Past, Present and Future of the Columbia River Treaty: A Case for Modernization"
).delete(force_policy=HARD_DELETE)
```
- For `WebsiteContent` with title "Singapore-Malaysia Water Conflict", change the youtube id to something else, change the title to something else.
- Run `manage.py overwrite_ocw_course_content --bucket ocw-to-hugo-output-qa --content-field metadata.video_metadata.youtube_id --filter 11-382-water-diplomacy-spring-2021  --create-new`
- Check that the `WebsiteContent` you deleted is created again, and that the other resource you edited still has the modified title but has reverted to the original youtube id.
- You can also try out the new options to `overwrite_ocw_course_content`, for example by creating a `courses.json` file containing: `["11-382-water-diplomacy-spring-2021", "res-tll-004-stem-concept-videos-fall-2013"]` and then running the command with the `--filter-json course.json` option instead.

