### PR TITLE
make retry_on_failure preserve type hints

### DIFF
--- a/content_sync/decorators.py
+++ b/content_sync/decorators.py
@@ -2,7 +2,7 @@
 import functools
 import logging
 from time import sleep
-from typing import Callable, Optional
+from typing import Any, Callable, Optional, TypeVar
 
 from django.conf import settings
 from django_redis import get_redis_connection
@@ -11,14 +11,17 @@ from github.GithubException import RateLimitExceededException
 from content_sync.models import ContentSyncState
 
 
+F = TypeVar("F", bound=Callable[..., Any])
+
 log = logging.getLogger(__name__)
 
 
-def retry_on_failure(func: Callable) -> Callable:
+def retry_on_failure(func: F) -> F:
     """
     Retry a function a certain number of times if it fails.
     """
 
+    @functools.wraps(func)
     def wrapper(*args, **kwargs):
         retries = settings.CONTENT_SYNC_RETRIES
         while retries > 0:


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None; *This is a change I made while working on #1268. We're putting that on hold for now, but this change seems worth keeping... Type hints on `repo` and others were very helpful when I was trying to learn about our github API package.*

#### What's this PR do?
This PR makes `retry_on_failure` preserve type hints. A bunch of methods had type hints but were being overwrriten by `retry_on_failure`. Now `retry_on_failure` will preserve the hints.

```python
GithubApiWrapper

    @retry_on_failure
    def get_repo(self) -> Repository:
        ...
```

**Before / After**
<img width="200" alt="Screen Shot 2022-05-10 at 10 27 44 AM" src="https://user-images.githubusercontent.com/9010790/167653581-4877be72-2872-4ebd-8de7-d5368c5846b7.png"> <img width="200" alt="Screen Shot 2022-05-10 at 10 29 23 AM" src="https://user-images.githubusercontent.com/9010790/167653614-bce44387-c75b-4f74-86a8-0e8674997e2b.png">


#### How should this be manually tested?
Tests should pass. Check hints work now if you want.