### PR TITLE
[markdown cleanup] fix superscript/subscript escaping issues

### DIFF
--- a/websites/management/commands/markdown_cleaning/cleanup_rule.py
+++ b/websites/management/commands/markdown_cleaning/cleanup_rule.py
@@ -106,6 +106,21 @@ class PyparsingRule(MarkdownCleanupRule):
     def replace_match(
         self, s: str, l: int, toks: ParseResults, website_content: WebsiteContent
     ):
+        """
+        Called on each match of the parser. The match will be replaced by the
+        return value of this function.
+
+        The first three arguments `(s, l, toks)` the same as for any parse
+        action used with PyParsing. For more, see
+        See https://pyparsing-docs.readthedocs.io/en/latest/pyparsing.html#pyparsing.ParserElement.set_parse_action
+
+        Args:
+            - s: The entire original text (**not** the text of this match; the
+            entire document being parsed)
+            - l: index within s at which this match starts
+            - toks: The parser's tokenization of the match
+            - website_content: The WebsiteContent object that `s` belongs to.
+        """
         pass
 
     def __init__(self) -> None:

--- a/websites/management/commands/markdown_cleaning/subsup_fixes.py
+++ b/websites/management/commands/markdown_cleaning/subsup_fixes.py
@@ -1,0 +1,77 @@
+import re
+
+from websites.management.commands.markdown_cleaning.cleanup_rule import PyparsingRule
+from websites.management.commands.markdown_cleaning.parsing_utils import (
+    ShortcodeParam,
+    ShortcodeTag,
+)
+from websites.management.commands.markdown_cleaning.shortcode_grammar import (
+    ShortcodeParser,
+    ShortcodeParseResult,
+)
+
+
+class SubSupFixes(PyparsingRule):
+    """
+    This fixes two issues with {{< sub >}} and {{< sup >}} shortcodes
+
+    - leading +/- need to be escaped in the subscript/superscript values because
+    we call markdownify on these values. If they are both leading AND unescaped,
+    markdownify treats them as list bullets
+
+    Do auto-escape leading *. There aren't very many, and most of the time they
+    seem to be intended as bold/italics.
+
+    - a bunch of +/-/* got extra escapes, probably from before CKEditor was
+    updated to handle "legacy" shortcodes.
+    """
+
+    alias = "subsup"
+
+    Parser = ShortcodeParser
+
+    def should_parse(self, s: str):
+        variants = [R"{{< sub", R"{{< sup"]
+        return any(v in s for v in variants)
+
+    def replace_match(self, s: str, l: int, toks: ShortcodeParseResult, wc):
+        shortcode = toks.shortcode
+        original_text = toks.original_text
+        if not shortcode.name in ["sub", "sup"]:
+            return original_text
+
+        old_param = shortcode.get(0)
+        new_param = self.get_new_subsup_value(old_param)
+
+        if new_param == old_param:
+            return original_text
+
+        new_shortcode = ShortcodeTag(
+            name=shortcode.name,
+            percent_delimiters=shortcode.percent_delimiters,
+            params=[ShortcodeParam(new_param)],
+            closer=shortcode.closer,
+        )
+        return new_shortcode.to_hugo()
+
+    @staticmethod
+    def get_new_subsup_value(text: str):
+        """
+        Get the new value for text in a subscript / superscript.
+        """
+
+        escaped_bullet = re.compile(r"\\\\(?P<bullet>[\-\+\*])")
+
+        def replacer(match: re.Match):
+            return f'\\{match.group("bullet")}'
+
+        new_text = escaped_bullet.sub(replacer, text)
+
+        # escape leading +/- because markdown interprets them as lists.
+        # But do NOT escape leading * because almost always it's part of italics/bold.
+        # Handle leading * manually if we need to. There are only 2 or 3.
+        bullets = ["-", "+"]
+        if any(new_text.startswith(b) for b in bullets):
+            new_text = "\\" + new_text
+
+        return new_text

