### PR TITLE
add inline code support to ckeditor

### DIFF
--- a/static/js/lib/ckeditor/CKEditor.ts
+++ b/static/js/lib/ckeditor/CKEditor.ts
@@ -14,7 +14,8 @@ import ListPlugin from "@ckeditor/ckeditor5-list/src/list"
 import ParagraphPlugin from "@ckeditor/ckeditor5-paragraph/src/paragraph"
 import TablePlugin from "@ckeditor/ckeditor5-table/src/table"
 import TableToolbarPlugin from "@ckeditor/ckeditor5-table/src/tabletoolbar"
-import CodeBlock from "@ckeditor/ckeditor5-code-block/src/codeblock"
+import CodeBlockPlugin from "@ckeditor/ckeditor5-code-block/src/codeblock"
+import CodePlugin from "@ckeditor/ckeditor5-basic-styles/src/code"
 
 import { editor } from "@ckeditor/ckeditor5-core"
 
@@ -77,6 +78,8 @@ export const FullEditorConfig = {
     AutoformatPlugin,
     BoldPlugin,
     ItalicPlugin,
+    // note that this is just for inline (not block-level) code
+    CodePlugin,
     UnderlinePlugin,
     BlockQuotePlugin,
     HeadingPlugin,
@@ -89,7 +92,7 @@ export const FullEditorConfig = {
     ParagraphPlugin,
     TablePlugin,
     TableToolbarPlugin,
-    CodeBlock,
+    CodeBlockPlugin,
     ResourceEmbed,
     ResourcePicker,
     ResourceLink,
@@ -111,6 +114,7 @@ export const FullEditorConfig = {
       "bulletedList",
       "numberedList",
       "blockQuote",
+      "code",
       "codeBlock",
       "insertTable",
       "undo",
@@ -138,6 +142,7 @@ export const MinimalEditorConfig = {
     AutoformatPlugin,
     BoldPlugin,
     ItalicPlugin,
+    CodePlugin,
     UnderlinePlugin,
     BlockQuotePlugin,
     LinkPlugin,
@@ -151,6 +156,7 @@ export const MinimalEditorConfig = {
       "bold",
       "italic",
       "underline",
+      "code",
       "link",
       "bulletedList",
       "numberedList",

--- a/static/js/types/ckeditor.d.ts
+++ b/static/js/types/ckeditor.d.ts
@@ -69,3 +69,5 @@ declare module '@ckeditor/ckeditor5-table/src/tabletoolbar';
 declare module '@ckeditor/ckeditor5-table/src/table';
 
 declare module '@ckeditor/ckeditor5-code-block/src/codeblock';
+
+declare module '@ckeditor/ckeditor5-basic-styles/src/code';


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable
  - [x] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?

none

#### What's this PR do?

add the Code text formatting plugin which allows creating inline code blocks w/in a line `like this` w/in ckeditor.

#### How should this be manually tested?

test that it works! should be able to save and re-open easily.

#### Screenshots (if appropriate)

<img width="1528" alt="Screen Shot 2022-03-16 at 9 34 08 AM" src="https://user-images.githubusercontent.com/6207644/158601641-3bc5a96e-2daa-42d6-9862-1ff1c07fdb7f.png">
