### PR TITLE
Revert API change

### DIFF
--- a/websites/factories.py
+++ b/websites/factories.py
@@ -43,7 +43,6 @@ class WebsiteFactory(DjangoModelFactory):
     short_id = factory.Sequence(lambda n: "site-shortid-%s" % n)
     metadata = factory.Faker("json")
     publish_date = factory.Faker("date_time", tzinfo=pytz.utc)
-    first_published_to_production = factory.Faker("date_time", tzinfo=pytz.utc)
     draft_publish_date = factory.Faker("date_time", tzinfo=pytz.utc)
     starter = factory.SubFactory(WebsiteStarterFactory)
     owner = factory.SubFactory(UserFactory)
@@ -54,19 +53,11 @@ class WebsiteFactory(DjangoModelFactory):
 
     class Params:
         published = factory.Trait(
-            publish_date=factory.Faker("past_datetime", tzinfo=pytz.utc),
-            first_published_to_production=factory.Faker(
-                "past_datetime", tzinfo=pytz.utc
-            ),
+            publish_date=factory.Faker("past_datetime", tzinfo=pytz.utc)
         )
-        unpublished = factory.Trait(
-            publish_date=None, first_published_to_production=None
-        )
+        unpublished = factory.Trait(publish_date=None)
         future_publish = factory.Trait(
-            publish_date=factory.Faker("future_datetime", tzinfo=pytz.utc),
-            first_published_to_production=factory.Faker(
-                "future_datetime", tzinfo=pytz.utc
-            ),
+            publish_date=factory.Faker("future_datetime", tzinfo=pytz.utc)
         )
 
 

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -102,8 +102,6 @@ class WebsiteSerializer(serializers.ModelSerializer):
                             WebsiteContentDetailSerializer(instructor).data
                         )
                 site_metadata.metadata["instructors"] = instructors
-            else:
-                site_metadata.metadata["instructors"] = []
             return site_metadata.metadata
 
     class Meta:

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -29,7 +29,7 @@ from websites.api import (
 from websites.models import Website, WebsiteContent, WebsiteStarter
 from websites.permissions import is_global_admin, is_site_admin
 from websites.site_config_api import SiteConfig
-from websites.utils import get_dict_field, permissions_group_name_for_role
+from websites.utils import permissions_group_name_for_role
 
 
 log = logging.getLogger(__name__)
@@ -80,29 +80,6 @@ class WebsiteSerializer(serializers.ModelSerializer):
     """ Serializer for websites """
 
     starter = WebsiteStarterSerializer(read_only=True)
-    metadata = serializers.SerializerMethodField(read_only=True)
-
-    def get_metadata(self, instance):
-        """
-        Get the site metadata, but tweak the instructors key to resemble what the theme template for
-        new courses currently expects (this template should change in the future to retrieve course
-        info in a manner similar to featured courses, instead of relying on this api response).
-        """
-        site_metadata = instance.websitecontent_set.filter(type="sitemetadata").first()
-        if site_metadata and site_metadata.metadata is not None:
-            instructor_uids = get_dict_field(
-                site_metadata.metadata, "instructors.content"
-            )
-            if instructor_uids:
-                instructors = []
-                for uid in instructor_uids:
-                    instructor = WebsiteContent.objects.filter(text_id=uid).first()
-                    if instructor:
-                        instructors.append(
-                            WebsiteContentDetailSerializer(instructor).data
-                        )
-                site_metadata.metadata["instructors"] = instructors
-            return site_metadata.metadata
 
     class Meta:
         model = Website
@@ -116,7 +93,6 @@ class WebsiteSerializer(serializers.ModelSerializer):
             "source",
             "draft_publish_date",
             "publish_date",
-            "first_published_to_production",
             "metadata",
             "starter",
             "owner",

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -67,13 +67,13 @@ def test_serialize_website_course(instructors):
             }
         }
     else:
