### PR TITLE
add API_BEARER_TOKEN to the Hugo step in the site build pipelines

### DIFF
--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -65,6 +65,7 @@ jobs:
     attempts: 3
     timeout: 300m
     params:
+      API_BEARER_TOKEN: ((api-token))
       GTM_ACCOUNT_ID: ((gtm-account-id))
       OCW_IMPORT_STARTER_SLUG: ((ocw-import-starter-slug))
       OCW_STUDIO_BASE_URL: ((ocw-studio-url))

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -125,6 +125,7 @@ jobs:
         timeout: 20m
         attempts: 3
         params:
+          API_BEARER_TOKEN: ((api-token))
           GTM_ACCOUNT_ID: ((gtm-account-id))
           OCW_STUDIO_BASE_URL: ((ocw-studio-url))
           STATIC_API_BASE_URL: ((static-api-base-url))


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1328

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-themes/pull/679, we set up the `www` theme to publish a sitemap with a `sitemapindex` element that uses the `ocw-studio` API to iterate all the published sites in any given envorinment the build is running in and write a path to that site's sitemap into the index.  This PR changes the site and mass build pipeline templates so that `API_BEARER_TOKEN` is injected into the environment before the Hugo build so that Hugo can successfully query the `ocw-studio` API.

#### How should this be manually tested?
 - Set the following in your `.env` (you can use the value for `API_BEARER_TOKEN` from RC if you want, but it's only necessary if you actually were to run the pipeline):
```
API_BEARER_TOKEN=<any test value>
CONCOURSE_URL=http://concourse:8080
CONCOURSE_PASSWORD=test
CONCOURSE_USERNAME=test
CONCOURSE_TEAM=main
```
 - Run `ocw-studio` with `docker-compose --profile concourse up`
 - Run `docker-compose run --rm web ./manage.py backpopulate_pipelines <site_id>` for any site in your local instance
 - Inspect the pipeline definition using the `fly` CLI, for example `fly -t ci get-pipeline -p live/site:<site_id>` and make sure `API_BEARER_TOKEN` is set
 - Run `docker-compose run --rm web ./manage.py upsert_mass_build_pipeline`
 - Inspect the pipeline definition using the `fly` CLI, for example `fly -t local get-pipeline -p mass-build-sites/version:live` and make sure `API_BEARER_TOKEN` is specified
