### PR TITLE
merge new metadata with old metadata

### DIFF
--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -376,6 +376,11 @@ class WebsiteContentDetailSerializer(
             validated_data["metadata"]["file_type"] = detect_mime_type(
                 validated_data["file"]
             )
+        if "metadata" in validated_data:
+            validated_data["metadata"] = {
+                **instance.metadata,
+                **validated_data["metadata"],
+            }
         instance = super().update(
             instance, {"updated_by": self.user_from_request(), **validated_data}
         )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets? #1093 

#### What's this PR do?
Updates `WebsiteContentDetailSerializer` so that `update` merges new metadata with old metadata, rather than overwriting the old metadata.

A few notes:
- similar to https://datatracker.ietf.org/doc/html/rfc7396
- but does not implement the "null means delete" thing
- not consistent with how we are handling other json fields (e.g., `Website.metadata`

Might be nice to have a more uniform solution to this

#### How should this be manually tested?
_But use your local not RC:_

1. Open an instructor insights page in admin panel, e.g., https://ocw-studio-rc.odl.mit.edu/admin/websites/websitecontent/515029/change/?_changelist_filters=q%3Dc211db95-89db-de17-36b3-806670e359ff
2. Add `"layout": "instructor_insights"` to the metadata if it's not present.
3. Open the corresponding page in studio, https://ocw-studio-rc.odl.mit.edu/sites/18-330-introduction-to-numerical-analysis-spring-2012/type/page/edit/c211db95-89db-de17-36b3-806670e359ff/
4. Save a simple edit

Check that the metadata still exists in admin panel after the studio save.
