### PR TITLE
remove image inacessible

### DIFF
--- a/websites/management/commands/markdown_cleaning/removal_rules.py
+++ b/websites/management/commands/markdown_cleaning/removal_rules.py
@@ -1,0 +1,20 @@
+from websites.management.commands.markdown_cleaning.cleanup_rule import (
+    RegexpCleanupRule,
+)
+
+
+class RemoveInaccesibleGif(RegexpCleanupRule):
+    """
+    Remove all instances of "![This resource may not render correctly in a screen reader.](/images/inacessible.gif)".
+    """
+
+    alias = "inaccessible"
+
+    # Yes, literally this. Period.
+    # Helpfully, inacessible is mispelled which makes it even more specific!.
+    regex = r"!\[This resource may not render correctly in a screen reader\.\]\(/images/inacessible\.gif\)"
+
+    fields = ["markdown", "metadata.optional_text", "metadata.related_resources_text"]
+
+    def replace_match(self, match, website_content) -> str:
+        return ""

--- a/websites/management/commands/markdown_cleanup.py
+++ b/websites/management/commands/markdown_cleanup.py
@@ -26,6 +26,9 @@ from websites.management.commands.markdown_cleaning.legacy_shortcodes_data_fix i
 from websites.management.commands.markdown_cleaning.metadata_relative_urls import (
     MetadataRelativeUrlsFix,
 )
+from websites.management.commands.markdown_cleaning.removal_rules import (
+    RemoveInaccesibleGif,
+)
 from websites.management.commands.markdown_cleaning.remove_extra_resource_args import (
     RemoveExtraResourceArgs,
 )
@@ -55,6 +58,7 @@ class Command(BaseCommand):
         ValidateUrls,
         ShortcodeLoggingRule,
         RemoveExtraResourceArgs,
+        RemoveInaccesibleGif,
     ]
 
     def add_arguments(self, parser: CommandParser) -> None:


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - ~[ ] Code is tested~ _I did not bother, because it's easy to test manually and this will be run exactly once, then we can remove it from the repo._
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1157#issue-1179600704

#### What's this PR do?
Remove all instances of
```
![This resource may not render correctly in a screen reader.](/images/inacessible.gif)
```
in OCW.

#### How should this be manually tested?
Run
```
docker-compose run --rm run web python manage.py markdown_cleanup inaccessible -o inaccessible.csv
```
To generate a CSV of changes that will be made by this command. Add `--commit` to commit the changes and sync to backend (github). Check that the text is replaced as expected.


#### What GIF best describes this PR or how it makes you feel?
`/images/inacessible.gif`
