### PR TITLE
Cc/rootrel with parentage

### DIFF
--- a/websites/management/commands/markdown_cleaning/link_parser.py
+++ b/websites/management/commands/markdown_cleaning/link_parser.py
@@ -1,5 +1,6 @@
 import json
 from dataclasses import dataclass, field
+from typing import Protocol
 
 from pyparsing import (
     CharsNotIn,
@@ -48,6 +49,11 @@ class MarkdownLink:
         prefix = "!" if self.is_image else ""
         title_suffix = " " + json.dumps(self.title) if self.title else ""
         return f"{prefix}[{self.text}]({self.destination}{title_suffix})"
+
+class LinkParseResult(Protocol):
+
+    link: MarkdownLink
+    original_text: str
 
 
 class LinkParser(WrappedParser):

--- a/websites/management/commands/markdown_cleaning/link_parser.py
+++ b/websites/management/commands/markdown_cleaning/link_parser.py
@@ -50,6 +50,7 @@ class MarkdownLink:
         title_suffix = " " + json.dumps(self.title) if self.title else ""
         return f"{prefix}[{self.text}]({self.destination}{title_suffix})"
 
+
 class LinkParseResult(Protocol):
 
     link: MarkdownLink

--- a/websites/management/commands/markdown_cleaning/link_parser.py
+++ b/websites/management/commands/markdown_cleaning/link_parser.py
@@ -1,4 +1,3 @@
-import json
 from dataclasses import dataclass, field
 from typing import Protocol
 
@@ -23,6 +22,7 @@ from websites.management.commands.markdown_cleaning.parsing_utils import (
     WrappedParser,
     restore_initial_default_whitespace_chars,
     unescape_quoted_string,
+    escape_double_quotes,
 )
 
 
@@ -47,7 +47,7 @@ class MarkdownLink:
     def to_markdown(self):
         """Generate markdown representation of this link/image."""
         prefix = "!" if self.is_image else ""
-        title_suffix = " " + json.dumps(self.title) if self.title else ""
+        title_suffix = f' "{escape_double_quotes(self.title)}"' if self.title else ""
         return f"{prefix}[{self.text}]({self.destination}{title_suffix})"
 
 

--- a/websites/management/commands/markdown_cleaning/link_parser.py
+++ b/websites/management/commands/markdown_cleaning/link_parser.py
@@ -20,9 +20,9 @@ from pyparsing import (
 
 from websites.management.commands.markdown_cleaning.parsing_utils import (
     WrappedParser,
+    escape_double_quotes,
     restore_initial_default_whitespace_chars,
     unescape_quoted_string,
-    escape_double_quotes,
 )
 
 

--- a/websites/management/commands/markdown_cleaning/parsing_utils.py
+++ b/websites/management/commands/markdown_cleaning/parsing_utils.py
@@ -72,12 +72,12 @@ class WrappedParser:
         return self.grammar.scanString(string)
 
 
-
 def escape_double_quotes(s: str):
     """Encase `s` in double quotes and escape double quotes within `s`."""
     return s.replace('"', '\\"')
 
-def unescape_string_quoted_with(text: str, single_quotes = False):
+
+def unescape_string_quoted_with(text: str, single_quotes=False):
     """
     Given a string encased in quotes of type `quote_char` and in which all
     interior instances of `quote_char` are escaped, strip the encasing instances
@@ -85,10 +85,12 @@ def unescape_string_quoted_with(text: str, single_quotes = False):
     """
     q = "'" if single_quotes else '"'
 
-    if f'\\\\{q}' in text:
-        raise NotImplementedError("Unescaping quoted strings in which backslashes precede quotes is not implemented.")
+    if f"\\\\{q}" in text:
+        raise NotImplementedError(
+            "Unescaping quoted strings in which backslashes precede quotes is not implemented."
+        )
 
-    all_escaped = text[1:-1].count(q) == text[1:-1].count(f'\\{q}')
+    all_escaped = text[1:-1].count(q) == text[1:-1].count(f"\\{q}")
     if text.startswith(q) and text.endswith(q) and all_escaped:
         return text[1:-1].replace(f"\\{q}", q)
 

--- a/websites/management/commands/markdown_cleaning/parsing_utils.py
+++ b/websites/management/commands/markdown_cleaning/parsing_utils.py
@@ -1,7 +1,7 @@
 import json
 from dataclasses import dataclass
-from uuid import UUID
 from typing import Union
+from uuid import UUID
 
 from pyparsing import ParserElement, ParseResults, originalTextFor
 

--- a/websites/management/commands/markdown_cleaning/parsing_utils.py
+++ b/websites/management/commands/markdown_cleaning/parsing_utils.py
@@ -1,6 +1,7 @@
 import json
 from dataclasses import dataclass
 from uuid import UUID
+from typing import Union
 
 from pyparsing import ParserElement, ParseResults, originalTextFor
 
@@ -190,10 +191,9 @@ class ShortcodeTag:
         return json.dumps(s)
 
     @classmethod
-    def resource_link(cls, uuid: UUID, text: str, fragment=""):
+    def resource_link(cls, uuid: Union[str, UUID], text: str, fragment=""):
         """Convenience method to create valid resource_link ShortcodeTag objects."""
-        if not isinstance(uuid, UUID):
-            raise ValueError("resource_link first argument must be valid uuid.")
+        cls.validate_uuid(uuid)
         args = [str(uuid), text]
         if fragment:
             args.append("#" + fragment)
@@ -205,8 +205,12 @@ class ShortcodeTag:
         )
 
     @classmethod
-    def resource(cls, uuid: UUID):
+    def resource(cls, uuid: Union[str, UUID]):
         """Convenience method to create valid resource_link ShortcodeTag objects."""
-        if not isinstance(uuid, UUID):
-            raise ValueError("resource first argument must be valid uuid.")
+        cls.validate_uuid(uuid)
         return cls(name="resource", percent_delimiters=False, args=[str(uuid)])
+
+    @staticmethod
+    def validate_uuid(uuid: Union[str, UUID]) -> None:
+        if not isinstance(uuid, UUID):
+            UUID(uuid)

--- a/websites/management/commands/markdown_cleaning/parsing_utils.py
+++ b/websites/management/commands/markdown_cleaning/parsing_utils.py
@@ -1,4 +1,3 @@
-import json
 from dataclasses import dataclass
 from typing import Union
 from uuid import UUID
@@ -73,73 +72,41 @@ class WrappedParser:
         return self.grammar.scanString(string)
 
 
-def standardize_title(s, l, toks):
-    text: str = toks[0]
-    if text.startswith("'") and text.endswith("'"):
-        double_quoted = (
-            text[1:-1]  # remove the outer single quote
-            .replace("\\'", "'")  # unescape single quotes
-            .replace('"', '\\"')  # escape double quotes
-        )
-        return json.loads(double_quoted)
-    elif text.startswith('"') and text.endswith('"'):
-        return json.loads(text[1:-1])
 
+def escape_double_quotes(s: str):
+    """Encase `s` in double quotes and escape double quotes within `s`."""
+    return s.replace('"', '\\"')
 
-def unescape_single_quoted_string(text: str):
+def unescape_string_quoted_with(text: str, single_quotes = False):
     """
-    Unescape quotes in a string that:
-        - is encased in single quotes
-        - in which all inner single quotes are backslash escaped
+    Given a string encased in quotes of type `quote_char` and in which all
+    interior instances of `quote_char` are escaped, strip the encasing instances
+    and unescape the interior instances.
     """
-    all_escaped = text[1:-1].count("'") == text[1:-1].count('\\"')
-    if text.startswith("'") and text.endswith("'") and all_escaped:
-        double_quoted = (
-            '"'
-            + (
-                text[1:-1]  # remove the outer single quote
-                .replace("\\'", "'")  # unescape single quotes
-                .replace('"', '\\"')  # escape double quotes
-            )
-            + '"'
-        )
-        try:
-            decoded = json.loads(double_quoted)
-            if isinstance(decoded, str):
-                return decoded
-        except json.decoder.JSONDecodeError:
-            pass
+    q = "'" if single_quotes else '"'
+
+    if f'\\\\{q}' in text:
+        raise NotImplementedError("Unescaping quoted strings in which backslashes precede quotes is not implemented.")
+
+    all_escaped = text[1:-1].count(q) == text[1:-1].count(f'\\{q}')
+    if text.startswith(q) and text.endswith(q) and all_escaped:
+        return text[1:-1].replace(f"\\{q}", q)
 
     raise ValueError(f"{text} is not a valid single-quoted string")
 
 
-def unescape_double_quoted_string(text: str):
-    """
-    Unescape quotes and backslashes in a string that:
-        - is encased in double quotes
-        - in which all inner double quotes are backslash escaped
-        - in which backslashes are backslash-escaped
-    """
-    try:
-        decoded = json.loads(text)
-        if isinstance(decoded, str):
-            return decoded
-    except json.decoder.JSONDecodeError as err:
-        raise ValueError(f"{text} is not a valid double-quoted string") from err
-
-
 def unescape_quoted_string(text: str):
     """
-    Unescape a quoted string. That:
+    Unescape a quoted string. That is:
         - if the string is single-quote-escaped, unescape all single quotes
         - if the string is double-quote-escaped, escape all double quotes
 
     Otherwise throws an error.
     """
     if text.startswith("'") and text.endswith("'"):
-        return unescape_single_quoted_string(text)
+        return unescape_string_quoted_with(text, True)
     else:
-        return unescape_double_quoted_string(text)
+        return unescape_string_quoted_with(text, False)
 
 
 @dataclass
@@ -188,7 +155,7 @@ class ShortcodeTag:
 
     @staticmethod
     def hugo_escape(s: str):
-        return json.dumps(s)
+        return f'"{escape_double_quotes(s)}"'
 
     @classmethod
     def resource_link(cls, uuid: Union[str, UUID], text: str, fragment=""):

--- a/websites/management/commands/markdown_cleaning/parsing_utils_test.py
+++ b/websites/management/commands/markdown_cleaning/parsing_utils_test.py
@@ -122,12 +122,10 @@ def test_unescape_quoted_string_raises_value_errors(bad_text):
     with pytest.raises(ValueError):
         assert unescape_quoted_string(bad_text)
 
+
 @pytest.mark.parametrize(
     "bad_text",
-    [
-        "' cat \\\\' dog '",
-        '" cat \\\\" dog "'
-    ],
+    ["' cat \\\\' dog '", '" cat \\\\" dog "'],
 )
 def test_unescape_quoted_string_raises_not_implemented_errors(bad_text):
     with pytest.raises(NotImplementedError):

--- a/websites/management/commands/markdown_cleaning/parsing_utils_test.py
+++ b/websites/management/commands/markdown_cleaning/parsing_utils_test.py
@@ -91,13 +91,13 @@ def test_original_text_records_during_transform_text():
     [
         (R'''"cats \"and\" 'dogs' are cool."''', R"""cats "and" 'dogs' are cool."""),
         (
-            R'''"backslashes \\\" are \\ ok"''',
-            R"""backslashes \" are \ ok""",
+            R'''"special characters « and backslashes \ \" are \ ok"''',
+            R"""special characters « and backslashes \ " are \ ok""",
         ),
         (R"""'cats \'and\' "dogs" are cool.'""", R"""cats 'and' "dogs" are cool."""),
         (
-            R"""'backslashes \\\' are \\ ok'""",
-            R"""backslashes \' are \ ok""",
+            R"""'special characters « and backslashes \ \' are \ ok'""",
+            R"""special characters « and backslashes \ ' are \ ok""",
         ),
     ],
 )
