### PR TITLE
handle links/images inside links correctly

### DIFF
--- a/websites/management/commands/markdown_cleaning/link_parser.py
+++ b/websites/management/commands/markdown_cleaning/link_parser.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass, field
-from typing import Protocol
+from dataclasses import dataclass
+from typing import Protocol, Union
 
 from pyparsing import (
     CharsNotIn,
@@ -42,7 +42,7 @@ class MarkdownLink:
     #       - link: MarkdownLinkOrImage
     #       - original_text: str
     # - start_index, end_index are the start/end of this link within self.text
-    text_links: list = field(default_factory=tuple)
+    text_links: Union[tuple, None] = None
 
     def to_markdown(self):
         """Generate markdown representation of this link/image."""
@@ -88,7 +88,7 @@ class LinkParser(WrappedParser):
     angle-bracket destination variant treated properly.
     """
 
-    def __init__(self):
+    def __init__(self, recursive=False):
 
         # By default pyparsing collapses whitespace characters.
         # Markdown cares about whitespace containing double newlines, so we
@@ -110,7 +110,10 @@ class LinkParser(WrappedParser):
             # Use self.scan_string not grammar.scan_string
             # so that parse actions attached to LinkParser fire for the nested
             # links, which seems desirable.
-            text_links = tuple(self.scan_string(text))
+            if recursive:
+                text_links = tuple(self.scan_string(text))
+            else:
+                text_links = None
 
             link = MarkdownLink(
                 text=text,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets? #1145; followup to #1165 

#### What's this PR do?
Previously, images inside links would be handled replaced but then the replacement would be overriden. For example:

**Original text**
```
Hello
and [![alt text](rootrel_link)](other_link_not_rootrel)
goodbye
```
**After first replacement:** The first replacement recognizes inner link as rootrelative and changes it:
```
Hello
and [{{< resource uuid >}}](/link/to/other/thing)
goodbye
```
The second replacement would use the *original text* since `other_link_not_rootrel` is not a rootrelative link.

So the overall result is that the second replacement would undo the first.

#### How should this be manually tested?
1. **Unless you've done this recently:** First, populate `parent_uid`: `docker-compose run --rm web python manage.py overwrite_ocw_course_content --bucket ocw-to-hugo-output-qa --content-field="metadata.parent_uid"` which is needed for this command.

    - This populates `metadata.parent_uid` AND sets the `parent_id` FK on WebsiteContent objects, see #1115
    - If you have any of the courses below locally, you may need to delete them in order to run `overwrite_ocw_course_content` unfiltered. (They no longer exist on rc/prod)
        ```
        'physics'
        'engineering'
        'biology'
        'chemistry'
        'mathematics'
        'more'
        'iit-jee'
        'humanities-and-social-sciences'
        ```


3. Run `docker-compose run --rm web python manage.py markdown_cleanup rootrelative_urls -o rootrel.csv --commit` to generate a list of changes AND commit them.
4. Check a few of the updated markdown files in django admin (e.g., `cb450631-87a2-c7dc-85af-dde2b940fa82`) and verify it was actually updated
