### PR TITLE
changed italic delimiter to "*"

### DIFF
--- a/static/js/lib/ckeditor/plugins/TableMarkdownSyntax.test.tsx
+++ b/static/js/lib/ckeditor/plugins/TableMarkdownSyntax.test.tsx
@@ -30,7 +30,7 @@ describe("table shortcodes", () => {
     const editor = await getEditor("")
     markdownTest(
       editor,
-      "{{< tableopen >}}{{< tbodyopen >}}{{< tropen >}}{{< tdopen >}}\n\nmy _row_\n\n{{< tdclose >}}{{< trclose >}}{{< tbodyclose >}}{{< tableclose >}}",
+      "{{< tableopen >}}{{< tbodyopen >}}{{< tropen >}}{{< tdopen >}}\n\nmy *row*\n\n{{< tdclose >}}{{< trclose >}}{{< tbodyclose >}}{{< tableclose >}}",
       `<table>
         <tbody>
           <tr>
@@ -45,7 +45,7 @@ describe("table shortcodes", () => {
     const editor = await getEditor("")
     markdownTest(
       editor,
-      "{{< tableopen >}}{{< tbodyopen >}}{{< tropen >}}{{< tdopen >}}\n\n- foo\n- _bar_\n\n{{< tdclose >}}{{< tdopen >}}\n\n# Heading\n\n{{< tdclose >}}{{< trclose >}}{{< tbodyclose >}}{{< tableclose >}}",
+      "{{< tableopen >}}{{< tbodyopen >}}{{< tropen >}}{{< tdopen >}}\n\n- foo\n- *bar*\n\n{{< tdclose >}}{{< tdopen >}}\n\n# Heading\n\n{{< tdclose >}}{{< trclose >}}{{< tbodyclose >}}{{< tableclose >}}",
       `<table>
         <tbody>
           <tr>

--- a/static/js/lib/ckeditor/turndown.ts
+++ b/static/js/lib/ckeditor/turndown.ts
@@ -47,6 +47,10 @@ export function html2md(html: string): string {
 // the default is "*", which is strange
 turndownService.options.bulletListMarker = "-"
 
+// The default is "_", which causes issues with MathJax
+// Github issue for reference https://github.com/mitodl/ocw-hugo-themes/issues/501
+turndownService.options.emDelimiter = "*"
+
 // this is sort of a hack. Turndown marks certain nodes as "blank" and will
 // then ignore rules defined for them. What we do here is intercept the
 // handling of these 'blank' nodes so that we can use rules define for them if

--- a/static/js/test_constants.ts
+++ b/static/js/test_constants.ts
@@ -4,7 +4,7 @@ Amazing stuff! Paragraphs!
 
 And another paragraph!
 
-**bold** and even _ita**lic and bold** text_
+**bold** and even *ita**lic and bold** text*
 
 - a
 - list

--- a/static/js/test_constants.ts
+++ b/static/js/test_constants.ts
@@ -12,6 +12,7 @@ And another paragraph!
 - items
 - including
 - [links](https://reactjs.org/docs/hooks-faq.html#how-can-i-measure-a-dom-node)
+- Testing MathJax formulas with emphasis *dftT=μtT μtT*.
 
 also have some
 
@@ -30,6 +31,7 @@ export const TEST_HTML = `<h2 id="a-heading">A heading</h2>
 <li>items</li>
 <li>including</li>
 <li><a href="https://reactjs.org/docs/hooks-faq.html#how-can-i-measure-a-dom-node">links</a></li>
+<li>Testing MathJax formulas with emphasis  <em>dftT=μtT μtT</em>.</li>
 </ul>
 <p>also have some</p>
 <blockquote><p>block quotes</p></blockquote>


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Part of https://github.com/mitodl/ocw-hugo-themes/issues/501

#### What's this PR do?
Replaces italic delimiter from  '_' to '*' 

#### How should this be manually tested?
This PR can be tested by verifying the following
- Verify italics style works
- Verify it works in table
- Verify it works with mathjax formulas
- Verify it works with bold

#### Screenshots (if appropriate)
<img width="1036" alt="Screenshot 2022-03-21 at 7 08 51 PM" src="https://user-images.githubusercontent.com/87968618/159280260-fde43131-f481-476a-bf21-c11a5befce71.png">

