### PR TITLE
Improved site search for names, short_ids

### DIFF
--- a/websites/views.py
+++ b/websites/views.py
@@ -114,13 +114,19 @@ class WebsiteViewSet(
         if search is not None:
             # search query param is used in react-select typeahead, and should
             # match on the title, name, and short_id
+            search_filter = Q(search=SearchQuery(search))
+            if "." in search:
+                # postgres text search behaves oddly with periods but not dashes
+                search_filter = search_filter | Q(
+                    search=SearchQuery(search.replace(".", "-"))
+                )
             queryset = queryset.annotate(
                 search=SearchVector(
                     "name",
                     "title",
                     "short_id",
                 )
-            ).filter(search=SearchQuery(search))
+            ).filter(search_filter)
 
         if resourcetype is not None:
             queryset = queryset.filter(metadata__resourcetype=resourcetype)

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -388,6 +388,11 @@ def test_website_endpoint_search(drf_client):
 
     WebsiteFactory.create(title="Apple", name="Bacon", short_id="Cheese").save()
     WebsiteFactory.create(title="Xylophone", name="Yellow", short_id="Zebra").save()
+    WebsiteFactory.create(
+        title="U.S. Military Power",
+        name="17-482-u-s-military-power-spring-2015",
+        short_id="17.482-Spring-2015",
+    ).save()
     for word in ["Apple", "Bacon", "Cheese"]:
         resp = drf_client.get(reverse("websites_api-list"), {"search": word})
         assert [website["title"] for website in resp.data.get("results")] == ["Apple"]
@@ -395,6 +400,11 @@ def test_website_endpoint_search(drf_client):
         resp = drf_client.get(reverse("websites_api-list"), {"search": word})
         assert [website["title"] for website in resp.data.get("results")] == [
             "Xylophone"
+        ]
+    for word in ["U.S. military", "17-482", "17.482"]:
+        resp = drf_client.get(reverse("websites_api-list"), {"search": word})
+        assert [website["title"] for website in resp.data.get("results")] == [
+            "U.S. Military Power"
         ]
 
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1069

#### What's this PR do?
Tweaks the search query for ocw-studio site search so that expected results for partial course names or short_ids are returned.

#### How should this be manually tested?
Read the issue description and make various searches for partial site names, short_ids, and titles.  If you have site `21m-380-music-and-technology-sound-design-spring-2016` imported, then searches for "21m-380", "21M.380", or "Music and Technology" should all return that course (and maybe a few others).