@@ -118,8 +118,19 @@ def test_unescape_quoted_string(escaped, unescaped):
         "'missing 'escapes' so sad '",
     ],
 )
-def test_unescape_quoted_string(bad_text):
+def test_unescape_quoted_string_raises_value_errors(bad_text):
     with pytest.raises(ValueError):
+        assert unescape_quoted_string(bad_text)
+
+@pytest.mark.parametrize(
+    "bad_text",
+    [
+        "' cat \\\\' dog '",
+        '" cat \\\\" dog "'
+    ],
+)
+def test_unescape_quoted_string_raises_not_implemented_errors(bad_text):
+    with pytest.raises(NotImplementedError):
         assert unescape_quoted_string(bad_text)
 
 
@@ -147,6 +158,7 @@ def test_shortcode(closer, percent_delimiters, expected):
     [
         ([], R"{{< meow >}}"),
         (["abc", "x y  z", 'f "g" h'], R'{{< meow "abc" "x y  z" "f \"g\" h" >}}'),
+        (["Previous «« cool"], R'{{< meow "Previous «« cool" >}}'),
     ],
 )
 def test_shortcode_serialization(shortcode_args, expected):

--- a/websites/management/commands/markdown_cleaning/rootrelative_urls.py
+++ b/websites/management/commands/markdown_cleaning/rootrelative_urls.py
@@ -153,8 +153,7 @@ class RootRelativeUrlRule(RegexpCleanupRule):
             pass
 
         try:
