### PR TITLE
theme assets build cache busting take 2

### DIFF
--- a/content_sync/constants.py
+++ b/content_sync/constants.py
@@ -1,4 +1,3 @@
 """Contents for content_sync"""
 VERSION_LIVE = "live"
 VERSION_DRAFT = "draft"
-SOFT_PURGE_HEADER = "\n              - -H\n              - 'Fastly-Soft-Purge: 1'"

--- a/content_sync/constants.py
+++ b/content_sync/constants.py
@@ -1,3 +1,4 @@
 """Contents for content_sync"""
 VERSION_LIVE = "live"
 VERSION_DRAFT = "draft"
+SOFT_PURGE_HEADER = "\n              - -H\n              - 'Fastly-Soft-Purge: 1'"

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -17,7 +17,7 @@ from concoursepy.api import Api as BaseConcourseApi
 from django.conf import settings
 from requests import HTTPError
 
-from content_sync.constants import VERSION_DRAFT, VERSION_LIVE, SOFT_PURGE_HEADER
+from content_sync.constants import SOFT_PURGE_HEADER, VERSION_DRAFT, VERSION_LIVE
 from content_sync.decorators import retry_on_failure
 from content_sync.pipelines.base import (
     BaseMassPublishPipeline,

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -45,6 +45,7 @@ PURGE_HEADER = (
     else "\n              - -H\n              - 'Fastly-Soft-Purge: 1'"
 )
 
+
 class ConcourseApi(BaseConcourseApi):
     """
     Customized pipeline_name of concoursepy.api.Api that allows for getting/setting headers

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -370,7 +370,7 @@ def test_upsert_pipeline(mocker, settings, pipeline_exists):
     assert settings.AWS_PREVIEW_BUCKET_NAME in config_str
     assert settings.AWS_PUBLISH_BUCKET_NAME in config_str
     assert (
-        f"s3-remote:ol-eng-artifacts/ocw-hugo-themes/{settings.GITHUB_WEBHOOK_BRANCH}"
+        f"s3://ol-eng-artifacts/ocw-hugo-themes/{settings.GITHUB_WEBHOOK_BRANCH}"
         in config_str
     )
 

--- a/content_sync/pipelines/definitions/concourse/theme-assets-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/theme-assets-pipeline.yml
@@ -1,25 +1,10 @@
 ---
-resource_types:
-- name: rclone
-  type: docker-image
-  source:
-    repository: mitodl/concourse-rclone-resource
-    tag: latest
 resources:
 - name: ocw-hugo-themes
   type: git
   source:
     uri: ((ocw-hugo-themes-uri))
     branch: ((ocw-hugo-themes-branch))
-- name: ocw-artifacts
-  type: rclone
-  source:
-    config: |
-      [s3-remote]
-      type = s3
-      provider = AWS
-      env_auth = true
-      region = us-east-1
 jobs:
 - name: build-theme-assets
   serial: true
@@ -47,30 +32,38 @@ jobs:
           yarn install --pure-lockfile
           npm run build:webpack
           npm run build:githash
-  - put: ocw-artifacts
-    params:
-      source: ocw-hugo-themes/base-theme/dist
-      destination:
-      - dir: s3-remote:((ocw-bucket-draft))
-        command: copy
+  - task: copy-s3-buckets
+    timeout: 20m
+    attempts: 3
+    config:
+      inputs:
+        - name: ocw-hugo-themes
+      platform: linux
+      image_resource:
+        type: docker-image
+        source: {repository: amazon/aws-cli, tag: latest}
+      run:
+        path: sh
         args:
-        - --ignore-size
-        - --checksum
-  - put: ocw-artifacts
-    params:
-      source: ocw-hugo-themes/base-theme/dist
-      destination:
-      - dir: s3-remote:((ocw-bucket-live))
-        command: copy
+          - -exc
+          - |
+            aws s3 sync ocw-hugo-themes/base-theme/dist s3://((ocw-bucket-draft)) --metadata site-id=ocw-hugo-themes
+            aws s3 sync ocw-hugo-themes/base-theme/dist s3://((ocw-bucket-live)) --metadata site-id=ocw-hugo-themes
+            aws s3 cp ocw-hugo-themes/base-theme/data/webpack.json s3://ol-eng-artifacts/ocw-hugo-themes/((ocw-hugo-themes-branch)) --metadata site-id=ocw-hugo-themes
+  - task: clear-cdn-cache
+    timeout: 5m
+    attempts: 3
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source: {repository: curlimages/curl}
+      run:
+        path: curl
         args:
-        - --ignore-size
-        - --checksum
-  - put: ocw-artifacts
-    params:
-      source: ocw-hugo-themes/base-theme/data/webpack.json
-      destination:
-      - dir: s3-remote:ol-eng-artifacts/ocw-hugo-themes/((ocw-hugo-themes-branch))
-        command: copy
-        args:
-        - --ignore-size
-        - --checksum
+          - -f
+          - -X
+          - POST
+          - -H
+          - 'Fastly-Key: ((fastly.api_token))'((purge_header))
+          - https://api.fastly.com/service/((fastly.service_id))/ocw-hugo-themes

--- a/content_sync/pipelines/definitions/concourse/theme-assets-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/theme-assets-pipeline.yml
@@ -47,10 +47,10 @@ jobs:
         args:
           - -exc
           - |
-            aws s3 sync ocw-hugo-themes/base-theme/dist s3://((ocw-bucket-draft)) --metadata site-id=ocw-hugo-themes
-            aws s3 sync ocw-hugo-themes/base-theme/dist s3://((ocw-bucket-live)) --metadata site-id=ocw-hugo-themes
+            aws s3 cp ocw-hugo-themes/base-theme/dist s3://((ocw-bucket-draft)) --recursive --metadata site-id=ocw-hugo-themes
+            aws s3 cp ocw-hugo-themes/base-theme/dist s3://((ocw-bucket-live)) --recursive --metadata site-id=ocw-hugo-themes
             aws s3 cp ocw-hugo-themes/base-theme/data/webpack.json s3://ol-eng-artifacts/ocw-hugo-themes/((ocw-hugo-themes-branch)) --metadata site-id=ocw-hugo-themes
-  - task: clear-cdn-cache
+  - task: clear-cdn-cache-draft
     timeout: 5m
     attempts: 3
     config:
@@ -65,5 +65,22 @@ jobs:
           - -X
           - POST
           - -H
-          - 'Fastly-Key: ((fastly.api_token))'((purge_header))
-          - https://api.fastly.com/service/((fastly.service_id))/ocw-hugo-themes
+          - 'Fastly-Key: ((fastly_draft.api_token))'((purge_header))
+          - https://api.fastly.com/service/((fastly_draft.service_id))/ocw-hugo-themes
+  - task: clear-cdn-cache-live
+    timeout: 5m
+    attempts: 3
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source: {repository: curlimages/curl}
+      run:
+        path: curl
+        args:
+          - -f
+          - -X
+          - POST
+          - -H
+          - 'Fastly-Key: ((fastly_live.api_token))'((purge_header))
+          - https://api.fastly.com/service/((fastly_live.service_id))/ocw-hugo-themes


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1077

#### What's this PR do?
Currently site builds and mass publishes triggered from `ocw-studio` have a step at the end to purge the cache in Fastly based on a Surrogate Key configured to work off of the S3 metadata property `site-id`.  The theme assets build currently does not do this, and this PR sets it up to do that.  The theme assets are deployed to draft and live buckets, the `webpack.json` file is deployed to `ol-eng-assets` and then the cache is purged.

#### How should this be manually tested?
 - Make sure your `.env` is configured for local development and not pointing at RC
 - Spin up your local `ocw-studio` with Concourse support with `docker-compose --profile concourse up`
 - Run `docker-compose run --rm web ./manage.py upsert_theme_assets_pipeline` and ensure the command completes with no errors
 - Go to http://localhost:8080 and login with the default credentials of test / test
 - Verify that the theme assets pipeline is present

Further testing in actually running the pipeline will need to be done on RC once this PR merges.