### PR TITLE
Sort websites by first_published_to_production

### DIFF
--- a/websites/factories.py
+++ b/websites/factories.py
@@ -43,6 +43,7 @@ class WebsiteFactory(DjangoModelFactory):
     short_id = factory.Sequence(lambda n: "site-shortid-%s" % n)
     metadata = factory.Faker("json")
     publish_date = factory.Faker("date_time", tzinfo=pytz.utc)
+    first_published_to_production = factory.Faker("date_time", tzinfo=pytz.utc)
     draft_publish_date = factory.Faker("date_time", tzinfo=pytz.utc)
     starter = factory.SubFactory(WebsiteStarterFactory)
     owner = factory.SubFactory(UserFactory)
@@ -53,11 +54,19 @@ class WebsiteFactory(DjangoModelFactory):
 
     class Params:
         published = factory.Trait(
-            publish_date=factory.Faker("past_datetime", tzinfo=pytz.utc)
+            publish_date=factory.Faker("past_datetime", tzinfo=pytz.utc),
+            first_published_to_production=factory.Faker(
+                "past_datetime", tzinfo=pytz.utc
+            ),
         )
-        unpublished = factory.Trait(publish_date=None)
+        unpublished = factory.Trait(
+            publish_date=None, first_published_to_production=None
+        )
         future_publish = factory.Trait(
-            publish_date=factory.Faker("future_datetime", tzinfo=pytz.utc)
+            publish_date=factory.Faker("future_datetime", tzinfo=pytz.utc),
+            first_published_to_production=factory.Faker(
+                "future_datetime", tzinfo=pytz.utc
+            ),
         )
 
 

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -93,6 +93,7 @@ class WebsiteSerializer(serializers.ModelSerializer):
             "source",
             "draft_publish_date",
             "publish_date",
+            "first_published_to_production",
             "metadata",
             "starter",
             "owner",

--- a/websites/views.py
+++ b/websites/views.py
@@ -100,10 +100,10 @@ class WebsiteViewSet(
             # Anonymous users should get a list of all published websites (used for ocw-www carousel)
             ordering = "-first_published_to_production"
             queryset = Website.objects.filter(
-                first_published_to_production__lte=now_in_utc(),
-                websitecontent__type="sitemetadata",
-                websitecontent__metadata__isnull=False,
-            ).distinct()
+                publish_date__lte=now_in_utc(),
+                # Replace this after imported ocw sites have metadata stored in WebsiteContent objects
+                metadata__isnull=False,
+            )
         elif is_global_admin(user):
             # Global admins should get a list of all websites, published or not.
             queryset = Website.objects.all()

--- a/websites/views.py
+++ b/websites/views.py
@@ -98,12 +98,12 @@ class WebsiteViewSet(
         user = self.request.user
         if self.request.user.is_anonymous:
             # Anonymous users should get a list of all published websites (used for ocw-www carousel)
-            ordering = "-publish_date"
+            ordering = "-first_published_to_production"
             queryset = Website.objects.filter(
-                publish_date__lte=now_in_utc(),
-                # Replace this after imported ocw sites have metadata stored in WebsiteContent objects
-                metadata__isnull=False,
-            )
+                first_published_to_production__lte=now_in_utc(),
+                websitecontent__type="sitemetadata",
+                websitecontent__metadata__isnull=False,
+            ).distinct()
         elif is_global_admin(user):
             # Global admins should get a list of all websites, published or not.
             queryset = Website.objects.all()

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -51,12 +51,16 @@ MOCK_GITHUB_DATA = {
 
 @pytest.fixture
 def websites(course_starter):
-    """ Create some websites for tests """
+    """ Create some websites for tests, with all but one having a sitemetadata WebsiteContent object"""
     courses = WebsiteFactory.create_batch(3, published=True, starter=course_starter)
     noncourses = WebsiteFactory.create_batch(2, published=True)
     WebsiteFactory.create(published=True, starter=course_starter, metadata=None)
-    WebsiteFactory.create(unpublished=True, starter=course_starter)
-    WebsiteFactory.create(future_publish=True)
+    others = [
+        WebsiteFactory.create(unpublished=True, starter=course_starter),
+        WebsiteFactory.create(future_publish=True),
+    ]
+    for site in [*courses, *noncourses, *others]:
+        WebsiteContentFactory.create(website=site, type="sitemetadata")
     return SimpleNamespace(courses=courses, noncourses=noncourses)
 
 
@@ -82,15 +86,19 @@ def test_websites_endpoint_list(drf_client, filter_by_type, websites, settings):
         resp = drf_client.get(reverse("websites_api-list"))
         assert resp.data.get("count") == 5
     for idx, site in enumerate(
-        sorted(expected_websites, reverse=True, key=lambda site: site.publish_date)
+        sorted(
+            expected_websites,
+            reverse=True,
+            key=lambda site: site.first_published_to_production,
+        )
     ):
         assert resp.data.get("results")[idx]["uuid"] == str(site.uuid)
         assert resp.data.get("results")[idx]["starter"]["slug"] == (
             settings.OCW_IMPORT_STARTER_SLUG if filter_by_type else site.starter.slug
         )
-        assert resp.data.get("results")[idx]["publish_date"] <= now.strftime(
-            ISO_8601_FORMAT
-        )
+        assert resp.data.get("results")[idx][
+            "first_published_to_production"
+        ] <= now.strftime(ISO_8601_FORMAT)
 
 
 def test_websites_endpoint_list_permissions(drf_client, permission_groups):
@@ -342,6 +350,7 @@ def test_websites_endpoint_detail_get_denied(drf_client):
         if user:
             drf_client.force_login(user)
         website = WebsiteFactory.create()
+        WebsiteContentFactory.create(website=website, type="sitemetadata")
         resp = drf_client.get(
             reverse("websites_api-detail", kwargs={"name": website.name})
         )

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -51,16 +51,12 @@ MOCK_GITHUB_DATA = {
 
 @pytest.fixture
 def websites(course_starter):
-    """ Create some websites for tests, with all but one having a sitemetadata WebsiteContent object"""
+    """ Create some websites for tests """
     courses = WebsiteFactory.create_batch(3, published=True, starter=course_starter)
     noncourses = WebsiteFactory.create_batch(2, published=True)
     WebsiteFactory.create(published=True, starter=course_starter, metadata=None)
-    others = [
-        WebsiteFactory.create(unpublished=True, starter=course_starter),
-        WebsiteFactory.create(future_publish=True),
-    ]
-    for site in [*courses, *noncourses, *others]:
-        WebsiteContentFactory.create(website=site, type="sitemetadata")
+    WebsiteFactory.create(unpublished=True, starter=course_starter)
+    WebsiteFactory.create(future_publish=True)
     return SimpleNamespace(courses=courses, noncourses=noncourses)
 
 
@@ -350,7 +346,6 @@ def test_websites_endpoint_detail_get_denied(drf_client):
         if user:
             drf_client.force_login(user)
         website = WebsiteFactory.create()
-        WebsiteContentFactory.create(website=website, type="sitemetadata")
         resp = drf_client.get(
             reverse("websites_api-detail", kwargs={"name": website.name})
         )


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Part of #1188

#### What's this PR do?
Changes the order field to `first_published_to_production`.  Does not make the additional changes necessary for new sites created in studio to show up in the list of new courses on the home page (see #1202 for that).

#### How should this be manually tested?
Go to `https://localhost:8043/api/websites` as an anonymous user and verify that the websites are listed in descending order by `Website.first_published_to_production`, and only imported ocw sites with metadata show up.

