### PR TITLE
Fix gdrive import for ocw-www

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,9 +305,14 @@ be uploaded to Google Drive first, and then the "Sync w/Google Drive" button wil
 
 - Add the following to your .env file:
     ``` 
-    AWS_STORAGE_BUCKET_NAME: The S3 bucket to upload google drive files to.  Also populate AWS authentication settings.
+    AWS_STORAGE_BUCKET_NAME=The S3 bucket to upload google drive files to.  Also populate AWS authentication settings.
     DRIVE_SHARED_ID=The id of your Google Team Drive
     DRIVE_SERVICE_ACCOUNT_CREDS=The required Google service account credentials in JSON format.
     DRIVE_IMPORT_RECENT_FILES_SECONDS=Optional, default 3600. The frequency to check for new/updated files.
     DRIVE_UPLOADS_PARENT_FOLDER_ID=Optional, the folder id in the team drive where course folders should go.
    ```
+  
+- If your site configuration for resources has a non-standard field name for type, add the following to your .env file:
+    ``` 
+    RESOURCE_TYPE_FIELDS=resourcetype,filetype,<your_custom_field_name>
+    ```

--- a/app.json
+++ b/app.json
@@ -405,7 +405,7 @@
       "required": false
     },
     "RESOURCE_TYPE_FIELDS": {
-      "description": "List of site configuration resource fields that are used to store resource type",
+      "description": "List of site configuration fields that are used to store resource type",
       "required": false
     },
     "ROBOTS_CACHE_TIMEOUT": {

--- a/app.json
+++ b/app.json
@@ -266,12 +266,12 @@
       "description": "If false, disables the node_modules cache to fix yarn install",
       "value": "false"
     },
-    "OCW_IMPORT_STARTER_SLUG": {
-      "description": "The slug of the WebsiteStarter to assign to courses imported from ocw-to-hugo",
-      "required": false
-    },
     "OCW_GTM_ACCOUNT_ID": {
       "description": "The Google Tag Manager account ID to use in OCW site build pipelines",
+      "required": false
+    },
+    "OCW_IMPORT_STARTER_SLUG": {
+      "description": "The slug of the WebsiteStarter to assign to courses imported from ocw-to-hugo",
       "required": false
     },
     "OCW_NEXT_SEARCH_WEBHOOK_KEY": {
@@ -402,6 +402,10 @@
     },
     "REDIS_URL": {
       "description": "Redis URL for non-production use",
+      "required": false
+    },
+    "RESOURCE_TYPE_FIELDS": {
+      "description": "List of site configuration resource fields that are used to store resource type",
       "required": false
     },
     "ROBOTS_CACHE_TIMEOUT": {

--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -371,8 +371,11 @@ def create_gdrive_resource_content(drive_file: DriveFile):
                 metadata={
                     **SiteConfig(
                         drive_file.website.starter.config
-                    ).generate_item_metadata(CONTENT_TYPE_RESOURCE, cls=WebsiteContent),
-                    "resourcetype": resource_type,
+                    ).generate_item_metadata(
+                        CONTENT_TYPE_RESOURCE,
+                        cls=WebsiteContent,
+                        resource_type=resource_type,
+                    ),
                     "file_type": drive_file.mime_type,
                 },
             )

--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -360,6 +360,9 @@ def create_gdrive_resource_content(drive_file: DriveFile):
                     get_valid_base_filename(basename, CONTENT_TYPE_RESOURCE)
                 ),
             )
+            resource_type_fields = {
+                field: resource_type for field in settings.RESOURCE_TYPE_FIELDS
+            }
             resource = WebsiteContent.objects.create(
                 website=drive_file.website,
                 title=drive_file.name,
@@ -374,9 +377,9 @@ def create_gdrive_resource_content(drive_file: DriveFile):
                     ).generate_item_metadata(
                         CONTENT_TYPE_RESOURCE,
                         cls=WebsiteContent,
-                        resource_type=resource_type,
-                    ),
-                    "file_type": drive_file.mime_type,
+                        file_type=drive_file.mime_type,
+                        **resource_type_fields,
+                    )
                 },
             )
         else:

--- a/localdev/configs/basic-site-config.yml
+++ b/localdev/configs/basic-site-config.yml
@@ -34,3 +34,4 @@ collections:
       - {"label": "Title", "name": "title", "widget": "string", "required": true}
       - {"label": "Image", "name": "image", "widget": "file", "required": false}
       - {"label": "Resource Type", "name": "resourcetype", "widget": "select", "required": false}
+      - {"label": "File Type", "name": "file_type", "widget": "string", "required": false}

--- a/localdev/configs/basic-site-config.yml
+++ b/localdev/configs/basic-site-config.yml
@@ -33,3 +33,4 @@ collections:
     fields:
       - {"label": "Title", "name": "title", "widget": "string", "required": true}
       - {"label": "Image", "name": "image", "widget": "file", "required": false}
+      - {"label": "Resource Type", "name": "resourcetype", "widget": "select", "required": false}

