### PR TITLE
Update fastly vars for mass-publish pipeline definition

### DIFF
--- a/content_sync/pipelines/definitions/concourse/mass-publish.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-publish.yml
@@ -145,7 +145,7 @@ jobs:
           - -X
           - POST
           - -H
-          - 'Fastly-Key: ((fastly.api_token))'
+          - 'Fastly-Key: ((fastly_((version)).api_token))'
           - -H
           - 'Fastly-Soft-Purge: 1'
-          - https://api.fastly.com/service/((fastly.service_id))/purge_all
+          - https://api.fastly.com/service/((fastly_((version)).service_id))/purge_all


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #1197 

#### What's this PR do?
Updates the mass-publish pipeline definition so that the fastly variables begin with `fastly_<version>.` instead of `fastly.`

#### How should this be manually tested?
- Run `docker-compose --profile concourse up`
- Run `docker-compose run web python manage.py upsert_mass_publish_pipeline`
- Run the following to check that the fastly variables are correct (starting with `fastly_live` or `fastly_draft`):
  `fly -t local login -c http://concourse:8080`
  `fly -t local get-pipeline -p mass-publish/version:live`
  `fly -t local get-pipeline -p mass-publish/version:draft`

```
        - 'Fastly-Key: ((fastly_draft.api_token))'
        - -H
        - 'Fastly-Soft-Purge: 1'
        - https://api.fastly.com/service/((fastly_draft.service_id))/purge_all
```

```
        - 'Fastly-Key: ((fastly_live.api_token))'
        - -H
        - 'Fastly-Soft-Purge: 1'
        - https://api.fastly.com/service/((fastly_live.service_id))/purge_all
```                