### PR TITLE
set parent_id when overwriting metadata.parent_uid

### DIFF
--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -165,9 +165,9 @@ def update_content_from_s3_data(website, text_id, content_data, update_field):
         text_id (str): Tthe content's text_id
         content_data (dict): Dictionary of content data from s3 bucket
         update_field (str): the field to update
-    
+
     Returns:
-        The WebsiteContent object if it existed, None otherwise. 
+        The WebsiteContent object if it existed, None otherwise.
     """
     is_metadata_field = False
 

--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -120,7 +120,7 @@ def import_ocw2hugo_content(bucket, prefix, website):  # pylint:disable=too-many
 
 def update_ocw2hugo_content(
     bucket, prefix, website, update_field, create_new_content=False
-):  # pylint:disable=too-many-locals
+):
     """
     update the update_field of all content files for an ocw course from hugo2ocw output
 
@@ -169,6 +169,12 @@ def update_content_from_s3_data(website, text_id, content_data, update_field):
     Returns:
         The WebsiteContent object if it existed, None otherwise.
     """
+    log.info('content:')
+    log.info(content_data)
+    log.info('update_field')
+    log.info(update_field)
+
+
     is_metadata_field = False
 
     if update_field and update_field.startswith("metadata."):

--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -157,6 +157,18 @@ def update_ocw2hugo_content(
 
 
 def update_content_from_s3_data(website, text_id, content_data, update_field):
+    """
+    Update the update_field of a single content file for an ocw course from hugo2ocw output
+
+    Args:
+        website (Website): The content's website
+        text_id (str): Tthe content's text_id
+        content_data (dict): Dictionary of content data from s3 bucket
+        update_field (str): the field to update
+    
+    Returns:
+        The WebsiteContent object if it existed, None otherwise. 
+    """
     is_metadata_field = False
 
     if update_field and update_field.startswith("metadata."):
@@ -185,6 +197,7 @@ def update_content_from_s3_data(website, text_id, content_data, update_field):
             content_data.get(update_field, ""),
         )
     content_file.save()
+    return content_file
 
 
 def get_learning_resource_types(content_json):

--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -169,12 +169,6 @@ def update_content_from_s3_data(website, text_id, content_data, update_field):
     Returns:
         The WebsiteContent object if it existed, None otherwise.
     """
-    log.info('content:')
-    log.info(content_data)
-    log.info('update_field')
-    log.info(update_field)
-
-
     is_metadata_field = False
 
     if update_field and update_field.startswith("metadata."):

--- a/ocw_import/api_test.py
+++ b/ocw_import/api_test.py
@@ -1,9 +1,12 @@
 """ Tests for ocw_import.api """
 import json
 import re
+from unittest.mock import patch, Mock
+from copy import deepcopy 
 
 import pytest
 from moto import mock_s3