--- a/main/settings.py
+++ b/main/settings.py
@@ -1072,3 +1072,8 @@ SEARCH_API_URL = get_string(
     default=None,
     description="The URL to open discussions search to inject into the theme assets build",
 )
+RESOURCE_TYPE_FIELDS = get_delimited_list(
+    name="RESOURCE_TYPE_FIELDS",
+    default=["resourcetype", "filetype"],
+    description="List of site configuration resource fields that are used to store resource type",
+)

--- a/main/settings.py
+++ b/main/settings.py
@@ -1075,5 +1075,5 @@ SEARCH_API_URL = get_string(
 RESOURCE_TYPE_FIELDS = get_delimited_list(
     name="RESOURCE_TYPE_FIELDS",
     default=["resourcetype", "filetype"],
-    description="List of site configuration resource fields that are used to store resource type",
+    description="List of site configuration fields that are used to store resource type",
 )

--- a/static/js/resources/basic-site-config.json
+++ b/static/js/resources/basic-site-config.json
@@ -64,6 +64,12 @@
           "name": "image",
           "required": false,
           "widget": "file"
+        },
+        {
+          "label": "Resource Type",
+          "name": "resourcetype",
+          "required": false,
+          "widget": "select"
         }
       ],
       "folder": "content/resource",

--- a/static/js/resources/basic-site-config.json
+++ b/static/js/resources/basic-site-config.json
@@ -70,6 +70,12 @@
           "name": "resourcetype",
           "required": false,
           "widget": "select"
+        },
+        {
+          "label": "File Type",
+          "name": "file_type",
+          "required": false,
+          "widget": "string"
         }
       ],
       "folder": "content/resource",

--- a/websites/site_config_api.py
+++ b/websites/site_config_api.py
@@ -118,7 +118,7 @@ class SiteConfig:
         return None
 
     def generate_item_metadata(
-        self, name: str, cls: object = None, resource_type=None
+        self, name: str, cls: object = None, resource_type: Optional[str] = None
     ) -> Dict:
         """Generate a metadata dict with blank keys for the specified item"""
         item_dict = {}

--- a/websites/site_config_api.py
+++ b/websites/site_config_api.py
@@ -4,7 +4,6 @@ from typing import Dict, Iterator, Optional
 
 from django.utils.functional import cached_property
 
