### PR TITLE
Sync Website.title with the sitemetadata course_title

### DIFF
--- a/app.json
+++ b/app.json
@@ -139,6 +139,10 @@
       "description": "Gdrive folder for video uploads",
       "required": false
     },
+    "FIELD_METADATA_TITLE": {
+      "description": "The site metadata field for title",
+      "required": false
+    },
     "FIELD_RESOURCETYPE": {
       "description": "The site config metadata field for the resource type",
       "required": false

--- a/main/settings.py
+++ b/main/settings.py
@@ -548,6 +548,11 @@ FIELD_RESOURCETYPE = get_string(
     default="resourcetype",
     description="The site config metadata field for the resource type",
 )
+FIELD_METADATA_TITLE = get_string(
+    name="FIELD_METADATA_TITLE",
+    default="course_title",
+    description="The site metadata field for title",
+)
 
 # YouTube OCW metadata fields
 YT_FIELD_CAPTIONS = get_string(

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -218,6 +218,7 @@ export interface NewWebsitePayload {
 export interface WebsiteStatus {
   uuid: string
   name: string
+  title: string
   /** ISO 8601 datetime string or null */
   publish_date: string | null
   /** ISO 8601 datetime string or null */

--- a/static/js/util/factories/websites.ts
+++ b/static/js/util/factories/websites.ts
@@ -221,6 +221,7 @@ export const makeWebsiteStatus = (website?: Website): WebsiteStatus => {
   return {
     uuid:                            website.uuid,
     name:                            website.name,
+    title:                           website.title,
     publish_date:                    website.publish_date,
     draft_publish_date:              website.draft_publish_date,
     has_unpublished_draft:           website.has_unpublished_draft,

--- a/websites/api.py
+++ b/websites/api.py
@@ -382,3 +382,11 @@ def incomplete_content_warnings(website):
         )
 
     return messages
+
+
+def sync_website_title(content: WebsiteContent):
+    """Sync sitemetadata title with Website.title"""
+    title = get_dict_field(content.metadata, settings.FIELD_METADATA_TITLE)
+    if title:
+        content.website.title = title
+        content.website.save()

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -24,13 +24,14 @@ from websites import constants
 from websites.api import (
     detect_mime_type,
     incomplete_content_warnings,
+    sync_website_title,
     update_youtube_thumbnail,
 )
 from websites.constants import CONTENT_TYPE_METADATA
 from websites.models import Website, WebsiteContent, WebsiteStarter
 from websites.permissions import is_global_admin, is_site_admin
 from websites.site_config_api import SiteConfig
-from websites.utils import get_dict_field, permissions_group_name_for_role
+from websites.utils import permissions_group_name_for_role
 
 
 log = logging.getLogger(__name__)
@@ -391,10 +392,7 @@ class WebsiteContentDetailSerializer(
         update_website_backend(instance.website)
         # Sync the metadata title and website title if appropriate
         if instance.type == CONTENT_TYPE_METADATA:
-            title = get_dict_field(instance.metadata, settings.FIELD_METADATA_TITLE)
-            if title:
-                instance.website.title = title
-                instance.website.save()
+            sync_website_title(instance)
         return instance
 
     def get_content_context(self, instance):  # pylint:disable=too-many-branches
@@ -519,6 +517,8 @@ class WebsiteContentCreateSerializer(
             }
         )
         update_website_backend(instance.website)
+        if instance.type == CONTENT_TYPE_METADATA:
+            sync_website_title(instance)
         return instance
 
     class Meta:

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -1,4 +1,6 @@
 """ Tests for websites.serializers """
+from types import SimpleNamespace
+
 import pytest
 from dateutil.parser import parse as parse_date
 from django.core.files.uploadedfile import SimpleUploadedFile
@@ -9,6 +11,7 @@ from users.factories import UserFactory
 from users.models import User
 from videos.constants import YT_THUMBNAIL_IMG
 from websites.constants import (
+    CONTENT_TYPE_METADATA,
     CONTENT_TYPE_RESOURCE,
     ROLE_EDITOR,
     WEBSITE_SOURCE_OCW_IMPORT,
@@ -35,6 +38,20 @@ from websites.site_config_api import SiteConfig
 
 
 pytestmark = pytest.mark.django_db
+# pylint:disable=redefined-outer-name
+
+
+@pytest.fixture
+def mocked_website_funcs(mocker):
+    """Mocked website-related functions"""
+    return SimpleNamespace(
+        update_website_backend=mocker.patch(
+            "websites.serializers.update_website_backend"
+        ),
+        create_website_pipeline=mocker.patch(
+            "websites.serializers.create_website_publishing_pipeline"
+        ),
+    )
 
 
 def test_serialize_website_course():
@@ -118,6 +135,7 @@ def test_website_status_serializer(mocker, settings, drive_folder, warnings):
     settings.DRIVE_SERVICE_ACCOUNT_CREDS = {"key": "value"}
     settings.DRIVE_SHARED_ID = "abc123"
     values = {
+        "title": "site title",
         "publish_date": "2021-11-01T00:00:00Z",
         "draft_publish_date": "2021-11-02T00:00:00Z",
         "has_unpublished_live": True,
@@ -383,14 +401,8 @@ def test_website_content_detail_serializer_content_context(  # pylint:disable=to
     )
 
 
-def test_website_content_detail_serializer_save(mocker):
+def test_website_content_detail_serializer_save(mocker, mocked_website_funcs):
     """WebsiteContentDetailSerializer should modify only certain fields"""
-    mock_update_website_backend = mocker.patch(
-        "websites.serializers.update_website_backend"
-    )
-    mock_create_website_pipeline = mocker.patch(
-        "websites.serializers.create_website_publishing_pipeline"
-    )
     content = WebsiteContentFactory.create(
         type=CONTENT_TYPE_RESOURCE,
         metadata={
@@ -432,18 +444,41 @@ def test_website_content_detail_serializer_save(mocker):
         "created": "brand new!",
     }
     assert content.updated_by == user
-    mock_update_website_backend.assert_called_once_with(content.website)
-    mock_create_website_pipeline.assert_not_called()
+    mocked_website_funcs.update_website_backend.assert_called_once_with(content.website)
+    mocked_website_funcs.create_website_pipeline.assert_not_called()
 
 
-def test_website_content_detail_serializer_save_null_metadata(mocker):
+@pytest.mark.parametrize("has_title_field", [True, False])
+def test_website_content_detail_serializer_save_site_meta(  # pylint:disable=unused-argument
+    settings, mocker, mocked_website_funcs, has_title_field
+):
+    """Website title should be updated if the expected title field is in metadata"""
+    settings.FIELD_METADATA_TITLE = "course_title"
+    new_title = "Updated Site Title"
+    title_field = settings.FIELD_METADATA_TITLE if has_title_field else "other_title"
+    content = WebsiteContentFactory.create(
+        type=CONTENT_TYPE_METADATA,
+        metadata={},
+    )
+    assert content.website.title != new_title
+    serializer = WebsiteContentDetailSerializer(
+        data={"metadata": {title_field: new_title}},
+        instance=content,
+        context={
+            "view": mocker.Mock(kwargs={"parent_lookup_website": content.website.name}),
+            "request": mocker.Mock(user=UserFactory.create()),
+        },
+    )
+    serializer.is_valid(raise_exception=True)
+    serializer.save()
+    content.refresh_from_db()
+    assert (content.website.title == new_title) is has_title_field
+
+
+def test_website_content_detail_serializer_save_null_metadata(
+    mocker, mocked_website_funcs
+):
     """WebsiteContentDetailSerializer should save if metadata is null"""
-    mock_update_website_backend = mocker.patch(
-        "websites.serializers.update_website_backend"
-    )
-    mock_create_website_pipeline = mocker.patch(
-        "websites.serializers.create_website_publishing_pipeline"
-    )
     content = WebsiteContentFactory.create(
         type=CONTENT_TYPE_RESOURCE,
         metadata=None,
@@ -472,19 +507,18 @@ def test_website_content_detail_serializer_save_null_metadata(mocker):
     assert content.markdown == new_markdown
     assert content.metadata == {"meta": "data"}
     assert content.updated_by == user
-    mock_update_website_backend.assert_called_once_with(content.website)
-    mock_create_website_pipeline.assert_not_called()
+    mocked_website_funcs.update_website_backend.assert_called_once_with(content.website)
+    mocked_website_funcs.create_website_pipeline.assert_not_called()
 
 
 @pytest.mark.parametrize("add_context_data", [True, False])
-def test_website_content_create_serializer(mocker, add_context_data):
+def test_website_content_create_serializer(
+    mocker, mocked_website_funcs, add_context_data
+):
     """
     WebsiteContentCreateSerializer should create a new WebsiteContent object, using context data as an override
     if extra context data is passed in.
     """
-    mock_update_website_backend = mocker.patch(
-        "websites.serializers.update_website_backend"
-    )
     website = WebsiteFactory.create()
     user = UserFactory.create()
     metadata = {"description": "some text"}
@@ -518,7 +552,7 @@ def test_website_content_create_serializer(mocker, add_context_data):
     serializer.is_valid(raise_exception=True)
     serializer.save()
     content = WebsiteContent.objects.get(title=payload["title"])
-    mock_update_website_backend.assert_called_once_with(content.website)
+    mocked_website_funcs.update_website_backend.assert_called_once_with(content.website)
     assert content.website_id == website.pk
     assert content.owner == user
     assert content.updated_by == user


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
Closes #1243 

#### What's this PR do?
If a `WebsiteContent` object of type `sitemetadata` has a `course_site` field (specified in the new `settings.FIELD_METADATA_TITLE`), then update the related `Website.title` to have the same value.

#### How should this be manually tested?
- Go to the metadata edit page for a new site and enter a course title, then save.  The `Website` title should be updated on the page to the new value, and should appear in the sites list with the new value.
- Edit the metadata title again and and save, the website title on the page should update to reflect that.
- Edit some other content for the site - pages, resources, etc.  They should save normally without any errors.
