### PR TITLE
Cc/legacy shortcode fix

### DIFF
--- a/static/js/lib/ckeditor/plugins/LegacyShortcodes.test.ts
+++ b/static/js/lib/ckeditor/plugins/LegacyShortcodes.test.ts
@@ -5,7 +5,7 @@ import LegacyShortcodes from "./LegacyShortcodes"
 import { LEGACY_SHORTCODES } from "./constants"
 import Paragraph from "@ckeditor/ckeditor5-paragraph/src/paragraph"
 
-const quizTestMD = `{{< quiz_multiple_choice questionId="Q1_div" >}}{{< quiz_choices >}}{{< quiz_choice isCorrect="false" >}}sound, satisfiable{{< /quiz_choice >}}{{< quiz_choice isCorrect="false" >}}valid, satisfiable{{< /quiz_choice >}}{{< quiz_choice isCorrect="true" >}}sound, valid{{< /quiz_choice >}}{{< quiz_choice isCorrect="false" >}}valid, true{{< /quiz_choice >}}{{< /quiz_choices >}}{{< quiz_solution / >}}{{< /quiz_multiple_choice >}}`
+const quizTestMD = `{{< quiz_multiple_choice questionId="Q1_div" >}}{{< quiz_choices >}}{{< quiz_choice isCorrect="false" >}}sound, satisfiable{{< /quiz_choice >}}{{< quiz_choice isCorrect="false" >}}valid, satisfiable{{< /quiz_choice >}}{{< quiz_choice isCorrect="true" >}}sound, valid{{< /quiz_choice >}}{{< quiz_choice isCorrect="false" >}}valid, true{{< /quiz_choice >}}{{< /quiz_choices >}}{{< quiz_solution >}}{{< /quiz_multiple_choice >}}`
 
 const getEditor = createTestEditor([Paragraph, LegacyShortcodes, Markdown])
 