+from django.forms.models import model_to_dict
 
 from ocw_import.api import (
     get_learning_resource_types,
@@ -11,6 +14,7 @@ from ocw_import.api import (
     import_ocw2hugo_course,
     import_ocw2hugo_sitemetadata,
     update_ocw2hugo_course,
+    update_content_from_s3_data
 )
 from ocw_import.conftest import (
     MOCK_BUCKET_NAME,
@@ -545,3 +549,87 @@ def test_update_ocw2hugo_course_content(
             ).count()
             == (1 if create_new_content else 0)
         )
+
+class TestUpdateContentFromS3Data:
+    """
+    Test that updating a single content object with s3 data only updates the
+    specified fields.
+    """
+
+    def do_update(self, update_field: str):
+        text_id = 'some_file'
+        website = WebsiteFactory.build()
+        content = WebsiteContentFactory.build(
+            text_id=text_id,
+            markdown='original markdown',
+            metadata={"title": 'original title'},
+            website=website
+        )
+        content.save = Mock()
+        # prepare the parent, but do not set content.parent_id.
+        # that's one of the things we'll test
+        parent = WebsiteContentFactory.build()
+
+        s3_content_data = {
+            "markdown": "s3 markdown",
+            "metadata": {
+                "title": "s3 title",
+                "author": "s3 author",
+                "parent_title": "s3 parent title"
+            },
+            "parent": parent
+        }
+        self.content = content
+        self.parent = parent
+        self.original_content_values = deepcopy(model_to_dict(content))
+
+        with patch("websites.models.WebsiteContent.objects") as mock:
+            mock.filter.return_value.first.return_value = content
+            update_content_from_s3_data(website, text_id, s3_content_data, update_field)
+        
+    def test_update_non_metadata_field(self):
+        """
+        Only content.markdown should change.
+        """
+        self.do_update('markdown')
+        assert self.content.save.call_count == 1
+        assert self.content.markdown == 's3 markdown'
+        assert self.content.metadata == {
+            "title": "original title"
+        }
+        assert self.content.parent_id is None
+    
+    def test_update_metadata_title(self):
+        """
+        Only metadata.title should change, and no new metadata keys.
+        """
+        self.do_update('metadata.title')
+        assert self.content.save.call_count == 1
+        assert self.content.markdown == 'original markdown'
+        assert self.content.metadata == {
+            "title": "s3 title"
+        }
+        assert self.content.parent_id is None
+
+    def test_update_metadata_author(self):
+        """
+        metadata.author should be added, no other changes.
+        """
+        self.do_update('metadata.author')
+        assert self.content.save.call_count == 1
+        assert self.content.markdown == 'original markdown'
+        assert self.content.metadata == {
+            "title": "original title",
+            "author": "s3 author"
+        }
+        assert self.content.parent_id is None
+    
+    def test_update_metadata_parent_title(self):
+        self.do_update('metadata.parent_title')
+        assert self.content.save.call_count == 1
+        assert self.content.markdown == 'original markdown'
+        assert self.content.metadata == {
+            "title": "original title",
+            "parent_title": "s3 parent title"
+        }
+        assert self.content.parent_id == self.parent.id

--- a/ocw_import/api_test.py
+++ b/ocw_import/api_test.py
@@ -567,14 +567,14 @@ class TestUpdateContentFromS3Data:
         content.save = Mock()
         # prepare the parent, but do not set content.parent_id.
         # that's one of the things we'll test
-        parent = WebsiteContentFactory.build()
+        parent = WebsiteContentFactory.build(id=123)
 
         s3_content_data = {
             "markdown": "s3 markdown",
             "metadata": {
                 "title": "s3 title",
                 "author": "s3 author",
-                "parent_title": "s3 parent title",
+                "parent_uid": "s3_parent_uid",
             },
             "parent": parent,
         }
@@ -619,15 +619,16 @@ class TestUpdateContentFromS3Data:
         }
         assert content.parent_id is None
 
-    def test_update_metadata_parent_title(self):
+    def test_update_metadata_parent_uid(self):
         """
-        Test that updating metadata.parent_title also updates parent_id FK.
+        Test that updating metadata.parent_uid also updates parent_id FK.
         """
-        content, parent = self.get_updated_content_and_parent("metadata.parent_title")
+        content, parent = self.get_updated_content_and_parent("metadata.parent_uid")
         assert content.save.call_count == 1
         assert content.markdown == "original markdown"
         assert content.metadata == {
             "title": "original title",
-            "parent_title": "s3 parent title",
+            "parent_uid": "s3_parent_uid",
         }
+        assert parent.id is not None
         assert content.parent_id == parent.id

--- a/ocw_import/management/commands/overwrite_ocw_course_content.py
+++ b/ocw_import/management/commands/overwrite_ocw_course_content.py
@@ -82,10 +82,12 @@ class Command(BaseCommand):
         if filter_json:
             with open(filter_json) as input_file:
                 filter_list = json.load(input_file)
-        else:
+        elif options["filter"]:
             filter_list = [
                 name.strip() for name in options["filter"].split(",") if name
             ]
+        else:
+            filter_list = None
 
         if not create_new and not content_field:
             self.stderr.write("Either --content-field or --create-new is required")


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
This is a followup to https://github.com/mitodl/ocw-to-hugo/issues/482, toward #1041 

#### What's this PR do?
When using `overwrite_ocw_course_content` to import `metadata.parent_uid`, also set `parent_id`.

#### How should this be manually tested?

1. Have `6-004-computation-structures-spring-2017` locally
2. Inspect WebsiteContent object `c675efdb-a53d-c4ec-1d14-46b3d44fda1e` in the admin panel
3. Observe that it has `metadata.parent_title` but no `metadata.parent_uid` or `parent` 
4. Run `docker-compose run --rm web python manage.py overwrite_ocw_course_content --bucket ocw-to-hugo-output-qa  --content-field="metadata.parent_uid" --filter 6-004-computation-structures-spring-2017`
5. Inspect the WebsiteContent object again and observe that it now has *both* `metadata.parent_uid` and `parent`. 

If you do not have `6-004-computation-structures-spring-2017` locally, do the above with any object that has metadata `parent_title` but not `parent_uid`. There are lots. 