### PR TITLE
Cc/better shortcode parsing

### DIFF
--- a/static/js/lib/ckeditor/plugins/ResourceEmbed.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceEmbed.ts
@@ -14,10 +14,8 @@ import {
   RESOURCE_EMBED,
   RESOURCE_EMBED_COMMAND
 } from "./constants"
-import { Shortcode, makeHtmlString } from "./util"
+import { Shortcode, makeHtmlString, replaceShortcodes } from "./util"
 import { isNotNil } from "../../../util"
-
-export const RESOURCE_SHORTCODE_REGEX = /{{< resource .*? >}}/g
 
 /**
  * Class for defining Markdown conversion rules for ResourceEmbed
@@ -31,19 +29,20 @@ class ResourceMarkdownSyntax extends MarkdownSyntaxPlugin {
     return function resourceExtension(): Showdown.ShowdownExtension[] {
       return [
         {
-          type:    "lang",
-          regex:   RESOURCE_SHORTCODE_REGEX,
-          replace: (s: string) => {
-            const shortcode = Shortcode.fromString(s)
-            const uuid = shortcode.get(0) ?? shortcode.get("uuid")
-            const href = shortcode.get("href")
-            const hrefUuid = shortcode.get("href_uuid")
-            const attrs = {
-              "data-uuid":      uuid,
-              "data-href":      href,
-              "data-href-uuid": hrefUuid
+          type:   "lang",
+          filter: (text: string) => {
+            const replacer = (shortcode: Shortcode) => {
+              const uuid = shortcode.get(0) ?? shortcode.get("uuid")
+              const href = shortcode.get("href")
+              const hrefUuid = shortcode.get("href_uuid")
+              const attrs = {
+                "data-uuid":      uuid,
+                "data-href":      href,
+                "data-href-uuid": hrefUuid
+              }
+              return makeHtmlString("section", attrs)
             }
-            return makeHtmlString("section", attrs)
+            return replaceShortcodes(text, replacer, { name: "resource" })
           }
         }
       ]

--- a/static/js/lib/ckeditor/plugins/util.test.ts
+++ b/static/js/lib/ckeditor/plugins/util.test.ts
@@ -414,8 +414,10 @@ describe("replaceShortcodes", () => {
   )
 
   it("only affects shortcodes of specified name", () => {
-    const text = "{{< some_shortcode >}} and {{< still_lowercase >}}"
-    const expected = "{{< SOME_SHORTCODE >}} and {{< still_lowercase >}}"
+    const text =
+      "hello {{< some_shortcode >}} and {{< some_shortcode_same_beginning >}}"
+    const expected =
+      "hello {{< SOME_SHORTCODE >}} and {{< some_shortcode_same_beginning >}}"
     const replacer = jest.fn(capitalizingReplacer)
     const replaced = replaceShortcodes(text, replacer, {
       name: "some_shortcode"

--- a/static/js/lib/ckeditor/plugins/util.test.ts
+++ b/static/js/lib/ckeditor/plugins/util.test.ts
@@ -363,6 +363,47 @@ describe("findNestedExpressions", () => {
     expect(findNestedExpressions(text, opener, closer)).toStrictEqual([])
   })
 
+  test.each([
+    {
+      //                      0         1         2         3
+      //                      0123456789012345678901234567890123456789
+      text:                  'rats << cats "<<" bats >> hats',
+      expected:              { start: 5, end: 25 },
+      ignoreWithinDblQuotes: true
+    },
+    {
+      //                      0         1         2         3
+      //                      0123456789012345678901234567890123456789
+      text:                  'rats << cats ">>" bats >> hats',
+      expected:              { start: 5, end: 25 },
+      ignoreWithinDblQuotes: true
+    },
+    {
+      //                      0         1         2         3
+      //                      0123456789012345678901234567890123456789
+      text:                  'rats "still << finds if whole >> is in quotes" hats',
+      expected:              { start: 12, end: 32 },
+      ignoreWithinDblQuotes: true
+    },
+    {
+      //                      0         1         2         3
+      //                      0123456789012345678901234567890123456789
+      text:                  'rats << cats ">>" bats >> hats',
+      expected:              { start: 5, end: 16 },
+      ignoreWithinDblQuotes: false
+    },
+  ])(
+    "ignores openers/closers in quotation marks",
+    ({ text, expected, ignoreWithinDblQuotes }) => {
+      const opener = "<<"
+      const closer = ">>"
+
+      expect(
+        findNestedExpressions(text, opener, closer, ignoreWithinDblQuotes)
+      ).toStrictEqual([expected])
+    }
+  )
+
   test("with opener and closer of unequal lengths", () => {
     const opener = "[[["
     const closer = ">"
@@ -394,6 +435,22 @@ describe("replaceShortcodes", () => {
     {
       text:               'hello {{% shortcode "{{< sup 1 >}}" %}} other',
       expected:           'hello {{% SHORTCODE "{{< sup 1 >}}" %}} other',
+      isPercentDelimited: true
+    },
+    {
+      // ignores closer in quotes
+      text:
+        'hello {{% shortcode "false %}} closer" %}} and another one {{% shortcode "fa\\"lse %}} closer" %}} cool',
+      expected:
+        'hello {{% SHORTCODE "false %}} closer" %}} and another one {{% SHORTCODE "fa\\"lse %}} closer" %}} cool',
+      isPercentDelimited: true
+    },
+    {
+      // ignores opener in quotes
+      text:
+        'hello {{% shortcode "false {{% opener" %}} and another one {{% shortcode "fa\\"lse {{% opener" %}} cool',
+      expected:
+        'hello {{% SHORTCODE "false {{% opener" %}} and another one {{% SHORTCODE "fa\\"lse {{% opener" %}} cool',
       isPercentDelimited: true
     },
     {

--- a/static/js/lib/ckeditor/plugins/util.ts
+++ b/static/js/lib/ckeditor/plugins/util.ts
@@ -13,12 +13,12 @@ interface SubstringRange {
  *
  * @example
  * ```
- *           // 0         1         2         3         4
- *           // 01234567890123456789012345678901234567890123456789
+ *            // 0         1         2         3         4
+ *            // 01234567890123456789012345678901234567890123456789
  * const text = "Hello {{< shortcode {{< sup 12 >}} >}} goodbye.
  * const opener = "{{<"
  * matches = findNestedExpressions(text, "{{<", ">}}")
- * expect(matches).toEqual([{ start: 7, end: 39 }])
+ * expect(matches).toEqual([{ start: 6, end: 38 }])
  * ```
  * Note that `end` is the string index of the next character after the closer.
  * In this way, `end - start` is the substring length.
@@ -39,6 +39,20 @@ export const findNestedExpressions = (
   return matches
 }
 
+/**
+ * Find the next balanced instance of opener...closer in text starting at the
+ * specified index within text.
+ *
+ * @example
+ * ```
+ *            // 0         1         2         3         4
+ *            // 01234567890123456789012345678901234567890123456789
+ * const text = "hello [ b [ ] ] world [ [ ] [ ] ] bye"
+ * const startingFrom = 16
+ * const range = findNestedExpression(text, "[", "]", startingFrom)
+ * expect(range).toEqual({ start: 22, end: 33 })
+ * ```
+ */
 const findNestedExpression = (
   text: string,
   opener: string,

--- a/static/js/lib/ckeditor/plugins/util.ts
+++ b/static/js/lib/ckeditor/plugins/util.ts
@@ -360,15 +360,17 @@ export const replaceShortcodes = (
   })
   if (matches.length === 0) return text
   const pieces = matches.reduce(
-    (pieces, range, i, ranges) => {
+    (acc, range, i, ranges) => {
       const shortcode = Shortcode.fromString(
         text.substring(range.start, range.end)
       )
-      pieces.push(replacer(shortcode))
+      // accumulate the replacement
+      acc.push(replacer(shortcode))
+      // and the text up until the next replacement
       const isLast = i + 1 === ranges.length
       const nextStart = isLast ? text.length : ranges[i + 1].start
-      pieces.push(text.substring(range.end, nextStart))
-      return pieces
+      acc.push(text.substring(range.end, nextStart))
+      return acc
     },
     [text.substring(0, matches[0].start)]
   )

--- a/static/js/lib/ckeditor/plugins/util.ts
+++ b/static/js/lib/ckeditor/plugins/util.ts
@@ -353,10 +353,11 @@ export const replaceShortcodes = (
   }: { name: string; isPercentDelimited?: boolean }
 ) => {
   const opener = isPercentDelimited ? "{{%" : "{{<"
-  const namedOpener = `${opener} ${name}`
+  const openerAndNameRegex = new RegExp([opener, "\\s*", name, "\\s+"].join(""))
   const closer = isPercentDelimited ? "%}}" : ">}}"
   const matches = findNestedExpressions(text, opener, closer).filter(m => {
-    return text.substring(m.start, m.start + namedOpener.length) === namedOpener
+    if (name === undefined) return true
+    return openerAndNameRegex.test(text.substring(m.start, m.end))
   })
   if (matches.length === 0) return text
   const pieces = matches.reduce(


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1280 

#### What's this PR do?
This PR improves the frontend Markdown --> HTML converter to better handle shortocdes. In particular, this fixes an issue with shortcodes inside shortcodes. 

Shortcodes inside shortcodes will not display well in Hugo. Currently they crash studio. With this PR they will at least not crash studio.

#### How should this be manually tested?
*If you'd prefer to test with real data / have a copy of prod courses locally, this spreadsheet lists a bunch (all) pages affected by the bug being fixed here: https://docs.google.com/spreadsheets/d/1q19lGfqbUrcC0CraBrA9YsY9q_8C3ejeeDFc2JX3XKo/edit?usp=sharing*

1. On master, edit a page in studio and create a resource link.
2. In the admin panel, edit the resource link so it looks like
    ```
    {{% resource_link uuid "superscripts! {{< sup 2 >}} oh no" %}}
    ```
3. View that content in Studio and observe that the editor fails to load.
4. Repeat (3) on this branch. Editor should load fine. 