### PR TITLE
Change the mass-publish API endpoint filter

### DIFF
--- a/websites/views.py
+++ b/websites/views.py
@@ -233,13 +233,13 @@ class WebsitePublishViewSet(viewsets.ViewSet):
         version = self.request.query_params.get("version")
         if version not in (VERSION_LIVE, VERSION_DRAFT):
             raise ValidationError("Invalid version")
+        publish_date_field = (
+            "publish_date" if version == VERSION_LIVE else "draft_publish_date"
+        )
 
-        # Get all sites, minus any never-published sites created in studio (for specified version)
+        # Get all sites, minus any sites that have never been successfully published
         sites = (
-            Website.objects.exclude(
-                Q(**{f"{version}_publish_status": None})
-                & Q(**{"source": constants.WEBSITE_SOURCE_STUDIO})
-            )
+            Website.objects.exclude(Q(**{f"{publish_date_field}__isnull": True}))
             .prefetch_related("starter")
             .order_by("name")
         )


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #1222

#### What's this PR do?
Changes the filter for the mass-publish API endpoint to exclude sites based on null live/draft publish date, regardless of source.

#### How should this be manually tested?
- Go to http://localhost:8043/api/publish/?version=live  (you will need to include an authorization header in the form of a bearer token equal to `<settings.API_BEARER_TOKEN>`) and note the first site result.
- If not already set, assign a date to `draft_publish_date` for that site and make sure it shows up in results at http://localhost:8043/api/publish/?version=draft 
- Change `publish_date` to `None`.  The site should be included in the output of http://localhost:8043/api/publish/?version=draft but not http://localhost:8043/api/publish/?version=live
- Change `draft_publish_date` to `None`.  The site should not be included in the output of http://localhost:8043/api/publish/?version=draft or http://localhost:8043/api/publish/?version=live 
