### PR TITLE
Fix mass publish command

### DIFF
--- a/content_sync/management/commands/mass_publish.py
+++ b/content_sync/management/commands/mass_publish.py
@@ -102,7 +102,7 @@ class Command(BaseCommand):
         if source_str:
             website_qset = website_qset.filter(source=source_str)
         # do not publish any sites that have been unpublished or never been published before
-        website_qset = website_qset.exclude(unpublished=True)
+        website_qset = website_qset.filter(unpublish_status__isnull=True)
         if version == VERSION_DRAFT:
             website_qset = website_qset.exclude(draft_publish_date__isnull=True)
         else:

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -283,11 +283,8 @@ def test_websites_endpoint_preview_error(mocker, drf_client):
     assert resp.data == {"details": "422 {}"}
 
 
-@pytest.mark.parametrize(
-    "unpublished, unpublish_status",
-    [[True, PUBLISH_STATUS_NOT_STARTED], [False, None]],
-)
-def test_websites_endpoint_publish(mocker, drf_client, unpublished, unpublish_status):
+@pytest.mark.parametrize("unpublish_status", [PUBLISH_STATUS_NOT_STARTED, None])
+def test_websites_endpoint_publish(mocker, drf_client, unpublish_status):
     """
     A user with admin permissions should be able to request a website publish and revert
     any previous unpublish request
@@ -295,9 +292,7 @@ def test_websites_endpoint_publish(mocker, drf_client, unpublished, unpublish_st
     mock_publish_website = mocker.patch("websites.views.trigger_publish")
     now = datetime.datetime(2020, 1, 1, tzinfo=pytz.utc)
     mocker.patch("websites.views.now_in_utc", return_value=now)
-    website = WebsiteFactory.create(
-        unpublished=unpublished, unpublish_status=unpublish_status
-    )
+    website = WebsiteFactory.create(unpublish_status=unpublish_status)
     admin = UserFactory.create()
     admin.groups.add(website.admin_group)
     drf_client.force_login(admin)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
N/A

#### What's this PR do?
Fixes a bug introduced by #1270 

#### How should this be manually tested?
- Set up local concourse settings and run `docker-compose --profile concourse up`
- Run `docker-compose run web python manage.py mass_publish -nmb --filter <site_name> live`, it shouldn't throw an error (but the pipeline will fail).