-        instructor_meta = {}
+        instructor_meta = None
 
     WebsiteContentFactory.create(
         website=site, type="sitemetadata", metadata=instructor_meta
     )
     expected_api_meta = (
-        {"instructors": []}
+        None
         if not instructor_meta
         else {
             "instructors": [
@@ -145,9 +145,11 @@ def test_website_serializer(has_starter, has_sitemeta):
     website = (
         WebsiteFactory.create() if has_starter else WebsiteFactory.create(starter=None)
     )
-    if has_sitemeta:
-        WebsiteContentFactory.create(website=website, type="sitemetadata")
-    expected_meta = {"instructors": []} if has_sitemeta else None
+    expected_meta = (
+        WebsiteContentFactory.create(website=website, type="sitemetadata").metadata
+        if has_sitemeta
+        else None
+    )
     serialized_data = WebsiteSerializer(instance=website).data
     assert serialized_data["name"] == website.name
     assert serialized_data["title"] == website.title

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -37,62 +37,18 @@ from websites.site_config_api import SiteConfig
 pytestmark = pytest.mark.django_db
 
 
-@pytest.mark.parametrize("instructors", [[], ["Prof. Jane Doe", "Dr. John Smith"]])
-def test_serialize_website_course(instructors):
+def test_serialize_website_course():
     """
     Verify that a serialized website contains expected fields
     """
     site = WebsiteFactory.create()
-    instructor_contents = []
-    if instructors:
-        instructor_site = WebsiteFactory.create()
-        for instructor in instructors:
-            names = instructor.split()
-            instructor_contents.append(
-                WebsiteContentFactory.create(
-                    website=instructor_site,
-                    type="instructor",
-                    title=instructor,
-                    metadata={
-                        "last_name": names[2],
-                        "first_name": names[1],
-                        "salutation": names[0],
-                    },
-                )
-            )
-        instructor_meta = {
-            "instructors": {
-                "content": [instructor.text_id for instructor in instructor_contents],
-                "website": instructor_site.name,
-            }
-        }
-    else:
-        instructor_meta = None
-
-    WebsiteContentFactory.create(
-        website=site, type="sitemetadata", metadata=instructor_meta
-    )
-    expected_api_meta = (
-        None
-        if not instructor_meta
-        else {
-            "instructors": [
-                WebsiteContentDetailSerializer(instructor).data
-                for instructor in instructor_contents
-            ]
-        }
-    )
-
     serialized_data = WebsiteSerializer(instance=site).data
     assert serialized_data["name"] == site.name
     assert serialized_data["short_id"] == site.short_id
     assert serialized_data["publish_date"] == site.publish_date.strftime(
         ISO_8601_FORMAT
     )
-    assert serialized_data[
-        "first_published_to_production"
-    ] == site.first_published_to_production.strftime(ISO_8601_FORMAT)
-    assert serialized_data["metadata"] == expected_api_meta
+    assert serialized_data["metadata"] == site.metadata
     assert isinstance(serialized_data["starter"], dict)
     assert (
         serialized_data["starter"]
@@ -139,21 +95,15 @@ def test_website_detail_deserialize():
 
 
 @pytest.mark.parametrize("has_starter", [True, False])
-@pytest.mark.parametrize("has_sitemeta", [True, False])
-def test_website_serializer(has_starter, has_sitemeta):
+def test_website_serializer(has_starter):
     """WebsiteSerializer should serialize a Website object with the correct fields"""
     website = (
-        WebsiteFactory.create() if has_starter else WebsiteFactory.create(starter=None)
-    )
-    expected_meta = (
-        WebsiteContentFactory.create(website=website, type="sitemetadata").metadata
-        if has_sitemeta
-        else None
+        WebsiteFactory.build() if has_starter else WebsiteFactory.build(starter=None)
     )
     serialized_data = WebsiteSerializer(instance=website).data
     assert serialized_data["name"] == website.name
     assert serialized_data["title"] == website.title
-    assert serialized_data["metadata"] == expected_meta
+    assert serialized_data["metadata"] == website.metadata
     assert "config" not in serialized_data
 
 

--- a/websites/views.py
+++ b/websites/views.py
@@ -98,12 +98,12 @@ class WebsiteViewSet(
         user = self.request.user
         if self.request.user.is_anonymous:
             # Anonymous users should get a list of all published websites (used for ocw-www carousel)
-            ordering = "-first_published_to_production"
+            ordering = "-publish_date"
             queryset = Website.objects.filter(
-                first_published_to_production__lte=now_in_utc(),
-                websitecontent__type="sitemetadata",
-                websitecontent__metadata__isnull=False,
-            ).distinct()
+                publish_date__lte=now_in_utc(),
+                # Replace this after imported ocw sites have metadata stored in WebsiteContent objects
+                metadata__isnull=False,
+            )
         elif is_global_admin(user):
             # Global admins should get a list of all websites, published or not.
             queryset = Website.objects.all()


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested


#### What are the relevant tickets?
Related to #1188 

#### What's this PR do?
Reverts changes to the websites API, because the course image thumbnail metadata isn't output in a format that ocw-hugo-themes can interpret.

#### How should this be manually tested?
Tests should pass
