### PR TITLE
Fix MIT logo link

### DIFF
--- a/static/js/components/Header.tsx
+++ b/static/js/components/Header.tsx
@@ -65,13 +65,13 @@ export default function Header(props: HeaderProps): JSX.Element {
     <header className="p-3">
       <div className="d-flex justify-content-between">
         <div>
-          <Link to="https://www.mit.edu">
+          <a href="https://www.mit.edu" target="_blank" rel="noreferrer">
             <img
               src="/static/images/mit-logo.png"
               className="pr-1 border-right border-dark"
               alt="MIT"
             />
-          </Link>
+          </a>
           <Link to={sitesBaseUrl.toString()}>
             <img
               className="logo pl-2"


### PR DESCRIPTION
<Link /> is for routing within the application

#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested

#### What are the relevant tickets?
Closes #1340 

#### What's this PR do?
Fixes the MIT logo link. It was using react-router's `<Link />` component which is for routing within a single-page app. This link should just use anchor.

#### How should this be manually tested?
Click the MIT logo link and you should go to the MIT website.
