### PR TITLE
improve link logging

### DIFF
--- a/websites/management/commands/markdown_cleaning/cleaner.py
+++ b/websites/management/commands/markdown_cleaning/cleaner.py
@@ -15,6 +15,26 @@ from websites.models import WebsiteContent
 from websites.utils import get_dict_field, set_dict_field
 
 
+def get_ocw_url(content: WebsiteContent):
+    """Return an ocw.mit.edu url to the given content."""
+    rootrel = get_rootrelative_url_from_content(content)
+    return f"https://ocw.mit.edu{rootrel}"
+
+
+def get_studio_url(content: WebsiteContent):
+    """Return an ocw-studio.odl.mit.edu url to the given content."""
+    site_name = content.website.name
+    if content.type == "sitemetadata":
+        return f"https://ocw-studio.odl.mit.edu/sites/{site_name}/type/metadata/"
+    return f"https://ocw-studio.odl.mit.edu/sites/{site_name}/type/page/edit/{content.text_id}/"
+
+
+def get_github_url(content: WebsiteContent):
+    """Return a github.mit.edu url to the given content."""
+    short_id = content.website.short_id
+    return f"https://github.mit.edu/mitocwcontent/{short_id}/tree/main/{content.dirpath}/{content.filename}.md"
+
+
 class WebsiteContentMarkdownCleaner:
     """Facilitates find-and-replace on WebsiteContent markdown fields.
 
@@ -44,7 +64,10 @@ class WebsiteContentMarkdownCleaner:
         "replaced_on_site_name",
         "replaced_on_site_short_id",
         "replaced_on_page_uuid",
-        "replaced_on_page_url",
+        "root_relative_url",
+        "ocw_url",
+        "github_url",
+        "studio_url",
     ]
 
     def __init__(self, rule: MarkdownCleanupRule):
@@ -137,9 +160,12 @@ class WebsiteContentMarkdownCleaner:
                     "replaced_on_site_name": change.content.website.name,
                     "replaced_on_site_short_id": change.content.website.short_id,
                     "replaced_on_page_uuid": change.content.text_id,
-                    "replaced_on_page_url": get_rootrelative_url_from_content(
+                    "root_relative_url": get_rootrelative_url_from_content(
                         change.content
                     ),
+                    "ocw_url": get_ocw_url(change.content),
+                    "studio_url": get_studio_url(change.content),
+                    "github_url": get_github_url(change.content),
                     **asdict(change.notes),
                 }
                 writer.writerow(row)

--- a/websites/management/commands/markdown_cleaning/link_logging_rule.py
+++ b/websites/management/commands/markdown_cleaning/link_logging_rule.py
@@ -1,7 +1,14 @@
 from dataclasses import dataclass
+from functools import partial
+from urllib.parse import urlparse
 
 from websites.management.commands.markdown_cleaning.cleanup_rule import PyparsingRule
-from websites.management.commands.markdown_cleaning.link_parser import LinkParser
+from websites.management.commands.markdown_cleaning.link_parser import (
+    LinkParser,
+    LinkParseResult,
+)
+from websites.management.commands.markdown_cleaning.utils import ContentLookup
+from websites.models import WebsiteContent
 
 
 class LinkLoggingRule(PyparsingRule):
@@ -14,7 +21,7 @@ class LinkLoggingRule(PyparsingRule):
 
     alias = "link_logging"
 
-    Parser = LinkParser
+    Parser = partial(LinkParser, recursive=True)
 
     fields = [
         "markdown",
@@ -28,20 +35,20 @@ class LinkLoggingRule(PyparsingRule):
 
     @dataclass
     class ReplacementNotes:
+        link_type: str
         text: str
         destination: str
         title: str
         is_image: bool
+        scheme: str
+        broken_best_guess: str = "No"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.content_lookup = ContentLookup()
 
     def replace_match(self, s: str, l: int, toks, website_content):
-        link = toks.link
-        notes = self.ReplacementNotes(
-            text=link.text,
-            destination=link.destination,
-            title=link.title,
-            is_image=link.is_image,
-        )
-        return toks.original_text, notes
+        return toks.original_text, self.classify_link(toks, website_content)
 
     def should_parse(self, text: str):
         """Should the text be parsed?
