### PR TITLE
Use first_published_to_production instead of publish_date for sorting new courses, get metadata from WebsiteContent

### DIFF
--- a/websites/factories.py
+++ b/websites/factories.py
@@ -43,6 +43,7 @@ class WebsiteFactory(DjangoModelFactory):
     short_id = factory.Sequence(lambda n: "site-shortid-%s" % n)
     metadata = factory.Faker("json")
     publish_date = factory.Faker("date_time", tzinfo=pytz.utc)
+    first_published_to_production = factory.Faker("date_time", tzinfo=pytz.utc)
     draft_publish_date = factory.Faker("date_time", tzinfo=pytz.utc)
     starter = factory.SubFactory(WebsiteStarterFactory)
     owner = factory.SubFactory(UserFactory)
@@ -53,11 +54,19 @@ class WebsiteFactory(DjangoModelFactory):
 
     class Params:
         published = factory.Trait(
-            publish_date=factory.Faker("past_datetime", tzinfo=pytz.utc)
+            publish_date=factory.Faker("past_datetime", tzinfo=pytz.utc),
+            first_published_to_production=factory.Faker(
+                "past_datetime", tzinfo=pytz.utc
+            ),
         )
-        unpublished = factory.Trait(publish_date=None)
+        unpublished = factory.Trait(
+            publish_date=None, first_published_to_production=None
+        )
         future_publish = factory.Trait(
-            publish_date=factory.Faker("future_datetime", tzinfo=pytz.utc)
+            publish_date=factory.Faker("future_datetime", tzinfo=pytz.utc),
+            first_published_to_production=factory.Faker(
+                "future_datetime", tzinfo=pytz.utc
+            ),
         )
 
 

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -93,6 +93,7 @@ class WebsiteSerializer(serializers.ModelSerializer):
             "source",
             "draft_publish_date",
             "publish_date",
+            "first_published_to_production",
             "metadata",
             "starter",
             "owner",

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -29,8 +29,7 @@ from websites.api import (
 from websites.models import Website, WebsiteContent, WebsiteStarter
 from websites.permissions import is_global_admin, is_site_admin
 from websites.site_config_api import SiteConfig
-from websites.utils import permissions_group_name_for_role
-
+from websites.utils import permissions_group_name_for_role, get_dict_field
 
 log = logging.getLogger(__name__)
 
@@ -80,6 +79,29 @@ class WebsiteSerializer(serializers.ModelSerializer):
     """ Serializer for websites """
 
     starter = WebsiteStarterSerializer(read_only=True)
+    metadata = serializers.SerializerMethodField(read_only=True)
+
+    def get_metadata(self, instance):
+        """
+        Get the site metadata, but tweak the instructors key to resemble what the theme template for
+        new courses currently expects (this template should change in the future to retrieve course
+        info in a manner similar to featured courses, instead of relying on this api response.
+        """
+        site_metadata = instance.websitecontent_set.filter(type="sitemetadata").first()
+        if site_metadata:
+            instructor_uids = get_dict_field(
+                site_metadata.metadata, "instructors.content"
+            )
+            if instructor_uids:
+                instructors = [
+                    WebsiteContentDetailSerializer(instructor).data
+                    for instructor in WebsiteContent.objects.filter(
+                        text_id__in=instructor_uids
+                    )
+                ]
+                site_metadata.metadata["instructors"] = instructors
+            return site_metadata.metadata
+        return {}
 
     class Meta:
         model = Website

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -94,12 +94,13 @@ class WebsiteSerializer(serializers.ModelSerializer):
                 site_metadata.metadata, "instructors.content"
             )
             if instructor_uids:
