### PR TITLE
fix erroneous prompting when saving new pages

### DIFF
--- a/static/js/components/SiteContentEditor.test.tsx
+++ b/static/js/components/SiteContentEditor.test.tsx
@@ -349,6 +349,14 @@ describe("SiteContent", () => {
     sinon.assert.calledWith(fetchWebsiteListingStub)
     sinon.assert.calledWith(dismissStub)
     sinon.assert.calledWith(setDirtyStub, false)
+
+    /**
+     * setDirty should be called before and only before dismiss (it is called
+     * multiple times).
+     */
+    expect(setDirtyStub.calledBefore(dismissStub)).toBe(true)
+    expect(setDirtyStub.calledAfter(dismissStub)).toBe(false)
+
     // @ts-ignore
     expect(store.getState().entities.websiteContentDetails).toStrictEqual({
       [contentDetailKey({

--- a/static/js/components/SiteContentEditor.tsx
+++ b/static/js/components/SiteContentEditor.tsx
@@ -151,11 +151,11 @@ export default function SiteContentEditor(props: Props): JSX.Element | null {
     // update the publish status
     refreshWebsiteStatus()
 
+    setDirty(false)
     if (dismiss) {
       // turn off modal on success
       dismiss()
     }
-    setDirty(false)
   }
 
   return (


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#991, followup to #1263 

#### What's this PR do?
Fixes an issue with #1263 where confirmation prompts were being issued inappropriately when creating new pages.

#### How should this be manually tested?
1. Create a new page and save it. You should not be prompted for confirmation about discarded data.
2. Create a new page/resource/whatever and close the drawer without saving. You should be prompted.
3. Edit a page and save. You should not be prompted
4. Edit a page and discard. You should be prompted.
