### PR TITLE
improve frontend shortcode regex to not be fooled by delimiters in shortcode args

### DIFF
--- a/static/js/lib/ckeditor/plugins/ResourceEmbed.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceEmbed.ts
@@ -17,7 +17,7 @@ import {
 import { Shortcode, makeHtmlString } from "./util"
 import { isNotNil } from "../../../util"
 
-export const RESOURCE_SHORTCODE_REGEX = /{{< resource .*? >}}/g
+const RESOURCE_SHORTCODE_REGEX = Shortcode.regex("resource", false)
 
 /**
  * Class for defining Markdown conversion rules for ResourceEmbed

--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
@@ -17,16 +17,7 @@ export const encodeShortcodeArgs = (...args: (string | undefined)[]) =>
 const decodeShortcodeArgs = (encoded: string) =>
   JSON.parse(decodeURIComponent(encoded))
 
-/**
- * (\S+) to match and capture the UUID
- * "(.*?)" to match and capture the label text
- * (?: "(.*?)")? to match the optional anchor ID param
- *
- * Limitations:
- *   - gets fooled by label texts that include literal `" %}}` values. For
- *     example, % resource_link uuid123 "silly " %}} link" %}}.
- */
-export const RESOURCE_LINK_SHORTCODE_REGEX = /{{% resource_link .*? %}}/g
+const RESOURCE_LINK_SHORTCODE_REGEX = Shortcode.regex("resource_link", true)
 
 /**
  * Class for defining Markdown conversion rules for Resource links


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1280 

#### What's this PR do?
This PR improves the frontend Markdown --> HTML converter to better handle shortocdes. In particular, this fixes an issue with shortcode delimiters inside shortcode arguments, e.g.,
```
{{% resource_link uuid "E = MC{{< sup 2 >}}" %}}
{{% resource_link uuid "why %}}" %}}
```

#### How should this be manually tested?
*If you'd prefer to test with real data / have a copy of prod courses locally, this spreadsheet lists a bunch (all) pages affected by the bug being fixed here: https://docs.google.com/spreadsheets/d/1q19lGfqbUrcC0CraBrA9YsY9q_8C3ejeeDFc2JX3XKo/edit?usp=sharing*

1. On master, edit a page in studio and create a resource link.
2. In the admin panel, edit the resource link so it looks like
    ```
    {{% resource_link uuid "superscripts! {{< sup 2 >}} oh no" %}}
    ```
3. View that content in Studio and observe that the editor fails to load.
4. Repeat (3) on this branch. Editor should load fine. 
5. Also test things like `{{% resource_link uuid "not %}} fooled" %}}` or `{{% resource_link uuid "not {{% fooled" %}}`

### Other context
An earlier version of this work was #1315 which took a "find balancing closer" approach. This was (a) unnecessary and (b) problematic for things like `{{% resource_link uuid "not {{% fooled" %}}`. When finding the end of a shortcode we don't need to find a balancing delimiter, just the next delimiter that is **not inside a quoted string**.