-                instructors = [
-                    WebsiteContentDetailSerializer(instructor).data
-                    for instructor in WebsiteContent.objects.filter(
-                        text_id__in=instructor_uids
-                    )
-                ]
+                instructors = []
+                for uid in instructor_uids:
+                    instructor = WebsiteContent.objects.filter(text_id=uid).first()
+                    if instructor:
+                        instructors.append(
+                            WebsiteContentDetailSerializer(instructor).data
+                        )
                 site_metadata.metadata["instructors"] = instructors
             return site_metadata.metadata
 

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -29,7 +29,8 @@ from websites.api import (
 from websites.models import Website, WebsiteContent, WebsiteStarter
 from websites.permissions import is_global_admin, is_site_admin
 from websites.site_config_api import SiteConfig
-from websites.utils import permissions_group_name_for_role, get_dict_field
+from websites.utils import get_dict_field, permissions_group_name_for_role
+
 
 log = logging.getLogger(__name__)
 
@@ -85,10 +86,10 @@ class WebsiteSerializer(serializers.ModelSerializer):
         """
         Get the site metadata, but tweak the instructors key to resemble what the theme template for
         new courses currently expects (this template should change in the future to retrieve course
-        info in a manner similar to featured courses, instead of relying on this api response.
+        info in a manner similar to featured courses, instead of relying on this api response).
         """
         site_metadata = instance.websitecontent_set.filter(type="sitemetadata").first()
-        if site_metadata:
+        if site_metadata and site_metadata.metadata is not None:
             instructor_uids = get_dict_field(
                 site_metadata.metadata, "instructors.content"
             )
@@ -101,7 +102,6 @@ class WebsiteSerializer(serializers.ModelSerializer):
                 ]
                 site_metadata.metadata["instructors"] = instructors
             return site_metadata.metadata
-        return {}
 
     class Meta:
         model = Website

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -48,6 +48,9 @@ def test_serialize_website_course():
     assert serialized_data["publish_date"] == site.publish_date.strftime(
         ISO_8601_FORMAT
     )
+    assert serialized_data[
+        "first_published_to_production"
+    ] == site.first_published_to_production.strftime(ISO_8601_FORMAT)
     assert serialized_data["metadata"] == site.metadata
     assert isinstance(serialized_data["starter"], dict)
     assert (

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -37,11 +37,54 @@ from websites.site_config_api import SiteConfig
 pytestmark = pytest.mark.django_db
 
 
-def test_serialize_website_course():
+@pytest.mark.parametrize("instructors", [[], ["Prof. Jane Doe", "Dr. John Smith"]])
+def test_serialize_website_course(instructors):
     """
     Verify that a serialized website contains expected fields
     """
     site = WebsiteFactory.create()
+    instructor_contents = []
+    if instructors:
+        instructor_site = WebsiteFactory.create()
+        for instructor in instructors:
+            names = instructor.split()
+            instructor_contents.append(
+                WebsiteContentFactory.create(
+                    website=instructor_site,
+                    type="instructor",
+                    title=instructor,
+                    metadata={
+                        "last_name": names[2],
+                        "first_name": names[1],
+                        "salutation": names[0],
+                    },
+                )
+            )
+        instructor_meta = {
+            "instructors": {
+                "content": sorted(
+                    [instructor.text_id for instructor in instructor_contents]
+                ),
+                "website": instructor_site.name,
+            }
+        }
+    else:
+        instructor_meta = None
+
+    WebsiteContentFactory.create(
+        website=site, type="sitemetadata", metadata=instructor_meta
+    )
+    expected_api_meta = (
+        None
+        if not instructor_meta
+        else {
+            "instructors": [
+                WebsiteContentDetailSerializer(instructor).data
+                for instructor in sorted(instructor_contents, key=lambda i: i.text_id)
+            ]
+        }
+    )
+
     serialized_data = WebsiteSerializer(instance=site).data
     assert serialized_data["name"] == site.name
     assert serialized_data["short_id"] == site.short_id
@@ -51,7 +94,7 @@ def test_serialize_website_course():
     assert serialized_data[
         "first_published_to_production"
     ] == site.first_published_to_production.strftime(ISO_8601_FORMAT)
-    assert serialized_data["metadata"] == site.metadata
+    assert serialized_data["metadata"] == expected_api_meta
     assert isinstance(serialized_data["starter"], dict)
     assert (
         serialized_data["starter"]
@@ -98,15 +141,21 @@ def test_website_detail_deserialize():
 
 
 @pytest.mark.parametrize("has_starter", [True, False])
-def test_website_serializer(has_starter):
+@pytest.mark.parametrize("has_sitemeta", [True, False])
+def test_website_serializer(has_starter, has_sitemeta):
     """WebsiteSerializer should serialize a Website object with the correct fields"""
     website = (
-        WebsiteFactory.build() if has_starter else WebsiteFactory.build(starter=None)
+        WebsiteFactory.create() if has_starter else WebsiteFactory.create(starter=None)
+    )
+    expected_meta = (
+        WebsiteContentFactory.create(website=website, type="sitemetadata").metadata
+        if has_sitemeta
+        else None
     )
     serialized_data = WebsiteSerializer(instance=website).data
     assert serialized_data["name"] == website.name
     assert serialized_data["title"] == website.title
-    assert serialized_data["metadata"] == website.metadata
+    assert serialized_data["metadata"] == expected_meta
     assert "config" not in serialized_data
 
 

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -62,9 +62,7 @@ def test_serialize_website_course(instructors):
             )
         instructor_meta = {
             "instructors": {
-                "content": sorted(
-                    [instructor.text_id for instructor in instructor_contents]
-                ),
+                "content": [instructor.text_id for instructor in instructor_contents],
                 "website": instructor_site.name,
             }
         }
@@ -80,7 +78,7 @@ def test_serialize_website_course(instructors):
         else {
             "instructors": [
                 WebsiteContentDetailSerializer(instructor).data
-                for instructor in sorted(instructor_contents, key=lambda i: i.text_id)
+                for instructor in instructor_contents
             ]
         }
     )

