### PR TITLE
add SITEMAP_DOMAIN to the app and pipeline templates

### DIFF
--- a/app.json
+++ b/app.json
@@ -449,6 +449,10 @@
       "description": "Site name",
       "required": false
     },
+    "SITEMAP_DOMAIN": {
+      "description": "The domain to be used in Hugo builds for fully qualified URLs in the sitemap",
+      "required": false
+    },
     "SOCIAL_AUTH_SAML_CONTACT_NAME": {
       "description": "The SAML contact name for our app",
       "required": false

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -352,6 +352,7 @@ class SitePipeline(BaseSitePipeline, ConcoursePipeline):
                     .replace("((theme-deployed-trigger))", theme_deployed_trigger)
                     .replace("((theme-created-trigger))", theme_created_trigger)
                     .replace("((build-drafts))", build_drafts)
+                    .replace("((sitemap-domain))", settings.SITEMAP_DOMAIN)
                 )
             self.upsert_config(config_str, pipeline_name)
 
@@ -478,6 +479,7 @@ class MassBuildSitesPipeline(BaseMassBuildSitesPipeline, ConcoursePipeline):
                 .replace("((open-discussions-url))", settings.OPEN_DISCUSSIONS_URL)
                 .replace("((open-webhook-key))", settings.OCW_NEXT_SEARCH_WEBHOOK_KEY)
                 .replace("((build-drafts))", build_drafts)
+                .replace("((sitemap-domain))", settings.SITEMAP_DOMAIN)
             )
         log.debug(config_str)
         self.upsert_config(config_str, self.PIPELINE_NAME)

--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -70,6 +70,7 @@ jobs:
       OCW_STUDIO_BASE_URL: ((ocw-studio-url))
       STATIC_API_BASE_URL: ((static-api-base-url))
       GIT_KEY: ((git-private-key-var))
+      SITEMAP_DOMAIN: ((sitemap-domain))
     config:
       platform: linux
       image_resource:

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -129,6 +129,7 @@ jobs:
           OCW_STUDIO_BASE_URL: ((ocw-studio-url))
           STATIC_API_BASE_URL: ((static-api-base-url))
           OCW_IMPORT_STARTER_SLUG: ((ocw-import-starter-slug))
+          SITEMAP_DOMAIN: ((sitemap-domain))
         config:
           platform: linux
           image_resource:

--- a/main/settings.py
+++ b/main/settings.py
@@ -1091,3 +1091,8 @@ RESOURCE_TYPE_FIELDS = get_delimited_list(
     default=["resourcetype", "filetype"],
     description="List of site configuration fields that are used to store resource type",
 )
+SITEMAP_DOMAIN = get_string(
+    name="SITEMAP_DOMAIN",
+    default="ocw.mit.edu",
+    description="The domain to be used in Hugo builds for fully qualified URLs in the sitemap"
+)

--- a/main/settings.py
+++ b/main/settings.py
@@ -1094,5 +1094,5 @@ RESOURCE_TYPE_FIELDS = get_delimited_list(
 SITEMAP_DOMAIN = get_string(
     name="SITEMAP_DOMAIN",
     default="ocw.mit.edu",
-    description="The domain to be used in Hugo builds for fully qualified URLs in the sitemap"
+    description="The domain to be used in Hugo builds for fully qualified URLs in the sitemap",
 )


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [x] Settings
  - [x] New settings are documented and present in `app.json`
  - [x] New settings have reasonable development defaults, if applicable
  - [x] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
Related to https://github.com/mitodl/ocw-hugo-themes/issues/673

#### What's this PR do?
This PR adds the new setting `SITEMAP_DOMAIN` to the app configuration and utilizes it in the individual and mass site build pipeline templates.  It will be used to construct a fully qualified URL in sitemap templates during the Hugo build to improve Google search rankings.

#### How should this be manually tested?
 - Set `SITEMAP_DOMAIN` in your `.env` file to any value you desire, i.e. `ocw.mit.edu`
 - Make sure you have the following in your `.env` file:
   - `SITEMAP_DOMAIN=ocw.mit.edu` (or whatever else you want as a test)
   - `CONCOURSE_URL=http://concourse:8080`
   - `CONCOURSE_PASSWORD=test`
   - `CONCOURSE_USERNAME=test`
   - `CONCOURSE_TEAM=main`
 - Spin up your local instance of `ocw-studio` on this branch with: `docker-compose --profile concourse up --build`
 - If you don't have a test `ocw-course` site in your instance, take a moment to go into the UI and create one and note the slug of the site
 - Once everything is spun up and you have your test course, in a separate terminal run:
   - `docker-compose run --rm web ./manage.py backpopulate_pipelines --filter <your test course slug here>`
   - `docker-compose run --rm web ./manage.py upsert_mass_build_pipeline`
 - Visit your local Concourse instance at http://localhost:8080 and login with the username and password noted above (note: after you login you might be redirected to http://concourse:8080 and you'll need replace that with `localhost` again
 - Make sure you install the fly CLI for Concourse by clicking the icon matching your OS in the bottom right of the page
 - Once you have `fly` installed, add your local instance as a target by using [`fly login`](https://concourse-ci.org/fly.html#fly-login) (I called my target `local`)
 - Run `fly -t local get-pipeline --pipeline live/site:<your site slug here> | grep SITEMAP_DOMAIN`
 - Ensure that you see the domain you set assigned to `SITEMAP_DOMAIN`
 - Run `fly -t local get-pipeline --pipeline mass-build-sites/version:live | grep SITEMAP_DOMAIN`
 - Ensure that you see the domain you set assigned to `SITEMAP_DOMAIN`
