### PR TITLE
Tweak internal site search so "HST.<number>" returns results

### DIFF
--- a/websites/views.py
+++ b/websites/views.py
@@ -114,7 +114,7 @@ class WebsiteViewSet(
         if search is not None:
             # search query param is used in react-select typeahead, and should
             # match on the title, name, and short_id
-            search_filter = Q(search=SearchQuery(search))
+            search_filter = Q(search=SearchQuery(search)) | Q(search__icontains=search)
             if "." in search:
                 # postgres text search behaves oddly with periods but not dashes
                 search_filter = search_filter | Q(

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -393,6 +393,11 @@ def test_website_endpoint_search(drf_client):
         name="17-482-u-s-military-power-spring-2015",
         short_id="17.482-Spring-2015",
     ).save()
+    WebsiteFactory.create(
+        title="Biomedical Signal and Image Processing",
+        name="hst-582j-biomedical-signal-and-image-processing-spring-2007",
+        short_id="HST.582J-Spring-2007",
+    ).save()
     for word in ["Apple", "Bacon", "Cheese"]:
         resp = drf_client.get(reverse("websites_api-list"), {"search": word})
         assert [website["title"] for website in resp.data.get("results")] == ["Apple"]
@@ -405,6 +410,11 @@ def test_website_endpoint_search(drf_client):
         resp = drf_client.get(reverse("websites_api-list"), {"search": word})
         assert [website["title"] for website in resp.data.get("results")] == [
             "U.S. Military Power"
+        ]
+    for word in ["signal and image", "HsT.582", "hSt-582"]:
+        resp = drf_client.get(reverse("websites_api-list"), {"search": word})
+        assert [website["title"] for website in resp.data.get("results")] == [
+            "Biomedical Signal and Image Processing"
         ]
 
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes #1069 again

#### What's this PR do?
Postgres's full-text search is finicky and won't return results for "HST.582J", "hst-582j", etc.  So the search query was expanded to also include an OR `icontains` condition.

#### How should this be manually tested?
Read the issue description and make various searches for partial site names, short_ids, and titles.  If you have site `21m-380-music-and-technology-sound-design-spring-2016` imported, then searches for "21m-380", "21M.380", or "Music and Technology" should all return that course (and maybe a few others).

Also import site `hst-582j-biomedical-signal-and-image-processing-spring-2007` and make sure it shows up if searching for `hst-582`, 'hst.582'
