### PR TITLE
fix a small bug in the website search

### DIFF
--- a/static/js/hooks/websites.ts
+++ b/static/js/hooks/websites.ts
@@ -80,8 +80,6 @@ interface ReturnProps {
  * The hook returns two things, an array of `Option` objects which
  * can be directly used in a `Select` field and a `loadOptions` function
  * which can be used to fetch new options.
- *
- * Pass `fetchOnStartup = false` to skip fetching options on startup.
  */
 export function useWebsiteSelectOptions(
   valueField = "uuid",

--- a/websites/views.py
+++ b/websites/views.py
@@ -111,7 +111,7 @@ class WebsiteViewSet(
             # Other authenticated users should get a list of websites they are editors/admins/owners for.
             queryset = get_objects_for_user(user, constants.PERMISSION_VIEW)
 
-        if search is not None:
+        if search is not None and search != "":
             # search query param is used in react-select typeahead, and should
             # match on the title, name, and short_id
             search_filter = Q(search=SearchQuery(search))

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -408,6 +408,18 @@ def test_website_endpoint_search(drf_client):
         ]
 
 
+def test_website_endpoint_empty_search(drf_client):
+    """ should limit the queryset based on the search param """
+    superuser = UserFactory.create(is_superuser=True)
+    drf_client.force_login(superuser)
+    WebsiteFactory.create()
+    WebsiteFactory.create()
+    WebsiteFactory.create()
+    resp = drf_client.get(reverse("websites_api-list"), {"search": ""})
+    expected_uuids = sorted([site.uuid.__str__() for site in Website.objects.all()])
+    assert expected_uuids == sorted([site["uuid"] for site in resp.data["results"]])
+
+
 def test_websites_autogenerate_name(mocker, drf_client):
     """ Website POST endpoint should auto-generate a name if one is not supplied """
     mock_create_website_pipeline = mocker.patch(


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?

closes #1139

#### What's this PR do?

This changes the application of the `search` param on the website listing API.
Previously, it was filtering even if the search was `""`, which led to no
results being returned. This changes the behavior a little bit so that
filtering is only applied if the search string is _not_ `""`.

This has a nice side effect that the `WebsiteCollectionWidget` will be
populated w/ options when the user first clicks in to it.

#### How should this be manually tested?

Check that results are returned if you visit http://localhost:8043/api/websites/?limit=10&offset=0&published=true&search=

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)

This shows it in action:

https://user-images.githubusercontent.com/6207644/158882517-1b650410-06be-48aa-abab-2c9b28adb7bf.mov