### PR TITLE
Avoid unnecessary dupe transcode jobs, retry on gdrive->s3 upload errors a few times before raising

### DIFF
--- a/gdrive_sync/api_test.py
+++ b/gdrive_sync/api_test.py
@@ -32,7 +32,8 @@ from gdrive_sync.constants import (
 from gdrive_sync.factories import DriveFileFactory
 from gdrive_sync.models import DriveFile
 from main.s3_utils import get_s3_resource
-from videos.constants import VideoStatus
+from videos.constants import VideoJobStatus, VideoStatus
+from videos.factories import VideoFactory, VideoJobFactory
 from websites.constants import (
     CONTENT_FILENAMES_FORBIDDEN,
     CONTENT_TYPE_RESOURCE,
@@ -124,7 +125,6 @@ def test_get_parent_tree(mock_service):
 @pytest.mark.parametrize("current_s3_key", [None, "courses/website/current-file.png"])
 def test_stream_to_s3(settings, mocker, is_video, current_s3_key):
     """stream_to_s3 should make expected drive api and S3 upload calls"""
-    mock_service = mocker.patch("gdrive_sync.api.get_drive_service")
     mock_download = mocker.patch("gdrive_sync.api.GDriveStreamReader")
     mock_boto3 = mocker.patch("gdrive_sync.api.boto3")
     mock_bucket = mock_boto3.resource.return_value.Bucket.return_value
@@ -135,7 +135,6 @@ def test_stream_to_s3(settings, mocker, is_video, current_s3_key):
         drive_path=f"website/{DRIVE_FOLDER_VIDEOS_FINAL if is_video else DRIVE_FOLDER_FILES_FINAL}",
     )
     api.stream_to_s3(drive_file)
-    mock_service.return_value.permissions.return_value.create.assert_called_once()
     if current_s3_key:
         expected_key = current_s3_key
     elif is_video:
@@ -163,24 +162,35 @@ def test_stream_to_s3(settings, mocker, is_video, current_s3_key):
         ExtraArgs=expected_extra_args,
     )
     mock_download.assert_called_once_with(drive_file)
-    mock_service.return_value.permissions.return_value.delete.assert_called_once()
     drive_file.refresh_from_db()
     assert drive_file.status == DriveFileStatus.UPLOAD_COMPLETE
     assert drive_file.s3_key == expected_key
 
 
 @pytest.mark.django_db
-def test_stream_to_s3_error(mocker):
-    """Task should mark DriveFile status as failed if an s3 upload error occurs"""
-    mock_service = mocker.patch("gdrive_sync.api.get_drive_service")
+@pytest.mark.parametrize("num_errors", [2, 3, 4])
+def test_stream_to_s3_error(settings, mocker, num_errors):
+    """Task should mark DriveFile status as failed if an s3 upload error occurs more often than retries"""
+    settings.CONTENT_SYNC_RETRIES = 3
+    should_raise = num_errors >= 3
+    mocker.patch("gdrive_sync.api.GDriveStreamReader")
     mock_boto3 = mocker.patch("gdrive_sync.api.boto3")
-    mock_boto3.resource.return_value.Bucket.side_effect = HTTPError()
+    mock_boto3.resource.return_value.Bucket.side_effect = [
+        *[HTTPError() for _ in range(num_errors)],
+        mocker.Mock(),
+    ]
     drive_file = DriveFileFactory.create()
-    with pytest.raises(HTTPError):
+    if should_raise:
+        with pytest.raises(HTTPError):
+            api.stream_to_s3(drive_file)
+    else:
         api.stream_to_s3(drive_file)
     drive_file.refresh_from_db()
-    assert drive_file.status == DriveFileStatus.UPLOAD_FAILED
-    mock_service.return_value.permissions.return_value.delete.assert_called_once()
+    assert drive_file.status == (
+        DriveFileStatus.UPLOAD_FAILED
+        if should_raise
+        else DriveFileStatus.UPLOAD_COMPLETE
+    )
 
 
 @pytest.mark.django_db