@@ -31,20 +31,42 @@ describe("ResourceEmbed plugin", () => {
   test.each(LEGACY_SHORTCODES)(
     "should take in and return %p closing shortcode",
     async shortcode => {
-      const md = `{{< /${shortcode} >}}`
-      const editor = await getEditor(md)
+      const md1 = `{{< /${shortcode} >}}`
+      const editor1 = await getEditor(md1)
       // @ts-ignore
-      expect(editor.getData()).toBe(md)
+      expect(editor1.getData()).toBe(md1)
+
+      /**
+       * Hugo documentation uses the first version so it should be preferred.
+       * But Hugo accepts this version and image-gallery uses it.
+       * The editor will normalize it to the first version.
+       */
+      const md2 = `{{</ ${shortcode} >}}`
+      const editor2 = await getEditor(md2)
+      // @ts-ignore
+      expect(editor2.getData()).toBe(md1)
     }
   )
 
   test.each(LEGACY_SHORTCODES)(
-    "should take in and return %p shortcode with arguments",
+    "should take in and return %p shortcode with positional parameters",
     async shortcode => {
-      const md = `{{< ${shortcode} arguments foo=123 html=<for some reason/> >}}`
+      const md = `{{< ${shortcode} arguments "and chemistry H{{< sub 2 >}}0" >}}`
+      const expected = `{{< ${shortcode} "arguments" "and chemistry H{{< sub 2 >}}0" >}}`
       const editor = await getEditor(md)
       // @ts-ignore
-      expect(editor.getData()).toBe(md)
+      expect(editor.getData()).toBe(expected)
+    }
+  )
+
+  test.each(LEGACY_SHORTCODES)(
+    "should take in and return %p shortcode with named parameters",
+    async shortcode => {
+      const md = `{{< ${shortcode} foo=123 html="<for some reason/>" >}}`
+      const expected = `{{< ${shortcode} foo="123" html="<for some reason/>" >}}`
+      const editor = await getEditor(md)
+      // @ts-ignore
+      expect(editor.getData()).toBe(expected)
     }
   )
 

--- a/static/js/lib/ckeditor/plugins/LegacyShortcodes.ts
+++ b/static/js/lib/ckeditor/plugins/LegacyShortcodes.ts
@@ -5,7 +5,7 @@ import { editor } from "@ckeditor/ckeditor5-core"
 import MarkdownSyntaxPlugin from "./MarkdownSyntaxPlugin"
 import { TurndownRule } from "../../../types/ckeditor_markdown"
 import { LEGACY_SHORTCODES } from "./constants"
-import { replaceShortcodes, Shortcode } from './util'
+import { replaceShortcodes, Shortcode } from "./util"
 
 const shortcodeClass = (shortcode: string) => `legacy-shortcode-${shortcode}`
 
@@ -20,11 +20,11 @@ class LegacyShortcodeSyntax extends MarkdownSyntaxPlugin {
   get showdownExtension() {
     return (): ShowdownExtension[] => [
       {
-        type:    "lang",
-        filter:   text => {
+        type:   "lang",
+        filter: text => {
           const replacer = (shortcode: Shortcode, originalText: string) => {
             if (LEGACY_SHORTCODES.includes(shortcode.name)) {
-              const paramsText = shortcode.params.map(p => p.toHugo()).join(' ')
+              const paramsText = shortcode.params.map(p => p.toHugo()).join(" ")
               const tag = `<span ${DATA_ISCLOSING}="${shortcode.isClosing}" ${
                 shortcode.params.length > 0 ?
                   `${DATA_ARGUMENTS}="${encodeURIComponent(paramsText)}"` :
@@ -35,7 +35,7 @@ class LegacyShortcodeSyntax extends MarkdownSyntaxPlugin {
             return originalText
           }
           return replaceShortcodes(text, replacer)
-        },
+        }
       }
     ]
   }

--- a/static/js/lib/ckeditor/plugins/ResourceEmbed.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceEmbed.ts
@@ -14,10 +14,8 @@ import {
   RESOURCE_EMBED,
   RESOURCE_EMBED_COMMAND
 } from "./constants"
-import { Shortcode, makeHtmlString } from "./util"
+import { Shortcode, makeHtmlString, replaceShortcodes } from "./util"
 import { isNotNil } from "../../../util"
-
-export const RESOURCE_SHORTCODE_REGEX = /{{< resource .*? >}}/g
 
 /**
  * Class for defining Markdown conversion rules for ResourceEmbed
@@ -31,19 +29,20 @@ class ResourceMarkdownSyntax extends MarkdownSyntaxPlugin {
     return function resourceExtension(): Showdown.ShowdownExtension[] {
       return [
         {
-          type:    "lang",
-          regex:   RESOURCE_SHORTCODE_REGEX,
-          replace: (s: string) => {
-            const shortcode = Shortcode.fromString(s)
-            const uuid = shortcode.get(0) ?? shortcode.get("uuid")
-            const href = shortcode.get("href")
-            const hrefUuid = shortcode.get("href_uuid")
-            const attrs = {
-              "data-uuid":      uuid,
-              "data-href":      href,
-              "data-href-uuid": hrefUuid
+          type:   "lang",
+          filter: (text: string) => {
+            const replacer = (shortcode: Shortcode) => {
+              const uuid = shortcode.get(0) ?? shortcode.get("uuid")
+              const href = shortcode.get("href")
+              const hrefUuid = shortcode.get("href_uuid")
+              const attrs = {
+                "data-uuid":      uuid,
+                "data-href":      href,
+                "data-href-uuid": hrefUuid
+              }
+              return makeHtmlString("section", attrs)
             }
-            return makeHtmlString("section", attrs)
+            return replaceShortcodes(text, replacer, { name: "resource" })
           }
         }
       ]

--- a/static/js/lib/ckeditor/plugins/util.test.ts
+++ b/static/js/lib/ckeditor/plugins/util.test.ts
@@ -173,21 +173,21 @@ describe("Shortcode", () => {
     it.each([
       {
         text:     "{{< /some_shortcode >}}",
-        expected: new Shortcode('some_shortcode', [], false, true)
+        expected: new Shortcode("some_shortcode", [], false, true)
       },
       {
         text:     "{{< / some_shortcode >}}",
-        expected: new Shortcode('some_shortcode', [], false, true)
+        expected: new Shortcode("some_shortcode", [], false, true)
       },
       {
         text:     "{{</ some_shortcode >}}",
-        expected: new Shortcode('some_shortcode', [], false, true)
+        expected: new Shortcode("some_shortcode", [], false, true)
       },
       {
         text:     "{{% /some_shortcode %}}",
-        expected: new Shortcode('some_shortcode', [], true, true)
+        expected: new Shortcode("some_shortcode", [], true, true)
       }
-    ])('parses closing shortcodes', ({ text, expected }) => {
+    ])("parses closing shortcodes", ({ text, expected }) => {
       const result = Shortcode.fromString(text)
       expect(result).toStrictEqual(expected)
     })
@@ -255,9 +255,9 @@ describe("Shortcode", () => {
       }
     )
 
-    it('includes / for closing shortcodes', () => {
+    it("includes / for closing shortcodes", () => {
       const shortcode = new Shortcode("some_shortcode", [], false, true)
-      expect(shortcode.toHugo()).toBe('{{< /some_shortcode >}}')
+      expect(shortcode.toHugo()).toBe("{{< /some_shortcode >}}")
     })
   })
 

--- a/static/js/lib/ckeditor/plugins/util.test.ts
+++ b/static/js/lib/ckeditor/plugins/util.test.ts
@@ -414,8 +414,10 @@ describe("replaceShortcodes", () => {
   )
 
   it("only affects shortcodes of specified name", () => {
-    const text = "{{< some_shortcode >}} and {{< still_lowercase >}}"
-    const expected = "{{< SOME_SHORTCODE >}} and {{< still_lowercase >}}"
+    const text =
+      "hello {{< some_shortcode >}} and {{< some_shortcode_same_beginning >}}"
+    const expected =
+      "hello {{< SOME_SHORTCODE >}} and {{< some_shortcode_same_beginning >}}"
     const replacer = jest.fn(capitalizingReplacer)
     const replaced = replaceShortcodes(text, replacer, {
       name: "some_shortcode"

--- a/static/js/lib/ckeditor/plugins/util.test.ts
+++ b/static/js/lib/ckeditor/plugins/util.test.ts
@@ -465,4 +465,13 @@ describe("replaceShortcodes", () => {
     expect(replaced).toBe(expected)
     expect(replacer).toHaveBeenCalledTimes(1)
   })
+
+  it("affects all shortcodes if no name is specified", () => {
+    const text = "{{< some_shortcode >}} and {{< other_shortcode >}}"
+    const expected = "{{< SOME_SHORTCODE >}} and {{< OTHER_SHORTCODE >}}"
+    const replacer = jest.fn(capitalizingReplacer)
+    const replaced = replaceShortcodes(text, replacer)
+    expect(replaced).toBe(expected)
+    expect(replacer).toHaveBeenCalledTimes(2)
+  })
 })

--- a/static/js/lib/ckeditor/plugins/util.ts
+++ b/static/js/lib/ckeditor/plugins/util.ts
@@ -177,15 +177,18 @@ export class Shortcode {
   params: ShortcodeParam[]
 
   isPercentDelimited: boolean
+  isClosing: boolean
 
   constructor(
     name: string,
     params: ShortcodeParam[],
-    isPercentDelimited = false
+    isPercentDelimited = false,
+    isClosing = false
   ) {
     this.name = name
     this.params = params
     this.isPercentDelimited = isPercentDelimited
+    this.isClosing = isClosing
 
     const hasPositionalParams = params.some(p => p.name === undefined)
     const hasNamedParams = params.some(p => p.name !== undefined)
@@ -203,12 +206,15 @@ export class Shortcode {
    */
   toHugo() {
     const stringifiedArgs = this.params.map(p => p.toHugo())
-    const interior = [this.name, ...stringifiedArgs].join(" ")
+    const name = this.isClosing ? `/${this.name}` : this.name
+    const interior = [name, ...stringifiedArgs].join(" ")
     if (this.isPercentDelimited) {
       return `{{% ${interior} %}}`
     }
     return `{{< ${interior} >}}`
   }
+
+  private static IS_CLOSING_REGEXP = /\s*(?<isClosing>\/)?\s*/
 
   /**
    * Regexp used for matching individual shortcode arguments.
@@ -232,8 +238,14 @@ export class Shortcode {
   static fromString(s: string): Shortcode {
     Shortcode.heuristicValidation(s)
     const isPercentDelmited = s.startsWith("{{%") && s.endsWith("%}}")
-    const [nameMatch, ...argMatches] = s
-      .slice(3, -3)
+
+    const interior = s.slice(3, -3)
+    const isClosingMatch = interior.match(Shortcode.IS_CLOSING_REGEXP)
+    // re ! the IS_CLOSING_REGEXP regexp will always match and has groups
+    const isClosing = isClosingMatch!.groups!.isClosing === '/'
+    const nameAndArgs = interior.slice(isClosingMatch![0].length)
+
+    const [nameMatch, ...argMatches] = nameAndArgs
       .matchAll(Shortcode.ARG_REGEXP)
     const name = Shortcode.getArgMatchValue(nameMatch)
     const params = argMatches.map(match => {
@@ -243,7 +255,7 @@ export class Shortcode {
       )
     })
 
-    return new Shortcode(name, params, isPercentDelmited)
+    return new Shortcode(name, params, isPercentDelmited, isClosing)
   }
 
   /**
@@ -353,7 +365,9 @@ export const replaceShortcodes = (
   }: { name: string; isPercentDelimited?: boolean }
 ) => {
   const opener = isPercentDelimited ? "{{%" : "{{<"
-  const openerAndNameRegex = new RegExp([opener, "\\s*", name, "\\s+"].join(""))
+  const openerAndNameRegex = new RegExp(
+    [opener, "\\s*/?\\s*", name, "\\s+"].join("")
+  )
   const closer = isPercentDelimited ? "%}}" : ">}}"
   const matches = findNestedExpressions(text, opener, closer).filter(m => {
     if (name === undefined) return true

--- a/static/js/lib/ckeditor/plugins/util.ts
+++ b/static/js/lib/ckeditor/plugins/util.ts
@@ -13,12 +13,12 @@ interface SubstringRange {
  *
  * @example
  * ```
- *           // 0         1         2         3         4
- *           // 01234567890123456789012345678901234567890123456789
+ *            // 0         1         2         3         4
+ *            // 01234567890123456789012345678901234567890123456789
  * const text = "Hello {{< shortcode {{< sup 12 >}} >}} goodbye.
  * const opener = "{{<"
  * matches = findNestedExpressions(text, "{{<", ">}}")
- * expect(matches).toEqual([{ start: 7, end: 39 }])
+ * expect(matches).toEqual([{ start: 6, end: 38 }])
  * ```
  * Note that `end` is the string index of the next character after the closer.
  * In this way, `end - start` is the substring length.
@@ -39,6 +39,20 @@ export const findNestedExpressions = (
   return matches
 }
 
+/**
+ * Find the next balanced instance of opener...closer in text starting at the
+ * specified index within text.
+ *
+ * @example
+ * ```
+ *            // 0         1         2         3         4
+ *            // 01234567890123456789012345678901234567890123456789
+ * const text = "hello [ b [ ] ] world [ [ ] [ ] ] bye"
+ * const startingFrom = 16
+ * const range = findNestedExpression(text, "[", "]", startingFrom)
+ * expect(range).toEqual({ start: 22, end: 33 })
+ * ```
+ */
 const findNestedExpression = (
   text: string,
   opener: string,

--- a/static/js/lib/ckeditor/plugins/util.ts
+++ b/static/js/lib/ckeditor/plugins/util.ts
@@ -360,15 +360,17 @@ export const replaceShortcodes = (
   })
   if (matches.length === 0) return text
   const pieces = matches.reduce(
-    (pieces, range, i, ranges) => {
+    (acc, range, i, ranges) => {
       const shortcode = Shortcode.fromString(
         text.substring(range.start, range.end)
       )
-      pieces.push(replacer(shortcode))
+      // accumulate the replacement
+      acc.push(replacer(shortcode))
+      // and the text up until the next replacement
       const isLast = i + 1 === ranges.length
       const nextStart = isLast ? text.length : ranges[i + 1].start
-      pieces.push(text.substring(range.end, nextStart))
-      return pieces
+      acc.push(text.substring(range.end, nextStart))
+      return acc
     },
     [text.substring(0, matches[0].start)]
   )

--- a/static/js/lib/ckeditor/plugins/util.ts
+++ b/static/js/lib/ckeditor/plugins/util.ts
@@ -351,7 +351,7 @@ export class Shortcode {
   }
 }
 
-type ShortcodeReplacer = (shortcode: Shortcode) => string
+type ShortcodeReplacer = (shortcode: Shortcode, originalText: string) => string
 
 /**
  * Replace instances of a specific shortcode using `replacer`.
@@ -362,7 +362,7 @@ export const replaceShortcodes = (
   {
     isPercentDelimited = false,
     name
-  }: { name: string; isPercentDelimited?: boolean }
+  }: { name?: string; isPercentDelimited?: boolean } = {}
 ) => {
   const opener = isPercentDelimited ? "{{%" : "{{<"
   const openerAndNameRegex = new RegExp(
@@ -376,11 +376,10 @@ export const replaceShortcodes = (
   if (matches.length === 0) return text
   const pieces = matches.reduce(
     (acc, range, i, ranges) => {
-      const shortcode = Shortcode.fromString(
-        text.substring(range.start, range.end)
-      )
+      const originalText = text.substring(range.start, range.end)
+      const shortcode = Shortcode.fromString(originalText)
       // accumulate the replacement
-      acc.push(replacer(shortcode))
+      acc.push(replacer(shortcode, originalText))
       // and the text up until the next replacement
       const isLast = i + 1 === ranges.length
       const nextStart = isLast ? text.length : ranges[i + 1].start

--- a/static/js/lib/ckeditor/plugins/util.ts
+++ b/static/js/lib/ckeditor/plugins/util.ts
@@ -242,11 +242,12 @@ export class Shortcode {
     const interior = s.slice(3, -3)
     const isClosingMatch = interior.match(Shortcode.IS_CLOSING_REGEXP)
     // re ! the IS_CLOSING_REGEXP regexp will always match and has groups
-    const isClosing = isClosingMatch!.groups!.isClosing === '/'
+    const isClosing = isClosingMatch!.groups!.isClosing === "/"
     const nameAndArgs = interior.slice(isClosingMatch![0].length)
 
-    const [nameMatch, ...argMatches] = nameAndArgs
-      .matchAll(Shortcode.ARG_REGEXP)
+    const [nameMatch, ...argMatches] = nameAndArgs.matchAll(
+      Shortcode.ARG_REGEXP
+    )
     const name = Shortcode.getArgMatchValue(nameMatch)
     const params = argMatches.map(match => {
       return new ShortcodeParam(

--- a/static/js/lib/ckeditor/plugins/util.ts
+++ b/static/js/lib/ckeditor/plugins/util.ts
@@ -353,10 +353,11 @@ export const replaceShortcodes = (
   }: { name: string; isPercentDelimited?: boolean }
 ) => {
   const opener = isPercentDelimited ? "{{%" : "{{<"
-  const namedOpener = `${opener} ${name}`
+  const openerAndNameRegex = new RegExp([opener, "\\s*", name, "\\s+"].join(""))
   const closer = isPercentDelimited ? "%}}" : ">}}"
   const matches = findNestedExpressions(text, opener, closer).filter(m => {
-    return text.substring(m.start, m.start + namedOpener.length) === namedOpener
+    if (name === undefined) return true
+    return openerAndNameRegex.test(text.substring(m.start, m.end))
   })
   if (matches.length === 0) return text
   const pieces = matches.reduce(


### PR DESCRIPTION
This builds on #1315 so waiting for that to be reviewed first.

#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1317 

#### What's this PR do?
This improves the LegacyShortcodes plugin for CKEditor. "Legacy" Shortcodes are shortcodes that cannot be edited or created in Studio, i.e., only exist due to the migration of legacy content. Alice did some work so that we could safely edit pages containing such legacy shortcodes. This PR uses the some of the work from #1315 to improve upon this in two ways:
- Some legacy shortcodes included shortocdes inside shortcodes, e.g., ... The old approach did not handle this, but the approach from #1315 does
- Makes closing shortcodes a bit more flexible. The old code expected `{{< /shortcode-name...`. But some shortcodes, particularly image galleries, used `{{</ shortcode-name`, ie with no space between "<" and "/". _Hugo documentation uses the first form, but Hugo itself tolerates both forms as closing shrotcode tags._

#### How should this be manually tested?
Manually insert some legacy shortcodes into a content page and check that the page (but not the shortcodes themselves) can still be edited safely. Here are some legacy shortcodes: _The actual argument values don't matter._
```
opening: {{< quiz_choice arg1 "{{< sup 2 >}}" >}} ... and now closing {{< /quiz_choice foo="arg1" bar="arg2" >}}

opening: {{< quiz_choices arg1 "{{< sup 2 >}}" >}} ... and now closing {{< /quiz_choices foo="arg1" bar="arg2" >}}

opening: {{< quiz_multiple_choice arg1 "{{< sup 2 >}}" >}} ... and now closing {{< /quiz_multiple_choice foo="arg1" bar="arg2" >}}

opening: {{< quiz_solution arg1 "{{< sup 2 >}}" >}} ... and now closing {{< /quiz_solution foo="arg1" bar="arg2" >}}

opening: {{< resource_file arg1 "{{< sup 2 >}}" >}} ... and now closing {{< /resource_file foo="arg1" bar="arg2" >}}

opening: {{< video-gallery arg1 "{{< sup 2 >}}" >}} ... and now closing {{< /video-gallery foo="arg1" bar="arg2" >}}

opening: {{< youtube arg1 "{{< sup 2 >}}" >}} ... and now closing {{< /youtube foo="arg1" bar="arg2" >}}

opening: {{< anchor arg1 "{{< sup 2 >}}" >}} ... and now closing {{< /anchor foo="arg1" bar="arg2" >}}

opening: {{< approx-students arg1 "{{< sup 2 >}}" >}} ... and now closing {{< /approx-students foo="arg1" bar="arg2" >}}

opening: {{< br arg1 "{{< sup 2 >}}" >}} ... and now closing {{< /br foo="arg1" bar="arg2" >}}

opening: {{< div-with-class arg1 "{{< sup 2 >}}" >}} ... and now closing {{< /div-with-class foo="arg1" bar="arg2" >}}

opening: {{< fullwidth-cell arg1 "{{< sup 2 >}}" >}} ... and now closing {{< /fullwidth-cell foo="arg1" bar="arg2" >}}

opening: {{< h arg1 "{{< sup 2 >}}" >}} ... and now closing {{< /h foo="arg1" bar="arg2" >}}

opening: {{< image-gallery-item arg1 "{{< sup 2 >}}" >}} ... and now closing {{< /image-gallery-item foo="arg1" bar="arg2" >}}

opening: {{< image-gallery arg1 "{{< sup 2 >}}" >}} ... and now closing {{< /image-gallery foo="arg1" bar="arg2" >}}

opening: {{< quote arg1 "{{< sup 2 >}}" >}} ... and now closing {{< /quote foo="arg1" bar="arg2" >}}

opening: {{< simplecast arg1 "{{< sup 2 >}}" >}} ... and now closing {{< /simplecast foo="arg1" bar="arg2" >}}

opening: {{< sub arg1 "{{< sup 2 >}}" >}} ... and now closing {{< /sub foo="arg1" bar="arg2" >}}

opening: {{< sup arg1 "{{< sup 2 >}}" >}} ... and now closing {{< /sup foo="arg1" bar="arg2" >}}

```