### PR TITLE
short ID added with title in sites list

### DIFF
--- a/static/js/components/AuthenticationAlert.test.tsx
+++ b/static/js/components/AuthenticationAlert.test.tsx
@@ -58,7 +58,9 @@ describe("Prompting for authentication", () => {
 
       setMockWebsiteResponse(authRejectionBody, 403)
 
-      const siteLink = await waitFor(() => result.getByText(website.title))
+      const siteLink = await waitFor(() =>
+        result.getByText(`${website.title} (${website.short_id})`)
+      )
       await act(() => user.click(siteLink))
 
       const dialog = await waitFor(() => result.getByRole("dialog"))
@@ -84,7 +86,9 @@ describe("Prompting for authentication", () => {
 
     setMockWebsiteResponse({ detail: "misc client error" }, 400)
 
-    const siteLink = await waitFor(() => result.getByText(website.title))
+    const siteLink = await waitFor(() =>
+      result.getByText(`${website.title} (${website.short_id})`)
+    )
     await act(() => user.click(siteLink))
 
     /**

--- a/static/js/pages/SitesDashboard.test.tsx
+++ b/static/js/pages/SitesDashboard.test.tsx
@@ -67,7 +67,9 @@ describe("SitesDashboard", () => {
       expect(li.prop("to")).toBe(
         siteDetailUrl.param({ name: website.name }).toString()
       )
-      expect(li.find("Link").text()).toBe(website.title)
+      expect(li.find("Link").text()).toBe(
+        `${website.title} (${website.short_id})`
+      )
       expect(li.prop("subtitle")).toBe(siteDescription(website))
       idx++
     }

--- a/static/js/pages/SitesDashboard.tsx
+++ b/static/js/pages/SitesDashboard.tsx
@@ -73,7 +73,7 @@ export default function SitesDashboard(): JSX.Element {
         <StudioList>
           {listing.results.map((site: Website) => (
             <StudioListItem
-              title={site.title}
+              title={`${site.title} (${site.short_id})`}
               subtitle={siteDescription(site) ?? ""}
               to={siteDetailUrl.param({ name: site.name }).toString()}
               key={site.uuid}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1265

#### What's this PR do?
- Adds `short ID` along with title in sites list in `studio-url/sites` with `format: title (short ID)`. Format is still yet to be confirmed 

#### How should this be manually tested?
- Checkout this branch
- Go to `/sites`, verify that short ID is also shown along with title for every site listed.

#### Screenshots (if appropriate)
<img width="793" alt="image" src="https://user-images.githubusercontent.com/93309234/168597905-e5ed375a-9386-4a0d-8f50-7dc55732bcfa.png">
