### PR TITLE
Cc/user store

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@dnd-kit/core": "^3.1.1",
     "@dnd-kit/sortable": "^4.0.0",
     "@mitodl/ckeditor5-resource-link": "^31.0.0",
+    "@reduxjs/toolkit": "^1.8.1",
     "@sentry/browser": "^6.10.0",
     "@swc/core": "^1.2.95",
     "@swc/jest": "^0.2.4",

--- a/static/js/components/Header.test.tsx
+++ b/static/js/components/Header.test.tsx
@@ -1,14 +1,14 @@
 import React from "react"
 import { act } from "@testing-library/react"
-import IntegrationTestHelper from "../util/IntegrationTestHelper"
 import * as dtl from "@testing-library/dom"
 import userEvent from "@testing-library/user-event"
 import {
+  IntegrationTestHelper,
   assertInstanceOf,
   absoluteUrl,
   flushEventQueue,
   mergeXProd
-} from "../test_util"
+} from "../testing_utils"
 
 import Header from "./Header"
 import { logoutUrl, siteApiDetailUrl } from "../lib/urls"
@@ -47,7 +47,7 @@ describe("Header without loaded website", () => {
 
   it("does not show username+logout for anonymous users", () => {
     const helper = new IntegrationTestHelper()
-    SETTINGS.user = null // SETTINGS is set in our global setup
+    helper.patchInitialReduxState({ user: { user: null } })
     const [result] = helper.render(<Header />)
     const links = result.container.querySelector("div.links")
     expect(links).toBe(null)

--- a/static/js/components/Header.tsx
+++ b/static/js/components/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react"
-import { useStore } from "react-redux"
+import { useAppDispatch, useAppSelector } from "../hooks/redux"
 import { Link } from "react-router-dom"
 import { requestAsync } from "redux-query"
 import useInterval from "@use-it/interval"
@@ -22,7 +22,8 @@ export interface HeaderProps {
 
 export default function Header(props: HeaderProps): JSX.Element {
   const { website } = props
-  const store = useStore()
+  const dispatch = useAppDispatch()
+  const { user } = useAppSelector(state => state.user)
   const [search, setSearchParams] = useSearchParams()
   const drawerOpen = search.has("publish")
 
@@ -51,7 +52,7 @@ export default function Header(props: HeaderProps): JSX.Element {
             )))
       ) {
         try {
-          await store.dispatch(requestAsync(websiteStatusRequest(website.name)))
+          await dispatch(requestAsync(websiteStatusRequest(website.name)))
         } catch (err) {
           console.error(err)
         }
@@ -79,9 +80,9 @@ export default function Header(props: HeaderProps): JSX.Element {
             />
           </Link>
         </div>
-        {SETTINGS.user !== null ? (
+        {user !== null ? (
           <div className="links">
-            <span className="pr-5">{SETTINGS.user.name}</span>
+            <span className="pr-5">{user.name}</span>
             <a href={logoutUrl.toString()}>Log out</a>
           </div>
         ) : null}

--- a/static/js/hooks/redux.ts
+++ b/static/js/hooks/redux.ts
@@ -1,0 +1,12 @@
+import { useDispatch, useSelector, TypedUseSelectorHook } from "react-redux"
+import { AppDispatch, ReduxState } from "../store"
+
+/**
+ * Like `useDispatch` from react-redux, but typed for our app's store.
+ */
+export const useAppDispatch = (): AppDispatch => useDispatch<AppDispatch>()
+
+/**
+ * Like `useSelector` from react-redux, but typed for our app's store.
+ */
+export const useAppSelector: TypedUseSelectorHook<ReduxState> = useSelector

--- a/static/js/index.tsx
+++ b/static/js/index.tsx
@@ -2,7 +2,7 @@ import React, { ComponentType } from "react"
 import ReactDOM from "react-dom"
 import { AppContainer } from "react-hot-loader"
 
-import configureStore from "./store/configureStore"
+import { store } from "./store"
 import Root, { RootProps } from "./Root"
 
 import * as Sentry from "@sentry/browser"
@@ -16,8 +16,6 @@ Sentry.init({
   release:     SETTINGS.release_version,
   environment: SETTINGS.environment
 })
-
-const store = configureStore()
 
 const rootEl = document.getElementById("container")
 

--- a/static/js/lib/redux_query.ts
+++ b/static/js/lib/redux_query.ts
@@ -1,5 +1,5 @@
 import { getCookie } from "./api/util"
-import { ReduxState } from "../reducers"
+import { ReduxState } from "../store"
 import { QueriesState, Entities } from "redux-query"
 
 export const DEFAULT_POST_OPTIONS = {

--- a/static/js/pages/HomePage.test.tsx
+++ b/static/js/pages/HomePage.test.tsx
@@ -1,25 +1,35 @@
 import React from "react"
-import { shallow } from "enzyme"
+import { screen } from "@testing-library/react"
+import {
+  IntegrationTestHelper,
+  assertInstanceOf,
+  absoluteUrl
+} from "../testing_utils"
 
 import HomePage from "./HomePage"
 
-describe("HomePage", () => {
-  it("shows the Touchstone login button if the user is logged out", () => {
-    SETTINGS.user = null
-    const wrapper = shallow(<HomePage />)
-    const link = wrapper.find("a[href='/login/saml/?idp=default']")
-    expect(link.exists()).toBeTruthy()
-    expect(link.text()).toBe("Login with MIT Touchstone")
+const LOGIN_TEXT = "Login with MIT Touchstone"
+
+describe("Homepage", () => {
+  it("does show Touchstone Login when the user is logged out", () => {
+    const helper = new IntegrationTestHelper()
+    helper.patchInitialReduxState({ user: { user: null } })
+    const [result] = helper.render(<HomePage />)
+    const link = result.getByText(LOGIN_TEXT)
+    assertInstanceOf(link, HTMLAnchorElement)
+    expect(link.href).toBe(absoluteUrl("/login/saml/?idp=default"))
   })
 
-  it("should set the title", () => {
-    const wrapper = shallow(<HomePage />)
-    expect(wrapper.find("DocumentTitle").prop("title")).toBe("OCW Studio")
+  it("does NOT show Touchstone Login is NOT visible if user is already logged in", () => {
+    const helper = new IntegrationTestHelper()
+    helper.render(<HomePage />)
+    const link = screen.queryByText(LOGIN_TEXT)
+    expect(link).toBe(null)
   })
 
-  it("hides the Touchstone login button if the user is logged in", () => {
-    const wrapper = shallow(<HomePage />)
-    const link = wrapper.find("a[href='/login/saml/?idp=default']")
-    expect(link.exists()).toBeFalsy()
+  it("sets the document title", () => {
+    const helper = new IntegrationTestHelper()
+    helper.render(<HomePage />)
+    expect(document.title).toBe("OCW Studio")
   })
 })

--- a/static/js/pages/HomePage.test.tsx
+++ b/static/js/pages/HomePage.test.tsx
@@ -20,7 +20,7 @@ describe("Homepage", () => {
     expect(link.href).toBe(absoluteUrl("/login/saml/?idp=default"))
   })
 
-  it("does NOT show Touchstone Login is NOT visible if user is already logged in", () => {
+  it("does NOT show Touchstone Login if user is already logged in", () => {
     const helper = new IntegrationTestHelper()
     helper.render(<HomePage />)
     const link = screen.queryByText(LOGIN_TEXT)

--- a/static/js/pages/HomePage.tsx
+++ b/static/js/pages/HomePage.tsx
@@ -1,13 +1,15 @@
 import React from "react"
+import { useAppSelector } from "../hooks/redux"
 import DocumentTitle, { formatTitle } from "../components/DocumentTitle"
 
 export default function HomePage(): JSX.Element | null {
+  const { user } = useAppSelector(state => state.user)
   return (
     <div className="container home-page">
       <DocumentTitle title={formatTitle()} />
       <div className="row pt-5 home-page-div">
         <div className="home-page-background">
-          {!SETTINGS.user ? (
+          {!user ? (
             <div className="text-center">
               <a
                 href="/login/saml/?idp=default"

--- a/static/js/reducers/index.ts
+++ b/static/js/reducers/index.ts
@@ -1,4 +1,4 @@
-import { combineReducers } from "redux"
+import { combineReducers } from "@reduxjs/toolkit"
 import { entitiesReducer, queriesReducer } from "redux-query"
 
 const rootReducer = combineReducers({

--- a/static/js/selectors/websites.ts
+++ b/static/js/selectors/websites.ts
@@ -9,7 +9,7 @@ import {
   WebsiteListingResponse,
   WebsitesListing
 } from "../query-configs/websites"
-import { ReduxState } from "../reducers"
+import { ReduxState } from "../store"
 import {
   ContentListingParams,
   WebsiteStarter,

--- a/static/js/store/configureStore.ts
+++ b/static/js/store/configureStore.ts
@@ -3,13 +3,12 @@ import { createLogger } from "redux-logger"
 import { queryMiddleware } from "redux-query"
 
 import { makeRequest } from "./network_interface"
-import rootReducer, { ReduxState } from "../reducers"
+import rootReducer, { ReduxState } from "./rootReducer"
 import { getQueries, getEntities } from "../lib/redux_query"
 
 export type Store = ReturnType<typeof configureStore>
 
 // Setup middleware
-// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
 export default function configureStore(initialState?: ReduxState) {
   const COMMON_MIDDLEWARE = [
     queryMiddleware(makeRequest, getQueries, getEntities)
@@ -35,9 +34,9 @@ export default function configureStore(initialState?: ReduxState) {
 
   if ((module as any).hot) {
     // Enable Webpack hot module replacement for reducers
-    (module as any).hot.accept("../reducers", () => {
+    (module as any).hot.accept("./rootReducer", () => {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const nextRootReducer = require("../reducers")
+      const nextRootReducer = require("./rootReducer")
 
       store.replaceReducer(nextRootReducer)
     })

--- a/static/js/store/index.ts
+++ b/static/js/store/index.ts
@@ -1,0 +1,9 @@
+import { ReduxState } from "./rootReducer"
+import configureStore, { Store } from "./configureStore"
+
+export const store = configureStore()
+
+export type AppDispatch = typeof store.dispatch
+export type SelectorReturn<T> = (state: ReduxState) => T
+
+export { ReduxState, Store }

--- a/static/js/store/rootReducer.ts
+++ b/static/js/store/rootReducer.ts
@@ -1,9 +1,11 @@
 import { combineReducers } from "@reduxjs/toolkit"
 import { entitiesReducer, queriesReducer } from "redux-query"
+import user from "./user"
 
 const rootReducer = combineReducers({
   entities: entitiesReducer,
-  queries:  queriesReducer
+  queries:  queriesReducer,
+  user:     user.reducer
 })
 export default rootReducer
 

--- a/static/js/store/user/index.ts
+++ b/static/js/store/user/index.ts
@@ -1,0 +1,39 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit"
+import { User } from "../../types/user"
+
+interface UserState {
+  user: User | null
+  hasSessionExpired: boolean
+}
+
+const initialState: UserState = {
+  /**
+   * SETTINGS.user does exist and comes from django.
+   * This should be the only usage in our app. All other usage of `user` should
+   * refer to the store. SETTINGS.user is intentionally untyped to promote using
+   * the store value.
+   */
+  // @ts-expect-error intentially untyped
+  user:              SETTINGS.user,
+  hasSessionExpired: false
+}
+
+const userSlice = createSlice({
+  name:     "user",
+  initialState,
+  reducers: {
+    setUser(state, action: PayloadAction<User>) {
+      state.user = action.payload
+    },
+    setExpired(state) {
+      state.hasSessionExpired = true
+    },
+    clearUser(state) {
+      state.user = null
+      state.hasSessionExpired = false
+    }
+  }
+})
+
+export const { setExpired, setUser, clearUser } = userSlice.actions
+export default userSlice

--- a/static/js/test_setup.ts
+++ b/static/js/test_setup.ts
@@ -8,7 +8,7 @@ failOnConsole()
 
 Enzyme.configure({ adapter: new Adapter() })
 
-const _createSettings = (): SETTINGS => ({
+const _createSettings = (): typeof SETTINGS => ({
   reactGaDebug:    "",
   gaTrackingID:    "",
   public_path:     "",
@@ -16,6 +16,7 @@ const _createSettings = (): SETTINGS => ({
   release_version: "0.0.0",
   sentry_dsn:      "",
   gdrive_enabled:  false,
+  // @ts-expect-error Settings.user comes from django, but is left off SETTINGS type to encourage getting it from the store.
   user:            {
     username: "example",
     name:     "Jane Doe",

--- a/static/js/testing_utils/index.ts
+++ b/static/js/testing_utils/index.ts
@@ -1,0 +1,4 @@
+export * from "../test_util"
+
+export { ReduxPatch } from "./IntegrationTestHelper"
+export { default as IntegrationTestHelper } from "./IntegrationTestHelper"

--- a/static/js/types/globals.d.ts
+++ b/static/js/types/globals.d.ts
@@ -1,4 +1,6 @@
-/* eslint-disable */
+/* eslint-disable camelcase */
+/* eslint-disable one-var */
+/* eslint-disable no-var */
 
 interface SETTINGS {
   reactGaDebug: string;
@@ -8,17 +10,21 @@ interface SETTINGS {
   release_version: string;
   sentry_dsn: string;
   gdrive_enabled: bool;
-  user: {
-    username: string;
-    email: string;
-    name: string;
-  } | null;
+  /**
+   * Settings.user does exist, but leaving it untyped to help encourage using
+   * `store.user` instead.
+   */
+  // user: User | null;
 }
+export declare global {
 
-declare var SETTINGS: SETTINGS;
+  declare var SETTINGS: SETTINGS
 
-declare var _testing: boolean;
+  declare var _testing: boolean
 
-declare var __REDUX_DEVTOOLS_EXTENSION__: Function;
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  declare var __REDUX_DEVTOOLS_EXTENSION__: Function
 
-declare var __webpack_public_path__: string;
+  declare var __webpack_public_path__: string
+
+}

--- a/static/js/types/user.d.ts
+++ b/static/js/types/user.d.ts
@@ -1,0 +1,5 @@
+export interface User {
+  username: string;
+  email: string;
+  name: string;
+}

--- a/static/js/types/util.ts
+++ b/static/js/types/util.ts
@@ -4,3 +4,14 @@ type Without<T, U> = { [P in Exclude<keyof T, keyof U>]?: never }
 export type XOR<T, U> = T | U extends Record<string, unknown>
   ? (Without<T, U> & U) | (Without<U, T> & T)
   : T | U
+
+/**
+ * Like Typescript's Partial, but recursive.
+ *
+ * See https://stackoverflow.com/a/61132308/2747370
+ */
+export type DeepPartial<T> = T extends object
+  ? {
+      [P in keyof T]?: DeepPartial<T[P]>
+    }
+  : T

--- a/static/js/util/integration_test_helper_old.tsx
+++ b/static/js/util/integration_test_helper_old.tsx
@@ -11,11 +11,12 @@ import {
 import { Action } from "redux"
 import { Router, Route } from "react-router"
 
-import { ReduxState } from "../reducers"
+import { ReduxState } from "../store"
 import configureStore, { Store } from "../store/configureStore"
 import { getQueries } from "../lib/redux_query"
 
 import * as networkInterfaceFuncs from "../store/network_interface"
+import { getInitialState } from "../testing_utils/IntegrationTestHelper"
 
 /**
  * Avoid using this for new tests. Prefer `IntegrationTestHelper.tsx` instead.
@@ -167,17 +168,20 @@ export default class IntegrationTestHelper {
   configureRenderer(
     Component: ComponentType<any> | FunctionComponent<any>,
     defaultProps = {},
-    defaultState?: ReduxState
+    defaultStatePatch?: Partial<ReduxState>
   ) {
     return async (
       extraProps = {},
       beforeRenderActions = [],
-      perRenderDefaultState?: ReduxState
+      perRenderDefaultStatePatch?: Partial<ReduxState>
     ): Promise<{
       wrapper: ReactWrapper
       store: Store
     }> => {
-      const store = configureStore(defaultState ?? perRenderDefaultState)
+      const initialState = getInitialState(
+        defaultStatePatch ?? perRenderDefaultStatePatch
+      )
+      const store = configureStore(initialState)
       beforeRenderActions.forEach(action => store.dispatch(action))
 
       const ComponentWithProps = () => (

--- a/yarn.lock
+++ b/yarn.lock
@@ -1344,6 +1344,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@reduxjs/toolkit@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "@reduxjs/toolkit@npm:1.8.1"
+  dependencies:
+    immer: ^9.0.7
+    redux: ^4.1.2
+    redux-thunk: ^2.4.1
+    reselect: ^4.1.5
+  peerDependencies:
+    react: ^16.9.0 || ^17.0.0 || ^18
+    react-redux: ^7.2.1 || ^8.0.0-beta
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-redux:
+      optional: true
+  checksum: be5cdea975a8a631fe2d88cafc7077554c7bc3621a4a7031556cc17e5dec26359018f2614c325895e7ab50865f5c511025d1e589ca01de7e2bd88d95e0a1a963
+  languageName: node
+  linkType: hard
+
 "@sentry/browser@npm:^6.10.0":
   version: 6.19.3
   resolution: "@sentry/browser@npm:6.19.3"
@@ -7283,6 +7303,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"immer@npm:^9.0.7":
+  version: 9.0.12
+  resolution: "immer@npm:9.0.12"
+  checksum: bcbec6d76dac65e49068eb67ece4d407116e62b8cde3126aa89c801e408f5047763ba0aeb62f1938c1aa704bb6612f1d8302bb2a86fa1fc60fcc12d8b25dc895
+  languageName: node
+  linkType: hard
+
 "immutable@npm:^4.0.0":
   version: 4.0.0
   resolution: "immutable@npm:4.0.0"
@@ -9986,6 +10013,7 @@ __metadata:
     "@dnd-kit/core": ^3.1.1
     "@dnd-kit/sortable": ^4.0.0
     "@mitodl/ckeditor5-resource-link": ^31.0.0
+    "@reduxjs/toolkit": ^1.8.1
     "@sentry/browser": ^6.10.0
     "@swc/core": ^1.2.95
     "@swc/jest": ^0.2.4
@@ -11794,12 +11822,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"redux-thunk@npm:^2.4.1":
+  version: 2.4.1
+  resolution: "redux-thunk@npm:2.4.1"
+  peerDependencies:
+    redux: ^4
+  checksum: af5abb425fb9dccda02e5f387d6f3003997f62d906542a3d35fc9420088f550dc1a018bdc246c7d23ee852b4d4ab8b5c64c5be426e45a328d791c4586a3c6b6e
+  languageName: node
+  linkType: hard
+
 "redux@npm:^4.0.0, redux@npm:^4.0.5":
   version: 4.1.2
   resolution: "redux@npm:4.1.2"
   dependencies:
     "@babel/runtime": ^7.9.2
   checksum: 6a839cee5bd580c5298d968e9e2302150e961318253819bcd97f9d945a5a409559eacddf6026f4118bb68b681c593d90e8a2c5bbf278f014aff9bf0d2d8fa084
+  languageName: node
+  linkType: hard
+
+"redux@npm:^4.1.2":
+  version: 4.2.0
+  resolution: "redux@npm:4.2.0"
+  dependencies:
+    "@babel/runtime": ^7.9.2
+  checksum: 75f3955c89b3f18edf5411e5fb482aa2e4f41a416183e8802a6bf6472c4fc3d47675b8b321d147f8af8e0f616436ac507bf5a25f1c4d6180e797b549c7db2c1d
   languageName: node
   linkType: hard
 
@@ -11903,7 +11949,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"reselect@npm:^4.0.0":
+"reselect@npm:^4.0.0, reselect@npm:^4.1.5":
   version: 4.1.5
   resolution: "reselect@npm:4.1.5"
   checksum: 54c13c1e795b2ea70cba8384138aebe78adda00cbea303cc94b64da0a70d74c896cc9a03115ae38b8bff990e7a60dcd6452ab68cbec01b0b38c1afda70714cf0


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Toward https://github.com/mitodl/ocw-studio/issues/1177

#### What's this PR do?
This PR moves user information from `window.SETTINGS` (provided by the backend in a Django template) to a redux store.

Alice once indicated to me that we've moved away from redux a bit in the recent past, so I was a little hesitant to introduce it here. That said,
- the user store is created using [redux toolkit](https://redux-toolkit.js.org/introduction/getting-started), the "official, opinionated, batteries-included toolset for efficient Redux development"
- user info seems like a very reasonable thing to keep in the a redux store (pretty global info)
- the immediate motivation for this is to access (and set) user information in middleware. Specifically...we are using `redux-query` for API calls. By moving the user information to the redux store, it will be easy to create redux middleware that triggers a "please go login again" alert when 401 Unauthenticated errors come from the backend.

#### How should this be manually tested?
You should still be able to log in and out.
