### PR TITLE
Get gdrive file body via the google drive api and stream that to s3

### DIFF
--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -63,7 +63,7 @@ class GDriveStreamReader:
         """Read and return the next chunk of bytes from the GDrive file"""
         if amount:
             # Make sure the chunksize is the same as what's requested by boto3
-            self.downloader._chunksize = 8388608  # pylint:disable=protected-access
+            self.downloader._chunksize = amount  # pylint:disable=protected-access
         if self.done is False:
             self.fh.seek(0)
             self.fh.truncate()

--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -350,7 +350,6 @@ def import_ocw2hugo_sitemetadata(
     metadata["course_image"] = course_data["course_image"]
     metadata["course_image_thumbnail"] = course_data["course_image_thumbnail"]
     metadata["legacy_uid"] = course_data["legacy_uid"]
-    metadata["highlights_text"] = course_data["highlights_text"]
 
     with open("static/js/resources/departments.json", "r") as departments_json_file:
         departments_json = json.load(departments_json_file)

--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -350,6 +350,7 @@ def import_ocw2hugo_sitemetadata(
     metadata["course_image"] = course_data["course_image"]
     metadata["course_image_thumbnail"] = course_data["course_image_thumbnail"]
     metadata["legacy_uid"] = course_data["legacy_uid"]
+    metadata["highlights_text"] = course_data["highlights_text"]
 
     with open("static/js/resources/departments.json", "r") as departments_json_file:
         departments_json = json.load(departments_json_file)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #1162

#### What's this PR do?
Creates a `GDriveStreamReader` class that is passed to `S3.Bucket.upload_fileobj` method to read the gdrive file body in chunks while streaming to S3.  This approach does not seem to exhibit the same flaky behavior as requesting the download url for the gdrive file.

#### How should this be manually tested?
- Put some assorted files of various sizes (including some over ~10 MB) into the gdrive folder for one of your sites and then click the sync button.  
- Make sure the files are all imported correctly and are readable/viewable/playable.  
- Also keep an eye on memory usage with `docker stats` and make sure it doesn't get excessively high.

