### PR TITLE
Allow mass-publish to process a list of site names from a json file or comma-delimited string

### DIFF
--- a/ocw_import/management/commands/overwrite_ocw_course_content.py
+++ b/ocw_import/management/commands/overwrite_ocw_course_content.py
@@ -49,7 +49,7 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--filter-json",
-            dest="filter-json",
+            dest="filter_json",
             default=None,
             help="If specified, only import courses that contain comma-delimited site names specified in a JSON file",
         )
@@ -74,7 +74,7 @@ class Command(BaseCommand):
             # make sure it ends with a '/'
             prefix = prefix.rstrip("/") + "/"
         bucket_name = options["bucket"]
-        filter_json = options["filter-json"]
+        filter_json = options["filter_json"]
         limit = options["limit"]
         create_new = options["create_new"]
         content_field = options["content_field"]
@@ -83,7 +83,9 @@ class Command(BaseCommand):
             with open(filter_json) as input_file:
                 filter_list = json.load(input_file)
         else:
-            filter_list = options["filter"]
+            filter_list = [
+                name.strip() for name in options["filter"].split(",") if name
+            ]
 
         if not create_new and not content_field:
             self.stderr.write("Either --content-field or --create-new is required")


### PR DESCRIPTION
…r comma-delimited string

#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1126 

#### What's this PR do?
Modifies the management arg options so that a list of site names can be specified as a comma-delimited list or in a JSON file.  Also tweaks the `overwrite_ocw_course_content` command to formulate the name list the same way.

#### How should this be manually tested?
These should all work and queue up the expected number of sites for publishing:

From a JSON file:
```
manage.py mass_publish --filter-json courses.json draft
```
where `courses.json` looks like this:
```json
[
  "8-591j-systems-biology-fall-2004",
  "15-057-systems-optimization-spring-2003",
  "6-776-high-speed-communication-circuits-spring-2005"
]
```

From a string:
```
manage.py mass_publish --filter 11-382-water-diplomacy-spring-2021,6-00-introduction-to-computer-science-and-programming-fall-2008 draft
```

No filter (all sites that match other criteria in the query):
```
manage.py mass_publish draft
```