### PR TITLE
New sites API: Filter out sites without sitemetadata content instead of Website.metadata

### DIFF
--- a/websites/views.py
+++ b/websites/views.py
@@ -34,6 +34,7 @@ from users.models import User
 from websites import constants
 from websites.api import get_valid_new_filename, update_website_status
 from websites.constants import (
+    CONTENT_TYPE_METADATA,
     RESOURCE_TYPE_DOCUMENT,
     RESOURCE_TYPE_IMAGE,
     RESOURCE_TYPE_OTHER,
@@ -100,8 +101,9 @@ class WebsiteViewSet(
             # Anonymous users should get a list of all published websites (used for ocw-www carousel)
             ordering = "-first_published_to_production"
             queryset = Website.objects.filter(
+                first_published_to_production__isnull=False,
                 first_published_to_production__lte=now_in_utc(),
-                websitecontent__type="sitemetadata",
+                websitecontent__type=CONTENT_TYPE_METADATA,
                 websitecontent__metadata__isnull=False,
             ).distinct()
         elif is_global_admin(user):

--- a/websites/views.py
+++ b/websites/views.py
@@ -100,10 +100,10 @@ class WebsiteViewSet(
             # Anonymous users should get a list of all published websites (used for ocw-www carousel)
             ordering = "-first_published_to_production"
             queryset = Website.objects.filter(
-                publish_date__lte=now_in_utc(),
-                # Replace this after imported ocw sites have metadata stored in WebsiteContent objects
-                metadata__isnull=False,
-            )
+                first_published_to_production__lte=now_in_utc(),
+                websitecontent__type="sitemetadata",
+                websitecontent__metadata__isnull=False,
+            ).distinct()
         elif is_global_admin(user):
             # Global admins should get a list of all websites, published or not.
             queryset = Website.objects.all()

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -51,12 +51,16 @@ MOCK_GITHUB_DATA = {
 
 @pytest.fixture
 def websites(course_starter):
-    """ Create some websites for tests """
+    """ Create some websites for tests, with all but one having a sitemetadata WebsiteContent object"""
     courses = WebsiteFactory.create_batch(3, published=True, starter=course_starter)
     noncourses = WebsiteFactory.create_batch(2, published=True)
     WebsiteFactory.create(published=True, starter=course_starter, metadata=None)
-    WebsiteFactory.create(unpublished=True, starter=course_starter)
-    WebsiteFactory.create(future_publish=True)
+    others = [
+        WebsiteFactory.create(unpublished=True, starter=course_starter),
+        WebsiteFactory.create(future_publish=True),
+    ]
+    for site in [*courses, *noncourses, *others]:
+        WebsiteContentFactory.create(website=site, type="sitemetadata")
     return SimpleNamespace(courses=courses, noncourses=noncourses)
 
 
@@ -346,6 +350,7 @@ def test_websites_endpoint_detail_get_denied(drf_client):
         if user:
             drf_client.force_login(user)
         website = WebsiteFactory.create()
+        WebsiteContentFactory.create(website=website, type="sitemetadata")
         resp = drf_client.get(
             reverse("websites_api-detail", kwargs={"name": website.name})
         )


### PR DESCRIPTION
~~Blocked by https://github.com/mitodl/ocw-hugo-themes/issues/599~~

#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1188

#### What's this PR do?
- Sorts the anonymous websites api response by reverse `first_published_to_production` field
- Instead of filtering out sites with null `Website.metadata` (excludes all new sites created in studio), filter out sites without a `sitemetadata` resource.

#### How should this be manually tested?
Check the output of `http://localhost:8043/api/websites` in an incognito browser, make sure it is sorted by `first_published_to_production` , most recent first and includes published sites created in studio.  If necessary, create a new site, add metadata to it, and set the `first_published_to_production` to the current date/time in django admin.



#### Any background context you want to provide?
~~Should not be merged until after https://github.com/mitodl/ocw-hugo-themes/issues/599 is released, otherwise the new courses carousel on the home page will break.~~