-            _, legacy_filename = os.path.split(site_rel_path)
-            match = self.legacy_file_lookup.find(site.uuid, legacy_filename)
+            match = self.legacy_file_lookup.find(site.uuid, site_rel_path)
             return match, "unique file match"
         except self.legacy_file_lookup.MultipleMatchError as error:
             raise self.NotFoundError(error)

--- a/websites/management/commands/markdown_cleaning/rootrelative_urls.py
+++ b/websites/management/commands/markdown_cleaning/rootrelative_urls.py
@@ -100,6 +100,14 @@ class RootRelativeUrlRule(RegexpCleanupRule):
         except KeyError:
             pass
 
+        if any(p == site_rel_path for p in ['/pages/index.htm', '/index.htm']):
+            try:
+                wc = self.content_lookup.find_within_site(site.uuid, '/')
+                return wc, "links to course root"
+            except KeyError:
+                pass
+
+
         try:
             prepend = "/pages"
             wc = self.content_lookup.find_within_site(

--- a/websites/management/commands/markdown_cleaning/rootrelative_urls_test.py
+++ b/websites/management/commands/markdown_cleaning/rootrelative_urls_test.py
@@ -10,9 +10,9 @@ from websites.management.commands.markdown_cleaning.rootrelative_urls import (
     RootRelativeUrlRule,
 )
 from websites.management.commands.markdown_cleaning.testing_utils import (
+    allow_invalid_shortcode_uuids,
     patch_website_all,
     patch_website_contents_all,
-    allow_invalid_shortcode_uuids
 )
 
 

--- a/websites/management/commands/markdown_cleaning/rootrelative_urls_test.py
+++ b/websites/management/commands/markdown_cleaning/rootrelative_urls_test.py
@@ -12,6 +12,7 @@ from websites.management.commands.markdown_cleaning.rootrelative_urls import (
 from websites.management.commands.markdown_cleaning.testing_utils import (
     patch_website_all,
     patch_website_contents_all,
+    allow_invalid_shortcode_uuids
 )
 
 
@@ -33,18 +34,18 @@ def get_markdown_cleaner(websites, website_contents):
         (
             "site_one",
             R"A link to [same course](/courses/site_one/pages/stuff/page1) goes to resource_link",
-            R'A link to {{% resource_link uuid-1 "same course" %}} goes to resource_link',
+            R'A link to {{% resource_link "uuid-1" "same course" %}} goes to resource_link',
         ),
         # finds correct content even though "some_department"
         (
             "site_one",
             R"A link to [same course](/courses/some_department/site_one/pages/stuff/page1) goes to resource_link",
-            R'A link to {{% resource_link uuid-1 "same course" %}} goes to resource_link',
+            R'A link to {{% resource_link "uuid-1" "same course" %}} goes to resource_link',
         ),
         (
             "site_one",
             R"A link to [same course](/courses/some_department/site_one/pages/stuff/page1#some-fragment) goes to resource_link",
-            R'A link to {{% resource_link uuid-1 "same course" "#some-fragment" %}} goes to resource_link',
+            R'A link to {{% resource_link "uuid-1" "same course" "#some-fragment" %}} goes to resource_link',
         ),
         (
             "site_two",
@@ -64,6 +65,7 @@ def get_markdown_cleaner(websites, website_contents):
         ),
     ],
 )
