### PR TITLE
make legacy uid hidden

### DIFF
--- a/localdev/configs/ocw-course-site-config.yml
+++ b/localdev/configs/ocw-course-site-config.yml
@@ -678,7 +678,7 @@ collections:
                 Higher Education: [ ]
           - label: "Legacy UID"
             name: "legacy_uid"
-            widget: "string"
+            widget: "hidden"
   - category: Settings
     label: Menu
     name: menu

--- a/static/js/resources/ocw-course-site-config.json
+++ b/static/js/resources/ocw-course-site-config.json
@@ -835,7 +835,7 @@
             {
               "label": "Legacy UID",
               "name": "legacy_uid",
-              "widget": "string"
+              "widget": "hidden"
             }
           ],
           "file": "data/course.json",


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
closes closes https://github.com/mitodl/ocw-studio/issues/1254
Should be reviewed with https://github.com/mitodl/ocw-hugo-projects/pull/170

#### What's this PR do?
Makes legacy_uid uneditable

#### How should this be manually tested?
This should be tested with https://github.com/mitodl/ocw-hugo-projects/pull/170

Update the  ocw-course starter on https://ocw-studio-rc.odl.mit.edu to the starter in the ocw-hugo-projects  pr. 
Delete the legacy_uid from the metadata for an imported course through the admin ui. 
Run `heroku run python manage.py -a ocw-studio-rc import_ocw_course_sites -b ocw-to-hugo-output-qa --filter <course-slug>` to verify that the legacy_uid field is repopulated in the metadata and set to what it was before. 
Go to the metadata page in the course editing ui. Verify that legacy uid is not an editable field