-from main import settings
 from main.utils import remove_trailing_slashes
 from websites.constants import (
     WEBSITE_CONFIG_CONTENT_DIR_KEY,
@@ -117,9 +116,7 @@ class SiteConfig:
                 return config_item
         return None
 
-    def generate_item_metadata(
-        self, name: str, cls: object = None, resource_type: Optional[str] = None
-    ) -> Dict:
+    def generate_item_metadata(self, name: str, cls: object = None, **kwargs) -> Dict:
         """Generate a metadata dict with blank keys for the specified item"""
         item_dict = {}
         item = self.find_item_by_name(name)
@@ -133,8 +130,8 @@ class SiteConfig:
                 if subfields:
                     item_dict[key] = {}
                 else:
-                    if key in settings.RESOURCE_TYPE_FIELDS:
-                        value = resource_type or ""
+                    if key in kwargs:
+                        value = kwargs[key] or ""
                     else:
                         value = (
                             []

--- a/websites/site_config_api.py
+++ b/websites/site_config_api.py
@@ -4,6 +4,7 @@ from typing import Dict, Iterator, Optional
 
 from django.utils.functional import cached_property
 
+from main import settings
 from main.utils import remove_trailing_slashes
 from websites.constants import (
     WEBSITE_CONFIG_CONTENT_DIR_KEY,
@@ -116,7 +117,9 @@ class SiteConfig:
                 return config_item
         return None
 
-    def generate_item_metadata(self, name: str, cls: object = None) -> Dict:
+    def generate_item_metadata(
+        self, name: str, cls: object = None, resource_type=None
+    ) -> Dict:
         """Generate a metadata dict with blank keys for the specified item"""
         item_dict = {}
         item = self.find_item_by_name(name)
@@ -130,13 +133,20 @@ class SiteConfig:
                 if subfields:
                     item_dict[key] = {}
                 else:
-                    value = (
-                        [] if config_field.field.get("multiple", False) is True else ""
-                    )
+                    if key in settings.RESOURCE_TYPE_FIELDS:
+                        value = resource_type or ""
+                    else:
+                        value = (
+                            []
+                            if config_field.field.get("multiple", False) is True
+                            else ""
+                        )
                     if config_field.parent_field is None:
                         item_dict[key] = value
                     else:
-                        item_dict[config_field.parent_field["name"]][key] = value
+                        parent_field = config_field.parent_field["name"]
+                        item_dict[parent_field] = item_dict.get(parent_field, {})
+                        item_dict[parent_field][key] = value
         return item_dict
 
     def find_item_by_filepath(self, filepath: str) -> Optional[ConfigItem]:

--- a/websites/site_config_api_test.py
+++ b/websites/site_config_api_test.py
@@ -165,13 +165,14 @@ def test_find_file_field(basic_site_config, content_type, field_name):
 
 @pytest.mark.parametrize("cls", [None, WebsiteContent])
 @pytest.mark.parametrize("resource_type", [None, "Image"])
-def test_generate_item_metadata(parsed_site_config, cls, resource_type):
+@pytest.mark.parametrize("file_type", [None, "image/png"])
+def test_generate_item_metadata(parsed_site_config, cls, resource_type, file_type):
     """generate_item_metadata should return the expected dict"""
     class_data = {} if cls else {"title": "", "file": ""}
     expected_data = {
         "description": "",
         "resourcetype": resource_type or "",
-        "file_type": "",
+        "file_type": file_type or "",
         "learning_resource_types": [],
         "license": "",
         "image_metadata": {"image-alt": "", "caption": "", "credit": ""},
@@ -185,6 +186,8 @@ def test_generate_item_metadata(parsed_site_config, cls, resource_type):
     }
     site_config = SiteConfig(parsed_site_config)
     assert (
-        site_config.generate_item_metadata("resource", cls, resource_type=resource_type)
+        site_config.generate_item_metadata(
+            "resource", cls, resourcetype=resource_type, file_type=file_type
+        )
         == expected_data
     )

--- a/websites/site_config_api_test.py
+++ b/websites/site_config_api_test.py
@@ -166,13 +166,16 @@ def test_find_file_field(basic_site_config, content_type, field_name):
 @pytest.mark.parametrize("cls", [None, WebsiteContent])
 @pytest.mark.parametrize("resource_type", [None, "Image"])
 @pytest.mark.parametrize("file_type", [None, "image/png"])
-def test_generate_item_metadata(parsed_site_config, cls, resource_type, file_type):
+@pytest.mark.parametrize("with_kwargs", [True, False])
+def test_generate_item_metadata(
+    parsed_site_config, cls, resource_type, file_type, with_kwargs
+):
     """generate_item_metadata should return the expected dict"""
     class_data = {} if cls else {"title": "", "file": ""}
     expected_data = {
         "description": "",
-        "resourcetype": resource_type or "",
-        "file_type": file_type or "",
+        "resourcetype": (resource_type or "") if with_kwargs else "",
+        "file_type": (file_type or "") if with_kwargs else "",
         "learning_resource_types": [],
         "license": "",
         "image_metadata": {"image-alt": "", "caption": "", "credit": ""},
@@ -185,9 +188,9 @@ def test_generate_item_metadata(parsed_site_config, cls, resource_type, file_typ
         **class_data,
     }
     site_config = SiteConfig(parsed_site_config)
+    kwargs = (
+        {"resourcetype": resource_type, "file_type": file_type} if with_kwargs else {}
+    )
     assert (
-        site_config.generate_item_metadata(
-            "resource", cls, resourcetype=resource_type, file_type=file_type
-        )
-        == expected_data
+        site_config.generate_item_metadata("resource", cls, **kwargs) == expected_data
     )

--- a/websites/site_config_api_test.py
+++ b/websites/site_config_api_test.py
@@ -164,12 +164,13 @@ def test_find_file_field(basic_site_config, content_type, field_name):
 
 
 @pytest.mark.parametrize("cls", [None, WebsiteContent])
-def test_generate_item_metadata(parsed_site_config, cls):
+@pytest.mark.parametrize("resource_type", [None, "Image"])
+def test_generate_item_metadata(parsed_site_config, cls, resource_type):
     """generate_item_metadata should return the expected dict"""
     class_data = {} if cls else {"title": "", "file": ""}
     expected_data = {
         "description": "",
-        "resourcetype": "",
+        "resourcetype": resource_type or "",
         "file_type": "",
         "learning_resource_types": [],
         "license": "",
@@ -183,4 +184,7 @@ def test_generate_item_metadata(parsed_site_config, cls):
         **class_data,
     }
     site_config = SiteConfig(parsed_site_config)
-    assert site_config.generate_item_metadata("resource", cls) == expected_data
+    assert (
+        site_config.generate_item_metadata("resource", cls, resource_type=resource_type)
+        == expected_data
+    )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable

#### What are the relevant tickets?
Closes #943

#### What's this PR do?
Avoids a key error when generating item metadata for ocw-www resources.
Since the field stored to use resource type differs between ocw-course ("resourcetype") and ocw-www ("filetype") configs, added a new setting `RESOURCE_TYPE_FIELDS` which is a list of possible fields for this.  Alternatively, the configs could be made more consistent, but this seems like a simpler (and more flexible?) fix for now.

#### How should this be manually tested?
Copy `DRIVE_SERVICE_ACCOUNT_CREDS` and `DRIVE_SHARED_ID` from RC for settings.
Add an image or 2 to the gdrive folder for any ocw-course site as well as your ocw-www site.  
Sync the gdrive folder for each site. Both should work, and if you edit the new resource, it should have "Image" preselected as the resource/file type.  Also check the git repo for each and ensure that the new resource metadata looks good.
