### PR TITLE
specify docker container version for mitodl/ocw-course-publisher

### DIFF
--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -134,7 +134,7 @@ jobs:
           platform: linux
           image_resource:
             type: docker-image
-            source: {repository: mitodl/ocw-course-publisher, tag: latest}
+            source: {repository: mitodl/ocw-course-publisher, tag: 0.2}
           inputs:
             - name: ocw-hugo-themes
             - name: course-markdown

--- a/content_sync/pipelines/definitions/concourse/theme-assets-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/theme-assets-pipeline.yml
@@ -16,7 +16,7 @@ jobs:
       platform: linux
       image_resource:
         type: docker-image
-        source: {repository: mitodl/ocw-course-publisher, tag: latest}
+        source: {repository: mitodl/ocw-course-publisher, tag: 0.2}
       inputs:
       - name: ocw-hugo-themes
       outputs:


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1320

#### What's this PR do?
This PR pins the `mitodl/ocw-course-publisher` Docker container to 0.2 to ensure we're not just grabbing the latest version every time.

#### How should this be manually tested?
 - Set the following in your `.env`:
```
CONCOURSE_URL=http://concourse:8080
CONCOURSE_PASSWORD=test
CONCOURSE_USERNAME=test
CONCOURSE_TEAM=main
```
 - Run `ocw-studio` with `docker-compose --profile concourse up`
 - Run `docker-compose run --rm web ./manage.py backpopulate_pipelines <site_id>` for any site in your local instance
 - Inspect the pipeline definition using the `fly` CLI, for example `fly -t ci get-pipeline -p live/site:<site_id>` and make sure version 0.2 is specified
