### PR TITLE
fix: required=true for relation widgetvariant

### DIFF
--- a/static/js/components/forms/validation.ts
+++ b/static/js/components/forms/validation.ts
@@ -16,6 +16,7 @@ import {
   WidgetVariant
 } from "../../types/websites"
 import { FormSchema, SiteFormValues } from "../../types/forms"
+import { IS_A_REQUIRED_FIELD } from "../../constants"
 
 // This is added to properly handle file fields, which can have a "null" value
 setLocale({
@@ -69,7 +70,9 @@ export const getFieldSchema = (
       })
     } else {
       schema = yup.object().shape({
-        content: yup.string()
+        content: field.required ?
+          yup.string().required(`${field.name} ${IS_A_REQUIRED_FIELD}`) :
+          yup.string()
       })
     }
     break
@@ -117,7 +120,7 @@ export const getFieldSchema = (
     schema = yup.string()
   }
 
-  if (field.required) {
+  if (field.required && field.widget !== WidgetVariant.Relation) {
     schema = schema.required()
   }
   schema = schema.label(field.label)

--- a/static/js/constants.ts
+++ b/static/js/constants.ts
@@ -195,3 +195,5 @@ export const GOOGLE_DRIVE_SYNC_PROCESSING_STATES = [
   GoogleDriveSyncStatuses.SYNC_STATUS_PENDING,
   GoogleDriveSyncStatuses.SYNC_STATUS_PROCESSING
 ]
+
+export const IS_A_REQUIRED_FIELD = "is a required field"


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1161

#### What's this PR do?
- Conditionally calls formik `required()` for fields having widget: `relation`, required: `true` and multiple: `false`
(More detail of this issue has been explained [here](https://github.com/mitodl/ocw-hugo-projects/issues/147#issuecomment-1077505751))

#### How should this be manually tested?
- For `widget=relation` fields, set `required=true` in config of website starter. (make sure multiple is false)
- Add/Edit object which has the field for which required has been set to true.
- Verify that an appropriate error is shown when you try to save the object without selecting any value for that field.
- Any other use-case, that needs to be tested with respect to this change.

#### Screenshots (if appropriate)

<img width="521" alt="image" src="https://user-images.githubusercontent.com/93309234/163177221-1935c94f-6333-40aa-bd15-b2f47a47c896.png">

<img width="318" alt="image" src="https://user-images.githubusercontent.com/93309234/163177306-bb2df979-a37f-4ce5-acdd-049eb78380c8.png">


