### PR TITLE
Escape quotes in resource link text

### DIFF
--- a/static/js/lib/ckeditor/plugins/ResourceEmbed.test.tsx
+++ b/static/js/lib/ckeditor/plugins/ResourceEmbed.test.tsx
@@ -50,14 +50,4 @@ describe("ResourceEmbed plugin", () => {
       '<section data-href-uuid="abcwxyz" data-uuid="asdfasdfasdfasdf"></section>'
     )
   })
-
-  it("preserves href and href_uuid params", async () => {
-    const editor = await getEditor("")
-    markdownTest(
-      editor,
-      // This wouldn't really make sense but it's fun to check.
-      '{{< resource uuid="asdfasdfasdfasdf" href="https://www.mit.edu" href_uuid="abcwxyz" >}}',
-      '<section data-href="https://www.mit.edu" data-href-uuid="abcwxyz" data-uuid="asdfasdfasdfasdf"></section>'
-    )
-  })
 })

--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
@@ -92,15 +92,4 @@ describe("ResourceLink plugin", () => {
       )}">bark bark</a> Woof</p>`
     )
   })
-
-  it("[BUG] does not behave well if link title ends in backslash", async () => {
-    const editor = await getEditor("")
-    const { md2html } = getConverters(editor)
-    expect(md2html('{{% resource_link uuid123 "bad \\" %}}')).toBe(
-      // This is wrong. Should not end in &lt;/a&gt;
-      `<p><a class="resource-link" data-uuid="${encode(
-        "uuid123"
-      )}">bad &lt;/a&gt;</p>`
-    )
-  })
 })

--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
@@ -29,8 +29,8 @@ describe("ResourceLink plugin", () => {
     turndownService._customRulesSet = undefined
   })
 