+@allow_invalid_shortcode_uuids()
 def test_rootrel_rule_only_uses_resource_lines_for_same_site(
     markdown, site_name, expected_markdown
 ):
@@ -90,17 +92,17 @@ def test_rootrel_rule_only_uses_resource_lines_for_same_site(
         (
             "site_one",
             R"A link to [same course](/courses/department/site_one/) goes to resource_link",
-            R'A link to {{% resource_link uuid-1 "same course" %}} goes to resource_link',
+            R'A link to {{% resource_link "uuid-1" "same course" %}} goes to resource_link',
         ),
         (  # no trailing slash in link
             "site_one",
             R"A link to [same course](/courses/department/site_one) goes to resource_link",
-            R'A link to {{% resource_link uuid-1 "same course" %}} goes to resource_link',
+            R'A link to {{% resource_link "uuid-1" "same course" %}} goes to resource_link',
         ),
         (  # no trailing slash in link
             "site_one",
             R"A link to [same course](/courses/department/site_one#a-b-c) goes to resource_link",
-            R'A link to {{% resource_link uuid-1 "same course" "#a-b-c" %}} goes to resource_link',
+            R'A link to {{% resource_link "uuid-1" "same course" "#a-b-c" %}} goes to resource_link',
         ),
         (
             "site_two",
@@ -119,6 +121,7 @@ def test_rootrel_rule_only_uses_resource_lines_for_same_site(
         ),
     ],
 )
+@allow_invalid_shortcode_uuids()
 def test_rootrel_rule_handles_site_homeages_correctly(
     markdown, site_name, expected_markdown
 ):
@@ -144,7 +147,7 @@ def test_rootrel_rule_handles_site_homeages_correctly(
         (
             "site_one",
             R"cool image ![alt text here](/courses/dep/site_one/blah/old_image_filename123.jpg) cool ",
-            R"cool image {{< resource uuid-1 >}} cool ",
+            R'cool image {{< resource "uuid-1" >}} cool ',
         ),
         (  # Do not change cross-site images. They would need the AWS file...
             "site_two",
@@ -153,6 +156,7 @@ def test_rootrel_rule_handles_site_homeages_correctly(
         ),
     ],
 )
+@allow_invalid_shortcode_uuids()
 def test_rootrel_rule_uses_images_for_image(markdown, site_name, expected_markdown):
     w1 = WebsiteFactory.build(name="site_one")
     w2 = WebsiteFactory.build(name="site_two")

--- a/websites/management/commands/markdown_cleaning/testing_utils.py
+++ b/websites/management/commands/markdown_cleaning/testing_utils.py
@@ -1,8 +1,8 @@
 from contextlib import contextmanager
 from unittest.mock import patch
-from websites.management.commands.markdown_cleaning.parsing_utils import (
-    ShortcodeTag
-)
+
+from websites.management.commands.markdown_cleaning.parsing_utils import ShortcodeTag
+
 
 @contextmanager
 def patch_website_contents_all(website_contents):
@@ -17,7 +17,8 @@ def patch_website_all(websites):
         mock.return_value = websites
         yield mock
 
+
 @contextmanager
 def allow_invalid_shortcode_uuids():
-    with patch.object(ShortcodeTag, 'validate_uuid'):
+    with patch.object(ShortcodeTag, "validate_uuid"):
         yield

--- a/websites/management/commands/markdown_cleaning/testing_utils.py
+++ b/websites/management/commands/markdown_cleaning/testing_utils.py
@@ -1,6 +1,8 @@
 from contextlib import contextmanager
 from unittest.mock import patch
-
+from websites.management.commands.markdown_cleaning.parsing_utils import (
+    ShortcodeTag
+)
 
 @contextmanager
 def patch_website_contents_all(website_contents):
@@ -14,3 +16,8 @@ def patch_website_all(websites):
     with patch("websites.models.Website.objects.all") as mock:
         mock.return_value = websites
         yield mock
