### PR TITLE
fix transcript links

### DIFF
--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -239,12 +239,12 @@ def update_transcripts_for_video(video_id: int):
                 set_dict_field(
                     metadata,
                     settings.YT_FIELD_TRANSCRIPT,
-                    video.pdf_transcript_file.name,
+                    urljoin("/", video.pdf_transcript_file.name),
                 )
                 set_dict_field(
                     metadata,
                     settings.YT_FIELD_CAPTIONS,
-                    video.webvtt_transcript_file.name,
+                    urljoin("/", video.webvtt_transcript_file.name),
                 )
                 video_resource.save()
 

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -495,11 +495,11 @@ def test_update_transcripts_for_video(
     if update_transcript_return_value and is_ocw:
         assert (
             get_dict_field(resource.metadata, settings.YT_FIELD_CAPTIONS)
-            == "webvtt_transcript"
+            == "/webvtt_transcript"
         )
         assert (
             get_dict_field(resource.metadata, settings.YT_FIELD_TRANSCRIPT)
-            == "pdf_transcript"
+            == "/pdf_transcript"
         )
 
         if initial_status == VideoStatus.SUBMITTED_FOR_TRANSCRIPTION and (


### PR DESCRIPTION
#### Pre-Flight checklist
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested


#### What are the relevant tickets?
None

#### What's this PR do?
The transcript and caption urls for videos uploaded through gdrive are saved without a leading '/' in the resource metadata. That causes the transcript urls in the resource page to got to /courses/site_id/resources/resource_id/courses/site_id/file instead of /courses/
site_id/file. This adds the leading '/' to fix the issue

#### How should this be manually tested?
If you already have videos uploaded through gdrive that have transcripts you can test this by running `videos.tasks.update_transcripts_for_website` (which is a pre-publish action) for the website and checking that there is a leading slash in the transcript urls in the  metadata.

If you don't creating them locally is difficult since you have to spoof both the mediaconvert and the 3play webhooks. If the tests pass it should be ok to approve this and we can test thoroughly on rc.


