### PR TITLE
default metadata to empty object before iterating in seralizer

### DIFF
--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -376,10 +376,10 @@ class WebsiteContentDetailSerializer(
             validated_data["metadata"]["file_type"] = detect_mime_type(
                 validated_data["file"]
             )
-        metadata = instance.metadata if instance.metadata else {}
+        existing_metadata = instance.metadata if instance.metadata else {}
         if "metadata" in validated_data:
             validated_data["metadata"] = {
-                **metadata,
+                **existing_metadata,
                 **validated_data["metadata"],
             }
         instance = super().update(

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -376,9 +376,10 @@ class WebsiteContentDetailSerializer(
             validated_data["metadata"]["file_type"] = detect_mime_type(
                 validated_data["file"]
             )
+        metadata = instance.metadata if instance.metadata else {}
         if "metadata" in validated_data:
             validated_data["metadata"] = {
-                **instance.metadata,
+                **metadata,
                 **validated_data["metadata"],
             }
         instance = super().update(


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1122

#### What's this PR do?
The `WebsiteContent` serializer currently blindly iterates the existing `metadata` property when saving changes.  This PR defaults it to an empty object before doing this to prevent errors when saving.

#### How should this be manually tested?
 - Spin up your local instance of `ocw-studio` on this branch
 - Create a website using the `ocw-course` starter, making sure it is the latest released version from [`ocw-hugo-projects`](https://github.com/mitodl/ocw-hugo-projects/blob/main/ocw-course/ocw-studio.yaml)
 - Create a test page and save it
 - Go to Django admin and find your test page, blank out the metadata property and hit save
 - Go back into the site editing UI and open your page and save it again, you should get no errors and the page should save properly