+
+@contextmanager
+def allow_invalid_shortcode_uuids():
+    with patch.object(ShortcodeTag, 'validate_uuid'):
+        yield

--- a/websites/management/commands/markdown_cleaning/utils.py
+++ b/websites/management/commands/markdown_cleaning/utils.py
@@ -172,14 +172,16 @@ class LegacyFileLookup:
             dirpath="content/resources",
         )
 
-    NOTE: 
+    NOTE:
     """
 
     class MultipleMatchError(Exception):
         pass
 
     def __init__(self):
-        website_contents = WebsiteContent.all_objects.all().prefetch_related("website", "parent")
+        website_contents = WebsiteContent.all_objects.all().prefetch_related(
+            "website", "parent"
+        )
         contents_by_file = defaultdict(list)
         for wc in website_contents:
             if wc.file:
@@ -225,7 +227,7 @@ class LegacyFileLookup:
             - website_id: uuid of site in which content should exist
             - legacy_site_rel_path: legacy site relative path, i.e., the portion
                 of the legacy url after the site name.
-        
+
         The match between legacy_site_rel_path and content objects is
         performed primarily based on the `file` property. We use `file` NOT
         dirpath + filename because
@@ -245,12 +247,12 @@ class LegacyFileLookup:
         The corresponding `legacy_site_rel_path`s are:
             /lecture-notes/cdffit.m
             /assignments/cdffit.m
-        
+
         The corresponding OCW-Next content objects have:
-            file                    filename        dirpath           
-            .../uuid1_cdffit.m      cdffit-1        content/resources  
+            file                    filename        dirpath
+            .../uuid1_cdffit.m      cdffit-1        content/resources
             .../uuid2_cdffit.m      cdffit          content/resources
-        
+
         Looking only at these two content objects, we can't decide which one
         goes with `/assignments/cdffit.m` vs `/lecture-notes/cdffit.m`.(The
         beginning portion of `file` contains no useful information.)
@@ -259,8 +261,8 @@ class LegacyFileLookup:
         to look at the parent objects, too:
 
         The corresponding OCW-Next content objects have:
-            file                    filename        dirpath             parent_filename  parent_dirpath 
-            .../uuid1_cdffit.m      cdffit-1        content/resources   assignments      content/pages  
+            file                    filename        dirpath             parent_filename  parent_dirpath
+            .../uuid1_cdffit.m      cdffit-1        content/resources   assignments      content/pages
             .../uuid2_cdffit.m      cdffit          content/resources   lecture-notes    content/pages
         """
         url_dirpath, legacy_filename = os.path.split(legacy_site_rel_path)
@@ -268,11 +270,11 @@ class LegacyFileLookup:
         matches = self.contents_by_file[key]
         if len(matches) == 1:
             return matches[0]
-        
+
         def parent_matches_url(wc):
             if wc.parent is None:
                 return False
-            return url_dirpath in wc.parent.dirpath + '/' + wc.parent.filename
+            return url_dirpath in wc.parent.dirpath + "/" + wc.parent.filename
 
         refined = [m for m in matches if parent_matches_url(m)]
         if len(refined) == 1:

--- a/websites/management/commands/markdown_cleaning/utils_test.py
+++ b/websites/management/commands/markdown_cleaning/utils_test.py
@@ -191,14 +191,14 @@ def test_url_site_relativiser_raises_value_errors():
 
 
 @pytest.mark.parametrize(
-    ["site_uuid", "filename", "expected_index"],
+    ["site_uuid", "legacy_site_relative_url", "expected_index"],
     [
-        ("site-uuid-one", "someFileName.jpg", 0),
-        ("site-uuid-one", "somefilename.jpg", 1),
-        ("site-uuid-two", "someFileName.jpg", 2),
+        ("site-uuid-one", "/site/pages/someFileName.jpg", 0),
+        ("site-uuid-one", "/site/pages/things/somefilename.jpg", 1),
+        ("site-uuid-two", "/site/woofs/someFileName.jpg", 2),
     ],
 )
