### PR TITLE
tolerate quotes around resource, resource_link uuids

### DIFF
--- a/static/js/lib/ckeditor/plugins/ResourceEmbed.test.tsx
+++ b/static/js/lib/ckeditor/plugins/ResourceEmbed.test.tsx
@@ -1,6 +1,6 @@
 import ResourceEmbed from "./ResourceEmbed"
 import Markdown from "./Markdown"
-import { createTestEditor, markdownTest } from "./test_util"
+import { createTestEditor, markdownTest, getConverters } from "./test_util"
 import { turndownService } from "../turndown"
 
 const getEditor = createTestEditor([ResourceEmbed, Markdown])
@@ -25,6 +25,16 @@ describe("ResourceEmbed plugin", () => {
     markdownTest(
       editor,
       "{{< resource asdfasdfasdfasdf >}}",
+      '<section data-uuid="asdfasdfasdfasdf"></section>'
+    )
+  })
+
+  it("should tolerate quotation marks around its argument", async () => {
+    const editor = await getEditor("")
+    // This conversion is not quite lossless. We lose the optional quotes around
+    // shortcode argument.
+    const { md2html } = getConverters(editor)
+    expect(md2html('{{< resource "asdfasdfasdfasdf" >}}')).toBe(
       '<section data-uuid="asdfasdfasdfasdf"></section>'
     )
   })

--- a/static/js/lib/ckeditor/plugins/ResourceEmbed.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceEmbed.ts
@@ -14,7 +14,7 @@ import {
   RESOURCE_EMBED_COMMAND
 } from "./constants"
 
-export const RESOURCE_SHORTCODE_REGEX = /{{< resource (\S+) >}}/g
+export const RESOURCE_SHORTCODE_REGEX = /{{< resource "?([^\s"]+)"? >}}/g
 
 /**
  * Class for defining Markdown conversion rules for ResourceEmbed

--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
@@ -25,7 +25,7 @@ const decodeShortcodeArgs = (encoded: string) =>
  *   - gets fooled by label texts that include literal `" %}}` values. For
  *     example, % resource_link uuid123 "silly " %}} link" %}}.
  */
-export const RESOURCE_LINK_SHORTCODE_REGEX = /{{% resource_link (\S+) "(.*?)"(?: "(.*?)")? %}}/g
+export const RESOURCE_LINK_SHORTCODE_REGEX = /{{% resource_link "?([^\s"]+)"? "(.*?)"(?: "(.*?)")? %}}/g
 
 /**
  * Class for defining Markdown conversion rules for Resource links

--- a/static/js/lib/ckeditor/plugins/test_util.ts
+++ b/static/js/lib/ckeditor/plugins/test_util.ts
@@ -14,6 +14,13 @@ export const createTestEditor = (plugins: any[]) => async (
   return editor
 }
 
+export function getConverters(editor: editor.Editor) {
+  const { md2html, html2md } = (editor.data
+    .processor as unknown) as MarkdownDataProcessor
+
+  return { md2html, html2md }
+}
+
 export function markdownTest(
   editor: editor.Editor,
   markdown: string,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
This is toward #1123 ... 

#### What's this PR do?
Hugo allows shortcode arguments to be double quoted (and requires it if the arguments contain whitespace). Our CKEditor resource and resource_link plugins previously required the uuid argument to **not** be quoted. This changes that so CKeditor will tolerate quotes around the uuid.

See https://github.com/mitodl/ocw-studio/pull/1137/files#r829391102 for motivation. 

#### How should this be manually tested?
1. Create and save resource / resource links in CKEditor and check that everything works as before.
2. Manually add some double quotes around the uuid argument in admin panel, and check that the markdown saves ok after editing. (The double quotes will be lost, but that's ok.)
