### PR TITLE
fix: salutation appended in title

### DIFF
--- a/websites/models.py
+++ b/websites/models.py
@@ -31,7 +31,7 @@ from websites.constants import (
     CONTENT_FILEPATH_UNIQUE_CONSTRAINT,
 )
 from websites.site_config_api import SiteConfig
-from websites.utils import permissions_group_name_for_role
+from websites.utils import permissions_group_name_for_role, set_title_salutation
 
 
 def validate_yaml(value):
@@ -279,6 +279,7 @@ class WebsiteContent(TimestampedModel, SafeDeleteModel):
 
     def save(self, **kwargs):  # pylint: disable=arguments-differ
         """Update dirty flags on save"""
+        set_title_salutation(self)
         super().save(**kwargs)
         website = self.website
         website.has_unpublished_live = True

--- a/websites/utils.py
+++ b/websites/utils.py
@@ -47,3 +47,14 @@ def get_valid_base_filename(filename: str, content_type: str) -> str:
     if filename in constants.CONTENT_FILENAMES_FORBIDDEN:
         return f"{filename}-{content_type}"
     return filename
+
+
+def set_title_salutation(website_content):
+    """Set salutation in title if salutation found in metadata and not found in title"""
+    if (
+        website_content.type == constants.CONTENT_TYPE_INSTRUCTOR
+        and website_content.metadata.get("salutation", None)
+    ):
+        salutation = website_content.metadata["salutation"].strip()
+        if not website_content.title.startswith(salutation):
+            website_content.title = f"{salutation} {website_content.title}"

--- a/websites/utils_test.py
+++ b/websites/utils_test.py
@@ -1,12 +1,14 @@
 """Website utils tests"""
+from curses import meta
 import pytest
 
 from websites import constants
-from websites.factories import WebsiteFactory
+from websites.factories import WebsiteFactory, WebsiteContentFactory
 from websites.utils import (
     get_dict_query_field,
     permissions_group_name_for_role,
     set_dict_field,
+    set_title_salutation,
 )
 
 
@@ -79,3 +81,35 @@ def test_set_dict_field():
             "parameter_2": "value2",
         },
     }
+
+
+def test_set_title_salutation():
+    """
+    Verifies that set_title_salutation works as expected:
+    Append salutation in title only when needed
+    """
+    data_arr = [
+        {
+            "title": "John Cena",
+            "metadata": {"salutation": "Dr."},
+            "title_with_salutation": "Dr. John Cena",
+        },
+        {
+            "title": "John Cena",
+            "metadata": {"salutation": ""},
+            "title_with_salutation": "John Cena",
+        },
+        {
+            "title": "Dr. John Cena",
+            "metadata": {"salutation": "Dr."},
+            "title_with_salutation": "Dr. John Cena",
+        },
+    ]
+    for data in data_arr:
+        website_content = WebsiteContentFactory.build(
+            title=data["title"],
+            metadata=data["metadata"],
+            type=constants.CONTENT_TYPE_INSTRUCTOR,
+        )
+        set_title_salutation(website_content)
+        assert website_content.title == data["title_with_salutation"]

--- a/websites/utils_test.py
+++ b/websites/utils_test.py
@@ -1,5 +1,4 @@
 """Website utils tests"""
-from curses import meta
 import pytest
 
 from websites import constants

--- a/websites/utils_test.py
+++ b/websites/utils_test.py
@@ -2,7 +2,7 @@
 import pytest
 
 from websites import constants
-from websites.factories import WebsiteFactory, WebsiteContentFactory
+from websites.factories import WebsiteContentFactory, WebsiteFactory
 from websites.utils import (
     get_dict_query_field,
     permissions_group_name_for_role,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1073

#### What's this PR do?
- Appends salutation in title only when type is `instructor` and `salutation` is present in metadata
    - A util to append salutation with title is created in `websites/utils.py`
    - this util is called in `save` method of `WebsiteContent` model in `websites/models.py`
    - A test for this util has also been created. 

#### How should this be manually tested?
- Go to ocw-studio
- Add a new instructor
- Set a title without salutation and add salutation in metadata
- Verify that, on saving, this salutation is appended with title
- Save this instructor again and verify that salutation is not appended again if title already has a salutation.
- Repeat the above steps for 
     - `ocw-studio/admin` and `ocw-studio/sites` 
     - Creating a new instructor and saving a new instructor

#### Screenshots (if appropriate)

<img width="523" alt="image" src="https://user-images.githubusercontent.com/93309234/157629034-3a56bcf9-49ad-42b1-bee2-e1786fe0222f.png">

<img width="373" alt="image" src="https://user-images.githubusercontent.com/93309234/157629076-4b8dea9c-2916-4d2a-9ecb-c76ea0417b46.png">

<img width="526" alt="image" src="https://user-images.githubusercontent.com/93309234/157629158-ee33b4ea-a235-45d1-a5eb-aa3f2beed439.png">

#### Note:
`Title` is a different field from metadata which is set differently so I'm not sure whether it's a good solution to only take salutation from metadata and append it in the title. 
In case of instructor, if title is instructor's full name, then I think, title should not be asked upon saving/updating instuctor, title should be auto-populated when instructor is saved/updated. (title = salutation + first_name + middle_name + last_name).
But since in the issue ticket, the expected behavior is: `Salutation should be part of the instructor's title when added.` so I have updated the `save` method, but I don't think this is a good approach as there might be some use-cases where this approach will cause few issues, maybe or maybe not.
