### PR TITLE
do not emit declaration files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "allowJs": true,
     "checkJs": false,
     "jsx": "react",
-    "declaration": true,
     "outDir": "./dist/",
     "tsBuildInfoFile": ".tsbuildinfo",
     "strict": true,


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
*None; came across this while editing files for #1177*

#### What's this PR do?
do not emit declaration files

**tldr**: Because this is an app not a library, ie we do not use them and they cause some ts errors in IDEs (that we suppress during CI through `--noEmit`).

We currently have an error

> Exported variable 'getWebsiteDetailCursor' has or is using name '$CombinedState' from external module "/Users/chudzick/dev/ocw-studio/node_modules/redux/index" but cannot be named.

See https://github.com/microsoft/TypeScript/issues/5711 for some info about this error. Manually importing $CombinedState both seems silly and does not fix the issue (I think `re-select` would need to import it itself? I'm not sure. Possibly related to https://github.com/microsoft/TypeScript/issues/5711#issuecomment-231501080)

The error:
- is visible in some IDEs (e.g., VS Code)
- does not show up when running `npm run typecheck` since that uses the `--noEmit` CLI flag, which suppresses both compiled code and declarations from being emitted.
- **does** occur if you run `docker-compose run --rm watch npx tsc`

But our tsconfig does specify that declarations can be made...I'm not sure why. As I understand it, the setting makes sense for a library but not for an app.

#### How should this be manually tested?
Tests should pass. There should be no noticeable changes, except a better IDE experience... For example, if you're using VSCode, `static/js/selectors/websites.ts` would show TS errors in the IDE, whereas now it does not.