@@ -50,3 +57,76 @@ class LinkLoggingRule(PyparsingRule):
         markdown links.
         """
         return "](" in text
+
+    def classify_link(self, result: LinkParseResult, wc: WebsiteContent):
+        link = result.link
+        Notes = partial(
+            self.ReplacementNotes,
+            text=link.text,
+            destination=link.destination,
+            title=link.title,
+            is_image=link.is_image,
+        )
+        try:
+            url = urlparse(link.destination)
+        except ValueError:
+            return Notes(link_type="invalid url", scheme="")
+        Notes = partial(Notes, scheme=url.scheme)
+
+        skip_schemes_prefixes = ["http", "ftp", "mailto"]
+        if any(url.scheme.startswith(p) for p in skip_schemes_prefixes):
+            return Notes(link_type="global")
+
+        if url.path.startswith("/courses"):
+            try:
+                self.content_lookup.find(url.path)
+                return Notes(link_type="found course content")
+            except KeyError:
+                pass
+
+        if url.path.startswith(R"{{< baseurl >}}"):
+            try:
+                self.content_lookup.find(url.path, base_site=wc.website)
+                return Notes(link_type="baseurl: found course content")
+            except KeyError:
+                return Notes(link_type="baseurl: Not found", broken_best_guess="Yes")
+
+        if url.path == "":
+            return Notes(link_type="within-page link")
+
+        if "resolveuid" in url.path:
+            return Notes(link_type="Broken resolveuid link")
+        if "images/inacessible" in url.path:
+            return Notes(link_type="image/inaccessible")
+        if "icon-question" in url.path:
+            return Notes(link_type="icon-question")
+        if "images/trans.gif" in url.path:
+            return Notes(link_type="images/trans.gif")
+        if "mp_logo" in url.path:
+            return Notes(link_type="mit_press_logo")
+        if "faq-technical-requirements" in url.path:
+            return Notes(
+                link_type="faq-technical-requirements (https://ocw.mit.edu/help/faq-technical-requirements/)"
+            )
+        if "fair-use" in url.path or "fairuse" in url.path:
+            return Notes(link_type="fairuse (https://ocw.mit.edu/help/faq-fair-use/)")
+        if url.path.rstrip("/").endswith("/terms"):
+            return Notes(link_type="terms (https://ocw.mit.edu/terms/)")
+        if "images/educator/edu_" in url.path:
+            return Notes(
+                link_type='image/educate/edu_ ... used for "Semester Breakdown" on https://ocw.mit.edu/courses/sloan-school-of-management/15-279-management-communication-for-undergraduates-fall-2012/instructor-insights/'
+            )
+        if url.path.startswith("/ans7870"):
+            return Notes(link_type="/ans7870")
+        if url.path.startswith("/20-219IAP15"):
+            return Notes(
+                link_type="/20-219IAP15 ... (redirects https://ocw.mit.edu/courses/biological-engineering/20-219-becoming-the-next-bill-nye-writing-and-hosting-the-educational-show-january-iap-2015/) "
+            )
+        if url.path == "/images/a_logo_17.gif":
+            return Notes(link_type="/images/a_logo_17.gif")
+        if url.path.endswith("button_start.png"):
+            return Notes(link_type="button_start.png")
+        if "images/educator/classroom_" in url.path:
+            return Notes(link_type="images/educator/classroom_")
+
+        return Notes(link_type="Unknown", broken_best_guess="Yes")

--- a/websites/management/commands/markdown_cleaning/validate_urls.py
+++ b/websites/management/commands/markdown_cleaning/validate_urls.py
@@ -50,8 +50,13 @@ class ValidateUrls(RegexpCleanupRule):
         self.content_lookup = ContentLookup()
 
     def replace_match(self, match: re.Match, wc: WebsiteContent):
-        url = urlparse(match.group("url"))
         original_text = match[0]
+        try:
+            url = urlparse(match.group("url"))
+        except ValueError:
+            return original_text, self.ReplacementNotes(
+                url_path="unknown", link_type="invalid url"
+            )
         notes = partial(self.ReplacementNotes, url_path=url.path)
         note_works = partial(notes, broken_best_guess="No")
         note_broken = partial(notes, broken_best_guess="Yes")


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
Miscellaneous improvements to the output of `markdown_cleanup` and link logging rule that I made when opening #1233:
- now csv includes urls to github, studio, and ocw
- new `--limit` option for the management command, useful for testing
- copied/updated the classification from validate_urls to link_logging. Will probably delete validate_urls soon. (It's the old regexp based version of link_logging rule).

#### How should this be manually tested?
Run 
```
docker-compose run --rm web ./manage.py markdown_cleanup link_logging -o links.csv --limit 100
```
and check that the links in the CSV work.