-def test_legacy_file_lookup(site_uuid, filename, expected_index):
+def test_legacy_file_lookup(site_uuid, legacy_site_relative_url, expected_index):
     c1a = WebsiteContentFactory.build(
         website_id="site-uuid-one",
         file=f"/courses/site_one/{string_uuid()}_someFileName.jpg",
@@ -218,7 +218,7 @@ def test_legacy_file_lookup(site_uuid, filename, expected_index):
     expected = contents[expected_index]
     with patch_website_contents_all(contents):
         legacy_file_lookup = LegacyFileLookup()
-        assert legacy_file_lookup.find(site_uuid, filename) == expected
+        assert legacy_file_lookup.find(site_uuid, legacy_site_relative_url) == expected
 
 
 def test_legacy_file_lookup_nonunique_filenames():

--- a/websites/management/commands/markdown_cleaning/utils_test.py
+++ b/websites/management/commands/markdown_cleaning/utils_test.py
@@ -222,35 +222,35 @@ def test_legacy_file_lookup(site_uuid, legacy_site_relative_url, expected_index)
 
 
 def test_legacy_file_lookup_nonunique_filenames():
-    website = WebsiteFactory.build(uuid='site-uuid-one')
+    website = WebsiteFactory.build(uuid="site-uuid-one")
     parent_a = WebsiteContentFactory.build(
         website=website,
-        filename='alpha',
-        dirpath='content/pages/parent',
+        filename="alpha",
+        dirpath="content/pages/parent",
     )
     parent_b = WebsiteContentFactory.build(
         website=website,
-        filename='beta',
-        dirpath='content/pages/parent',
+        filename="beta",
+        dirpath="content/pages/parent",
     )
     c1a = WebsiteContentFactory.build(
         website=website,
         file=f"/courses/site_one/{string_uuid()}_some_file_name.jpg",
         text_id="content-uuid-1",
-        parent=parent_a
+        parent=parent_a,
     )
     c1b = WebsiteContentFactory.build(
         website=website,
         file=f"/courses/site_one/{string_uuid()}_some_file_name.jpg",
         text_id="content-uuid-2",
-        parent=parent_b
+        parent=parent_b,
     )
     contents = [c1a, c1b, parent_a, parent_b]
     with patch_website_contents_all(contents):
         legacy_file_lookup = LegacyFileLookup()
 
-        unique_parent_url = 'parent/alpha/some_file_name.jpg'
-        duplicate_parent_url = 'parent/some_file_name.jpg' 
+        unique_parent_url = "parent/alpha/some_file_name.jpg"
+        duplicate_parent_url = "parent/some_file_name.jpg"
         assert legacy_file_lookup.find(website.uuid, unique_parent_url) == c1a
         with pytest.raises(legacy_file_lookup.MultipleMatchError):
             assert legacy_file_lookup.find(website.uuid, duplicate_parent_url)

--- a/websites/management/commands/markdown_cleaning/validate_urls.py
+++ b/websites/management/commands/markdown_cleaning/validate_urls.py
@@ -43,7 +43,7 @@ class ValidateUrls(RegexpCleanupRule):
         link_type: str
         url_path: str
         links_to_course: str = ""
-        broken_best_guess: str = 'Yes'
+        broken_best_guess: str = "Yes"
 
     def __init__(self) -> None:
         super().__init__()
@@ -53,8 +53,8 @@ class ValidateUrls(RegexpCleanupRule):
         url = urlparse(match.group("url"))
         original_text = match[0]
         notes = partial(self.ReplacementNotes, url_path=url.path)
-        note_works = partial(notes, broken_best_guess='No')
-        note_broken = partial(notes, broken_best_guess='Yes')
+        note_works = partial(notes, broken_best_guess="No")
+        note_broken = partial(notes, broken_best_guess="Yes")
 
         if url.scheme.startswith("http"):
             return original_text, note_works(link_type="external link")
@@ -68,49 +68,58 @@ class ValidateUrls(RegexpCleanupRule):
             try:
                 linked_content = self.content_lookup.find(url.path)
                 return original_text, note_works(
-                    link_type="course content", links_to_course=linked_content.website.name
+                    link_type="course content",
+                    links_to_course=linked_content.website.name,
                 )
             except KeyError:
                 pass
-            
-            if url.path.endswith('_index.html'):
+
+            if url.path.endswith("_index.html"):
                 return original_text, note_broken("Fix underway: _index.html")
 
-        if url.path.lstrip('/').startswith('course') and '.' in url.path[-8:]:
+        if url.path.lstrip("/").startswith("course") and "." in url.path[-8:]:
             return original_text, note_broken("Fix underway: File issue")
-        if url.path.lstrip('/').startswith('resource') and '.' in url.path[-8:]:
+        if url.path.lstrip("/").startswith("resource") and "." in url.path[-8:]:
             return original_text, note_broken("Fix underway: File issue")
 
-        if url.path == '':
-            return original_text, note_works('within-page link')
+        if url.path == "":
+            return original_text, note_works("within-page link")
 
-        if 'resolveuid' in url.path:
+        if "resolveuid" in url.path:
             return original_text, note_broken("resolveuid link")
-        if 'images/inacessible' in url.path:
+        if "images/inacessible" in url.path:
             return original_text, note_broken("image/inaccessible")
-        if 'icon-question' in url.path:
+        if "icon-question" in url.path:
             return original_text, note_broken("icon-question")
-        if 'images/trans.gif' in url.path:
+        if "images/trans.gif" in url.path:
             return original_text, note_broken("images/trans.gif")
-        if 'mp_logo' in url.path:
+        if "mp_logo" in url.path:
             return original_text, note_broken("mit_press_logo")
-        if 'faq-technical-requirements' in url.path:
-            return original_text, note_broken('faq-technical-requirements (https://ocw.mit.edu/help/faq-technical-requirements/)')
-        if 'fair-use' in url.path or 'fairuse' in url.path:
-            return original_text, note_broken("fairuse (https://ocw.mit.edu/help/faq-fair-use/)")
-        if url.path.rstrip('/').endswith('/terms'):
+        if "faq-technical-requirements" in url.path:
+            return original_text, note_broken(
+                "faq-technical-requirements (https://ocw.mit.edu/help/faq-technical-requirements/)"
+            )
+        if "fair-use" in url.path or "fairuse" in url.path:
+            return original_text, note_broken(
+                "fairuse (https://ocw.mit.edu/help/faq-fair-use/)"
+            )
+        if url.path.rstrip("/").endswith("/terms"):
             return original_text, note_broken("terms (https://ocw.mit.edu/terms/)")
-        if 'images/educator/edu_' in url.path:
-            return original_text, note_broken('image/educate/edu_ ... used for "Semester Breakdown" on https://ocw.mit.edu/courses/sloan-school-of-management/15-279-management-communication-for-undergraduates-fall-2012/instructor-insights/')
-        if url.path.startswith('/ans7870'):
+        if "images/educator/edu_" in url.path:
+            return original_text, note_broken(
+                'image/educate/edu_ ... used for "Semester Breakdown" on https://ocw.mit.edu/courses/sloan-school-of-management/15-279-management-communication-for-undergraduates-fall-2012/instructor-insights/'
+            )
+        if url.path.startswith("/ans7870"):
             return original_text, note_broken("/ans7870 (TODO: investigate)")
-        if url.path.startswith('/20-219IAP15'):
-            return original_text, note_broken('/20-219IAP15 ... (redirects https://ocw.mit.edu/courses/biological-engineering/20-219-becoming-the-next-bill-nye-writing-and-hosting-the-educational-show-january-iap-2015/) ')
-        if url.path == '/images/a_logo_17.gif':
-            return original_text, note_broken('/images/a_logo_17.gif')
-        if url.path.endswith('button_start.png'):
-            return original_text, note_broken('button_start.png')
-        if 'images/educator/classroom_' in url.path:
-            return original_text, note_broken('images/educator/classroom_')
+        if url.path.startswith("/20-219IAP15"):
+            return original_text, note_broken(
+                "/20-219IAP15 ... (redirects https://ocw.mit.edu/courses/biological-engineering/20-219-becoming-the-next-bill-nye-writing-and-hosting-the-educational-show-january-iap-2015/) "
+            )
+        if url.path == "/images/a_logo_17.gif":
+            return original_text, note_broken("/images/a_logo_17.gif")
+        if url.path.endswith("button_start.png"):
+            return original_text, note_broken("button_start.png")
+        if "images/educator/classroom_" in url.path:
+            return original_text, note_broken("images/educator/classroom_")
 
-        return original_text, note_broken('Unknown')
+        return original_text, note_broken("Unknown")

--- a/websites/management/commands/markdown_cleaning/validate_urls.py
+++ b/websites/management/commands/markdown_cleaning/validate_urls.py
@@ -43,6 +43,7 @@ class ValidateUrls(RegexpCleanupRule):
         link_type: str
         url_path: str
         links_to_course: str = ""
+        broken_best_guess: str = 'Yes'
 
     def __init__(self) -> None:
         super().__init__()
@@ -52,17 +53,64 @@ class ValidateUrls(RegexpCleanupRule):
         url = urlparse(match.group("url"))
         original_text = match[0]
         notes = partial(self.ReplacementNotes, url_path=url.path)
+        note_works = partial(notes, broken_best_guess='No')
+        note_broken = partial(notes, broken_best_guess='Yes')
 
         if url.scheme.startswith("http"):
-            return original_text, notes(link_type="global link")
+            return original_text, note_works(link_type="external link")
+        if url.scheme.startswith("ftp"):
+            return original_text, note_works(link_type="ftp")
+        if url.scheme.startswith("mailto"):
+            return original_text, note_works(link_type="mailto")
 
-        if not url.path.startswith("/courses"):
-            return original_text, notes(link_type="not course link")
+        if url.path.startswith("/courses"):
 
-        try:
-            linked_content = self.content_lookup.find(url.path)
-            return original_text, notes(
-                link_type="course link", links_to_course=linked_content.website.name
-            )
-        except KeyError:
-            return original_text, notes(link_type="content not found")
+            try:
+                linked_content = self.content_lookup.find(url.path)
+                return original_text, note_works(
+                    link_type="course content", links_to_course=linked_content.website.name
+                )
+            except KeyError:
+                pass
+            
+            if url.path.endswith('_index.html'):
+                return original_text, note_broken("Fix underway: _index.html")
+
+        if url.path.lstrip('/').startswith('course') and '.' in url.path[-8:]:
+            return original_text, note_broken("Fix underway: File issue")
+        if url.path.lstrip('/').startswith('resource') and '.' in url.path[-8:]:
+            return original_text, note_broken("Fix underway: File issue")
+
+        if url.path == '':
+            return original_text, note_works('within-page link')
+
+        if 'resolveuid' in url.path:
+            return original_text, note_broken("resolveuid link")
+        if 'images/inacessible' in url.path:
+            return original_text, note_broken("image/inaccessible")
+        if 'icon-question' in url.path:
+            return original_text, note_broken("icon-question")
+        if 'images/trans.gif' in url.path:
+            return original_text, note_broken("images/trans.gif")
+        if 'mp_logo' in url.path:
+            return original_text, note_broken("mit_press_logo")
+        if 'faq-technical-requirements' in url.path:
+            return original_text, note_broken('faq-technical-requirements (https://ocw.mit.edu/help/faq-technical-requirements/)')
+        if 'fair-use' in url.path or 'fairuse' in url.path:
+            return original_text, note_broken("fairuse (https://ocw.mit.edu/help/faq-fair-use/)")
+        if url.path.rstrip('/').endswith('/terms'):
+            return original_text, note_broken("terms (https://ocw.mit.edu/terms/)")
+        if 'images/educator/edu_' in url.path:
+            return original_text, note_broken('image/educate/edu_ ... used for "Semester Breakdown" on https://ocw.mit.edu/courses/sloan-school-of-management/15-279-management-communication-for-undergraduates-fall-2012/instructor-insights/')
+        if url.path.startswith('/ans7870'):
+            return original_text, note_broken("/ans7870 (TODO: investigate)")
+        if url.path.startswith('/20-219IAP15'):
+            return original_text, note_broken('/20-219IAP15 ... (redirects https://ocw.mit.edu/courses/biological-engineering/20-219-becoming-the-next-bill-nye-writing-and-hosting-the-educational-show-january-iap-2015/) ')
+        if url.path == '/images/a_logo_17.gif':
+            return original_text, note_broken('/images/a_logo_17.gif')
+        if url.path.endswith('button_start.png'):
+            return original_text, note_broken('button_start.png')
+        if 'images/educator/classroom_' in url.path:
+            return original_text, note_broken('images/educator/classroom_')
+
+        return original_text, note_broken('Unknown')

--- a/websites/management/commands/markdown_cleanup.py
+++ b/websites/management/commands/markdown_cleanup.py
@@ -156,7 +156,10 @@ class Command(BaseCommand):
         cleaner = WebsiteContentMarkdownCleaner(rule)
 
         all_wc = (
-            WebsiteContent.all_objects.all().exclude(website__publish_date__isnull=True).order_by("id").prefetch_related("website")
+            WebsiteContent.all_objects.all()
+            .exclude(website__publish_date__isnull=True)
+            .order_by("id")
+            .prefetch_related("website")
         )
         page_size = 100
         pages = Paginator(all_wc, page_size)

--- a/websites/management/commands/markdown_cleanup.py
+++ b/websites/management/commands/markdown_cleanup.py
@@ -50,7 +50,9 @@ from websites.models import WebsiteContent
 
 class Command(BaseCommand):
     """
-    Performs regex replacements on markdown and updates checksums.
+    Performs regex replacements on markdown.
+
+    Excludes unpublished websites.
     """
 
     help = __doc__
@@ -154,7 +156,7 @@ class Command(BaseCommand):
         cleaner = WebsiteContentMarkdownCleaner(rule)
 
         all_wc = (
-            WebsiteContent.all_objects.all().order_by("id").prefetch_related("website")
+            WebsiteContent.all_objects.all().exclude(website__publish_date__isnull=True).order_by("id").prefetch_related("website")
         )
         page_size = 100
         pages = Paginator(all_wc, page_size)
@@ -162,6 +164,7 @@ class Command(BaseCommand):
         with tqdm(total=pages.count) as progress:
             for page in pages:
                 for wc in page:
+
                     updated = cleaner.update_website_content(wc)
                     if updated and commit:
                         wc.save()


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets? https://github.com/mitodl/ocw-studio/issues/1145

#### What's this PR do?
This PR:
- converts `markdown_cleanup rootrel_urls` to use the link parser introduced in #1154 
- changes `markdown_cleanup` management command to skip courses that have *never* been published.
- fix legacy links that link to files with duplicate legacy filenames (the main point of this PR)

#### How should this be manually tested?
1. First, populate `parent_uid`: `docker-compose run --rm web python manage.py overwrite_ocw_course_content --bucket ocw-to-hugo-output-qa --content-field="metadata.parent_uid"` which is needed for this command. See https://github.com/mitodl/ocw-studio/pull/1165/files#diff-c9f4154e325d48a617e2879b73236a5462ed6baa7aa2d2d6503b9106526b8e54R239

    *Note: This populates `metadata.parent_uid` AND sets the `parent_id` FK on WebsiteContent objects, see #1115*
3. Run `docker-compose run --rm web python manage.py markdown_cleanup rootrelative_urls -o rootrel.csv --csv-only-changes` to generate a list of changes that will be made when the command is run in `--comit` mode. Inspect list to makes ure it's reason / links work.

Optionally, run the command in `--commit mode` or without `--csv-only-changes`. If you run the command without `--csv-only-changes`, then the generated CSV will include ALL links on pages that contain ANY rootrelative links. This means that the CSV includes more than just "changes that will be made". In particular, it includes:
1. changes to be made, i.e., rows where `original_text != replacement`. 
2. rows that have not changed, i.e.,`original_text = replacement`. These rows might not have changed for a variety of reasons:
    - the corresponding root-relative links were not broke
    - the corresponding root-relative link was broken but could not be fixed _There are not too many of these_
    - the corresponding link was not a rootrelative link, but was on the same page as a rootrelative link

