### PR TITLE
remove delete_unpublished_courses

### DIFF
--- a/ocw_import/management/commands/import_ocw_course_sites.py
+++ b/ocw_import/management/commands/import_ocw_course_sites.py
@@ -77,7 +77,7 @@ class Command(BaseCommand):
             "-d",
             "--delete_unpublished",
             dest="delete_unpublished",
-            default=True,
+            default=False,
             type=bool,
             help="If True, delete all courses that have been unpublished in the source data",
         )

--- a/ocw_import/management/commands/import_ocw_course_sites.py
+++ b/ocw_import/management/commands/import_ocw_course_sites.py
@@ -74,14 +74,6 @@ class Command(BaseCommand):
             help="Do NOT sync all unsynced courses to the backend",
         )
         parser.add_argument(
-            "-d",
-            "--delete_unpublished",
-            dest="delete_unpublished",
-            default=False,
-            type=bool,
-            help="If True, delete all courses that have been unpublished in the source data",
-        )
-        parser.add_argument(
             "--git_delete",
             dest="delete_from_git",
             action="store_true",
@@ -97,7 +89,6 @@ class Command(BaseCommand):
         bucket_name = options["bucket"]
         filter_json = options["filter_json"]
         limit = options["limit"]
-        delete_unpublished = options["delete_unpublished"]
         delete_from_git = options["delete_from_git"]
 
         if filter_json:
@@ -139,7 +130,6 @@ Would you like to proceed with the import? (y/n): """
             course_paths=course_paths,
             prefix=prefix,
             limit=limit,
-            delete_unpublished=delete_unpublished,
             chunk_size=options["chunks"],
         )
         self.stdout.write(f"Starting task {task}...")

--- a/ocw_import/tasks.py
+++ b/ocw_import/tasks.py
@@ -12,8 +12,7 @@ from ocw_import.api import (
     import_ocw2hugo_course,
     update_ocw2hugo_course,
 )
-from websites.constants import WEBSITE_SOURCE_OCW_IMPORT
-from websites.models import Website, WebsiteStarter
+from websites.models import WebsiteStarter
 
 
 log = logging.getLogger(__name__)

--- a/ocw_import/tasks.py
+++ b/ocw_import/tasks.py
@@ -69,30 +69,6 @@ def update_ocw2hugo_course_paths(
         )
 
 
-@app.task()
-def delete_unpublished_courses(paths=None):
-    """
-    Delete all unpublished courses based on paths not present for existing Websites
-
-    Args:
-        paths: (list of str): list of course data template paths
-    """
-    if not paths:
-        return
-    course_ids = list(
-        map((lambda key: key.replace("/data/course_legacy.json", "", 1)), paths)
-    )
-    unpublished_courses = Website.objects.filter(
-        source=WEBSITE_SOURCE_OCW_IMPORT
-    ).exclude(name__in=course_ids)
-    if unpublished_courses.count() == 0:
-        log.info("No unpublished courses to delete")
-        return
-    else:
-        log.info("Deleting unpublished courses: %s", unpublished_courses)
-        unpublished_courses.delete()
-
-
 @app.task(bind=True)
 def import_ocw2hugo_courses(
     self,
@@ -100,7 +76,6 @@ def import_ocw2hugo_courses(
     course_paths=None,
     prefix=None,
     limit=None,
-    delete_unpublished=False,
     chunk_size=100,
 ):  # pylint:disable=too-many-arguments
     """
@@ -111,7 +86,6 @@ def import_ocw2hugo_courses(
         course_paths (list of str): The paths of the courses to be imported
         prefix (str): (Optional) S3 prefix before start of course_id path
         limit (int): (Optional) Only import this amount of courses
-        delete_unpublished (bool): (Optional) If true, delete unpublished courses from the DB
         chunk_size (int): Number of courses to process per task
     """
     if not bucket_name:
@@ -120,12 +94,6 @@ def import_ocw2hugo_courses(
         raise TypeError("Course paths must be specified")
     if limit is not None:
         course_paths = course_paths[:limit]
-    if delete_unpublished:
-        delete_unpublished_courses_task = delete_unpublished_courses.si(
-            paths=course_paths
-        )
-    else:
-        delete_unpublished_courses_task = None
     course_tasks = [
         import_ocw2hugo_course_paths.si(
             paths=paths,
@@ -134,13 +102,8 @@ def import_ocw2hugo_courses(
         )
         for paths in chunks(course_paths, chunk_size=chunk_size)
     ]
-    # Make sure that the delete task doesn't take place until after all the import tasks complete
     import_steps = celery.chord(celery.group(course_tasks), chord_finisher.si())
-    delete_steps = celery.group(
-        [delete_unpublished_courses_task] if delete_unpublished else []
-    )
-    workflow = celery.chain(import_steps, delete_steps)
-    raise self.replace(celery.group(workflow))
+    raise self.replace(celery.group(import_steps))
 
 
 @app.task(bind=True)

--- a/ocw_import/tasks.py
+++ b/ocw_import/tasks.py
@@ -100,7 +100,7 @@ def import_ocw2hugo_courses(
     course_paths=None,
     prefix=None,
     limit=None,
-    delete_unpublished=True,
+    delete_unpublished=False,
     chunk_size=100,
 ):  # pylint:disable=too-many-arguments
     """

--- a/ocw_import/tasks_test.py
+++ b/ocw_import/tasks_test.py
@@ -223,6 +223,7 @@ def test_import_ocw2hugo_courses_delete_unpublished(settings, mocker, mocked_cel
             bucket_name=MOCK_BUCKET_NAME,
             prefix=TEST_OCW2HUGO_PREFIX,
             course_paths=course_paths,
+            delete_unpublished=True
         )
     mock_delete_unpublished_courses.assert_called_with(paths=SINGLE_COURSE_PATHS)
     tmpdir.cleanup()

--- a/ocw_import/tasks_test.py
+++ b/ocw_import/tasks_test.py
@@ -1,16 +1,9 @@
 """ Tests for ocw_import.tasks """
-from tempfile import TemporaryDirectory
 
 import pytest
 from moto import mock_s3
 
-from ocw_import.api import import_ocw2hugo_course
-from ocw_import.conftest import (
-    MOCK_BUCKET_NAME,
-    TEST_OCW2HUGO_PREFIX,
-    setup_s3,
-    setup_s3_tmpdir,
-)
+from ocw_import.conftest import MOCK_BUCKET_NAME, TEST_OCW2HUGO_PREFIX, setup_s3
 from ocw_import.tasks import (
     fetch_ocw2hugo_course_paths,
     import_ocw2hugo_course_paths,
@@ -18,7 +11,6 @@ from ocw_import.tasks import (
     update_ocw2hugo_course_paths,
     update_ocw_resource_data,
 )
-from websites.models import Website
 
 
 # pylint:disable=too-many-arguments

--- a/ocw_import/tasks_test.py
+++ b/ocw_import/tasks_test.py
@@ -12,7 +12,6 @@ from ocw_import.conftest import (
     setup_s3_tmpdir,
 )
 from ocw_import.tasks import (
-    delete_unpublished_courses,
     fetch_ocw2hugo_course_paths,
     import_ocw2hugo_course_paths,
     import_ocw2hugo_courses,
@@ -99,23 +98,14 @@ def test_update_ocw2hugo_course_paths(mocker, paths, create_new_content):
         [1, ALL_COURSES_FILTER, 1, 1],
     ],
 )
-@pytest.mark.parametrize("delete_unpublished", [True, False])
 def test_import_ocw2hugo_courses(
-    settings,
-    mocked_celery,
-    mocker,
-    filter_list,
-    chunk_size,
-    limit,
-    call_count,
-    delete_unpublished,
+    settings, mocked_celery, mocker, filter_list, chunk_size, limit, call_count
 ):
     """
     import_ocw2hugo_course_paths should be called correct # times for given chunk size, limit, filter, and # of paths
     """
     setup_s3(settings)
     mock_import_paths = mocker.patch("ocw_import.tasks.import_ocw2hugo_course_paths.si")
-    mock_delete_task = mocker.patch("ocw_import.tasks.delete_unpublished_courses.si")
     course_paths = list(
         fetch_ocw2hugo_course_paths(
             MOCK_BUCKET_NAME, prefix=TEST_OCW2HUGO_PREFIX, filter_list=filter_list
@@ -128,10 +118,8 @@ def test_import_ocw2hugo_courses(
             prefix=TEST_OCW2HUGO_PREFIX,
             chunk_size=chunk_size,
             limit=limit,
-            delete_unpublished=delete_unpublished,
         )
     assert mock_import_paths.call_count == call_count
-    assert mock_delete_task.call_count == (1 if delete_unpublished else 0)
 
 
 @mock_s3
@@ -164,95 +152,6 @@ def test_import_ocw2hugo_courses_no_filter(mocker):
             bucket_name=MOCK_BUCKET_NAME, prefix=TEST_OCW2HUGO_PREFIX, chunk_size=100
         )
     assert mock_import_paths.call_count == 0
-
-
-@mock_s3
-def test_delete_unpublished_courses(settings, course_starter):
-    """ delete_unpublished_courses should remove Website objects when they aren't present in the passed in list of paths """
-    setup_s3(settings)
-    settings.OCW_IMPORT_STARTER_SLUG = "course"
-    for course_path in ALL_COURSES_PATHS:
-        import_ocw2hugo_course(
-            MOCK_BUCKET_NAME,
-            TEST_OCW2HUGO_PREFIX,
-            course_path,
-            starter_id=course_starter.id,
-        )
-    assert Website.objects.all().count() == 4
-    delete_unpublished_courses(paths=ALL_COURSES_PATHS)
-    assert Website.objects.all().count() == 4
-    delete_unpublished_courses(paths=SINGLE_COURSE_PATHS)
-    assert Website.objects.all().count() == 2
-
-
-@mock_s3
-def test_import_ocw2hugo_courses_delete_unpublished(settings, mocker, mocked_celery):
-    """ import_ocw2hugo_courses should call delete_unpublished when courses have been removed from the ocw-to-hugo directory """
-    mock_delete_unpublished_courses = mocker.patch(
-        "ocw_import.tasks.delete_unpublished_courses.si"
-    )
-    tmpdir = TemporaryDirectory()
-    setup_s3_tmpdir(settings, tmpdir.name)
-    course_paths = list(
-        fetch_ocw2hugo_course_paths(
-            MOCK_BUCKET_NAME,
-            prefix=TEST_OCW2HUGO_PREFIX,
-            filter_list=ALL_COURSES_FILTER,
-        )
-    )
-    with pytest.raises(mocked_celery.replace_exception_class):
-        import_ocw2hugo_courses.delay(
-            bucket_name=MOCK_BUCKET_NAME,
-            prefix=TEST_OCW2HUGO_PREFIX,
-            course_paths=course_paths,
-        )
-    mock_delete_unpublished_courses.assert_called_with(paths=ALL_COURSES_PATHS)
-    single_course_filter = ["1-050-engineering-mechanics-i-fall-2007"]
-    tmpdir.cleanup()
-    tmpdir = TemporaryDirectory()
-    setup_s3_tmpdir(settings, tmpdir.name, courses=single_course_filter)
-    course_paths = list(
-        fetch_ocw2hugo_course_paths(
-            MOCK_BUCKET_NAME,
-            prefix=TEST_OCW2HUGO_PREFIX,
-            filter_list=single_course_filter,
-        )
-    )
-    with pytest.raises(mocked_celery.replace_exception_class):
-        import_ocw2hugo_courses.delay(
-            bucket_name=MOCK_BUCKET_NAME,
-            prefix=TEST_OCW2HUGO_PREFIX,
-            course_paths=course_paths,
-            delete_unpublished=True
-        )
-    mock_delete_unpublished_courses.assert_called_with(paths=SINGLE_COURSE_PATHS)
-    tmpdir.cleanup()
-
-
-@mock_s3
-def test_import_ocw2hugo_courses_delete_unpublished_false(
-    settings, mocker, mocked_celery
-):
-    """ import_ocw2hugo_courses should not call delete_unpublished when the argument is false """
-    mock_delete_unpublished_courses = mocker.patch(
-        "ocw_import.tasks.delete_unpublished_courses.si"
-    )
-    setup_s3(settings)
-    course_paths = list(
-        fetch_ocw2hugo_course_paths(
-            MOCK_BUCKET_NAME,
-            prefix=TEST_OCW2HUGO_PREFIX,
-            filter_list=ALL_COURSES_FILTER,
-        )
-    )
-    with pytest.raises(mocked_celery.replace_exception_class):
-        import_ocw2hugo_courses.delay(
-            bucket_name=MOCK_BUCKET_NAME,
-            prefix=TEST_OCW2HUGO_PREFIX,
-            course_paths=course_paths,
-            delete_unpublished=False,
-        )
-    mock_delete_unpublished_courses.assert_not_called()
 
 
 @mock_s3


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1218

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/1214, a bug was introduced that allows for the possibility of mass-deleting courses.  This PR removes all code related to automatically deleting unpublished courses during the import process.

#### How should this be manually tested?
 - Spin up your local `ocw-studio` and ensure you're set up with S3 access
 - Run `docker-compose run --rm web ./manage.py import_ocw_course_sites -b ocw-to-hugo-output-qa --filter "8-591j-systems-biology-fall-2004, 15-057-systems-optimization-spring-2003, 6-776-high-speed-communication-circuits-spring-2005"`
 - Go to Django admin's `Website` section and note the current number of `Website` objects
 - Run `docker-compose run --rm web ./manage.py import_ocw_course_sites -b ocw-to-hugo-output-qa --filter "8-591j-systems-biology-fall-2004, 15-057-systems-optimization-spring-2003`
 - Go to Django admin's `Website` section and verify that the number of `Website` objects is the same