@@ -362,6 +372,60 @@ def test_process_file_result(
         assert drive_file.checksum == checksum
 
 
+@pytest.mark.parametrize("status", [DriveFileStatus.UPLOADING, DriveFileStatus.FAILED])
+@pytest.mark.parametrize("same_checksum", [True, False])
+@pytest.mark.parametrize("same_name", [True, False])
+def test_process_file_result_update(settings, mocker, status, same_checksum, same_name):
+    """
+    An existing drive file should not be processed again is the checksum and name are the same, ond the status
+    indicates that processing is complete or in progress.
+    """
+    settings.DRIVE_SHARED_ID = "test_drive"
+    settings.DRIVE_UPLOADS_PARENT_FOLDER_ID = "parent"
+    website = WebsiteFactory.create()
+    mocker.patch(
+        "gdrive_sync.api.get_parent_tree",
+        return_value=[
+            {
+                "id": "parent",
+                "name": "ancestor_exists",
+            },
+            {
+                "id": "websiteId",
+                "name": website.short_id,
+            },
+            {
+                "id": "subFolderId",
+                "name": DRIVE_FOLDER_FILES_FINAL,
+            },
+        ],
+    )
+    drive_file = DriveFileFactory.create(status=status, website=website)
+    file_result = {
+        "id": drive_file.file_id,
+        "name": drive_file.name if same_name else "new-name",
+        "mimeType": "image/jpeg",
+        "parents": ["subFolderId"],
+        "webContentLink": "http://link",
+        "createdTime": "2021-07-28T00:06:40.439Z",
+        "modifiedTime": "2021-07-29T14:25:19.375Z",
+        "md5Checksum": drive_file.checksum if same_checksum else "new-check-sum",
+        "trashed": False,
+    }
+    result = process_file_result(file_result)
+    assert (result is None) is (
+        same_name
+        and same_checksum
+        and status
+        in (
+            DriveFileStatus.UPLOADING,
+            DriveFileStatus.UPLOAD_COMPLETE,
+            DriveFileStatus.TRANSCODING,
+            DriveFileStatus.COMPLETE,
+        )
+    )
+
+
 def test_walk_gdrive_folder(mocker):
     """walk_gdrive_folder should yield all expected files"""
     files = [
@@ -497,6 +561,29 @@ def test_transcode_gdrive_video(settings, mocker, account_id, region, role_name)
         mock_convert_job.assert_called_once_with(drive_file.video)
     else:
         assert drive_file.video is None
+        mock_convert_job.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "prior_status",
+    [VideoJobStatus.CREATED, VideoJobStatus.CREATED, VideoJobStatus.FAILED],
+)
+def test_transcode_gdrive_video_prior_job(settings, mocker, prior_status):
+    """ create_media_convert_job should be called only if the prior job failed"""
+    settings.AWS_ACCOUNT_ID = "accountABC"
+    settings.AWS_REGION = "us-east-1"
+    settings.AWS_ROLE_NAME = "roleDEF"
+    mock_convert_job = mocker.patch("gdrive_sync.api.create_media_convert_job")
+    video = VideoFactory.create()
+    drive_file = DriveFileFactory.create(
+        website=video.website, video=video, s3_key=video.source_key
+    )
+    VideoJobFactory.create(video=video, status=prior_status)
+    transcode_gdrive_video(drive_file)
+    drive_file.refresh_from_db()
+    if prior_status != VideoJobStatus.CREATED:
+        mock_convert_job.assert_called_once_with(drive_file.video)
+    else:
         mock_convert_job.assert_not_called()
 
 

--- a/gdrive_sync/api_test.py
+++ b/gdrive_sync/api_test.py
@@ -377,7 +377,7 @@ def test_process_file_result(
 @pytest.mark.parametrize("same_name", [True, False])
 def test_process_file_result_update(settings, mocker, status, same_checksum, same_name):
     """
-    An existing drive file should not be processed again is the checksum and name are the same, ond the status
+    An existing drive file should not be processed again if the checksum and name are the same, ond the status
     indicates that processing is complete or in progress.
     """
     settings.DRIVE_SHARED_ID = "test_drive"

--- a/videos/api_test.py
+++ b/videos/api_test.py
@@ -6,7 +6,12 @@ import pytest
 
 from videos.api import create_media_convert_job, process_video_outputs
 from videos.conftest import TEST_VIDEOS_WEBHOOK_PATH
-from videos.constants import DESTINATION_ARCHIVE, DESTINATION_YOUTUBE, VideoStatus
+from videos.constants import (
+    DESTINATION_ARCHIVE,
+    DESTINATION_YOUTUBE,
+    VideoFileStatus,
+    VideoStatus,
+)
 from videos.factories import VideoFactory
 from videos.models import VideoFile, VideoJob
 
@@ -61,6 +66,9 @@ def test_process_video_outputs():
             video=video, destination=DESTINATION_YOUTUBE
         )
         assert "_youtube." in youtube_video.s3_key
+        assert youtube_video.status == VideoFileStatus.CREATED
+        assert youtube_video.destination_status is None
+        assert youtube_video.destination_id is None
         for videofile in VideoFile.objects.filter(
             video=video, destination=DESTINATION_ARCHIVE
         ):

--- a/videos/views_test.py
+++ b/videos/views_test.py
@@ -7,7 +7,7 @@ from django.urls import reverse
 
 from gdrive_sync.factories import DriveFileFactory
 from videos.conftest import TEST_VIDEOS_WEBHOOK_PATH
-from videos.constants import DESTINATION_YOUTUBE, VideoStatus
+from videos.constants import DESTINATION_YOUTUBE, VideoJobStatus, VideoStatus
 from videos.factories import VideoFactory, VideoJobFactory
 from websites.factories import WebsiteFactory
 
@@ -61,7 +61,7 @@ def test_transcode_jobs_success(settings, drf_client, video_group):
     video_job.refresh_from_db()
     assert video.videofiles.count() == 3
     assert video.videofiles.filter(destination=DESTINATION_YOUTUBE).count() == 1
-    assert video_job.status == data["detail"]["status"]
+    assert video_job.status == VideoJobStatus.COMPLETE
 
 
 def test_transcode_jobs_failure(settings, drf_client, video_group):
@@ -81,7 +81,7 @@ def test_transcode_jobs_failure(settings, drf_client, video_group):
     video_job.refresh_from_db()
     assert video.videofiles.count() == 0
     assert video.status == VideoStatus.FAILED
-    assert video_job.status == data["detail"]["status"]
+    assert video_job.status == VideoJobStatus.FAILED
 
 
 def test_transcode_jobs_wrong_account(drf_client):


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1215 

#### What's this PR do?
- Adds additional DriveFile statuses under which processing for existing objects should be skipped if the `name` and `checksum` values have not changed.
- Prevents another transcode job from being created if there is a prior transcode job that didn't complete/fail.
- If another transcode job does send a webhook back to studio, update the affected `VideoFile.status` back to `Created` so it will be picked up by the `videos.tasks.upload_youtube_videos` task.
- Adds the `@retry_on_fail` decorator to the `stream_to_s3` function in case there is[ an occasional failure streaming from google drive to S3](https://sentry.io/organizations/mit-office-of-digital-learning/issues/3171662861/?environment=production&project=5739976).

#### How should this be manually tested?
- Copy `DRIVE_*` and `AWS_*` settings from RC
- Upload a small video and non-video file to a site's google drive folder, under the appropriate subfolder for each (`videos_final`, `files_final`).
- Click the 'Sync w/Google Drive' button, wait for the new resources to show up.
- Verify that you can link to or embed the non-video file.
- Go to http://localhost:8043/admin/videos/video/, there should be a new object for the video you uploaded, and it should have one `VideoJob` (at the bottom).
- Using Postman or curl, make a POST request to http://localhost:8043/api/transcode-jobs/ with the following data, subsituting the correct values including the `VideoJob.job_id`:
```json
{
  "version": "0",
  "id": "c120fe11-87db-c292-b3e5-1cc90740f6e1",
  "detail-type": "MediaConvert Job State Change",
  "source": "aws.mediaconvert",
  "account": "<AWS_ACCOUNT_ID>",
  "time": "2021-08-05T16:52:33Z",
  "region": "us-east-1",
  "resources": [
    "arn:aws:mediaconvert:us-east-1:<AWS_ACCOUNT_ID>:jobs/<VIDEOJOB_ID>"
  ],
  "detail": {
    "timestamp": 1628172900136,
    "accountId": "<AWS_ACCOUNT_ID>",
    "queue": "arn:aws:mediaconvert:us-east-1:<AWS_ACCOUNT_ID>:queues/Default",
    "jobId": "<VIDEOJOB_ID>",
    "status": "COMPLETE",
    "userMetadata": {},
    "outputGroupDetails": [
      {
        "outputDetails": [
          {
            "outputFilePaths": [
              "s3://<AWS_STORAGE_BUCKET_NAME>/aws_mediaconvert_transcodes/<SITE_NAME>/<DRIVE_FILE_ID>/<VIDEO_FILENAME>.mp4"
            ],
            "durationInMs": 132033,
            "videoDetails": {
              "widthInPx": 1280,
              "heightInPx": 720
            }
          },
          {
            "outputFilePaths": [
              "s3://<AWS_STORAGE_BUCKET_NAME>/aws_mediaconvert_transcodes/<SITE_NAME>/<DRIVE_FILE_ID>/<VIDEO_FILENAME>_360p_16_9.mp4"
            ],
            "durationInMs": 132033,
            "videoDetails": {
              "widthInPx": 640,
              "heightInPx": 360
            }
          },
          {
            "outputFilePaths": [
              "s3://<AWS_STORAGE_BUCKET_NAME>/aws_mediaconvert_transcodes/<SITE_NAME>/<DRIVE_FILE_ID>/<VIDEO_FILENAME>_360p_4_3.mp4"
            ],
            "durationInMs": 132033,
            "videoDetails": {
              "widthInPx": 480,
              "heightInPx": 360
            }
          }
        ],
        "type": "FILE_GROUP"
      }
    ]
  }
}
```
- Verify there are now 3 `VideoFile` objects for the video, all with blank `destination_id`s and `status=Created`
- In a shell, run the following:
```python
from gdrive_sync.api import *
video = Video.objects.order_by("-created_on").first()
drive_file = DriveFile.objects.get(video=video)
transcode_gdrive_video(drive_file)
```
- Reload the admin page, verify there is still only one `VideoJob` 
- Go back to the shell and run this:
```python
VideoJob.objects.filter(job_id="<your job id>").update(status=VideoJobStatus.FAILED)
transcode_gdrive_video(drive_file)
```
- Reload the admin page, there should now be two `VideoJob` objects
- Update the Youtube `VideoFile` with a non-blank `destination_id` value, `destination_status=processed`, and `status=Complete` and save the changes.
- Run the POST request from above again, this time with the newest `VideoJob.job_id`
- Verify that the 3 `VideoFile` objects for the video once again have all blank `destination_id`s and `status=Created`