--- a/websites/management/commands/markdown_cleaning/subsup_fixes_test.py
+++ b/websites/management/commands/markdown_cleaning/subsup_fixes_test.py
@@ -1,0 +1,70 @@
+import pytest
+
+from websites.factories import WebsiteContentFactory, WebsiteFactory
+from websites.management.commands.markdown_cleaning.cleaner import (
+    WebsiteContentMarkdownCleaner,
+)
+from websites.management.commands.markdown_cleaning.subsup_fixes import SubSupFixes
+
+
+def get_markdown_cleaner():
+    """Convenience to get rule-specific markdown cleaner"""
+    rule = SubSupFixes()
+    return WebsiteContentMarkdownCleaner(rule)
+
+
+@pytest.mark.parametrize(
+    ["markdown", "expected_markdown"],
+    [
+        (
+            R'The quick {{< sub "-cat" >}} brown fox',
+            R'The quick {{< sub "\-cat" >}} brown fox',
+        ),
+        (
+            R'The quick {{< sub "+cat" >}} brown fox',
+            R'The quick {{< sub "\+cat" >}} brown fox',
+        ),
+        (
+            R'The quick {{< sub "**cat**" >}} brown fox',
+            R'The quick {{< sub "**cat**" >}} brown fox',
+        ),
+        (
+            R'The quick {{< sub "-2+2-1" >}} brown fox',
+            R'The quick {{< sub "\-2+2-1" >}} brown fox',
+        ),
+        (
+            R'The quick {{< sub "+2+2-1" >}} brown fox',
+            R'The quick {{< sub "\+2+2-1" >}} brown fox',
+        ),
+        (
+            R'The quick {{< sup "-cat" >}} brown fox',
+            R'The quick {{< sup "\-cat" >}} brown fox',
+        ),
+        (
+            R'The quick {{< sup "+cat" >}} brown fox',
+            R'The quick {{< sup "\+cat" >}} brown fox',
+        ),
+        (
+            R'The quick {{< sup "**cat**" >}} brown fox',
+            R'The quick {{< sup "**cat**" >}} brown fox',
+        ),
+        (
+            R'The quick {{< sup "-2+2-1" >}} brown fox',
+            R'The quick {{< sup "\-2+2-1" >}} brown fox',
+        ),
+        (
+            R'The quick {{< sup "+2+2-1" >}} brown fox',
+            R'The quick {{< sup "\+2+2-1" >}} brown fox',
+        ),
+    ],
+)
+def test_shortcode_standardizer(markdown, expected_markdown):
+    """Test subscript/superscript replacements"""
+    target_content = WebsiteContentFactory.build(
+        markdown=markdown, website=WebsiteFactory.build()
+    )
+
+    cleaner = get_markdown_cleaner()
+    cleaner.update_website_content(target_content)
+
+    assert target_content.markdown == expected_markdown

--- a/websites/management/commands/markdown_cleanup.py
+++ b/websites/management/commands/markdown_cleanup.py
@@ -39,6 +39,7 @@ from websites.management.commands.markdown_cleaning.rootrelative_urls import (
 from websites.management.commands.markdown_cleaning.shortcode_logging_rule import (
     ShortcodeLoggingRule,
 )
+from websites.management.commands.markdown_cleaning.subsup_fixes import SubSupFixes
 from websites.management.commands.markdown_cleaning.validate_urls import ValidateUrls
 from websites.models import WebsiteContent
 
@@ -68,6 +69,7 @@ class Command(BaseCommand):
         RemoveInaccesibleGif,
         LinkLoggingRule,
         LinkWrappedImagesRule,
+        SubSupFixes,
     ]
 
     def add_arguments(self, parser: CommandParser) -> None:


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets? https://github.com/mitodl/ocw-hugo-themes/issues/480


#### What's this PR do?
This PR fixes two issues with superscript/subscript shortcodes, e.g., `{{< sup "-pi*t/4" >}}`. In particular, escapes leading bullet characters (`-` and `+`) and removes extra escapes.

#### How should this be manually tested?
Run `docker-compose run --rm web ./manage.py markdown_cleanup subsup -o subsup.csv --commit --csv-only-changes
Creating ocw-studio_web_run` and inspect `subsup.csv` to make sure the changes look reasonable.

Also check that the replacements render nicely in Hugo, e.g.,
```
{{< sub "_n_\-4" >}}
{{< sup "\-(x+s cos t)" >}}
{{< sup "**(\*1)**" >}}
```

#### Any background context you want to provide?
The extra escapes probably predate #1013 
