### PR TITLE
[proposal] remove 'mobile' screen checkmark from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,6 @@
 #### Pre-Flight checklist
 
 - [ ] Screenshots and design review for any changes that affect layout or styling
-  - [ ] Desktop screenshots
-  - [ ] Mobile width screenshots
 - [ ] Migrations
   - [ ] Migration is backwards-compatible with current production code
 - [ ] Testing


### PR DESCRIPTION
a proposal - we haven't done any mobile styling for ocw-studio, since we expect that the userbase is going to be pretty exclusively using it as a 'desktop app' (i.e. using it at work) so I think we might as well just remove the checkbox.