### PR TITLE
Use get_redis_connection("redis").client() instead of app.backend.client

### DIFF
--- a/content_sync/decorators.py
+++ b/content_sync/decorators.py
@@ -89,7 +89,7 @@ def single_task(timeout: int, raise_block: Optional[bool] = True) -> Callable:
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             has_lock = False
-            client = get_redis_connection("redis").client()
+            client = get_redis_connection("redis")
             lock_id = f"{func.__name__}-id-{args[0] if args else 'single'}"
             lock = client.lock(lock_id, timeout=timeout)
             try:

--- a/content_sync/decorators.py
+++ b/content_sync/decorators.py
@@ -9,7 +9,6 @@ from django_redis import get_redis_connection
 from github.GithubException import RateLimitExceededException
 
 from content_sync.models import ContentSyncState
-from main.celery import app
 
 
 log = logging.getLogger(__name__)

--- a/content_sync/decorators.py
+++ b/content_sync/decorators.py
@@ -5,6 +5,7 @@ from time import sleep
 from typing import Callable, Optional
 
 from django.conf import settings
+from django_redis import get_redis_connection
 from github.GithubException import RateLimitExceededException
 
 from content_sync.models import ContentSyncState
@@ -88,8 +89,9 @@ def single_task(timeout: int, raise_block: Optional[bool] = True) -> Callable:
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             has_lock = False
+            client = get_redis_connection("redis").client()
             lock_id = f"{func.__name__}-id-{args[0] if args else 'single'}"
-            lock = app.backend.client.lock(lock_id, timeout=timeout)
+            lock = client.lock(lock_id, timeout=timeout)
             try:
                 has_lock = lock.acquire(blocking=False)
                 if has_lock:

--- a/content_sync/decorators_test.py
+++ b/content_sync/decorators_test.py
@@ -9,8 +9,8 @@ from content_sync.decorators import single_task
 @pytest.mark.parametrize("input_arg", [None, "foo"])
 def test_single_task(mocker, has_lock, raise_block, input_arg):
     """single_task should only allow 1 instance of inner task to run at same time"""
-    mock_app = mocker.patch("content_sync.decorators.app")
-    mock_app.backend.client.lock.return_value.acquire.side_effect = [True, has_lock]
+    mock_app = mocker.patch("content_sync.decorators.get_redis_connection")
+    mock_app.return_value.lock.return_value.acquire.side_effect = [True, has_lock]
 
     func = mocker.Mock(__name__="testfunc")
     decorated_func = single_task(timeout=2, raise_block=raise_block)
@@ -21,7 +21,7 @@ def test_single_task(mocker, has_lock, raise_block, input_arg):
             decorated_func(func)(*args)
     else:
         decorated_func(func)(*args)
-    mock_app.backend.client.lock.assert_any_call(
+    mock_app.return_value.lock.assert_any_call(
         f"testfunc-id-{input_arg or 'single'}", timeout=2
     )
     assert func.call_count == (2 if has_lock else 1)

--- a/main/settings.py
+++ b/main/settings.py
@@ -632,7 +632,7 @@ else:
     )
 REDIS_MAX_CONNECTIONS = get_int(
     name="REDIS_MAX_CONNECTIONS",
-    default=256,
+    default=48,
     description="Max number of redis connections",
 )
 

--- a/main/settings.py
+++ b/main/settings.py
@@ -635,6 +635,7 @@ REDIS_MAX_CONNECTIONS = get_int(
     default=48,
     description="Max number of redis connections",
 )
+DJANGO_REDIS_CLOSE_CONNECTION = True
 
 CELERY_BROKER_URL = get_string(
     name="CELERY_BROKER_URL",

--- a/requirements.in
+++ b/requirements.in
@@ -8,7 +8,7 @@ django-anymail[mailgun]==8.4
 django-guardian
 django-hijack
 django-hijack-admin
-django-redis
+django-redis==5.2.0
 djangorestframework==3.12.2
 django-robots
 django-safedelete==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -109,7 +109,7 @@ django-hijack==2.2.1
     #   django-hijack-admin
 django-hijack-admin==2.1.10
     # via -r requirements.in
-django-redis==4.12.1
+django-redis==5.2.0
     # via -r requirements.in
 django-robots==4.0
     # via -r requirements.in


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
N/A

#### What's this PR do?
- Changes how the redis client is obtained in the single_task decorator.  Using `get_redis_connection("redis")` is probably safer than using `app.backend.client`:

```python
In [19]: r.client()
Out[19]: Redis<ConnectionPool<Connection<host=redis-18773.c8.us-east-1-4.ec2.cloud.redislabs.com,port=18773,db=0>>>

In [20]: app.backend.client
Out[20]: Redis<ConnectionPool<Connection<host=redis-18773.c8.us-east-1-4.ec2.cloud.redislabs.com,port=18773,db=0>>>

In [21]: r.client().connection_pool.max_connections
Out[21]: 256

In [22]: app.backend.client.connection_pool.max_connections
Out[22]: 2147483648
```

- Upgrades django-redis to 5.2.0 to get [these changes](https://pyup.io/changelogs/django-redis/#5.0.0) in:
```
- ensure connections are closed
- disconnect connection pools on ``.close()``
```

- Adds `DJANGO_REDIS_CLOSE_CONNECTION=True` because the "[default django-redis behavior on close() is to keep the connections to Redis server](https://github.com/jazzband/django-redis/pull/496/files)"

#### How should this be manually tested?

- Run `docker-compose build` to get the latest version of django-redis

- Assuming you have lots of imported sites and are connected to your own github org:
```
from django_redis import get_redis_connection
from websites.models import *
from content_sync.tasks import *

client = get_redis_connection("redis")
print(client.info()["connected_clients"])

websites = Website.objects.all()
for i in range(250):
    sync_website_content.delay(websites[i].name)
print(client.info()["connected_clients"])
```

The tasks should run, and the number of connected clients afterward should be < REDIS_MAX_CONNECTIONS
Wait a minute or so, then check the number of connected clients again, it should have decreased.



