### PR TITLE
use the proper ocw-course-publisher image and specify version in mass-build-sites

### DIFF
--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -75,7 +75,7 @@ jobs:
       platform: linux
       image_resource:
         type: docker-image
-        source: {repository: ardiea/ocw-course-publisher, tag: latest}
+        source: {repository: mitodl/ocw-course-publisher, tag: 0.2}
       inputs:
         - name: publishable_sites
         - name: ocw-hugo-projects


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Fixes something missed from https://github.com/mitodl/ocw-studio/issues/1320

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/1321, we started specifying the version of the `ocw-course-publisher` Docker image.  This PR also specifies the version in `mass-build-sites` as it was using the wrong one.

#### How should this be manually tested?
 - Set the following in your `.env`:
```
CONCOURSE_URL=http://concourse:8080
CONCOURSE_PASSWORD=test
CONCOURSE_USERNAME=test
CONCOURSE_TEAM=main
```
 - Run `ocw-studio` with `docker-compose --profile concourse up`
 - Run `docker-compose run --rm web ./manage.py upsert_mass_build_pipeline`
 - Inspect the pipeline definition using the `fly` CLI, for example `fly -t local get-pipeline -p mass-build-sites/version:live` and make sure version 0.2 is specified and that it comes from the `mitodl` org
