### PR TITLE
check for 3play completion

### DIFF
--- a/videos/threeplay_api.py
+++ b/videos/threeplay_api.py
@@ -167,6 +167,7 @@ def update_transcripts_for_video(video: Video) -> bool:
     if (
         threeplay_transcript_json.get("data")
         and len(threeplay_transcript_json.get("data")) > 0
+        and threeplay_transcript_json.get("data")[0].get("status") == "complete"
     ):
         transcript_id = threeplay_transcript_json["data"][0].get("id")
         media_file_id = threeplay_transcript_json["data"][0].get("media_file_id")


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
closes https://github.com/mitodl/ocw-studio/issues/1342

#### What's this PR do?
3play used to return a 404 on transcript download links when the transcript was in progress. Now it returns an empty file. This pr adds a check for transcript completion so we don't save the empty files as caption and transcript files.

#### How should this be manually tested?
- Use rc settings for AWS_, DRIVE_ and THREEPLAY_ fields as well as PREPUBLISH_ACTIONS. 
- On master branch, place 1 small video file in your gdrive videos_final folder for a site and then sync.
- Wait 5 minutes or so to make sure the transcode job finished.
- Using Postman or curl, make a request to http://localhost:8043/api/transcode-jobs/ with the following data, and headers
```
{
  "version": "0",
  "id": "c120fe11-87db-c292-b3e5-1cc90740f6e1",
  "detail-type": "MediaConvert Job State Change",
  "source": "aws.mediaconvert",
  "account": "<AWS_ACCOUNT_ID>",
  "time": "2021-08-05T16:52:33Z",
  "region": "us-east-1",
  "resources": [
    "arn:aws:mediaconvert:us-east-1:<AWS_ACCOUNT_ID>:jobs/<VIDEOJOB_ID>"
  ],
  "detail": {
    "timestamp": 1628172900136,
    "accountId": "<AWS_ACCOUNT_ID>",
    "queue": "arn:aws:mediaconvert:us-east-1:<AWS_ACCOUNT_ID>:queues/Default",
    "jobId": "<VIDEOJOB_ID>",
    "status": "COMPLETE",
    "userMetadata": {},
    "outputGroupDetails": [
      {
        "outputDetails": [
          {
            "outputFilePaths": [
              "s3://<AWS_STORAGE_BUCKET_NAME>/aws_mediaconvert_transcodes/<SITE_NAME>/<DRIVE_FILE_ID>/<VIDEO_FILENAME>_youtube.mp4"
            ],
            "durationInMs": 132033,
            "videoDetails": {
              "widthInPx": 1280,
              "heightInPx": 720
            }
          },
        ],
        "type": "FILE_GROUP"
      }
    ]
  }
}
```
- Wait another 5 minutes for the file to be uploaded to 3play
- Publish the course from the ui. Don't worry about the publishing backend being set up, we just need to trigger the pre-publish action. Check that neither the transcript or or caption is set for the resource
- From the command line, set the destination_id for the VideoFile object to `GfjkPmTrhwE`, an already transcripted file. Also update the youtube id for the resource to `GfjkPmTrhwE`
- Publish the course from the ui again
-The transcript and caption should be set now