### PR TITLE
add code block support to CKEditor

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@ckeditor/ckeditor5-autoformat": "^31.0.0",
     "@ckeditor/ckeditor5-basic-styles": "^31.0.0",
     "@ckeditor/ckeditor5-block-quote": "^31.0.0",
+    "@ckeditor/ckeditor5-code-block": "31.0.0",
     "@ckeditor/ckeditor5-core": "^31.0.0",
     "@ckeditor/ckeditor5-dev-utils": "^26.1.0",
     "@ckeditor/ckeditor5-dev-webpack-plugin": "^26.1.0",

--- a/static/js/lib/ckeditor/CKEditor.ts
+++ b/static/js/lib/ckeditor/CKEditor.ts
@@ -14,6 +14,7 @@ import ListPlugin from "@ckeditor/ckeditor5-list/src/list"
 import ParagraphPlugin from "@ckeditor/ckeditor5-paragraph/src/paragraph"
 import TablePlugin from "@ckeditor/ckeditor5-table/src/table"
 import TableToolbarPlugin from "@ckeditor/ckeditor5-table/src/tabletoolbar"
+import CodeBlock from "@ckeditor/ckeditor5-code-block/src/codeblock"
 
 import { editor } from "@ckeditor/ckeditor5-core"
 
@@ -30,6 +31,45 @@ import DisallowNestedTables from "./plugins/DisallowNestedTables"
 import TableMarkdownSyntax from "./plugins/TableMarkdownSyntax"
 import MarkdownListSyntax from "./plugins/MarkdownListSyntax"
 import LegacyShortcodes from "./plugins/LegacyShortcodes"
+
+/**
+ * Programming languages we support in CKEditor code blocks
+ *
+ * This list is based on CKEditor's default list, here:
+ *
+ * https://github.com/ckeditor/ckeditor5/blob/master/packages/ckeditor5-code-block/src/codeblockediting.js#L60
+ *
+ * extended with a few more options.
+ */
+const SUPPORTED_PROGRAMMING_LANGUAGES = [
+  { language: "plaintext", label: "Plain text" },
+  { language: "matlab", label: "Matlab" },
+  { language: "julia", label: "Julia" },
+  { language: "c", label: "C" },
+  { language: "cs", label: "C#" },
+  { language: "cpp", label: "C++" },
+  { language: "css", label: "CSS" },
+  { language: "diff", label: "Diff" },
+  { language: "html", label: "HTML" },
+  { language: "java", label: "Java" },
+  { language: "javascript", label: "JavaScript" },
+  { language: "php", label: "PHP" },
+  { language: "python", label: "Python" },
+  { language: "ruby", label: "Ruby" },
+  { language: "typescript", label: "TypeScript" },
+  { language: "xml", label: "XML" }
+].sort((first, second) => {
+  const labelOne = first.label.toUpperCase()
+  const labelTwo = second.label.toUpperCase()
+
+  if (labelOne < labelTwo) {
+    return -1
+  }
+  if (labelOne > labelTwo) {
+    return 1
+  }
+  return 0
+})
 
 export const FullEditorConfig = {
   plugins: [
@@ -49,6 +89,7 @@ export const FullEditorConfig = {
     ParagraphPlugin,
     TablePlugin,
     TableToolbarPlugin,
+    CodeBlock,
     ResourceEmbed,
     ResourcePicker,
     ResourceLink,
@@ -70,6 +111,7 @@ export const FullEditorConfig = {
       "bulletedList",
       "numberedList",
       "blockQuote",
+      "codeBlock",
       "insertTable",
       "undo",
       "redo",
@@ -79,6 +121,9 @@ export const FullEditorConfig = {
   },
   image: {
     toolbar: ["imageStyle:full", "imageStyle:side", "|", "imageTextAlternative"]
+  },
+  codeBlock: {
+    languages: SUPPORTED_PROGRAMMING_LANGUAGES
   },
   table: {
     contentToolbar:  ["tableColumn", "tableRow", "mergeTableCells"],

--- a/static/js/types/ckeditor.d.ts
+++ b/static/js/types/ckeditor.d.ts
@@ -67,3 +67,5 @@ declare module '@mitodl/ckeditor5-resource-link/src/constants';
 declare module '@ckeditor/ckeditor5-table/src/tabletoolbar';
 
 declare module '@ckeditor/ckeditor5-table/src/table';
+
+declare module '@ckeditor/ckeditor5-code-block/src/codeblock';

--- a/yarn.lock
+++ b/yarn.lock
@@ -488,6 +488,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ckeditor/ckeditor5-code-block@npm:31.0.0":
+  version: 31.0.0
+  resolution: "@ckeditor/ckeditor5-code-block@npm:31.0.0"
+  dependencies:
+    ckeditor5: ^31.0.0
+  checksum: c3b8368d8f9e67d592fec64d0e139918a1d7b7a90844d572d152ddb1c3a4ae0403d42145f466eb4640e27f63fa92695a2d41aeac5558647ad65284b336afba37
+  languageName: node
+  linkType: hard
+
 "@ckeditor/ckeditor5-core@npm:^31.0.0":
   version: 31.0.0
   resolution: "@ckeditor/ckeditor5-core@npm:31.0.0"
@@ -9342,6 +9351,7 @@ __metadata:
     "@ckeditor/ckeditor5-autoformat": ^31.0.0
     "@ckeditor/ckeditor5-basic-styles": ^31.0.0
     "@ckeditor/ckeditor5-block-quote": ^31.0.0
+    "@ckeditor/ckeditor5-code-block": 31.0.0
     "@ckeditor/ckeditor5-core": ^31.0.0
     "@ckeditor/ckeditor5-dev-utils": ^26.1.0
     "@ckeditor/ckeditor5-dev-webpack-plugin": ^26.1.0


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
  - [x] Desktop screenshots
  - [ ] Mobile width screenshots
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?

closes #1083 

#### What's this PR do?

This adds [CKEditor's code block
feature](https://ckeditor.com/docs/ckeditor5/latest/features/code-blocks.html)
to our editor setup so that content authors can add and modify code blocks.

They are saved in the normal way in Markdown with three backticks and then the
language name, like so:

    ```js
    const foo = "bar"
    ````

the nice thing about this is that Hugo already supports correctly highlighting
blocks which have the language set on them like this, so it sort of just works!

#### How should this be manually tested?

Try out adding a code block in the Markdown editor. You should be able to do a few things:

- add a new code block, picking a language from the little dropdown and then
  typing some code into it
- use the button to toggle off / on 'code block'-ey ness for a selection of
  text in the editor
- switch the language of an already-created block

and then of course everything should save correctly and whatnot.

If you'd like to test building this in Hugo you can check out this PR on the config repo:

https://github.com/mitodl/ocw-hugo-projects/pull/136

and then also this PR on the theme repo:

https://github.com/mitodl/ocw-hugo-themes/pull/504

#### Screenshots (if appropriate)

here's a little screencast showing the basic functionality:


https://user-images.githubusercontent.com/6207644/156800663-cce4562e-c91b-48d2-a34f-3e2ea998e02b.mov
