### PR TITLE
set `YT_FIELD_DESCRIPTION` to `video_metadata.youtube_description`

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -562,7 +562,7 @@ YT_FIELD_ID = get_string(
 )
 YT_FIELD_DESCRIPTION = get_string(
     name="YT_FIELD_DESCRIPTION",
-    default="description",
+    default="video_metadata.youtube_description",
     description="The site config metadata field for YouTube description",
 )
 YT_FIELD_SPEAKERS = get_string(

--- a/main/utils.py
+++ b/main/utils.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Optional, Tuple
 from uuid import UUID, uuid4
 
+from django.db.models.fields.json import KeyTextTransform
 from django.http import HttpRequest
 
 
@@ -117,3 +118,26 @@ def truncate_words(content: str, length: int, suffix: Optional[str] = "...") -> 
         return content
     else:
         return content[: (length - len(suffix))].rsplit(" ", 1)[0] + suffix
+
+
+class NestableKeyTextTransform:
+    """
+    From https://stackoverflow.com/questions/65921227/how-to-use-keytexttransform-for-nested-json
+    Returns a KeyTextTransform for nested JSON fields
+
+    Args:
+        field (str): the top level field
+        path (str*): any amount of nested fields to dig down
+
+    Returns:
+        (KeyTextTransform): A KeyTextTransform for the nested value
+    """
+
+    def __new__(cls, field, *path):
+        if not path:
+            raise ValueError("Path must contain at least one key.")
+        head, *tail = path
+        field = KeyTextTransform(head, field)
+        for head in tail:
+            field = KeyTextTransform(head, field)
+        return field

--- a/videos/youtube_test.py
+++ b/videos/youtube_test.py
@@ -202,8 +202,8 @@ def test_update_video(settings, mocker, youtube_mocker, privacy):
         title=" ".join([title for i in range(11)]),
         metadata={
             "resourcetype": RESOURCE_TYPE_VIDEO,
-            "description": " ".join([description for _ in range(501)]),
             "video_metadata": {
+                "youtube_description": " ".join([description for _ in range(501)]),
                 "youtube_id": youtube_id,
                 "video_tags": tags,
                 "video_speakers": speakers,

--- a/videos/youtube_test.py
+++ b/videos/youtube_test.py
@@ -215,7 +215,10 @@ def test_update_video(settings, mocker, youtube_mocker, privacy):
     expected_desc = f'{" ".join([description.replace(">", "") for _ in range(499)])}...'
 
     assert len(content.title) > YT_MAX_LENGTH_TITLE
-    assert len(content.metadata["video_metadata"]["youtube_description"]) > YT_MAX_LENGTH_DESCRIPTION
+    assert (
+        len(content.metadata["video_metadata"]["youtube_description"])
+        > YT_MAX_LENGTH_DESCRIPTION
+    )
     assert len(expected_title) <= YT_MAX_LENGTH_TITLE
     assert len(expected_desc) <= YT_MAX_LENGTH_DESCRIPTION
 

--- a/videos/youtube_test.py
+++ b/videos/youtube_test.py
@@ -215,7 +215,7 @@ def test_update_video(settings, mocker, youtube_mocker, privacy):
     expected_desc = f'{" ".join([description.replace(">", "") for _ in range(499)])}...'
 
     assert len(content.title) > YT_MAX_LENGTH_TITLE
-    assert len(content.metadata["description"]) > YT_MAX_LENGTH_DESCRIPTION
+    assert len(content.metadata["video_metadata"]["youtube_description"]) > YT_MAX_LENGTH_DESCRIPTION
     assert len(expected_title) <= YT_MAX_LENGTH_TITLE
     assert len(expected_desc) <= YT_MAX_LENGTH_DESCRIPTION
 

--- a/websites/api.py
+++ b/websites/api.py
@@ -8,13 +8,13 @@ from uuid import UUID
 from django.conf import settings
 from django.core.files.uploadedfile import UploadedFile
 from django.db.models import CharField, Q, QuerySet
-from django.db.models.fields.json import KeyTextTransform
 from django.db.models.functions import Cast, Length
 from magic import Magic
 from mitol.common.utils import max_or_none, now_in_utc
 from mitol.mail.api import get_message_sender
 
 from content_sync.constants import VERSION_DRAFT
+from main.utils import NestableKeyTextTransform
 from users.models import User
 from videos.constants import (
     YT_MAX_LENGTH_DESCRIPTION,
@@ -230,11 +230,12 @@ def videos_with_truncatable_text(website: Website) -> List[WebsiteContent]:
     query_resource_type_field = get_dict_query_field(
         "metadata", settings.FIELD_RESOURCETYPE
     )
+    yt_description_fields = settings.YT_FIELD_DESCRIPTION.split(".")
     return (
         WebsiteContent.objects.annotate(
             desc_len=Length(
                 Cast(
-                    KeyTextTransform(settings.YT_FIELD_DESCRIPTION, "metadata"),
+                    NestableKeyTextTransform("metadata", *yt_description_fields),
                     CharField(),
                 )
             )

--- a/websites/api_test.py
+++ b/websites/api_test.py
@@ -335,8 +335,8 @@ def test_videos_with_truncatable_text(mocker, is_ocw):
                 website=website,
                 title=title,
                 metadata={
-                    "description": desc,
                     "resourcetype": RESOURCE_TYPE_VIDEO,
+                    "video_metadata": {"youtube_description": desc},
                     "video_files": {"video_captions_file": "abc123"},
                 },
             )

--- a/websites/api_test.py
+++ b/websites/api_test.py
@@ -342,7 +342,7 @@ def test_videos_with_truncatable_text(mocker, is_ocw):
             )
         )
     truncatable_content = videos_with_truncatable_text(website)
-    assert len(resources[1].metadata["video_metadata"]["description"]) > 5000
+    assert len(resources[1].metadata["video_metadata"]["youtube_description"]) > 5000
 
     if is_ocw:
         assert len(truncatable_content) == 2

--- a/websites/api_test.py
+++ b/websites/api_test.py
@@ -342,7 +342,7 @@ def test_videos_with_truncatable_text(mocker, is_ocw):
             )
         )
     truncatable_content = videos_with_truncatable_text(website)
-    assert len(resources[1].metadata["description"]) > 5000
+    assert len(resources[1].metadata["video_metadata"]["description"]) > 5000
 
     if is_ocw:
         assert len(truncatable_content) == 2


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-projects/issues/156

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-projects/pull/157, we added the `video_metadata.youtube_description` field.  This PR changes the default value of `YT_FIELD_DESCRIPTION` to point to this new field, which will make it so the YouTube description is updated with the value of this field when you publish video resources.

#### How should this be manually tested?
- Copy `YT_*` values from RC to your .env file
- Spin up your local instance of `ocw-studio` and make sure your `ocw-course` starter is up to date
- For one of your sites (with starter ocw-course), add a small video to the site's Google Drive folder and sync.
- Once you have a video resource, enter a description into the YouTube Description field
- Change the Youtube ID field to `ulPWKn5hJ3w` and save.
- In a shell, run the following:
   ```
    from websites.models import *
    from videos.models import *
    from videos.youtube import *
    website = Website.objects.get(name=<your_website_name>)
    VideoFile.objects.create(video=Video.objects.create(website=website), destination_id="ulPWKn5hJ3w")
    update_youtube_metadata(website)
    ```
- Go to https://www.youtube.com/watch?v=ulPWKn5hJ3w, and ensure that the video description matches what you entered

