### PR TITLE
add "other" tab to resource picker

### DIFF
--- a/static/js/components/RepeatableContentListing.tsx
+++ b/static/js/components/RepeatableContentListing.tsx
@@ -4,7 +4,6 @@ import { useMutation, useRequest } from "redux-query-react"
 import { useSelector, useStore } from "react-redux"
 import { requestAsync } from "redux-query"
 import useInterval from "@use-it/interval"
-import { DateTime } from "luxon"
 import { isNil } from "ramda"
 
 import DriveSyncStatusIndicator from "./DriveSyncStatusIndicator"
@@ -38,6 +37,7 @@ import { useURLParamFilter } from "../hooks/search"
 import { singular } from "pluralize"
 import SiteContentEditorDrawer from "./SiteContentEditorDrawer"
 import { useWebsite } from "../context/Website"
+import { formatUpdatedOn } from "../util/websites"
 
 export default function RepeatableContentListing(props: {
   configItem: RepeatableConfigItem
@@ -195,9 +195,7 @@ export default function RepeatableContentListing(props: {
               })
               .toString()}
             title={item.title ?? ""}
-            subtitle={`Updated ${DateTime.fromISO(
-              item.updated_on
-            ).toRelative()}`}
+            subtitle={`Updated ${formatUpdatedOn(item)}`}
           />
         ))}
       </StudioList>

