### PR TITLE
fix webvtt transcript

### DIFF
--- a/videos/management/commands/clear_webvtt_files.py
+++ b/videos/management/commands/clear_webvtt_files.py
@@ -1,0 +1,54 @@
+"""
+We should save webvtt caption files with the webvtt extensions. This deletes caption files without the extention
+from s3 and clears out the video resource metadata so it can be repopulates with the correct extension on publish
+"""
+
+import os
+
+import boto3
+from django.conf import settings
+from django.core.management import BaseCommand
+
+from videos.models import Video
+from websites.constants import RESOURCE_TYPE_VIDEO
+from websites.utils import set_dict_field
+
+
+script_path = os.path.dirname(os.path.realpath(__file__))
+
+
+class Command(BaseCommand):
+    """
+    delete _webvtt caption files without extension from s3 and clear resource metadata
+    """
+
+    help = __doc__
+
+    def handle(self, *args, **options):
+        """
+        Run the command
+        """
+
+        s3 = boto3.resource("s3")
+        bucket = settings.AWS_STORAGE_BUCKET_NAME
+
+        videos = Video.objects.filter(
+            webvtt_transcript_file__endswith="transcript_webvtt"
+        )
+        websites = set()
+        self.stdout.write(f"Removing {videos.count()} webvtt caption files.")
+
+        for video in videos:
+            s3.Object(bucket, video.webvtt_transcript_file.name).delete()
+            video.webvtt_transcript_file = None
+            video.save()
+
+            websites.add(video.website)
+
+        for website in websites:
+            for resource in website.websitecontent_set.filter(
+                metadata__resourcetype=RESOURCE_TYPE_VIDEO
+            ):
+                set_dict_field(resource.metadata, "video_files.video_captions_file", "")
+                resource.save()
+            self.stdout.write(f"Caption file data cleared for {website.name}")

--- a/videos/threeplay_api.py
+++ b/videos/threeplay_api.py
@@ -187,7 +187,7 @@ def update_transcripts_for_video(video: Video) -> bool:
         webvtt_response = fetch_file(webvtt_url)
         if webvtt_response:
             video.webvtt_transcript_file.save(
-                "transcript_webvtt", File(webvtt_response, name="transcript_webvtt")
+                "transcript.webvtt", File(webvtt_response, name="transcript.webvtt")
             )
 
         video.save()

--- a/videos/threeplay_api_test.py
+++ b/videos/threeplay_api_test.py
@@ -151,8 +151,10 @@ def test_update_transcripts_for_video(
 
     if webvtt_transcript_content:
         assert video_file.video.webvtt_transcript_file.path.startswith(
-            url_base + "_transcript_webvtt"
+            url_base + "_transcript"
         )
+        assert video_file.video.webvtt_transcript_file.path.endswith(".webvtt")
+
     else:
         assert video_file.video.webvtt_transcript_file == ""
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/ocw-studio/issues/1295

#### What's this PR do?
This pr save webvtt transcripts with extension .webvtt so that they are recognized as files by fastly and are available at ocw-site-url/courses/course-id/1file.webvtt

#### How should this be manually tested?
- Use rc settings for AWS_, DRIVE_ and THREEPLAY_ fields as well as PREPUBLISH_ACTIONS. 
- On master branch, place 1 small video file in your gdrive videos_final folder for a site and then sync.
- Wait 5 minutes or so to make sure the transcode job finished.
- Using Postman or curl, make a request to http://localhost:8043/api/transcode-jobs/ with the following data, and headers
```
{
  "version": "0",
  "id": "c120fe11-87db-c292-b3e5-1cc90740f6e1",
  "detail-type": "MediaConvert Job State Change",
  "source": "aws.mediaconvert",
  "account": "<AWS_ACCOUNT_ID>",
  "time": "2021-08-05T16:52:33Z",
  "region": "us-east-1",
  "resources": [
    "arn:aws:mediaconvert:us-east-1:<AWS_ACCOUNT_ID>:jobs/<VIDEOJOB_ID>"
  ],
  "detail": {
    "timestamp": 1628172900136,
    "accountId": "<AWS_ACCOUNT_ID>",
    "queue": "arn:aws:mediaconvert:us-east-1:<AWS_ACCOUNT_ID>:queues/Default",
    "jobId": "<VIDEOJOB_ID>",
    "status": "COMPLETE",
    "userMetadata": {},
    "outputGroupDetails": [
      {
        "outputDetails": [
          {
            "outputFilePaths": [
              "s3://<AWS_STORAGE_BUCKET_NAME>/aws_mediaconvert_transcodes/<SITE_NAME>/<DRIVE_FILE_ID>/<VIDEO_FILENAME>_youtube.mp4"
            ],
            "durationInMs": 132033,
            "videoDetails": {
              "widthInPx": 1280,
              "heightInPx": 720
            }
          },
        ],
        "type": "FILE_GROUP"
      }
    ]
  }
}
```
- This should create a new VideoFile object with destination='youtube'. From the command line, set the destination_id for the VideoFile object to `GfjkPmTrhwE`
- Publish the course from the ui. Don't worry about the publishing backend being set up, we just need to trigger the pre-publish action. In the resource metadata for the new file , Video Captions (WebVTT) URL should be set to something ending in `transcript_webvtt` with no extension
- Check out this PR
- Repeat the above steps for a second video
- The resource metadata for the second video should have a Video captions file that ends in `transcript.webvtt`
- Run `docker-compose run web python manage.py clear_webvtt_files`. 
- Publish the course again. Now both videos should have caption files ending `transcript.webvtt`. The s3 bucket for the course should not contain any `transcript_webvtt` files