### PR TITLE
Handle courses with no instructors

### DIFF
--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -102,6 +102,8 @@ class WebsiteSerializer(serializers.ModelSerializer):
                             WebsiteContentDetailSerializer(instructor).data
                         )
                 site_metadata.metadata["instructors"] = instructors
+            else:
+                site_metadata.metadata["instructors"] = []
             return site_metadata.metadata
 
     class Meta:

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -67,13 +67,15 @@ def test_serialize_website_course(instructors):
             }
         }
     else:
-        instructor_meta = None
+        instructor_meta = {}
 
     WebsiteContentFactory.create(
         website=site, type="sitemetadata", metadata=instructor_meta
     )
     expected_api_meta = (
-        None
+        {
+            "instructors": []
+        }
         if not instructor_meta
         else {
             "instructors": [
@@ -145,8 +147,10 @@ def test_website_serializer(has_starter, has_sitemeta):
     website = (
         WebsiteFactory.create() if has_starter else WebsiteFactory.create(starter=None)
     )
+    if has_sitemeta:
+        WebsiteContentFactory.create(website=website, type="sitemetadata")
     expected_meta = (
-        WebsiteContentFactory.create(website=website, type="sitemetadata").metadata
+        {"instructors": []}
         if has_sitemeta
         else None
     )

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -73,9 +73,7 @@ def test_serialize_website_course(instructors):
         website=site, type="sitemetadata", metadata=instructor_meta
     )
     expected_api_meta = (
-        {
-            "instructors": []
-        }
+        {"instructors": []}
         if not instructor_meta
         else {
             "instructors": [
@@ -149,11 +147,7 @@ def test_website_serializer(has_starter, has_sitemeta):
     )
     if has_sitemeta:
         WebsiteContentFactory.create(website=website, type="sitemetadata")
-    expected_meta = (
-        {"instructors": []}
-        if has_sitemeta
-        else None
-    )
+    expected_meta = {"instructors": []} if has_sitemeta else None
     serialized_data = WebsiteSerializer(instance=website).data
     assert serialized_data["name"] == website.name
     assert serialized_data["title"] == website.title


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
N/A

#### What's this PR do?
Prevents ocw-hugo-themes from breaking when there is a published course with metadata but no instructors.

#### How should this be manually tested?
Repeat instructions for https://github.com/mitodl/ocw-studio/pull/1191 but include a published course with no instructors, and make sure ocw-hugo-themes starts without errors and displays all the published courses.
