### PR TITLE
fix: course_collections renamed to course-collection

### DIFF
--- a/localdev/configs/ocw-www.yml
+++ b/localdev/configs/ocw-www.yml
@@ -15,7 +15,7 @@ collections:
         name: body
         widget: markdown
         link:
-          - course_collections
+          - course-collection
           - resource_collections
 
   - category: Content

--- a/static/js/components/widgets/ResourcePickerDialog.test.tsx
+++ b/static/js/components/widgets/ResourcePickerDialog.test.tsx
@@ -93,7 +93,7 @@ describe("ResourcePickerDialog", () => {
     },
     {
       mode:         RESOURCE_LINK,
-      contentNames: ["course_collections"],
+      contentNames: ["course-collection"],
       expectedTabs: [TabIds.CourseCollections]
     },
     {
@@ -103,7 +103,7 @@ describe("ResourcePickerDialog", () => {
     },
     {
       mode:         RESOURCE_LINK,
-      contentNames: ["resource", "page", "course_collections"],
+      contentNames: ["resource", "page", "course-collection"],
       expectedTabs: [
         TabIds.Documents,
         TabIds.Videos,

--- a/static/js/components/widgets/ResourcePickerDialog.test.tsx
+++ b/static/js/components/widgets/ResourcePickerDialog.test.tsx
@@ -93,7 +93,7 @@ describe("ResourcePickerDialog", () => {
     },
     {
       mode:         RESOURCE_LINK,
-      contentNames: ["course-collection"],
+      contentNames: ["course_collections"],
       expectedTabs: [TabIds.CourseCollections]
     },
     {
@@ -103,7 +103,7 @@ describe("ResourcePickerDialog", () => {
     },
     {
       mode:         RESOURCE_LINK,
-      contentNames: ["resource", "page", "course-collection"],
+      contentNames: ["resource", "page", "course_collections"],
       expectedTabs: [
         TabIds.Documents,
         TabIds.Videos,

--- a/static/js/components/widgets/ResourcePickerDialog.tsx
+++ b/static/js/components/widgets/ResourcePickerDialog.tsx
@@ -43,7 +43,7 @@ export enum TabIds {
   Images = "images",
   Videos = "videos",
   Pages = "pages",
-  CourseCollections = "course_collections",
+  CourseCollections = "course-collection",
   ResourceCollections = "resource_collections"
 }
 

--- a/static/js/components/widgets/ResourcePickerListing.test.tsx
+++ b/static/js/components/widgets/ResourcePickerListing.test.tsx
@@ -115,7 +115,7 @@ describe("ResourcePickerListing", () => {
         })
         .query({
           offset:        0,
-          type:          "course_collections",
+          type:          "course-collection",
           detailed_list: true
         })
         .toString(),
@@ -220,7 +220,7 @@ describe("ResourcePickerListing", () => {
 
   it("should fetch and display content collections", async () => {
     const { wrapper } = await render({
-      contentType:       "course_collections",
+      contentType:       "course-collection",
       resourcetype:      null,
       sourceWebsiteName: "ocw-www"
     })
@@ -236,7 +236,7 @@ describe("ResourcePickerListing", () => {
         .param({ name: "ocw-www" })
         .query({
           offset:        0,
-          type:          "course_collections",
+          type:          "course-collection",
           detailed_list: true
         })
         .toString()

--- a/static/js/constants.ts
+++ b/static/js/constants.ts
@@ -157,7 +157,7 @@ export const exampleSiteConfigFields: ConfigField[] = uniq(
 export enum ContentType {
   Resource = "resource",
   Page = "page",
-  CourseCollections = "course_collections",
+  CourseCollections = "course-collection",
   ResourceCollections = "resource_collections"
 }
 

--- a/static/js/resources/ocw-www.json
+++ b/static/js/resources/ocw-www.json
@@ -12,7 +12,7 @@
         {
           "label": "Body",
           "link": [
-            "course_collections",
+            "course-collection",
             "resource_collections"
           ],
           "name": "body",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1182

#### What's this PR do?
- Renames `course_collections` to `course-collection`

#### How should this be manually tested?
- Add/Edit any page of `ocw-www` in studio.
- Add Link.
- Verify all the course collections are listed in Course Collections tab.

#### Screenshots (if appropriate)
<img width="772" alt="image" src="https://user-images.githubusercontent.com/93309234/163135502-d3d830d2-0b57-40ef-910e-44c8a3c0aed4.png">
