### PR TITLE
prevent mass import

### DIFF
--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -66,7 +66,7 @@ def fetch_ocw2hugo_course_paths(bucket_name, prefix="", filter_list=None):
     Args:
         bucket_name (str): S3 bucket name
         prefix (str): (Optional) S3 prefix before start of course_id path
-        filter_list (str): (Optional) If specified, only yield course paths containing this string
+        filter_list (str): (Optional) If specified, only yield course paths that exist in this list
 
     Yields:
         str: The path to a course JSON document in S3

--- a/ocw_import/management/commands/import_ocw_course_sites.py
+++ b/ocw_import/management/commands/import_ocw_course_sites.py
@@ -120,8 +120,6 @@ class Command(BaseCommand):
                 bucket_name, prefix=prefix, filter_list=filter_list
             )
         )
-        if limit is not None:
-            course_paths = course_paths[:limit]
 
         if options["list"] is True:
             pydoc.pager("\n".join(course_paths))
@@ -141,6 +139,7 @@ Would you like to proceed with the import? (y/n): """
             bucket_name=bucket_name,
             course_paths=course_paths,
             prefix=prefix,
+            limit=limit,
             delete_unpublished=delete_unpublished,
             chunk_size=options["chunks"],
         )

--- a/ocw_import/management/commands/import_ocw_course_sites.py
+++ b/ocw_import/management/commands/import_ocw_course_sites.py
@@ -5,7 +5,6 @@ import pydoc
 from django.conf import settings
 from django.core.management import BaseCommand, CommandError
 from mitol.common.utils.datetime import now_in_utc
-from six.moves import input
 
 from content_sync.tasks import sync_unsynced_websites
 from ocw_import.api import fetch_ocw2hugo_course_paths

--- a/ocw_import/management/commands/import_ocw_course_sites.py
+++ b/ocw_import/management/commands/import_ocw_course_sites.py
@@ -120,12 +120,6 @@ class Command(BaseCommand):
                 bucket_name, prefix=prefix, filter_list=filter_list
             )
         )
-        if filter_list is not None:
-            course_paths = [
-                path
-                for path in course_paths
-                if any(filter_str in path for filter_str in filter_list)
-            ]
         if limit is not None:
             course_paths = course_paths[:limit]
 

--- a/ocw_import/management/commands/import_ocw_course_sites.py
+++ b/ocw_import/management/commands/import_ocw_course_sites.py
@@ -90,7 +90,7 @@ class Command(BaseCommand):
         )
         super().add_arguments(parser)
 
-    def handle(self, *args, **options):
+    def handle(self, *args, **options):  # pylint:disable=too-many-locals
         prefix = options["prefix"]
         if prefix:
             # make sure it ends with a '/'

--- a/ocw_import/tasks.py
+++ b/ocw_import/tasks.py
@@ -97,9 +97,8 @@ def delete_unpublished_courses(paths=None):
 def import_ocw2hugo_courses(
     self,
     bucket_name=None,
+    course_paths=None,
     prefix=None,
-    filter_str=None,
-    limit=None,
     delete_unpublished=True,
     chunk_size=100,
 ):  # pylint:disable=too-many-arguments
@@ -108,25 +107,21 @@ def import_ocw2hugo_courses(
 
     Args:
         bucket_name (str): S3 bucket name
+        course_paths (list of str): The paths of the courses to be imported
         prefix (str): (Optional) S3 prefix before start of course_id path
-        filter_str (str): (Optional) If specified, only yield course paths containing this string
-        limit (int or None): (Optional) If specified, limits the number of courses imported
         delete_unpublished (bool): (Optional) If true, delete unpublished courses from the DB
         chunk_size (int): Number of courses to process per task
     """
     if not bucket_name:
         raise TypeError("Bucket name must be specified")
