### PR TITLE
only query with published = true if cross_site is also true

### DIFF
--- a/static/js/components/widgets/RelationField.test.tsx
+++ b/static/js/components/widgets/RelationField.test.tsx
@@ -209,6 +209,21 @@ describe("RelationField", () => {
       ).toEqual(formatWebsiteOptions(websites, "name"))
     })
 
+    it("should not filter on published if cross_site is false", async () => {
+      await render({ cross_site: false, value: [] })
+      expect(global.fetch).toHaveBeenCalledWith(
+        siteApiContentListingUrl
+          .query({
+            detailed_list:   true,
+            content_context: true,
+            type:            "page",
+            published:       false
+          })
+          .toString(),
+        { credentials: "include" }
+      )
+    })
+
     it("should let the user pick a website and then content within that website", async () => {
       const { wrapper } = await render({ cross_site: true, value: [] })
       await act(async () => {

--- a/static/js/components/widgets/RelationField.test.tsx
+++ b/static/js/components/widgets/RelationField.test.tsx
@@ -185,7 +185,6 @@ describe("RelationField", () => {
               detailed_list:   true,
               content_context: true,
               type:            "page",
-              published:       true,
               ...(withResourcetypeFilter ? { resourcetype: "Image" } : {})
             })
             .toString()
@@ -209,19 +208,22 @@ describe("RelationField", () => {
       ).toEqual(formatWebsiteOptions(websites, "name"))
     })
 
-    it("should not filter on published if cross_site is false", async () => {
-      await render({ cross_site: false, value: [] })
-      expect(global.fetch).toHaveBeenCalledWith(
-        siteApiContentListingUrl
-          .query({
-            detailed_list:   true,
-            content_context: true,
-            type:            "page",
-            published:       false
-          })
-          .toString(),
-        { credentials: "include" }
-      )
+    //
+    ;[true, false].forEach(isCrossSite => {
+      it("should not filter on published if cross_site is not set", async () => {
+        await render({ cross_site: isCrossSite, value: [] })
+        expect(global.fetch).toHaveBeenCalledWith(
+          siteApiContentListingUrl
+            .query({
+              detailed_list:   true,
+              content_context: true,
+              type:            "page",
+              ...(isCrossSite ? { published: true } : {})
+            })
+            .toString(),
+          { credentials: "include" }
+        )
+      })
     })
 
     it("should let the user pick a website and then content within that website", async () => {
@@ -387,7 +389,6 @@ describe("RelationField", () => {
             content_context: true,
             search:          search,
             type:            "page",
-            published:       true,
             ...(withResourcetypeFilter ? { resourcetype: "Image" } : {})
           })
           .param({ name: website.name })

--- a/static/js/components/widgets/RelationField.test.tsx
+++ b/static/js/components/widgets/RelationField.test.tsx
@@ -208,21 +208,24 @@ describe("RelationField", () => {
       ).toEqual(formatWebsiteOptions(websites, "name"))
     })
 
-    it.each([true, false])("should not filter on published if cross_site is not set", async isCrossSite => {
-      await render({ cross_site: isCrossSite, value: [] })
-      expect(global.fetch).toHaveBeenCalledWith(
-        siteApiContentListingUrl
-          .query({
-            detailed_list:   true,
-            content_context: true,
-            type:            "page",
-            ...(isCrossSite ? { published: true } : {})
-          })
-          .param({ name: website.name })
-          .toString(),
-        { credentials: "include" }
-      )
-    })
+    it.each([true, false])(
+      "should not filter on published if cross_site is not set",
+      async isCrossSite => {
+        await render({ cross_site: isCrossSite, value: [] })
+        expect(global.fetch).toHaveBeenCalledWith(
+          siteApiContentListingUrl
+            .query({
+              detailed_list:   true,
+              content_context: true,
+              type:            "page",
+              ...(isCrossSite ? { published: true } : {})
+            })
+            .param({ name: website.name })
+            .toString(),
+          { credentials: "include" }
+        )
+      }
+    )
 
     it("should let the user pick a website and then content within that website", async () => {
       const { wrapper } = await render({ cross_site: true, value: [] })

--- a/static/js/components/widgets/RelationField.test.tsx
+++ b/static/js/components/widgets/RelationField.test.tsx
@@ -208,23 +208,20 @@ describe("RelationField", () => {
       ).toEqual(formatWebsiteOptions(websites, "name"))
     })
 
-    //
-    ;[true, false].forEach(isCrossSite => {
-      it("should not filter on published if cross_site is not set", async () => {
-        await render({ cross_site: isCrossSite, value: [] })
-        expect(global.fetch).toHaveBeenCalledWith(
-          siteApiContentListingUrl
-            .query({
-              detailed_list:   true,
-              content_context: true,
-              type:            "page",
-              ...(isCrossSite ? { published: true } : {})
-            })
-            .param({ name: website.name })
-            .toString(),
-          { credentials: "include" }
-        )
-      })
+    it.each([true, false])("should not filter on published if cross_site is not set", async isCrossSite => {
+      await render({ cross_site: isCrossSite, value: [] })
+      expect(global.fetch).toHaveBeenCalledWith(
+        siteApiContentListingUrl
+          .query({
+            detailed_list:   true,
+            content_context: true,
+            type:            "page",
+            ...(isCrossSite ? { published: true } : {})
+          })
+          .param({ name: website.name })
+          .toString(),
+        { credentials: "include" }
+      )
     })
 
     it("should let the user pick a website and then content within that website", async () => {

--- a/static/js/components/widgets/RelationField.test.tsx
+++ b/static/js/components/widgets/RelationField.test.tsx
@@ -220,6 +220,7 @@ describe("RelationField", () => {
               type:            "page",
               ...(isCrossSite ? { published: true } : {})
             })
+            .param({ name: website.name })
             .toString(),
           { credentials: "include" }
         )

--- a/static/js/components/widgets/RelationField.tsx
+++ b/static/js/components/widgets/RelationField.tsx
@@ -174,10 +174,11 @@ export default function RelationField(props: Props): JSX.Element {
     async (search: string | null, debounce: boolean) => {
       const params = collection ? { type: collection } : { page_content: true }
       const name = crossSite && focusedWebsite ? focusedWebsite : websiteName
+      console.log(`crossSite: ${crossSite}`)
       const url = siteApiContentListingUrl
         .query({
           detailed_list:   true,
-          published:       crossSite ? true : false,
+          ...(crossSite ? { published: true } : {}),
           content_context: true,
           ...(search ? { search } : {}),
           ...(filter &&

--- a/static/js/components/widgets/RelationField.tsx
+++ b/static/js/components/widgets/RelationField.tsx
@@ -174,7 +174,6 @@ export default function RelationField(props: Props): JSX.Element {
     async (search: string | null, debounce: boolean) => {
       const params = collection ? { type: collection } : { page_content: true }
       const name = crossSite && focusedWebsite ? focusedWebsite : websiteName
-      console.log(`crossSite: ${crossSite}`)
       const url = siteApiContentListingUrl
         .query({
           detailed_list:   true,

--- a/static/js/components/widgets/RelationField.tsx
+++ b/static/js/components/widgets/RelationField.tsx
@@ -177,7 +177,7 @@ export default function RelationField(props: Props): JSX.Element {
       const url = siteApiContentListingUrl
         .query({
           detailed_list:   true,
-          published:       true,
+          published:       crossSite ? true : false,
           content_context: true,
           ...(search ? { search } : {}),
           ...(filter &&


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1104

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/904, we added a filter to the relation widget that filters results in the frontend, filtering out unpublished content.  This was intended to prevent referencing content that hasn't been published yet, but is unnecessary if you're referencing content in the same site.  This is because if you publish a site, that content that you're referencing will be published as part of that.  Thus, this PR changes the filter so that it only applies if the relation widget is cross-site.

#### How should this be manually tested?
 - Spin up `ocw-studio` locally
 - Create a course and a few pages or use an existing course with some pages in it
 - Publish your course
 - Add a new page, but don't publish it
 - Go to the Menu section
 - Click add new and verify that you see both your published and unpublished pages to choose from