--- a/websites/views.py
+++ b/websites/views.py
@@ -98,11 +98,9 @@ class WebsiteViewSet(
         user = self.request.user
         if self.request.user.is_anonymous:
             # Anonymous users should get a list of all published websites (used for ocw-www carousel)
-            ordering = "-publish_date"
+            ordering = "-first_published_to_production"
             queryset = Website.objects.filter(
-                publish_date__lte=now_in_utc(),
-                # Replace this after imported ocw sites have metadata stored in WebsiteContent objects
-                metadata__isnull=False,
+                first_published_to_production__lte=now_in_utc()
             )
         elif is_global_admin(user):
             # Global admins should get a list of all websites, published or not.

--- a/websites/views.py
+++ b/websites/views.py
@@ -100,8 +100,10 @@ class WebsiteViewSet(
             # Anonymous users should get a list of all published websites (used for ocw-www carousel)
             ordering = "-first_published_to_production"
             queryset = Website.objects.filter(
-                first_published_to_production__lte=now_in_utc()
-            )
+                first_published_to_production__lte=now_in_utc(),
+                websitecontent__type="sitemetadata",
+                websitecontent__metadata__isnull=False,
+            ).distinct()
         elif is_global_admin(user):
             # Global admins should get a list of all websites, published or not.
             queryset = Website.objects.all()

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -54,7 +54,6 @@ def websites(course_starter):
     """ Create some websites for tests """
     courses = WebsiteFactory.create_batch(3, published=True, starter=course_starter)
     noncourses = WebsiteFactory.create_batch(2, published=True)
-    WebsiteFactory.create(published=True, starter=course_starter, metadata=None)
     WebsiteFactory.create(unpublished=True, starter=course_starter)
     WebsiteFactory.create(future_publish=True)
     return SimpleNamespace(courses=courses, noncourses=noncourses)
@@ -82,15 +81,19 @@ def test_websites_endpoint_list(drf_client, filter_by_type, websites, settings):
         resp = drf_client.get(reverse("websites_api-list"))
         assert resp.data.get("count") == 5
     for idx, site in enumerate(
-        sorted(expected_websites, reverse=True, key=lambda site: site.publish_date)
+        sorted(
+            expected_websites,
+            reverse=True,
+            key=lambda site: site.first_published_to_production,
+        )
     ):
         assert resp.data.get("results")[idx]["uuid"] == str(site.uuid)
         assert resp.data.get("results")[idx]["starter"]["slug"] == (
             settings.OCW_IMPORT_STARTER_SLUG if filter_by_type else site.starter.slug
         )
-        assert resp.data.get("results")[idx]["publish_date"] <= now.strftime(
-            ISO_8601_FORMAT
-        )
+        assert resp.data.get("results")[idx][
+            "first_published_to_production"
+        ] <= now.strftime(ISO_8601_FORMAT)
 
 
 def test_websites_endpoint_list_permissions(drf_client, permission_groups):
@@ -375,7 +378,7 @@ def test_websites_endpoint_publish_sorting(
         ]
     )
     if published:
