### PR TITLE
move website content drawer open / close / edit state to URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@types/showdown": "^1.9.4",
     "@types/sinon": "^10.0.2",
     "@types/turndown": "^5.0.1",
-    "@types/url-assembler": "^2.1.0",
+    "@types/url-assembler": "^2.1.1",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",
     "@use-it/interval": "^1.0.0",

--- a/static/js/components/ConfirmationModal.test.tsx
+++ b/static/js/components/ConfirmationModal.test.tsx
@@ -68,21 +68,6 @@ describe("ConfirmationModal", () => {
   })
 
   //
-  ;[
-    [
-      true,
-      "You have unsaved changes. Are you sure you want to discard your changes?"
-    ],
-    [false, true]
-  ].forEach(([dirty, expected]) => {
-    it(`renders a Prompt when dirty=${String(dirty)}`, () => {
-      const wrapper = render({ dirty })
-      // @ts-ignore
-      expect(wrapper.find("Prompt").prop("message")()).toBe(expected)
-    })
-  })
-
-  //
   ;[true, false].forEach(visible => {
     it(`${visible ? "is" : "is not"} visible`, () => {
       const wrapper = render({ confirmationModalVisible: visible })

--- a/static/js/components/ConfirmationModal.tsx
+++ b/static/js/components/ConfirmationModal.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-import { Prompt } from "react-router"
 import { useBeforeunload } from "react-beforeunload"
 
 import BasicModal from "./BasicModal"
@@ -27,13 +26,6 @@ export default function ConfirmationModal(props: Props): JSX.Element {
 
   return (
     <>
-      <Prompt
-        message={() =>
-          dirty ?
-            "You have unsaved changes. Are you sure you want to discard your changes?" :
-            true
-        }
-      />
       <BasicModal
         isVisible={confirmationModalVisible}
         hideModal={() => setConfirmationModalVisible(false)}

--- a/static/js/components/SiteContentEditorDrawer.test.tsx
+++ b/static/js/components/SiteContentEditorDrawer.test.tsx
@@ -1,0 +1,182 @@
+import React from "react"
+import { act } from "react-dom/test-utils"
+import * as rrDOM from "react-router-dom"
+
+import WebsiteContext from "../context/Website"
+
+import useConfirmation from "../hooks/confirmation"
+import { siteApiContentDetailUrl } from "../lib/urls"
+import IntegrationTestHelper, {
+  TestRenderer
+} from "../util/integration_test_helper"
+import {
+  makeRepeatableConfigItem,
+  makeWebsiteContentDetail,
+  makeWebsiteDetail
+} from "../util/factories/websites"
+
+import {
+  RepeatableConfigItem,
+  Website,
+  WebsiteContent
+} from "../types/websites"
+import SiteContentEditor from "./SiteContentEditor"
+import SiteContentEditorDrawer from "./SiteContentEditorDrawer"
+import { Editing } from "../types/modal_state"
+import ConfirmationModal from "./ConfirmationModal"
+import BasicModal from "./BasicModal"
+
+const { useParams } = rrDOM as jest.Mocked<typeof rrDOM>
+
+// ckeditor is not working properly in tests, but we don't need to test it here so just mock it away
+function mocko() {
+  return <div>mock</div>
+}
+
+jest.mock("./widgets/MarkdownEditor", () => ({
+  __esModule: true,
+  default:    mocko
+}))
+jest.mock("../hooks/confirmation", () => ({
+  __esModule: true,
+  default:    jest.fn()
+}))
+jest.mock("react-router-dom", () => ({
+  __esModule: true,
+  ...jest.requireActual("react-router-dom"),
+  useParams:  jest.fn()
+}))
+
+describe("SiteContentEditorDrawer", () => {
+  let helper: IntegrationTestHelper,
+    render: TestRenderer,
+    website: Website,
+    configItem: RepeatableConfigItem,
+    contentItem: WebsiteContent,
+    setConfirmationModalVisible: any,
+    conditionalClose: any,
+    fetchWebsiteContentListing: any
+
+  beforeEach(() => {
+    helper = new IntegrationTestHelper()
+    website = makeWebsiteDetail()
+    configItem = makeRepeatableConfigItem("resource")
+    contentItem = makeWebsiteContentDetail()
+
+    setConfirmationModalVisible = jest.fn()
+    conditionalClose = jest.fn()
+    // @ts-ignore
+    useConfirmation.mockClear()
+    // @ts-ignore
+    useConfirmation.mockReturnValue({
+      confirmationModalVisible: false,
+      setConfirmationModalVisible,
+      conditionalClose
+    })
+    useParams.mockClear()
+    useParams.mockReturnValue({})
+
+    fetchWebsiteContentListing = jest.fn()
+
+    helper.mockGetRequest(
+      siteApiContentDetailUrl
+        .param({
+          name:   website.name,
+          textId: contentItem.text_id
+        })
+        .toString(),
+      contentItem
+    )
+
+    render = helper.configureRenderer(
+      props => (
+        <WebsiteContext.Provider value={website}>
+          <SiteContentEditorDrawer {...props} />
+        </WebsiteContext.Provider>
+      ),
+      { configItem, fetchWebsiteContentListing }
+    )
+  })
+
+  afterEach(() => {
+    helper.cleanup()
+  })
+
+  it("passes setDirty to SiteContentEditor", async () => {
+    const { wrapper } = await render()
+    const siteContentEditor = wrapper.find(SiteContentEditor)
+    const setDirty =
+      // @ts-ignore
+      useConfirmation.mock.calls[useConfirmation.mock.calls.length - 1][0]
+        .setDirty
+    expect(siteContentEditor.prop("setDirty")).toBe(setDirty)
+  })
+
+  it("sets visibility on the confirmation modal", async () => {
+    const { wrapper } = await render({ website })
+    const setVisible = wrapper
+      .find(ConfirmationModal)
+      .prop("setConfirmationModalVisible")
+    act(() => setVisible(true))
+    expect(setConfirmationModalVisible).toBeCalledWith(true)
+  })
+
+  it("dismisses a modal", async () => {
+    const { wrapper } = await render({ website })
+    act(() => {
+      wrapper.find(ConfirmationModal).prop("dismiss")()
+    })
+    expect(conditionalClose).toBeCalledWith(true)
+  })
+
+  it("hides the drawer, maybe with a confirmation dialog first", async () => {
+    const { wrapper } = await render({ website })
+    act(() => {
+      wrapper
+        .find(BasicModal)
+        .at(1)
+        .prop("hideModal")()
+    })
+    expect(conditionalClose).toBeCalledWith(false)
+  })
+
+  it("dismisses a modal from the editor", async () => {
+    const { wrapper } = await render()
+    const editorModal = wrapper.find("BasicModal").at(1)
+    const siteContentEditor = editorModal.find(SiteContentEditor)
+    act(() => {
+      siteContentEditor.prop("dismiss")!()
+    })
+
+    expect(conditionalClose).toBeCalledWith(true)
+  })
+
+  it("sets a dirty flag", async () => {
+    const { wrapper } = await render({ website })
+    expect(wrapper.find("ConfirmationModal").prop("dirty")).toBeFalsy()
+    const setDirty =
+      // @ts-ignore
+      useConfirmation.mock.calls[useConfirmation.mock.calls.length - 1][0]
+        .setDirty
+    act(() => setDirty(true))
+    wrapper.update()
+    expect(wrapper.find("ConfirmationModal").prop("dirty")).toBeTruthy()
+  })
+
+  it("gets uuid prop for editing", async () => {
+    useParams.mockReturnValue({ uuid: contentItem.text_id })
+    const { wrapper } = await render()
+    const editor = wrapper.find(SiteContentEditor)
+    expect(editor.prop("editorState").editing()).toBeTruthy()
+    expect((editor.prop("editorState") as Editing<string>).wrapped).toBe(
+      contentItem.text_id
+    )
+  })
+
+  it("should pass fetchWebsiteContentListing to the Editor", async () => {
+    const { wrapper } = await render()
+    expect(
+      wrapper.find(SiteContentEditor).prop("fetchWebsiteContentListing")
+    ).toBe(fetchWebsiteContentListing)
+  })
+})

--- a/static/js/components/SiteContentEditorDrawer.tsx
+++ b/static/js/components/SiteContentEditorDrawer.tsx
@@ -1,0 +1,117 @@
+import React, { useCallback, useEffect, useState } from "react"
+import { useHistory, useLocation, useParams } from "react-router-dom"
+
+import { useWebsite } from "../context/Website"
+import { hasMainContentField } from "../lib/site_content"
+import {
+  WebsiteContentModalState,
+  RepeatableConfigItem
+} from "../types/websites"
+import useConfirmation from "../hooks/confirmation"
+import ConfirmationModal from "./ConfirmationModal"
+import BasicModal from "./BasicModal"
+import { singular } from "pluralize"
+import { createModalState } from "../types/modal_state"
+import SiteContentEditor from "./SiteContentEditor"
+import { siteContentListingUrl } from "../lib/urls"
+
+interface Props {
+  configItem: RepeatableConfigItem
+  fetchWebsiteContentListing: any
+}
+
+interface Params {
+  uuid: string
+}
+
+export default function SiteContentEditorDrawer(
+  props: Props
+): JSX.Element | null {
+  const { configItem, fetchWebsiteContentListing } = props
+
+  const [drawerState, setDrawerState] = useState<WebsiteContentModalState>(
+    createModalState("closed")
+  )
+
+  const website = useWebsite()
+
+  const { uuid } = useParams<Params>()
+
+  useEffect(() => {
+    if (uuid !== undefined) {
+      setDrawerState(createModalState("editing", uuid))
+    } else {
+      setDrawerState(createModalState("adding"))
+    }
+  }, [uuid])
+
+  const [dirty, setDirty] = useState<boolean>(false)
+
+  const history = useHistory()
+  const { search } = useLocation()
+
+  const closeDrawer = useCallback(() => {
+    const queryParams = new URLSearchParams(search)
+    history.push(
+      siteContentListingUrl
+        .param({
+          name:        website.name,
+          contentType: configItem.name
+        })
+        .query(queryParams)
+        .toString()
+    )
+  }, [website.name, configItem.name, search, history])
+
+  const {
+    confirmationModalVisible,
+    setConfirmationModalVisible,
+    conditionalClose
+  } = useConfirmation({
+    dirty,
+    setDirty,
+    close: closeDrawer
+  })
+
+  const labelSingular = configItem.label_singular ?? singular(configItem.label)
+
+  const modalTitle = `${
+    drawerState.editing() ? "Edit" : "Add"
+  } ${labelSingular}`
+
+  const modalClassName = `right ${
+    hasMainContentField(configItem.fields) ? "wide" : ""
+  }`
+
+  return (
+    <>
+      <ConfirmationModal
+        dirty={dirty}
+        confirmationModalVisible={confirmationModalVisible}
+        setConfirmationModalVisible={setConfirmationModalVisible}
+        dismiss={() => conditionalClose(true)}
+      />
+      <BasicModal
+        isVisible={drawerState.open()}
+        hideModal={() => conditionalClose(false)}
+        title={modalTitle}
+        className={modalClassName}
+      >
+        {() =>
+          drawerState.open() ? (
+            <div className="m-2">
+              <SiteContentEditor
+                loadContent={true}
+                configItem={configItem}
+                editorState={drawerState}
+                dismiss={() => conditionalClose(true)}
+                fetchWebsiteContentListing={fetchWebsiteContentListing}
+                setDirty={setDirty}
+              />
+            </div>
+          ) : null
+        }
+      </BasicModal>
+    </>
+  )
+}

--- a/static/js/components/SiteContentListing.test.tsx
+++ b/static/js/components/SiteContentListing.test.tsx
@@ -96,7 +96,7 @@ describe("SiteContentListing", () => {
         child === MockRepeatable ? repeatableConfigItem : singletonsConfigItem
 
       // @ts-ignore
-      const params = { name: website.name, contenttype: configItem.name }
+      const params = { name: website.name, contentType: configItem.name }
       mockUseRouteMatch.mockImplementation(() => ({
         params
       }))
@@ -114,7 +114,7 @@ describe("SiteContentListing", () => {
         child === MockRepeatable ? repeatableConfigItem : singletonsConfigItem
 
       // @ts-ignore
-      const params = { name: website.name, contenttype: configItem.name }
+      const params = { name: website.name, contentType: configItem.name }
       mockUseRouteMatch.mockImplementation(() => ({
         params
       }))
@@ -130,7 +130,7 @@ describe("SiteContentListing", () => {
   it("modifies config item fields before passing them on RepeatableContentListing", async () => {
     const params = {
       name:        website.name,
-      contenttype: repeatableConfigItem.name
+      contentType: repeatableConfigItem.name
     }
     mockUseRouteMatch.mockImplementation(() => ({
       params

--- a/static/js/components/SiteContentListing.tsx
+++ b/static/js/components/SiteContentListing.tsx
@@ -16,7 +16,7 @@ import { TopLevelConfigItem } from "../types/websites"
 import DocumentTitle, { formatTitle } from "./DocumentTitle"
 
 interface MatchParams {
-  contenttype: string
+  contentType: string
   name: string
 }
 
@@ -32,10 +32,10 @@ export default function SiteContentListing(): JSX.Element | null {
   const website = useWebsite()
 
   const match = useRouteMatch<MatchParams>()
-  const { contenttype } = match.params
+  const { contentType } = match.params
 
   const configItem = website?.starter?.config?.collections.find(
-    (config: TopLevelConfigItem) => config.name === contenttype
+    (config: TopLevelConfigItem) => config.name === contentType
   )
   if (!configItem) {
     return null
@@ -45,14 +45,14 @@ export default function SiteContentListing(): JSX.Element | null {
     <>
       <RepeatableContentListing configItem={addDefaultFields(configItem)} />
       <DocumentTitle
-        title={formatTitle(website.title, repeatableTitle(contenttype))}
+        title={formatTitle(website.title, repeatableTitle(contentType))}
       />
     </>
   ) : (
     <>
       <SingletonsContentListing configItem={configItem} />
       <DocumentTitle
-        title={formatTitle(website.title, singletonTitle(contenttype))}
+        title={formatTitle(website.title, singletonTitle(contentType))}
       />
     </>
   )

--- a/static/js/components/SiteSidebar.tsx
+++ b/static/js/components/SiteSidebar.tsx
@@ -54,7 +54,6 @@ function SidebarSection(props: SectionProps): JSX.Element {
       {configItems.map((item: TopLevelConfigItem) => (
         <NavLink
           key={item.name}
-          exact
           className="my-2"
           to={
             item.name === collaboratorsConfigName ?

--- a/static/js/hooks/confirmation.ts
+++ b/static/js/hooks/confirmation.ts
@@ -5,6 +5,7 @@ interface Args {
   setDirty: (dirty: boolean) => void
   close?: () => void
 }
+
 interface ReturnValue {
   confirmationModalVisible: boolean
   setConfirmationModalVisible: (visible: boolean) => void

--- a/static/js/lib/urls.test.ts
+++ b/static/js/lib/urls.test.ts
@@ -13,62 +13,87 @@ import {
   siteApiCollaboratorsDetailUrl,
   siteApiContentUrl,
   siteApiContentDetailUrl,
-  siteApiContentListingUrl
+  siteApiContentListingUrl,
+  siteContentNewUrl,
+  siteContentDetailUrl
 } from "./urls"
 
 describe("urls", () => {
   describe("Page URLs", () => {
-    describe("Site URLs", () => {
-      [
-        [10, "/sites/?offset=10"],
-        [20, "/sites/?offset=20"]
-      ].forEach(([offset, expectedLink]) => {
-        it(`renders a URL for the site dashboard with offset=${offset}`, () => {
-          expect(sitesBaseUrl.query({ offset }).toString()).toBe(expectedLink)
-        })
+    [
+      [10, "/sites/?offset=10"],
+      [20, "/sites/?offset=20"]
+    ].forEach(([offset, expectedLink]) => {
+      it(`renders a URL for the site dashboard with offset=${offset}`, () => {
+        expect(sitesBaseUrl.query({ offset }).toString()).toBe(expectedLink)
       })
+    })
 
-      it("returns a basic URL for the site dashboard", () => {
-        expect(sitesBaseUrl.toString()).toBe("/sites/")
-      })
+    it("returns a basic URL for the site dashboard", () => {
+      expect(sitesBaseUrl.toString()).toBe("/sites/")
+    })
 
-      it("makes a URL for creating new sites", () => {
-        expect(newSiteUrl.toString()).toBe("/new-site/")
-      })
+    it("makes a URL for creating new sites", () => {
+      expect(newSiteUrl.toString()).toBe("/new-site/")
+    })
 
-      it("renders a site URL", () => {
-        expect(siteDetailUrl.param({ name: "site-name" }).toString()).toBe(
-          "/sites/site-name/"
-        )
-      })
+    it("renders a site URL", () => {
+      expect(siteDetailUrl.param({ name: "site-name" }).toString()).toBe(
+        "/sites/site-name/"
+      )
+    })
 
-      it("renders a site listing URL", () => {
-        expect(
-          siteContentListingUrl
-            .param({ name: "site-name", contentType: "resource" })
-            .toString()
-        ).toBe("/sites/site-name/type/resource/")
-      })
+    it("renders a site listing URL", () => {
+      expect(
+        siteContentListingUrl
+          .param({ name: "site-name", contentType: "resource" })
+          .toString()
+      ).toBe("/sites/site-name/type/resource/")
+    })
 
-      it("renders a URL for collaborators", () => {
-        expect(
-          siteCollaboratorsUrl.param({ name: "site-name" }).toString()
-        ).toBe("/sites/site-name/collaborators/")
-      })
+    it("renders a URL for collaborators", () => {
+      expect(siteCollaboratorsUrl.param({ name: "site-name" }).toString()).toBe(
+        "/sites/site-name/collaborators/"
+      )
+    })
 
-      it("renders a URL for adding collaborators", () => {
-        expect(
-          siteCollaboratorsAddUrl.param({ name: "site-name" }).toString()
-        ).toBe("/sites/site-name/collaborators/new/")
-      })
+    it("renders a URL for adding collaborators", () => {
+      expect(
+        siteCollaboratorsAddUrl.param({ name: "site-name" }).toString()
+      ).toBe("/sites/site-name/collaborators/new/")
+    })
 
-      it("renders a URL for collaborators detail", () => {
-        expect(
-          siteCollaboratorsDetailUrl
-            .param({ name: "site-name", userId: 1 })
-            .toString()
-        ).toBe("/sites/site-name/collaborators/1/")
-      })
+    it("renders a URL for collaborators detail", () => {
+      expect(
+        siteCollaboratorsDetailUrl
+          .param({ name: "site-name", userId: 1 })
+          .toString()
+      ).toBe("/sites/site-name/collaborators/1/")
+    })
+
+    it("renders a new site content URL", () => {
+      expect(
+        siteContentNewUrl
+          .param({
+            name:        "mysite",
+            contentType: "best-type-of-content"
+          })
+          .toString()
+      ).toBe("/sites/mysite/type/best-type-of-content/new/")
+    })
+
+    it("renders an edit site content URL", () => {
+      expect(
+        siteContentDetailUrl
+          .param({
+            name:        "mysite",
+            contentType: "best-type-of-content",
+            uuid:        "3234-3212-fasdf-abcd"
+          })
+          .toString()
+      ).toBe(
+        "/sites/mysite/type/best-type-of-content/edit/3234-3212-fasdf-abcd/"
+      )
     })
   })
 

--- a/static/js/lib/urls.ts
+++ b/static/js/lib/urls.ts
@@ -10,6 +10,8 @@ export const newSiteUrl = UrlAssembler.prefix("/new-site/")
 
 export const siteDetailUrl = sitesBaseUrl.segment(":name/")
 export const siteContentListingUrl = siteDetailUrl.segment("type/:contentType/")
+export const siteContentNewUrl = siteContentListingUrl.segment("new/")
+export const siteContentDetailUrl = siteContentListingUrl.segment("edit/:uuid/")
 export const siteCollaboratorsUrl = siteDetailUrl.segment("collaborators/")
 export const siteCollaboratorsAddUrl = siteCollaboratorsUrl.segment("new/")
 export const siteCollaboratorsDetailUrl = siteCollaboratorsUrl.segment(

--- a/static/js/pages/App.tsx
+++ b/static/js/pages/App.tsx
@@ -17,7 +17,7 @@ import { getWebsiteDetailCursor } from "../selectors/websites"
 import WebsiteContext from "../context/Website"
 import PrivacyPolicyPage from "./PrivacyPolicyPage"
 import NotFound from "../components/NotFound"
-import { sitesBaseUrl } from "../lib/urls"
+import { siteDetailUrl, sitesBaseUrl } from "../lib/urls"
 
 interface SiteMatchParams {
   name: string
@@ -46,7 +46,7 @@ export default function App(): JSX.Element {
             <Route exact path="/" component={HomePage} />
             <Route exact path="/new-site" component={SiteCreationPage} />
             <Route exact path="/sites" component={SitesDashboard} />
-            <Route path="/sites/:name">
+            <Route path={siteDetailUrl.pathname}>
               {status === 404 ? (
                 <NotFound>
                   <div>

--- a/static/js/pages/SitePage.tsx
+++ b/static/js/pages/SitePage.tsx
@@ -1,11 +1,15 @@
 import React from "react"
-import { Route, Switch } from "react-router-dom"
+import { Route } from "react-router-dom"
 
 import SiteSidebar from "../components/SiteSidebar"
 import SiteContentListing from "../components/SiteContentListing"
 import SiteCollaboratorList from "../components/SiteCollaboratorList"
 import Card from "../components/Card"
-import { siteCollaboratorsUrl, siteDetailUrl } from "../lib/urls"
+import {
+  siteCollaboratorsUrl,
+  siteContentListingUrl,
+  siteDetailUrl
+} from "../lib/urls"
 
 import { useWebsite } from "../context/Website"
 import DocumentTitle, { formatTitle } from "../components/DocumentTitle"
@@ -34,27 +38,19 @@ export default function SitePage(props: SitePageProps): JSX.Element | null {
           <SiteSidebar website={website} />
         </Card>
         <div className="content pl-3">
-          <Switch>
-            <Route
-              path={siteCollaboratorsUrl.param("name", website.name).toString()}
-            >
-              <SiteCollaboratorList />
-            </Route>
-            <Route
-              exact
-              path={`${siteDetailUrl.param(
-                "name",
-                website.name
-              )}type/:contenttype`}
-            >
-              <SiteContentListing />
-            </Route>
-            <Route
-              path={siteDetailUrl.param({ name: website.name }).toString()}
-            >
-              <DocumentTitle title={formatTitle(website.title)} />
-            </Route>
-          </Switch>
+          <Route
+            path={siteCollaboratorsUrl.param("name", website.name).toString()}
+          >
+            <SiteCollaboratorList />
+          </Route>
+          <Route
+            path={siteContentListingUrl.param({ name: website.name }).pathname}
+          >
+            <SiteContentListing />
+          </Route>
+          <Route path={siteDetailUrl.param({ name: website.name }).toString()}>
+            <DocumentTitle title={formatTitle(website.title)} />
+          </Route>
         </div>
       </div>
     </div>

--- a/static/js/types/modal_state.ts
+++ b/static/js/types/modal_state.ts
@@ -42,7 +42,7 @@ abstract class ModalStateVariant<T> {
  * An Editing state, which provides for wrapping a value
  * related to the content being edited.
  */
-class Editing<T> extends ModalStateVariant<T> {
+export class Editing<T> extends ModalStateVariant<T> {
   state: "editing" = "editing"
   /**
    * The value wrapped in the Editing state

--- a/yarn.lock
+++ b/yarn.lock
@@ -2065,12 +2065,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/url-assembler@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "@types/url-assembler@npm:2.1.0"
+"@types/url-assembler@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "@types/url-assembler@npm:2.1.1"
   dependencies:
     "@types/qs": "*"
-  checksum: 3ce2dbb7f8b6508555fc6472d41579b28cec8c732179807fcd30eaec7f66e0dbe822d9d65316df780f928d4d975b48ea85227f8086af772f1f27da680cb50a65
+  checksum: c2361a6b5161049a338738e9da81f9a0e325e02548b180bf2230fd5b9e600e6fc6428e97416a7fba588c80f8d2d509a68b70e459bfd27dc9272da86074b99703
   languageName: node
   linkType: hard
 
@@ -9392,7 +9392,7 @@ __metadata:
     "@types/showdown": ^1.9.4
     "@types/sinon": ^10.0.2
     "@types/turndown": ^5.0.1
-    "@types/url-assembler": ^2.1.0
+    "@types/url-assembler": ^2.1.1
     "@typescript-eslint/eslint-plugin": ^5.4.0
     "@typescript-eslint/parser": ^5.4.0
     "@use-it/interval": ^1.0.0


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [x] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?

closes #1030

#### What's this PR do?

This PR moves the state which controls the presence and contents of the website content drawer into the URL bar. In particular, instead of basically toggling a boolean and deciding whether to show the drawer or not, instead we navigate to one of two new URLs:

| name | url |
| --- | --- |
| edit content | `/sites/:name/type/:contentType/edit/:uuid` |
| new content | `/sites/:name/type/:contentType/new/` |

they do what you'd expect. I tried to do what I could to keep every aspect of the UI the same except for the fact this this open / close state is now driven by the URL.

#### How should this be manually tested?

Extensively test editing and creating content and please try to find any weird bugs.

#### Screenshots (if appropriate)

![Screen Shot 2022-02-28 at 5 16 30 PM](https://user-images.githubusercontent.com/6207644/156067545-079552c0-f35d-40e2-93f0-7a029648882e.png)

