### PR TITLE
Cc/default active tab

### DIFF
--- a/static/js/components/widgets/ResourcePickerDialog.test.tsx
+++ b/static/js/components/widgets/ResourcePickerDialog.test.tsx
@@ -123,6 +123,22 @@ describe("ResourcePickerDialog", () => {
     }
   )
 
+  it.each([
+    { modes: [RESOURCE_LINK, RESOURCE_EMBED] as const },
+    { modes: [RESOURCE_EMBED, RESOURCE_LINK] as const }
+  ])("initially displays resource listing for first tab", async ({ modes }) => {
+    const { wrapper } = await render({ mode: modes[0] })
+    const firstTab = wrapper.find(TabPane).first()
+    // first tab has resource listing on initial render
+    expect(firstTab.find(ResourcePickerListing).exists()).toBe(true)
+
+    wrapper.setProps({ mode: modes[1] })
+
+    // and first tab has resource listing after mode change
+    const firstTabNewMode = wrapper.find(TabPane).first()
+    expect(firstTabNewMode.find(ResourcePickerListing).exists()).toBe(true)
+  })
+
   test("TabIds values are unique", () => {
     const uniqueTabIds = new Set(Object.values(TabIds))
     expect(Object.values(TabIds).length).toBe(uniqueTabIds.size)

--- a/static/js/components/widgets/ResourcePickerDialog.tsx
+++ b/static/js/components/widgets/ResourcePickerDialog.tsx
@@ -1,4 +1,10 @@
-import React, { SyntheticEvent, useCallback, useMemo, useEffect, useState } from "react"
+import React, {
+  SyntheticEvent,
+  useCallback,
+  useMemo,
+  useEffect,
+  useState
+} from "react"
 import { Nav, NavItem, NavLink, TabContent, TabPane } from "reactstrap"
 
 import Dialog from "../Dialog"
@@ -124,9 +130,13 @@ const modeText = {
 
 export default function ResourcePickerDialog(props: Props): JSX.Element {
   const { mode, isOpen, closeDialog, insertEmbed, contentNames } = props
-  const tabs = useMemo(() => contentNames
-    .flatMap(name => TABS[name])
-    .filter(tab => mode !== RESOURCE_EMBED || tab.embeddable), [mode, contentNames])
+  const tabs = useMemo(
+    () =>
+      contentNames
+        .flatMap(name => TABS[name])
+        .filter(tab => mode !== RESOURCE_EMBED || tab.embeddable),
+    [mode, contentNames]
+  )
   const [activeTabId, setActiveTabId] = useState(tabs[0].id)
 
   useEffect(() => setActiveTabId(tabs[0].id), [tabs])

--- a/static/js/components/widgets/ResourcePickerDialog.tsx
+++ b/static/js/components/widgets/ResourcePickerDialog.tsx
@@ -1,4 +1,4 @@
-import React, { SyntheticEvent, useCallback, useState } from "react"
+import React, { SyntheticEvent, useCallback, useMemo, useEffect, useState } from "react"
 import { Nav, NavItem, NavLink, TabContent, TabPane } from "reactstrap"
 
 import Dialog from "../Dialog"
@@ -124,11 +124,12 @@ const modeText = {
 
 export default function ResourcePickerDialog(props: Props): JSX.Element {
   const { mode, isOpen, closeDialog, insertEmbed, contentNames } = props
-
-  const tabs = contentNames
+  const tabs = useMemo(() => contentNames
     .flatMap(name => TABS[name])
-    .filter(tab => mode !== RESOURCE_EMBED || tab.embeddable)
+    .filter(tab => mode !== RESOURCE_EMBED || tab.embeddable), [mode, contentNames])
   const [activeTabId, setActiveTabId] = useState(tabs[0].id)
+
+  useEffect(() => setActiveTabId(tabs[0].id), [tabs])
 
   // filterInput is to store user input and is updated synchronously
   // so that the UI stays responsive

--- a/websites/management/commands/markdown_cleaning/link_logging_rule.py
+++ b/websites/management/commands/markdown_cleaning/link_logging_rule.py
@@ -39,7 +39,7 @@ class LinkLoggingRule(PyparsingRule):
             text=link.text,
             destination=link.destination,
             title=link.title,
-            is_image=link.is_image
+            is_image=link.is_image,
         )
         return toks.original_text, notes
 

--- a/websites/management/commands/markdown_cleaning/link_logging_rule.py
+++ b/websites/management/commands/markdown_cleaning/link_logging_rule.py
@@ -31,6 +31,7 @@ class LinkLoggingRule(PyparsingRule):
         text: str
         destination: str
         title: str
+        is_image: bool
 
     def replace_match(self, s: str, l: int, toks, website_content):
         link = toks.link
@@ -38,6 +39,7 @@ class LinkLoggingRule(PyparsingRule):
             text=link.text,
             destination=link.destination,
             title=link.title,
+            is_image=link.is_image
         )
         return toks.original_text, notes
 

--- a/websites/management/commands/markdown_cleaning/parsing_utils.py
+++ b/websites/management/commands/markdown_cleaning/parsing_utils.py
@@ -104,7 +104,7 @@ def unescape_string_quoted_with(text: str, single_quotes=False):
     if text.startswith(q) and text.endswith(q) and all_escaped:
         return escaped_quote_regex.sub(unescape, text[1:-1])
 
-    raise ValueError(f"{text} is not a valid single-quoted string")
+    raise ValueError(f"{text} is not a valid {q}-quoted string")
 
 
 def unescape_quoted_string(text: str):
@@ -127,7 +127,7 @@ class ShortcodeParam:
     name: Union[str, None] = None
 
     param_regex: ClassVar[re.Pattern] = re.compile(
-        r"^((?P<name>[0-9a-zA-Z_]+)=)?(?P<value>.*)$"
+        r"^((?P<name>[0-9a-zA-Z_\-]+)=)?(?P<value>.*)$"
     )
 
     @classmethod

--- a/websites/management/commands/markdown_cleaning/shortcode_grammar.py
+++ b/websites/management/commands/markdown_cleaning/shortcode_grammar.py
@@ -41,7 +41,7 @@ class ShortcodeParser(WrappedParser):
                 try:
                     params = [ShortcodeParam.from_hugo(s) for s in param_assignments]
                 except ValueError:
-                    params = [ShortcodeParam('UNKNOWN')]
+                    params = [ShortcodeParam("UNKNOWN")]
                 shortcode = ShortcodeTag(
                     name, params, percent_delimiters, closer=is_closing_tag
                 )

--- a/websites/management/commands/markdown_cleaning/shortcode_grammar.py
+++ b/websites/management/commands/markdown_cleaning/shortcode_grammar.py
@@ -38,10 +38,7 @@ class ShortcodeParser(WrappedParser):
                     else:
                         param_assignments.append(s)
 
-                try:
-                    params = [ShortcodeParam.from_hugo(s) for s in param_assignments]
-                except ValueError:
-                    params = [ShortcodeParam("UNKNOWN")]
+                params = [ShortcodeParam.from_hugo(s) for s in param_assignments]
                 shortcode = ShortcodeTag(
                     name, params, percent_delimiters, closer=is_closing_tag
                 )

--- a/websites/management/commands/markdown_cleaning/shortcode_grammar.py
+++ b/websites/management/commands/markdown_cleaning/shortcode_grammar.py
@@ -38,7 +38,10 @@ class ShortcodeParser(WrappedParser):
                     else:
                         param_assignments.append(s)
 
-                params = [ShortcodeParam.from_hugo(s) for s in param_assignments]
+                try:
+                    params = [ShortcodeParam.from_hugo(s) for s in param_assignments]
+                except ValueError:
+                    params = [ShortcodeParam('UNKNOWN')]
                 shortcode = ShortcodeTag(
                     name, params, percent_delimiters, closer=is_closing_tag
                 )

--- a/websites/management/commands/markdown_cleaning/shortcode_grammar_test.py
+++ b/websites/management/commands/markdown_cleaning/shortcode_grammar_test.py
@@ -89,3 +89,27 @@ def test_shortcode_grammar_with_nested_shortcodes():
     with pytest.raises(ValueError, match="nesting"):
         text_nested = R'{{< fake_shortcode uuid {{< sup 4 >}} "Cats and dogs" >}}'
         parser.parse_string(text_nested)
+
+
+def test_shortcode_parser_parses_named_parameter_and_dashes():
+    text = R'{{< image-gallery-item href="421516494150ff096b974c8f16c0086e_504693-01D.jpg" data-ngdesc="Kristen R leads a discussion" text="engineering is cool" >}}'
+    parser = ShortcodeParser()
+    parsed = parser.parse_string(text)
+
+    assert parsed.shortcode == ShortcodeTag(
+        name='image-gallery-item',
+        params=[
+            ShortcodeParam(
+                name='href',
+                value='421516494150ff096b974c8f16c0086e_504693-01D.jpg'
+            ),
+            ShortcodeParam(
+                 name='data-ngdesc',
+                 value='Kristen R leads a discussion',
+            ),
+            ShortcodeParam(
+                name='text',
+                value='engineering is cool'
+            )
+        ]
+    )

--- a/websites/management/commands/markdown_cleaning/shortcode_grammar_test.py
+++ b/websites/management/commands/markdown_cleaning/shortcode_grammar_test.py
@@ -97,19 +97,15 @@ def test_shortcode_parser_parses_named_parameter_and_dashes():
     parsed = parser.parse_string(text)
 
     assert parsed.shortcode == ShortcodeTag(
-        name='image-gallery-item',
+        name="image-gallery-item",
         params=[
             ShortcodeParam(
-                name='href',
-                value='421516494150ff096b974c8f16c0086e_504693-01D.jpg'
+                name="href", value="421516494150ff096b974c8f16c0086e_504693-01D.jpg"
             ),
             ShortcodeParam(
-                 name='data-ngdesc',
-                 value='Kristen R leads a discussion',
+                name="data-ngdesc",
+                value="Kristen R leads a discussion",
             ),
-            ShortcodeParam(
-                name='text',
-                value='engineering is cool'
-            )
-        ]
+            ShortcodeParam(name="text", value="engineering is cool"),
+        ],
     )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?  https://github.com/mitodl/ocw-studio/issues/1168

#### What's this PR do?
This is a followup to #1210 .. That PR removed the "Document" tab from embed (cf https://github.com/mitodl/ocw-studio/issues/1168#issuecomment-1090676620), which introduced a bug where no tab would be initially visible when the picker was opened in "Embed mode".

So this PR ensures that the initially active tab is one of the tabs available in the current mode.

#### How should this be manually tested?
1. Open a page in editing mode, and click "Add link". The first tab should be visible and you should be able to switch tabs.
2. Close out of the resource picker and click "Embed Resource". The first tab should be visible and you should be able to switch tabs.
3. Close the editor and repeat, but this time open Embed first.

#### Also
This PR also makes a small change to `ShortcodeParam` in the markdown cleanup management command. This change is unrelated to the rest. Tests should still pass. If you really want to test that change, run `docker-compose run --rm web python manage.py markdown_cleanup shortcode_logging -o shortcodes.csv` to generate a CSV of all shortcodes in ocw. But it takes like an hour and the csv is 350MB. 