### PR TITLE
Added video-gallery to add link ResourceDialogPicker

### DIFF
--- a/static/js/components/widgets/ResourcePickerDialog.tsx
+++ b/static/js/components/widgets/ResourcePickerDialog.tsx
@@ -44,7 +44,8 @@ export enum TabIds {
   Videos = "videos",
   Pages = "pages",
   CourseCollections = "course-collection",
-  ResourceCollections = "resource_collections"
+  ResourceCollections = "resource_collections",
+  VideoGallery = "video_gallery"
 }
 
 const documentTab: TabSettings = {
@@ -105,6 +106,15 @@ const resourcCollectionTab: TabSettings = {
   singleColumn: true
 }
 
+const videoGallery: TabSettings = {
+  title:        "Video Gallery",
+  id:           TabIds.VideoGallery,
+  contentType:  ContentType.VideoGallery,
+  resourcetype: null,
+  embeddable:   false,
+  singleColumn: true
+}
+
 /**
  * Maps a content name from our config schemas to a group of tabs.
  * Slightly awkward because most content types correspond to a single tab,
@@ -114,7 +124,8 @@ const TABS: Record<string, TabSettings[]> = {
   resource:             [documentTab, videoTab, imageTab, otherFilesTab],
   page:                 [pageTab],
   course_collections:   [courseCollectionTab],
-  resource_collections: [resourcCollectionTab]
+  resource_collections: [resourcCollectionTab],
+  video_gallery:        [videoGallery]
 }
 
 const modeText = {

--- a/static/js/constants.ts
+++ b/static/js/constants.ts
@@ -158,7 +158,8 @@ export enum ContentType {
   Resource = "resource",
   Page = "page",
   CourseCollections = "course-collection",
-  ResourceCollections = "resource_collections"
+  ResourceCollections = "resource_collections",
+  VideoGallery = "video_gallery"
 }
 
 export enum ResourceType {

--- a/static/scss/resource-picker-dialog.scss
+++ b/static/scss/resource-picker-dialog.scss
@@ -56,7 +56,7 @@
 
 .resource-picker-dialog {
   .modal-dialog {
-    max-width: 650px;
+    max-width: fit-content;
 
     .modal-body {
       min-height: 500px;

--- a/static/scss/resource-picker-dialog.scss
+++ b/static/scss/resource-picker-dialog.scss
@@ -56,7 +56,7 @@
 
 .resource-picker-dialog {
   .modal-dialog {
-    max-width: fit-content;
+    max-width: 650px;
 
     .modal-body {
       min-height: 500px;


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [x] Testing
   - [x] Changes have been manually tested


#### What are the relevant tickets?
part of #1152

#### What's this PR do?
 Adds vide_gallery to to add_link ResourceDialogPicker
 
#### How should this be manually tested?
To verify this commit
- Open /admin and update ocw-course-starter to include vide_gallery in `link` key for `pages`
- Open a course page in studion and click add link
- Verify video_gallery is available

#### Screenshots
<img width="1440" alt="Screenshot 2022-04-25 at 1 41 27 PM" src="https://user-images.githubusercontent.com/87968618/165053640-2df9795e-de00-46b5-aec4-977a4817c453.png">
<img width="1440" alt="Screenshot 2022-04-25 at 1 41 33 PM" src="https://user-images.githubusercontent.com/87968618/165053666-54f0b128-e1c7-4e88-b275-546eca09ec19.png">
