### PR TITLE
Set a configurable limit to the number of redis pool connections

### DIFF
--- a/app.json
+++ b/app.json
@@ -400,6 +400,10 @@
       "description": "RedisCloud connection url",
       "required": false
     },
+    "REDIS_MAX_CONNECTIONS": {
+      "description": "Max number of redis connections",
+      "required": false
+    },
     "REDIS_URL": {
       "description": "Redis URL for non-production use",
       "required": false

--- a/main/settings.py
+++ b/main/settings.py
@@ -630,6 +630,11 @@ else:
     _redis_url = get_string(
         name="REDIS_URL", default=None, description="Redis URL for non-production use"
     )
+REDIS_MAX_CONNECTIONS = get_int(
+    name="REDIS_MAX_CONNECTIONS",
+    default=256,
+    description="Max number of redis connections",
+)
 
 CELERY_BROKER_URL = get_string(
     name="CELERY_BROKER_URL",
@@ -694,7 +699,10 @@ CACHES = {
     "redis": {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": CELERY_BROKER_URL,
-        "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient"},
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient",
+            "CONNECTION_POOL_KWARGS": {"max_connections": REDIS_MAX_CONNECTIONS},
+        },
     },
 }
 

--- a/main/settings_test.py
+++ b/main/settings_test.py
@@ -11,6 +11,7 @@ from django.conf import settings
 from django.core import mail
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TestCase
+from django_redis import get_redis_connection
 from mitol.common import envs, pytest_utils
 
 
@@ -154,3 +155,8 @@ class TestSettings(TestCase):
             settings_vars["DEFAULT_DATABASE_CONFIG"]["DISABLE_SERVER_SIDE_CURSORS"]
             is False
         )
+
+    def test_redis_max_connections(self):
+        """Max connections for redis pool should be set to the default"""
+        r = get_redis_connection("redis")
+        assert r.connection_pool.max_connections == settings.REDIS_MAX_CONNECTIONS


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
https://sentry.io/organizations/mit-office-of-digital-learning/issues/3123801638/?environment=production&project=5739976&query=is%3Aunresolved

#### What's this PR do?
Sets a max number of redis pool connections to avoid overloading redis.

#### How should this be manually tested?
Start some celery tasks, they should run normally.