-  it("should take in and return 'resource' shortcode", async () => {
-    const md = '{{% resource_link 1234567890 "link text" %}}'
+  it("should take in and return 'resource_link' shortcode", async () => {
+    const md = '{{% resource_link "1234567890" "link text" %}}'
     const editor = await getEditor(md)
 
     // @ts-ignore
@@ -39,14 +39,14 @@ describe("ResourceLink plugin", () => {
 
   it("should not mash an anchor hash thingy", async () => {
     const md =
-      '{{% resource_link 1234-5678 "link text" "some-header-id" %}}{{% resource_link link-this-here-uuid "Title of the Link" "some-heading-id" %}}'
+      '{{% resource_link "1234-5678" "link text" "some-header-id" %}}{{% resource_link "link-this-here-uuid" "Title of the Link" "some-heading-id" %}}'
     const editor = await getEditor(md)
     // @ts-ignore
     expect(editor.getData()).toBe(md)
 
     markdownTest(
       editor,
-      '{{% resource_link 1234-5678 "link text" "#some-header-id" %}}',
+      '{{% resource_link "1234-5678" "link text" "#some-header-id" %}}',
       `<p><a class="resource-link" data-uuid="${encode(
         "1234-5678",
         "#some-header-id"
@@ -58,10 +58,21 @@ describe("ResourceLink plugin", () => {
     const editor = await getEditor("")
     markdownTest(
       editor,
-      '{{% resource_link asdfasdfasdfasdf "text here" %}}',
+      '{{% resource_link "asdfasdfasdfasdf" "text here" %}}',
       `<p><a class="resource-link" data-uuid="${encode(
         "asdfasdfasdfasdf"
       )}">text here</a></p>`
+    )
+  })
+
+  it("displays quotes properly", async () => {
+    const editor = await getEditor("")
+    markdownTest(
+      editor,
+      '{{% resource_link "asdfasdfasdfasdf" "not \\"escaped\\" in the html" %}}',
+      `<p><a class="resource-link" data-uuid="${encode(
+        "asdfasdfasdfasdf"
+      )}">not "escaped" in the html</a></p>`
     )
   })
 
@@ -69,7 +80,7 @@ describe("ResourceLink plugin", () => {
     const editor = await getEditor("")
     markdownTest(
       editor,
-      'dogs {{% resource_link uuid1 "woof" %}} cats {{% resource_link uuid2 "meow" %}}, cool',
+      'dogs {{% resource_link "uuid1" "woof" %}} cats {{% resource_link "uuid2" "meow" %}}, cool',
       `<p>dogs <a class="resource-link" data-uuid="${encode(
         "uuid1"
       )}">woof</a> cats <a class="resource-link" data-uuid="${encode(

--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
@@ -63,6 +63,8 @@ export default class ResourceLinkMarkdownSyntax extends MarkdownSyntaxPlugin {
             const uuid = shortcode.get(0)
             const text = shortcode.get(1)
             const fragment = shortcode.get(2)
+            console.log("text is:")
+            console.log(text)
             const encoded = fragment ?
               encodeShortcodeArgs(uuid, fragment) :
               encodeShortcodeArgs(uuid)
@@ -89,11 +91,11 @@ export default class ResourceLinkMarkdownSyntax extends MarkdownSyntaxPlugin {
               (node as any).getAttribute("data-uuid") as string
             )
 
-            if (anchor) {
-              return `{{% resource_link ${uuid} "${node.textContent}" "${anchor}" %}}`
-            } else {
-              return `{{% resource_link ${uuid} "${node.textContent}" %}}`
-            }
+            const text = node.textContent
+
+            if (text === null) return ""
+
+            return Shortcode.resourceLink(uuid, text, anchor).toHugo()
           }
         }
       }

--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
@@ -9,6 +9,7 @@ import {
   RESOURCE_LINK_CKEDITOR_CLASS,
   RESOURCE_LINK
 } from "@mitodl/ckeditor5-resource-link/src/constants"
+import { Shortcode } from "./util"
 
 export const encodeShortcodeArgs = (...args: (string | undefined)[]) =>
   encodeURIComponent(JSON.stringify(args))
@@ -25,7 +26,7 @@ const decodeShortcodeArgs = (encoded: string) =>
  *   - gets fooled by label texts that include literal `" %}}` values. For
  *     example, % resource_link uuid123 "silly " %}} link" %}}.
  */
-export const RESOURCE_LINK_SHORTCODE_REGEX = /{{% resource_link "?([^\s"]+)"? "(.*?)"(?: "(.*?)")? %}}/g
+export const RESOURCE_LINK_SHORTCODE_REGEX = /{{% resource_link .*? %}}/g
 
 /**
  * Class for defining Markdown conversion rules for Resource links
@@ -57,16 +58,15 @@ export default class ResourceLinkMarkdownSyntax extends MarkdownSyntaxPlugin {
         {
           type:    "lang",
           regex:   RESOURCE_LINK_SHORTCODE_REGEX,
-          replace: (
-            _s: string,
-            uuid: string,
-            linkText: string,
-            fragment?: string
-          ) => {
+          replace: (s: string) => {
+            const shortcode = Shortcode.fromString(s)
+            const uuid = shortcode.get(0)
+            const text = shortcode.get(1)
+            const fragment = shortcode.get(2)
             const encoded = fragment ?
               encodeShortcodeArgs(uuid, fragment) :
               encodeShortcodeArgs(uuid)
-            return `<a class="${RESOURCE_LINK_CKEDITOR_CLASS}" data-uuid="${encoded}">${linkText}</a>`
+            return `<a class="${RESOURCE_LINK_CKEDITOR_CLASS}" data-uuid="${encoded}">${text}</a>`
           }
         }
       ]

--- a/static/js/lib/ckeditor/plugins/util.spec.ts
+++ b/static/js/lib/ckeditor/plugins/util.spec.ts
@@ -1,4 +1,45 @@
-import { Shortcode } from "./util"
+import { unescapeStringQuotedWith, Shortcode, ShortcodeParam } from "./util"
+
+const makeParams = ({
+  value,
+  name
+}: {
+  value: string
+  name?: string
+}): ShortcodeParam => {
+  return new ShortcodeParam(value, name)
+}
+
+describe("unescapeStringQuotedWith", () => {
+  it.each([
+    {
+      escaped:   String.raw`"cats \"and\" 'dogs' are cool."`,
+      unescaped: String.raw`cats "and" 'dogs' are cool.`
+    },
+    {
+      escaped:   String.raw`"special characters « and backslashes \ \" are \ ok"`,
+      unescaped: String.raw`special characters « and backslashes \ " are \ ok`
+    },
+    {
+      escaped:   String.raw`"quotes are \" \\\" \\\\\" ok "`,
+      unescaped: String.raw`quotes are " \\" \\\\" ok `
+    }
+  ])("Unescapes interior quotes", ({ escaped, unescaped }) => {
+    expect(unescapeStringQuotedWith(escaped)).toBe(unescaped)
+  })
+
+  it("Throws when the input is not encased in quotes", () => {
+    expect(() => unescapeStringQuotedWith("cats")).toThrow(
+      /not a valid "-quoted string/
+    )
+  })
+
+  it("Throws when the input has unescaped interior quotes", () => {
+    expect(() => unescapeStringQuotedWith('"ca"ts"')).toThrow(
+      /not a valid "-quoted string/
+    )
+  })
+})
 
 describe("Shortcode", () => {
   describe("Shortcode.parse", () => {
@@ -7,22 +48,26 @@ describe("Shortcode", () => {
         '{{< some_shortcode cool_arg="cats and dogs" href_uuid=uuid456 >}}'
       const result = Shortcode.fromString(text)
 
-      const args = [
+      const params = [
         { name: "cool_arg", value: "cats and dogs" },
         { name: "href_uuid", value: "uuid456" }
-      ]
-      expect(result).toStrictEqual(new Shortcode("some_shortcode", args, false))
+      ].map(makeParams)
+      expect(result).toStrictEqual(
+        new Shortcode("some_shortcode", params, false)
+      )
     })
 
     it("parses shortcodes with positional params", () => {
       const text = '{{< some_shortcode "cats and dogs" uuid456 >}}'
       const result = Shortcode.fromString(text)
 
-      const args = [
+      const params = [
         { name: undefined, value: "cats and dogs" },
         { name: undefined, value: "uuid456" }
-      ]
-      expect(result).toStrictEqual(new Shortcode("some_shortcode", args, false))
+      ].map(makeParams)
+      expect(result).toStrictEqual(
+        new Shortcode("some_shortcode", params, false)
+      )
     })
 
     it.each([
@@ -35,7 +80,7 @@ describe("Shortcode", () => {
         const params = [
           { name: undefined, value: "must have quotes" },
           { name: undefined, value: "can_have_quotes" }
-        ]
+        ].map(makeParams)
         expect(result).toStrictEqual(
           new Shortcode("my_shortcode", params, false)
         )
@@ -52,23 +97,43 @@ describe("Shortcode", () => {
         const params = [
           { name: "abc", value: "must have quotes" },
           { name: "xyz", value: "can_have_quotes" }
-        ]
+        ].map(makeParams)
         expect(result).toStrictEqual(
           new Shortcode("my_shortcode", params, false)
         )
       }
     )
 
-    it("allows quotes inside the argument values", () => {
+    it("unescapes quotes in the parameter value", () => {
       const text =
         '{{< some_shortcode "this has \\" escaped quotes" not_this "this \\"one\\" does" >}}'
       const result = Shortcode.fromString(text)
-      const args = [
-        { name: undefined, value: 'this has \\" escaped quotes' },
+      const params = [
+        { name: undefined, value: 'this has " escaped quotes' },
         { name: undefined, value: "not_this" },
-        { name: undefined, value: 'this \\"one\\" does' }
-      ]
-      expect(result).toStrictEqual(new Shortcode("some_shortcode", args, false))
+        { name: undefined, value: 'this "one" does' }
+      ].map(makeParams)
+      expect(result).toStrictEqual(
+        new Shortcode("some_shortcode", params, false)
+      )
+      expect(result.get(0)).toBe('this has " escaped quotes')
+      expect(result.get(1)).toBe("not_this")
+      expect(result.get(2)).toBe('this "one" does')
+    })
+
+    test("[BUG] issue if param values end in backslashes", () => {
+      /**
+       * The shortcode below is invalid (Hugo will error) but Shortcode.fromString
+       * allows it. Do we care?
+       */
+      const text = '{{% resource_link uuid123 "ok \\\\" %}}'
+      expect(Shortcode.fromString(text)).toStrictEqual(
+        new Shortcode(
+          "resource_link",
+          [new ShortcodeParam("uuid123"), new ShortcodeParam("ok")],
+          true
+        )
+      )
     })
 
     it("throws error if content includes shortcode delimiter", () => {
@@ -105,22 +170,154 @@ describe("Shortcode", () => {
     )
   })
 
-  describe('Shortcode.get', () => {
+  describe("Shortcode.toHugo", () => {
+    it("escapes quotes in named parameter values", () => {
+      const shortcode = new Shortcode(
+        "my_shortcode",
+        [
+          new ShortcodeParam('Cats "and" dogs', "first"),
+          new ShortcodeParam(
+            'special characters « and backslashes \\ " are \\ ok',
+            "second_param"
+          )
+        ],
+        false
+      )
+      expect(shortcode.toHugo()).toBe(
+        '{{< my_shortcode first="Cats \\"and\\" dogs" second_param="special characters « and backslashes \\ \\" are \\ ok" >}}'
+      )
+    })
+
+    it("escapes quotes in positional parameter values", () => {
+      const shortcode = new Shortcode(
+        "my_shortcode",
+        [
+          new ShortcodeParam('Cats "and" dogs'),
+          new ShortcodeParam(
+            'special characters « and backslashes \\ " are \\ ok'
+          )
+        ],
+        false
+      )
+      expect(shortcode.toHugo()).toBe(
+        '{{< my_shortcode "Cats \\"and\\" dogs" "special characters « and backslashes \\ \\" are \\ ok" >}}'
+      )
+    })
+
+    it.each([
+      {
+        isPercentDelimited: false,
+        expected:           '{{< my_shortcode first="some value" >}}'
+      },
+      {
+        isPercentDelimited: true,
+        expected:           '{{% my_shortcode first="some value" %}}'
+      }
+    ])(
+      "uses percent delimiters when appropriate",
+      ({ isPercentDelimited, expected }) => {
+        const shortcode = new Shortcode(
+          "my_shortcode",
+          [new ShortcodeParam("some value", "first")],
+          isPercentDelimited
+        )
+        expect(shortcode.toHugo()).toBe(expected)
+      }
+    )
+  })
+
+  describe("Shortcode.get", () => {
     it.each([
       '{{< my_shortcdoe catsmeow "dogs woof" >}}',
       '{{< my_shortcdoe zeroth=catsmeow first="dogs woof" >}}'
-    ])('gets parameters by position', shortcodeText => {
+    ])("gets parameters by position", shortcodeText => {
       const shortcode = Shortcode.fromString(shortcodeText)
       expect(shortcode.get(0)).toBe("catsmeow")
       expect(shortcode.get(1)).toBe("dogs woof")
       expect(shortcode.get(2)).toBe(undefined)
     })
 
-    it('gets parameters by name', () => {
-      const shortcode = Shortcode.fromString('{{< my_shortcdoe zeroth=catsmeow first="dogs woof" >}}')
+    it("gets parameters by name", () => {
+      const shortcode = Shortcode.fromString(
+        '{{< my_shortcdoe zeroth=catsmeow first="dogs woof" >}}'
+      )
       expect(shortcode.get("zeroth")).toBe("catsmeow")
       expect(shortcode.get("first")).toBe("dogs woof")
       expect(shortcode.get("second")).toBe(undefined)
+    })
+  })
+
+  describe("Shortcode.resource", () => {
+    it.each([undefined, {}, { href: null }, { href: "" }])(
+      "makes resources without href or href_uuid",
+      options => {
+        const shortcode = Shortcode.resource("bestuuidever", options)
+        expect(shortcode).toStrictEqual(
+          new Shortcode("resource", [
+            new ShortcodeParam("bestuuidever", "uuid")
+          ])
+        )
+      }
+    )
+    it("makes resources with href", () => {
+      const shortcode = Shortcode.resource("bestuuidever", {
+        href: "some_href"
+      })
+      expect(shortcode).toStrictEqual(
+        new Shortcode("resource", [
+          new ShortcodeParam("bestuuidever", "uuid"),
+          new ShortcodeParam("some_href", "href")
+        ])
+      )
+    })
+    it("makes resources with hrefUuid", () => {
+      const shortcode = Shortcode.resource("bestuuidever", {
+        hrefUuid: "some_href_uuid"
+      })
+      expect(shortcode).toStrictEqual(
+        new Shortcode("resource", [
+          new ShortcodeParam("bestuuidever", "uuid"),
+          new ShortcodeParam("some_href_uuid", "href_uuid")
+        ])
+      )
+    })
+    it("throws if both href and hrefUuid are provided", () => {
+      expect(() =>
+        Shortcode.resource("c", { hrefUuid: "b", href: "c" })
+      ).toThrow(/At most one of href, hrefUuid/)
+    })
+  })
+
+  describe("Shortcode.resourceLink", () => {
+    it.each([
+      {
+        uuid:     "some-uuid",
+        text:     "some text",
+        suffix:   undefined,
+        expected: '{{% resource_link "some-uuid" "some text" %}}'
+      },
+      {
+        uuid:     "some-uuid",
+        text:     "some text",
+        suffix:   "",
+        expected: '{{% resource_link "some-uuid" "some text" %}}'
+      },
+      {
+        uuid:     "some-uuid",
+        text:     'some "cool" text',
+        suffix:   "?dog",
+        expected:
+          '{{% resource_link "some-uuid" "some \\"cool\\" text" "?dog" %}}'
+      },
+      {
+        uuid:     "some-uuid",
+        text:     "",
+        suffix:   "#cat",
+        expected: '{{% resource_link "some-uuid" "" "#cat" %}}'
+      }
+    ])("makes resource links", ({ uuid, text, suffix, expected }) => {
+      const shortcode = Shortcode.resourceLink(uuid, text, suffix)
+      expect(shortcode.toHugo()).toBe(expected)
     })
   })
 })

--- a/static/js/lib/ckeditor/plugins/util.spec.ts
+++ b/static/js/lib/ckeditor/plugins/util.spec.ts
@@ -23,6 +23,10 @@ describe("unescapeStringQuotedWith", () => {
     {
       escaped:   String.raw`"quotes are \" \\\" \\\\\" ok "`,
       unescaped: String.raw`quotes are " \\" \\\\" ok `
+    },
+    {
+      escaped:   String.raw`"consecutive quotes are \"\" are OK"`,
+      unescaped: String.raw`consecutive quotes are "" are OK`
     }
   ])("Unescapes interior quotes", ({ escaped, unescaped }) => {
     expect(unescapeStringQuotedWith(escaped)).toBe(unescaped)

--- a/static/js/lib/ckeditor/plugins/util.spec.ts
+++ b/static/js/lib/ckeditor/plugins/util.spec.ts
@@ -104,4 +104,23 @@ describe("Shortcode", () => {
       /Cannot mix named and positional/
     )
   })
+
+  describe('Shortcode.get', () => {
+    it.each([
+      '{{< my_shortcdoe catsmeow "dogs woof" >}}',
+      '{{< my_shortcdoe zeroth=catsmeow first="dogs woof" >}}'
+    ])('gets parameters by position', shortcodeText => {
+      const shortcode = Shortcode.fromString(shortcodeText)
+      expect(shortcode.get(0)).toBe("catsmeow")
+      expect(shortcode.get(1)).toBe("dogs woof")
+      expect(shortcode.get(2)).toBe(undefined)
+    })
+
+    it('gets parameters by name', () => {
+      const shortcode = Shortcode.fromString('{{< my_shortcdoe zeroth=catsmeow first="dogs woof" >}}')
+      expect(shortcode.get("zeroth")).toBe("catsmeow")
+      expect(shortcode.get("first")).toBe("dogs woof")
+      expect(shortcode.get("second")).toBe(undefined)
+    })
+  })
 })

--- a/static/js/lib/ckeditor/plugins/util.ts
+++ b/static/js/lib/ckeditor/plugins/util.ts
@@ -133,6 +133,9 @@ export class Shortcode {
     return `{{< ${interior} >}}`
   }
 
+  /**
+   * Regexp used for matching individual shortcode arguments.
+   */
   private static ARG_REGEXP = new RegExp(
     [
       /((?<name>[a-zA-Z_]+)=)?/.source,
@@ -145,7 +148,11 @@ export class Shortcode {
     "g"
   )
 
-  static fromString(s: string) {
+  /**
+   * Convert a shortcode string to a Shortcode object.
+   * @param s The shortcode as a string, e.g., `{{% resource_link "uuid" "text" %}}
+   */
+  static fromString(s: string): Shortcode {
     Shortcode.heuristicValidation(s)
     const isPercentDelmited = s.startsWith("{{%") && s.endsWith("%}}")
     const [nameMatch, ...argMatches] = s

--- a/static/js/lib/ckeditor/plugins/util.ts
+++ b/static/js/lib/ckeditor/plugins/util.ts
@@ -20,7 +20,7 @@ export const unescapeStringQuotedWith = (
 
   const escapedQuoteRegex = new RegExp(
     [
-      /(^|[^\\])/.source, // anything except a backlsash
+      /(?<!\\)/.source, // anything except a backslash WITHOUT advancing match position
       /(\\\\)*\\/.source, // an odd number of backlsashes
       q // a quote
     ].join(""),
@@ -35,6 +35,7 @@ export const unescapeStringQuotedWith = (
   const quoteCount = text.slice(1, -1).split(q).length - 1
   const escapedQuoteCount = text.match(escapedQuoteRegex)?.length ?? 0
   const allEscaped = quoteCount === escapedQuoteCount
+  console.log({ quoteCount, escapedQuoteCount })
   if (allEscaped && text.startsWith(q) && text.endsWith(q)) {
     return text.slice(1, -1).replace(escapedQuoteRegex, unescape)
   }

--- a/static/js/lib/ckeditor/plugins/util.ts
+++ b/static/js/lib/ckeditor/plugins/util.ts
@@ -150,7 +150,7 @@ export class Shortcode {
    */
   get(param: number | string): string | undefined {
     if (typeof param === "number") {
-      return this.params[0].value
+      return this.params[param]?.value
     }
     return this.params.find(p => p.name === param)?.value
   }

--- a/static/js/lib/ckeditor/plugins/util.ts
+++ b/static/js/lib/ckeditor/plugins/util.ts
@@ -89,6 +89,10 @@ export class ShortcodeParam {
 /**
  * Class to represent shortcodes. Includes some static methods to help create
  * shortcodes.
+ *
+ * Notes:
+ *  - double quotes in shortcode parameter values are un-escaped for internal
+ *  storage.
  */
 export class Shortcode {
   name: string
@@ -117,6 +121,8 @@ export class Shortcode {
 
   /**
    * Convert this shortcode to Hugo markdown.
+   *
+   * Re-escapes double quotes in parameter values
    */
   toHugo() {
     const stringifiedArgs = this.params.map(p => p.toHugo()).join(" ")

--- a/static/js/util/index.ts
+++ b/static/js/util/index.ts
@@ -19,6 +19,15 @@ export const hasNotNilProp = <T, K extends keyof T>(key: K) => (
 }
 
 /**
+ * Return a predicate `obj => boolean` that asserts `obj[key]` is truthy
+ */
+export const hasTruthyProp = <T, K extends keyof T>(key: K) => (
+  obj: T
+): obj is NonNullableProps<T, K> => {
+  return !!obj[key]
+}
+
+/**
  * Type predicate that asserts value is not null or undefined.
  */
 export const isNotNil = <T>(value: T): value is NonNullable<T> => {

--- a/websites/management/commands/markdown_cleaning/parsing_utils.py
+++ b/websites/management/commands/markdown_cleaning/parsing_utils.py
@@ -91,7 +91,7 @@ def unescape_string_quoted_with(text: str, single_quotes=False):
     q = "'" if single_quotes else '"'
 
     escaped_quote_regex = re.compile(
-        r"(^|[^\\])"  # anything except a backlsash
+        r"(?<!\\)"  # anything except a backslash WITHOUT advancing match position
         + r"(\\\\)*\\"  # an odd number of backlsashes
         + q  # a quote
     )

--- a/websites/management/commands/markdown_cleaning/parsing_utils.py
+++ b/websites/management/commands/markdown_cleaning/parsing_utils.py
@@ -84,7 +84,7 @@ def unescape_string_quoted_with(text: str, single_quotes=False):
     """
     Given a string encased in quotes and in which all interior quote characters
     are escaped, strip the encasing quotes and unescape the interior quotes.
- 
+
     By default, the quotation character is a double quotation mark.
     Use `singleQuotes=true` for single quotes.
     """

--- a/websites/management/commands/markdown_cleaning/parsing_utils.py
+++ b/websites/management/commands/markdown_cleaning/parsing_utils.py
@@ -82,9 +82,11 @@ def escape_double_quotes(s: str):
 
 def unescape_string_quoted_with(text: str, single_quotes=False):
     """
-    Given a string encased in quotes of type `quote_char` and in which all
-    interior instances of `quote_char` are escaped, strip the encasing instances
-    and unescape the interior instances.
+    Given a string encased in quotes and in which all interior quote characters
+    are escaped, strip the encasing quotes and unescape the interior quotes.
+ 
+    By default, the quotation character is a double quotation mark.
+    Use `singleQuotes=true` for single quotes.
     """
     q = "'" if single_quotes else '"'
 

--- a/websites/management/commands/markdown_cleaning/parsing_utils_test.py
+++ b/websites/management/commands/markdown_cleaning/parsing_utils_test.py
@@ -104,6 +104,10 @@ def test_original_text_records_during_transform_text():
             R'''"quotes are \" \\\" \\\\\" ok "''',
             R"""quotes are " \\" \\\\" ok """,
         ),
+        (
+            R'''"consecutive quotes are \"\" are OK"''',
+            R"""consecutive quotes are "" are OK""",
+        ),
     ],
 )
 def test_unescape_quoted_string(escaped, unescaped):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets? #1238 

#### What's this PR do?
_This fixes an issue where double quotes in resource links were not being escaped...._

This PR makes the resource link CKEditor plugin use our frontend `Shortcode` class and makes the frontend `Shortcode` class better mirror the `ShortcodeTag` class used in markdown cleanup commands on the backend. In particular, frontend `Shortcode` now un-escapes quotes in parameter values when parsing, and re-escapes them when converting to hugo.

This is important because it means that when our editor sees `{{% resource_link "some-uuid" "title \"with\" escaped quotes" %}}`, we now have an unescaped value to display to user in the WYSIWYG editor. And when the unescaped value is saved, it is re-escaped before being to our API.

#### How should this be manually tested?
On this branch:
1. Create a new resource link or find an existing one. To create a new one, open a page for editing and click "Add link".
2. Edit the link text (move your text cursor into it and start typing) and insert some text with double quotes
3. Save 
4. Inspect the markdown in Django admin. Quotes inside the title should be escaped.
5. Re-open the page. Quotes should not appear escaped to the user.