-    course_paths = list(fetch_ocw2hugo_course_paths(bucket_name, prefix=prefix))
+    if not course_paths:
+        raise TypeError("Course paths must be specified")
     if delete_unpublished:
         delete_unpublished_courses_task = delete_unpublished_courses.si(
             paths=course_paths
         )
     else:
         delete_unpublished_courses_task = None
-    if filter_str is not None:
-        course_paths = [path for path in course_paths if filter_str in path]
-    if limit is not None:
-        course_paths = course_paths[:limit]
     course_tasks = [
         import_ocw2hugo_course_paths.si(
             paths=paths,

--- a/ocw_import/tasks.py
+++ b/ocw_import/tasks.py
@@ -99,6 +99,7 @@ def import_ocw2hugo_courses(
     bucket_name=None,
     course_paths=None,
     prefix=None,
+    limit=None,
     delete_unpublished=True,
     chunk_size=100,
 ):  # pylint:disable=too-many-arguments
@@ -109,6 +110,7 @@ def import_ocw2hugo_courses(
         bucket_name (str): S3 bucket name
         course_paths (list of str): The paths of the courses to be imported
         prefix (str): (Optional) S3 prefix before start of course_id path
+        limit (int): (Optional) Only import this amount of courses
         delete_unpublished (bool): (Optional) If true, delete unpublished courses from the DB
         chunk_size (int): Number of courses to process per task
     """
@@ -116,6 +118,8 @@ def import_ocw2hugo_courses(
         raise TypeError("Bucket name must be specified")
     if not course_paths:
         raise TypeError("Course paths must be specified")
+    if limit is not None:
+        course_paths = course_paths[:limit]
     if delete_unpublished:
         delete_unpublished_courses_task = delete_unpublished_courses.si(
             paths=course_paths


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [x] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1167

#### What's this PR do?
After recently releasing the new OCW site live and going through a month long QA process getting the content into shape, it would be a big problem if `import_ocw_course_sites` were to be run unfiltered or with a vague filter.  The tasks that `import_ocw_course_sites` runs destructively updates content on imported legacy sites, and since a lot of manual work was done in production to get the site ready for launch, we want to avoid destroying this data.  This PR does a few things to prevent that:

 - Either `--filter` or `--filter-json` is now required when running the command
 - A confirmation step was added that lets you know how many sites will be imported, asking you to type `y` and hit enter before proceeding

#### How should this be manually tested?
 - Get `ocw-studio` up and running locally on this branch, making sure you've configured AWS access (okay to match RC) as well as a private Github org for publishing
 - Put the following in a `courses.json` file at the root of your `ocw-studio` folder:
```
[
  "8-591j-systems-biology-fall-2004",
  "15-057-systems-optimization-spring-2003",
  "6-776-high-speed-communication-circuits-spring-2005"
]
```
 - Once up and running, run the following commands:
   - `docker-compose run --rm web ./manage.py import_ocw_course_sites -b ocw-to-hugo-output-qa` - This should throw an error of `CommandError: This command cannot be run unfiltered.  Use the --filter or --filter-json argument to specify courses to import.`
   - `docker-compose run --rm web ./manage.py import_ocw_course_sites -b ocw-to-hugo-output-qa --filter "8-591j-systems-biology-fall-2004, 15-057-systems-optimization-spring-2003, 6-776-high-speed-communication-circuits-spring-2005"` - This should prompt you to confirm importing 3 courses, press y and then enter to confirm
   - `docker-compose run --rm web ./manage.py import_ocw_course_sites -b ocw-to-hugo-output-qa --filter-json courses.json` - This should also prompt you to confirm importing 3 courses, press y and then enter to confirm
   - `docker-compose run --rm web ./manage.py import_ocw_course_sites -b ocw-to-hugo-output-qa --filter "8-591j-systems-biology-fall-2004, 15-057-systems-optimization-spring-2003, 6-776-high-speed-communication-circuits-spring-2005"` - This should prompt you to confirm importing 3 courses, type anything other than `y` and hit enter and you should see `Aborting...`
