### PR TITLE
fix spacing issue for single-line table cell content

### DIFF
--- a/static/js/lib/ckeditor/plugins/TableMarkdownSyntax.test.tsx
+++ b/static/js/lib/ckeditor/plugins/TableMarkdownSyntax.test.tsx
@@ -155,4 +155,23 @@ describe("table shortcodes", () => {
     </table>`
     expect(htmlBeautify(md2html(md))).toBe(htmlBeautify(html))
   })
+
+  it.each([
+    [
+      "<table><thead><tr><th>my content</th></tr></thead></table>",
+      "{{< tableopen >}}{{< theadopen >}}{{< tropen >}}{{< thopen >}}\nmy content\n{{< thclose >}}{{< trclose >}}{{< theadclose >}}{{< tableclose >}}"
+    ],
+    [
+      "<table><tbody><tr><td>more content</td></tr></tbody></table>",
+      "{{< tableopen >}}{{< tbodyopen >}}{{< tropen >}}{{< tdopen >}}\nmore content\n{{< tdclose >}}{{< trclose >}}{{< tbodyclose >}}{{< tableclose >}}"
+    ]
+  ])(
+    "html2md should add newlines on table cell content when appropriate",
+    async (html, md) => {
+      const editor = await getEditor("")
+      const { html2md } = (editor.data
+        .processor as unknown) as MarkdownDataProcessor
+      expect(html2md(html)).toBe(md)
+    }
+  )
 })

--- a/static/js/lib/ckeditor/plugins/TableMarkdownSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/TableMarkdownSyntax.ts
@@ -5,9 +5,14 @@ import MarkdownSyntaxPlugin from "./MarkdownSyntaxPlugin"
 import { TurndownRule } from "../../../types/ckeditor_markdown"
 import { buildAttrsString } from "./util"
 
-import { TABLE_ELS, ATTRIBUTE_REGEX } from "./constants"
+import { TABLE_ELS, ATTRIBUTE_REGEX, CONTENT_TABLE_ELS } from "./constants"
 
 type Position = "open" | "close"
+
+const handleContentWhitespace = (content: string) =>
+  `${content.startsWith("\n") ? "" : "\n"}${content}${
+    content.endsWith("\n") ? "" : "\n"
+  }`
 
 export default class TableMarkdownSyntax extends MarkdownSyntaxPlugin {
   static get pluginName(): string {
@@ -50,7 +55,12 @@ export default class TableMarkdownSyntax extends MarkdownSyntaxPlugin {
                 )
               ) :
               ""
-            return `{{< ${name}open${attributes} >}}${content}{{< ${name}close >}}`
+
+            const processedContent = CONTENT_TABLE_ELS.includes(name) ?
+              handleContentWhitespace(content) :
+              content
+
+            return `{{< ${name}open${attributes} >}}${processedContent}{{< ${name}close >}}`
           }
         }
       }

--- a/static/js/lib/ckeditor/plugins/constants.ts
+++ b/static/js/lib/ckeditor/plugins/constants.ts
@@ -53,6 +53,8 @@ export const TABLE_ELS: TurndownService.TagName[] = [
   "tfoot"
 ]
 
+export const CONTENT_TABLE_ELS = ["th", "td"]
+
 // A whitelist of attributes that can be assigned to table cells
 export const TABLE_ALLOWED_ATTRS: string[] = ["colspan", "rowspan"]
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #1082

#### What's this PR do?

This fixes an issue we're seeing with single-line content in table cells. Basically, the issue is that if you have markdown formatting on that content it seems to be getting ignored by Hugo unless there is white space around it, so something like this:

```md
{{< tdopen >}}**great stuff!**{{< tdclose >}}
```

_should_ render to

```html
<td><strong>great stuff!</strong></td>
```

but instead it's rendering to 

```html
<td>**great stuff!**</td>
```

we can intervene in the html -> markdown conversion process and insert newlines, like so:

```md
{{< tdopen >}}
**great stuff!**
{{< tdclose >}}
```

which fixes the issue afaict

#### How should this be manually tested?

really try to exercise and break this - I think I fixed it in a way that shouldn't cause new problems, but this stuff is finicky.

Make sure at a minimum that you can have a single-line table cell, put markdown formatting on it, and have that show up in the rendered course.
