### PR TITLE
replace ocwnext with ocw

### DIFF
--- a/websites/management/commands/markdown_cleaning/baseurl_rule.py
+++ b/websites/management/commands/markdown_cleaning/baseurl_rule.py
@@ -54,7 +54,7 @@ class BaseurlReplacementRule(PyparsingRule):
         url = urlparse(dest_match.group("dest"))
 
         # This is probably a link with image as title, where the image is a < resource >
-        if R"{{<" in link.text or link.text_links:
+        if R"{{<" in link.text or "![" in link.text:
             return original_text, Notes(wraps_image=True)
         try:
             linked_content = self.content_lookup.find_within_site(

--- a/websites/management/commands/markdown_cleaning/ocwnext_rule.py
+++ b/websites/management/commands/markdown_cleaning/ocwnext_rule.py
@@ -1,0 +1,26 @@
+import re
+
+from websites.management.commands.markdown_cleaning.cleanup_rule import (
+    RegexpCleanupRule,
+)
+from websites.models import WebsiteContent
+
+
+class OCWNextReplacement(RegexpCleanupRule):
+    """
+    Convert ocwnext urls to root-relative.
+
+    We'll make them shortcodes or something later.
+    """
+
+    regex = r"https://ocwnext\.odl\.mit\.edu/"
+
+    alias = "ocwnext"
+
+    fields = [
+        "markdown",
+        "metadata.description",
+    ]
+
+    def replace_match(self, match: re.Match, website_content: WebsiteContent):
+        return "/"

--- a/websites/management/commands/markdown_cleanup.py
+++ b/websites/management/commands/markdown_cleanup.py
@@ -27,6 +27,9 @@ from websites.management.commands.markdown_cleaning.link_unescape import LinkUne
 from websites.management.commands.markdown_cleaning.metadata_relative_urls import (
     MetadataRelativeUrlsFix,
 )
+from websites.management.commands.markdown_cleaning.ocwnext_rule import (
+    OCWNextReplacement,
+)
 from websites.management.commands.markdown_cleaning.removal_rules import (
     RemoveInaccesibleGif,
 )
@@ -68,6 +71,7 @@ class Command(BaseCommand):
         RemoveInaccesibleGif,
         LinkLoggingRule,
         ResolveUIDRule,
+        OCWNextReplacement,
     ]
 
     def add_arguments(self, parser: CommandParser) -> None:


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
No ticket

#### What's this PR do?
This PR replaces `"https://ocwnext.odl.mit.edu"` with `"https://ocw.mit.edu"` in markdown bodies and course descriptions.

#### How should this be manually tested?
1. Inspect page `9ed1f397-cb0c-5ae3-0430-0d106f067b19` in admin panel. Note the link to ocwnext:

    > `Single Variable Calculus ([18.01](https://ocwnext.odl.mit.edu/courses/18-01-single-variable-calculus-fall-2006/))`

2. Run `docker-compose run --rm web python manage.py markdown_cleanup ocwnext -o ocwnext.csv --commit` Add `--skyp-sync` if you want to skip the syncing to github.
4. Inspect the page from (1) again. Note the link is now root-relative. Also:
    - inspect the generated CSV to see what was affected
    - inspect a few of the changed pages in admin panel or studio to check that the URLs look good /work