--- a/static/js/components/widgets/ResourcePickerDialog.test.tsx
+++ b/static/js/components/widgets/ResourcePickerDialog.test.tsx
@@ -72,32 +72,51 @@ describe("ResourcePickerDialog", () => {
 
   it.each([
     {
+      mode:         RESOURCE_EMBED,
       contentNames: ["resource"],
-      expectedTabs: [TabIds.Documents, TabIds.Videos, TabIds.Images]
+      expectedTabs: [TabIds.Videos, TabIds.Images]
     },
-    { contentNames: ["page"], expectedTabs: [TabIds.Pages] },
     {
+      mode:         RESOURCE_LINK,
+      contentNames: ["resource"],
+      expectedTabs: [
+        TabIds.Documents,
+        TabIds.Videos,
+        TabIds.Images,
+        TabIds.Other
+      ]
+    },
+    {
+      mode:         RESOURCE_LINK,
+      contentNames: ["page"],
+      expectedTabs: [TabIds.Pages]
+    },
+    {
+      mode:         RESOURCE_LINK,
       contentNames: ["course_collections"],
       expectedTabs: [TabIds.CourseCollections]
     },
     {
+      mode:         RESOURCE_LINK,
       contentNames: ["resource_collections"],
       expectedTabs: [TabIds.ResourceCollections]
     },
     {
+      mode:         RESOURCE_LINK,
       contentNames: ["resource", "page", "course_collections"],
       expectedTabs: [
         TabIds.Documents,
         TabIds.Videos,
         TabIds.Images,
+        TabIds.Other,
         TabIds.Pages,
         TabIds.CourseCollections
       ]
     }
   ])(
     "should render tabs based on contentNames. Case: $contentNames",
-    async ({ contentNames, expectedTabs }) => {
-      const { wrapper } = await render({ contentNames, expectedTabs })
+    async ({ mode, contentNames, expectedTabs }) => {
+      const { wrapper } = await render({ mode, contentNames, expectedTabs })
       expect(wrapper.find(TabPane).map(pane => pane.prop("tabId"))).toEqual(
         expectedTabs
       )
@@ -171,7 +190,13 @@ describe("ResourcePickerDialog", () => {
       contentType:  "resource",
       singleColumn: false
     },
-    { index: 3, resourcetype: null, contentType: "page", singleColumn: true }
+    {
+      index:        3,
+      resourcetype: ResourceType.Other,
+      contentType:  "resource",
+      singleColumn: true
+    },
+    { index: 4, resourcetype: null, contentType: "page", singleColumn: true }
   ])(
     "passes the correct props to ResourcePickerListing when main tab $index is clicked",
     async ({ resourcetype, contentType, singleColumn, index }) => {

--- a/static/js/components/widgets/ResourcePickerDialog.tsx
+++ b/static/js/components/widgets/ResourcePickerDialog.tsx
@@ -32,6 +32,7 @@ interface TabSettings {
 }
 
 export enum TabIds {
+  Other = "other",
   Documents = "documents",
   Images = "images",
   Videos = "videos",
@@ -45,7 +46,7 @@ const documentTab: TabSettings = {
   id:           TabIds.Documents,
   contentType:  ContentType.Resource,
   resourcetype: ResourceType.Document,
-  embeddable:   true,
+  embeddable:   false,
   singleColumn: true
 }
 const videoTab: TabSettings = {
@@ -63,6 +64,14 @@ const imageTab: TabSettings = {
   resourcetype: ResourceType.Image,
   embeddable:   true,
   singleColumn: false
+}
+const otherFilesTab: TabSettings = {
+  title:        "Other",
+  id:           TabIds.Other,
+  contentType:  ContentType.Resource,
+  resourcetype: ResourceType.Other,
+  embeddable:   false,
+  singleColumn: true
 }
 const pageTab: TabSettings = {
   title:        "Pages",
@@ -96,7 +105,7 @@ const resourcCollectionTab: TabSettings = {
  * except resources, which have separate tabs according to resourcetype
  */
 const TABS: Record<string, TabSettings[]> = {
-  resource:             [documentTab, videoTab, imageTab],
+  resource:             [documentTab, videoTab, imageTab, otherFilesTab],
   page:                 [pageTab],
   course_collections:   [courseCollectionTab],
   resource_collections: [resourcCollectionTab]
@@ -116,7 +125,9 @@ const modeText = {
 export default function ResourcePickerDialog(props: Props): JSX.Element {
   const { mode, isOpen, closeDialog, insertEmbed, contentNames } = props
 
-  const tabs = contentNames.flatMap(name => TABS[name])
+  const tabs = contentNames
+    .flatMap(name => TABS[name])
+    .filter(tab => mode !== RESOURCE_EMBED || tab.embeddable)
   const [activeTabId, setActiveTabId] = useState(tabs[0].id)
 
   // filterInput is to store user input and is updated synchronously

--- a/static/js/components/widgets/ResourcePickerListing.test.tsx
+++ b/static/js/components/widgets/ResourcePickerListing.test.tsx
@@ -31,7 +31,12 @@ describe("ResourcePickerListing", () => {
     focusResourceStub: any,
     setOpenStub: any,
     website: Website,
-    contentListingItems: WebsiteContent[][]
+    contentListingItems: {
+      videos: WebsiteContent[]
+      documents: WebsiteContent[]
+      pages: WebsiteContent[]
+      courseLists: WebsiteContent[]
+    }
 
   beforeEach(() => {
     helper = new IntegrationTestHelper()
@@ -51,12 +56,12 @@ describe("ResourcePickerListing", () => {
     // @ts-ignore
     useWebsite.mockReturnValue(website)
 
-    contentListingItems = [
-      [makeWebsiteContentDetail(), makeWebsiteContentDetail()],
-      [makeWebsiteContentDetail(), makeWebsiteContentDetail()],
-      [makeWebsiteContentDetail(), makeWebsiteContentDetail()],
-      [makeWebsiteContentDetail(), makeWebsiteContentDetail()]
-    ]
+    contentListingItems = {
+      videos:      [makeWebsiteContentDetail(), makeWebsiteContentDetail()],
+      documents:   [makeWebsiteContentDetail(), makeWebsiteContentDetail()],
+      pages:       [makeWebsiteContentDetail(), makeWebsiteContentDetail()],
+      courseLists: [makeWebsiteContentDetail(), makeWebsiteContentDetail()]
+    }
 
     helper.mockGetRequest(
       siteApiContentListingUrl
@@ -70,7 +75,7 @@ describe("ResourcePickerListing", () => {
           resourcetype:  ResourceType.Video
         })
         .toString(),
-      apiResponse(contentListingItems[0])
+      apiResponse(contentListingItems.videos)
     )
 
     helper.mockGetRequest(
@@ -86,7 +91,7 @@ describe("ResourcePickerListing", () => {
           resourcetype:  ResourceType.Document
         })
         .toString(),
-      apiResponse(contentListingItems[1])
+      apiResponse(contentListingItems.documents)
     )
 
     helper.mockGetRequest(
@@ -100,7 +105,7 @@ describe("ResourcePickerListing", () => {
           detailed_list: true
         })
         .toString(),
-      apiResponse(contentListingItems[2])
+      apiResponse(contentListingItems.pages)
     )
 
     helper.mockGetRequest(
@@ -114,7 +119,7 @@ describe("ResourcePickerListing", () => {
           detailed_list: true
         })
         .toString(),
-      apiResponse(contentListingItems[3])
+      apiResponse(contentListingItems.courseLists)
     )
   })
 
@@ -128,7 +133,7 @@ describe("ResourcePickerListing", () => {
       wrapper
         .find(".resource-picker-listing .resource-item")
         .map(el => el.find("h4").text())
-    ).toEqual(contentListingItems[0].map(item => item.title))
+    ).toEqual(contentListingItems.videos.map(item => item.title))
   })
 
   it("should call focusResource prop with resources", async () => {
@@ -138,13 +143,15 @@ describe("ResourcePickerListing", () => {
       .find(".resource-picker-listing .resource-item")
       .at(0)
       .simulate("click")
-    expect(focusResourceStub.calledWith(contentListingItems[0][0])).toBeTruthy()
+    expect(
+      focusResourceStub.calledWith(contentListingItems.videos[0])
+    ).toBeTruthy()
     wrapper.update()
   })
 
   it("should put a class on if a resource is focused", async () => {
     const { wrapper } = await render({
-      focusedResource: contentListingItems[0][0]
+      focusedResource: contentListingItems.videos[0]
     })
 
     expect(
@@ -157,9 +164,9 @@ describe("ResourcePickerListing", () => {
 
   it("should display an image for images", async () => {
     // @ts-ignore
-    contentListingItems[0][0].metadata.resourcetype = ResourceType.Image
+    contentListingItems.videos[0].metadata.resourcetype = ResourceType.Image
     // @ts-ignore
-    contentListingItems[0][0].file = "/path/to/image.jpg"
+    contentListingItems.videos[0].file = "/path/to/image.jpg"
     const { wrapper } = await render()
     expect(
       wrapper
@@ -172,9 +179,9 @@ describe("ResourcePickerListing", () => {
 
   it("should display a thumbnail for videos", async () => {
     // @ts-ignore
-    contentListingItems[0][0].metadata.resourcetype = ResourceType.Video
+    contentListingItems.videos[0].metadata.resourcetype = ResourceType.Video
     // @ts-ignore
-    contentListingItems[0][0].metadata.video_files = {
+    contentListingItems.videos[0].metadata.video_files = {
       video_thumbnail_file: "/path/to/image.jpg"
     }
     const { wrapper } = await render()
@@ -196,7 +203,7 @@ describe("ResourcePickerListing", () => {
       wrapper
         .find(".resource-picker-listing .resource-item")
         .map(el => el.find("h4").text())
-    ).toEqual(contentListingItems[2].map(item => item.title))
+    ).toEqual(contentListingItems.pages.map(item => item.title))
 
     sinon.assert.calledWith(
       helper.handleRequestStub,
@@ -221,7 +228,7 @@ describe("ResourcePickerListing", () => {
       wrapper
         .find(".resource-picker-listing .resource-item")
         .map(el => el.find("h4").text())
-    ).toEqual(contentListingItems[3].map(item => item.title))
+    ).toEqual(contentListingItems.courseLists.map(item => item.title))
 
     sinon.assert.calledWith(
       helper.handleRequestStub,
@@ -246,6 +253,21 @@ describe("ResourcePickerListing", () => {
     }
   )
 
+  it.each([false, true])(
+    "Includes 'Updated ...' iff singleColumn: true (case: %s)",
+    async singleColumn => {
+      const { wrapper } = await render({ singleColumn })
+      expect(
+        wrapper.find(".resource-picker-listing .resource-item").map(el =>
+          el
+            .find("h4")
+            .text()
+            .includes("Updated")
+        )
+      ).toStrictEqual([singleColumn, singleColumn])
+    }
+  )
+
   it("should allow the user to filter, sort resourcetype", async () => {
     const { wrapper } = await render({
       filter:       "newfilter",
@@ -256,6 +278,6 @@ describe("ResourcePickerListing", () => {
       wrapper
         .find(".resource-picker-listing .resource-item")
         .map(el => el.find("h4").text())
-    ).toEqual(contentListingItems[1].map(item => item.title))
+    ).toEqual(contentListingItems.documents.map(item => item.title))
   })
 })

--- a/static/js/components/widgets/ResourcePickerListing.tsx
+++ b/static/js/components/widgets/ResourcePickerListing.tsx
@@ -1,4 +1,4 @@
-import React, { SyntheticEvent, useMemo } from "react"
+import React, { useMemo } from "react"
 import classNames from "classnames"
 import { useRequest } from "redux-query-react"
 import { path } from "ramda"
@@ -12,6 +12,8 @@ import {
   getWebsiteContentListingCursor,
   WebsiteContentSelection
 } from "../../selectors/websites"
+import { formatUpdatedOn } from "../../util/websites"
+import { getExtensionName } from "../../util"
 
 interface Props {
   focusResource: (item: WebsiteContent) => void
@@ -68,43 +70,72 @@ export default function ResourcePickerListing(
       })}
     >
       {listing.results.map((item, idx) => {
-        const className = `resource-item${
-          focusedResource && focusedResource.text_id === item.text_id ?
-            " focused" :
-            ""
-        }`
-
-        let imageSrc: string | undefined
-
-        if (item.metadata) {
-          if (item.metadata.resourcetype === ResourceType.Image) {
-            imageSrc = path(["file"], item)
-          } else if (item.metadata.resourcetype === ResourceType.Video) {
-            imageSrc = path(
-              ["metadata", "video_files", "video_thumbnail_file"],
-              item
-            )
-          }
+        const focusItem: React.MouseEventHandler<HTMLDivElement> = event => {
+          event.preventDefault()
+          focusResource(item)
         }
 
         return (
-          <div
-            className={className}
+          <PickerListItem
+            //  text_id itself *should* be unique, since it's a uuid except for sitemetadata.
             key={`${item.text_id}_${idx}`}
-            onClick={(event: SyntheticEvent<HTMLDivElement>) => {
-              event.preventDefault()
-              focusResource(item)
-            }}
-          >
-            {imageSrc ? (
-              <div className="img-wrapper">
-                <img className="img-fluid w-100" src={imageSrc} />
-              </div>
-            ) : null}
-            <h4>{item.title}</h4>
-          </div>
+            isWholeRow={singleColumn}
+            websiteContent={item}
+            onClick={focusItem}
+            isFocused={item.text_id === focusedResource?.text_id}
+          />
         )
       })}
+    </div>
+  )
+}
+
+type ItemProps = {
+  isWholeRow: boolean
+  isFocused: boolean
+  websiteContent: WebsiteContent
+  onClick: React.MouseEventHandler<HTMLDivElement>
+}
+const PickerListItem = (props: ItemProps) => {
+  const { websiteContent, isFocused, isWholeRow } = props
+  const className = classNames({
+    "resource-item": true,
+    focused:         isFocused
+  })
+
+  let imageSrc: string | undefined, extension: string | undefined
+  if (websiteContent.metadata) {
+    if (websiteContent.metadata.resourcetype === ResourceType.Image) {
+      imageSrc = path(["file"], websiteContent)
+    } else if (websiteContent.metadata.resourcetype === ResourceType.Video) {
+      imageSrc = path(
+        ["metadata", "video_files", "video_thumbnail_file"],
+        websiteContent
+      )
+    } else {
+      extension = getExtensionName(websiteContent.file ?? "")
+    }
+  }
+  return (
+    <div className={className} onClick={props.onClick}>
+      {imageSrc ? (
+        <div>
+          <img className="img-fluid w-100" src={imageSrc} />
+        </div>
+      ) : null}
+      {isWholeRow ? (
+        <h4 className="d-flex justify-content-between align-items-baseline">
+          <span>
+            {websiteContent.title}
+            {extension && <span className="font-size-75"> (.{extension})</span>}
+          </span>
+          <span className="text-gray font-size-75">
+            Updated {formatUpdatedOn(websiteContent)}
+          </span>
+        </h4>
+      ) : (
+        <h4>{websiteContent.title}</h4>
+      )}
     </div>
   )
 }

--- a/static/js/util/index.test.ts
+++ b/static/js/util/index.test.ts
@@ -1,0 +1,13 @@
+import { getExtensionName } from "."
+
+describe("getExtensionName", () => {
+  it.each([
+    { path: "/bark/dog.pdf", ext: "pdf" },
+    { path: "dog.pdf", ext: "pdf" },
+    { path: "dog.woof.pdf", ext: "pdf" },
+    { path: "dogwoof", ext: "" },
+    { path: "/bark/dogwoof", ext: "" }
+  ])("returns the file extension", ({ path, ext }) => {
+    expect(getExtensionName(path)).toBe(ext)
+  })
+})

--- a/static/js/util/index.ts
+++ b/static/js/util/index.ts
@@ -1,3 +1,4 @@
+import { nth } from "lodash"
 /**
  * Create a new type that is the same as T except with properties K required and
  * not null/undefined.
@@ -22,4 +23,12 @@ export const hasNotNilProp = <T, K extends keyof T>(key: K) => (
  */
 export const isNotNil = <T>(value: T): value is NonNullable<T> => {
   return value !== undefined && value !== null
+}
+
+/**
+ * Given a filepath, return its extension
+ */
+export const getExtensionName = (path: string) => {
+  const filename = nth(path.split("/"), -1) ?? ""
+  return nth(filename.split(".").slice(1), -1) ?? ""
 }

--- a/static/js/util/websites.ts
+++ b/static/js/util/websites.ts
@@ -1,0 +1,17 @@
+import { WebsiteContentListItem } from "../types/websites"
+import { DateTime } from "luxon"
+
+/**
+ * Returns a string representation of when this item was last updated, relative
+ * to today. For example, "2 days ago"
+ */
+export const formatUpdatedOn = (wc: WebsiteContentListItem): string => {
+  const relative = DateTime.fromISO(wc.updated_on).toRelative()
+  if (relative === null) {
+    /**
+     * luxon will only return null if the date was invalid.
+     */
+    throw new Error("Invalid date.")
+  }
+  return relative
+}

--- a/static/scss/common.scss
+++ b/static/scss/common.scss
@@ -39,3 +39,7 @@ a.underline {
 .hover-pointer:hover {
   cursor: pointer;
 }
+
+.font-size-75 {
+  font-size: 75% !important;
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets? https://github.com/mitodl/ocw-studio/issues/1168

#### What's this PR do?
~This PR fixes broke links of the form...Just Kidding!~

This PR updates the resource picker dialog so that resources with `resourcetype="Other"` are now linkable. So, all resources should now be linkable. Also:
- fixed a bug where documents could be embedded. Checked with Peter/Ferdi...this was undesirable. 
- Added extension + "updated on" to help authors find relevant files. 

#### How should this be manually tested?
Using a new course or one you already have...
1. Upload some files to google drive and sync the content. Be sure to include a variety of file types: PDF, txt, json, zip files, whatever.

    _In particular, be sure to include some files whose MIME type does NOT start with 'text', 'image', or 'video'. These files will be classified as `resourcetype="Other"`. _
2. Go edit a page
3. Click "Add Link". Confirm that everything you uploaded is in one of the tabs, specifically json / docx, etc should be in "Other"
4. Confirm that extensions + updated on looks correct.
5. Confirm that Documents + Other are NOT available for embedding. 

Note: the Add Link -> "Document" and "Other" tabs are functionally equivalent right now, except one shows text documents and the other "Other" documents. 

<img width="535" alt="Screen Shot 2022-04-06 at 4 41 50 PM" src="https://user-images.githubusercontent.com/9010790/162069704-4b983055-0c2a-4509-ae02-bfa98da66a86.png">