-        assert resp.data.get("count") == 7
+        assert resp.data.get("count") == 6
     else:
         assert resp.data.get("count") == 1
     assert expected_uuids == sorted([site["uuid"] for site in resp.data["results"]])

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -51,11 +51,16 @@ MOCK_GITHUB_DATA = {
 
 @pytest.fixture
 def websites(course_starter):
-    """ Create some websites for tests """
+    """ Create some websites for tests, with all but one having a sitemetadata WebsiteContent object"""
     courses = WebsiteFactory.create_batch(3, published=True, starter=course_starter)
     noncourses = WebsiteFactory.create_batch(2, published=True)
-    WebsiteFactory.create(unpublished=True, starter=course_starter)
-    WebsiteFactory.create(future_publish=True)
+    WebsiteFactory.create(published=True, starter=course_starter, metadata=None)
+    others = [
+        WebsiteFactory.create(unpublished=True, starter=course_starter),
+        WebsiteFactory.create(future_publish=True),
+    ]
+    for site in [*courses, *noncourses, *others]:
+        WebsiteContentFactory.create(website=site, type="sitemetadata")
     return SimpleNamespace(courses=courses, noncourses=noncourses)
 
 
@@ -345,6 +350,7 @@ def test_websites_endpoint_detail_get_denied(drf_client):
         if user:
             drf_client.force_login(user)
         website = WebsiteFactory.create()
+        WebsiteContentFactory.create(website=website, type="sitemetadata")
         resp = drf_client.get(
             reverse("websites_api-detail", kwargs={"name": website.name})
         )
@@ -378,7 +384,7 @@ def test_websites_endpoint_publish_sorting(
         ]
     )
     if published:
-        assert resp.data.get("count") == 6
+        assert resp.data.get("count") == 7
     else:
         assert resp.data.get("count") == 1
     assert expected_uuids == sorted([site["uuid"] for site in resp.data["results"]])


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1188 

#### What's this PR do?
- Switches the sorting of the api query for new courses from `publish_date` to `first_published_to_production`
- In the websites API response, get the metadata from each site's associated `sitemetadata` `WebsiteContent` object instead of the `Website.metadata` field (because that field is null for all sites created in studio).
- Modify the instructors section of the metadata so that it contains the keys currently required by ocw-hugo-themes for the new courses carousel (see related issue [#599](https://github.com/mitodl/ocw-hugo-themes/issues/599))

#### How should this be manually tested?
In OCW Studio:
- Create 2 new sites.  Save metadata (including 1+ instructors) for one but not the other. 
- In django admin, manually set `first_published_to_production` for both to the current date/time.
-In an incognito browser window (not logged in to studio), go to http://localhost8043/api/websites and verify that:
  - the list of courses is in descending order by the `first_published_to_production` field
  - the new course with the metadata is present in the list and includes instructor info such as title
  - the new course without metadata is not present in the list.
  - imported sites are also in the list and have non-null metadata values.
  
For ocw-hugo-themes:  
- Set `OCW_STUDIO_BASE_URL=http://localhost:8043` in your `.env` file for `ocw-hugo-themes`, 
- run `npm run start:www`
- check that the carousel of new courses includes the first 10 courses as in the list above and looks/functions properly.


#### Any background context you want to provide?
If/when [#599](https://github.com/mitodl/ocw-hugo-themes/issues/599) is implemented, the code introduced here to modify the `instructors` part of the metadata can be removed, though it is more informative than the original format.

