### PR TITLE
improve legacy shortcode handling

### DIFF
--- a/static/js/lib/ckeditor/plugins/LegacyShortcodes.test.ts
+++ b/static/js/lib/ckeditor/plugins/LegacyShortcodes.test.ts
@@ -5,7 +5,7 @@ import LegacyShortcodes from "./LegacyShortcodes"
 import { LEGACY_SHORTCODES } from "./constants"
 import Paragraph from "@ckeditor/ckeditor5-paragraph/src/paragraph"
 
-const quizTestMD = `{{< quiz_multiple_choice questionId="Q1_div" >}}{{< quiz_choices >}}{{< quiz_choice isCorrect="false" >}}sound, satisfiable{{< /quiz_choice >}}{{< quiz_choice isCorrect="false" >}}valid, satisfiable{{< /quiz_choice >}}{{< quiz_choice isCorrect="true" >}}sound, valid{{< /quiz_choice >}}{{< quiz_choice isCorrect="false" >}}valid, true{{< /quiz_choice >}}{{< /quiz_choices >}}{{< quiz_solution / >}}{{< /quiz_multiple_choice >}}`
+const quizTestMD = `{{< quiz_multiple_choice questionId="Q1_div" >}}{{< quiz_choices >}}{{< quiz_choice isCorrect="false" >}}sound, satisfiable{{< /quiz_choice >}}{{< quiz_choice isCorrect="false" >}}valid, satisfiable{{< /quiz_choice >}}{{< quiz_choice isCorrect="true" >}}sound, valid{{< /quiz_choice >}}{{< quiz_choice isCorrect="false" >}}valid, true{{< /quiz_choice >}}{{< /quiz_choices >}}{{< quiz_solution >}}{{< /quiz_multiple_choice >}}`
 
 const getEditor = createTestEditor([Paragraph, LegacyShortcodes, Markdown])
 
@@ -31,20 +31,42 @@ describe("ResourceEmbed plugin", () => {
   test.each(LEGACY_SHORTCODES)(
     "should take in and return %p closing shortcode",
     async shortcode => {
-      const md = `{{< /${shortcode} >}}`
-      const editor = await getEditor(md)
+      const md1 = `{{< /${shortcode} >}}`
+      const editor1 = await getEditor(md1)
       // @ts-ignore
-      expect(editor.getData()).toBe(md)
+      expect(editor1.getData()).toBe(md1)
+
+      /**
+       * Hugo documentation uses the first version so it should be preferred.
+       * But Hugo accepts this version and image-gallery uses it.
+       * The editor will normalize it to the first version.
+       */
+      const md2 = `{{</ ${shortcode} >}}`
+      const editor2 = await getEditor(md2)
+      // @ts-ignore
+      expect(editor2.getData()).toBe(md1)
     }
   )
 
   test.each(LEGACY_SHORTCODES)(
-    "should take in and return %p shortcode with arguments",
+    "should take in and return %p shortcode with positional parameters",
     async shortcode => {
-      const md = `{{< ${shortcode} arguments foo=123 html=<for some reason/> >}}`
+      const md = `{{< ${shortcode} arguments "and chemistry H{{< sub 2 >}}0" >}}`
+      const expected = `{{< ${shortcode} "arguments" "and chemistry H{{< sub 2 >}}0" >}}`
       const editor = await getEditor(md)
       // @ts-ignore
-      expect(editor.getData()).toBe(md)
+      expect(editor.getData()).toBe(expected)
+    }
+  )
+
+  test.each(LEGACY_SHORTCODES)(
+    "should take in and return %p shortcode with named parameters",
+    async shortcode => {
+      const md = `{{< ${shortcode} foo=123 html="<for some reason/>" >}}`
+      const expected = `{{< ${shortcode} foo="123" html="<for some reason/>" >}}`
+      const editor = await getEditor(md)
+      // @ts-ignore
+      expect(editor.getData()).toBe(expected)
     }
   )
 

--- a/static/js/lib/ckeditor/plugins/util.test.ts
+++ b/static/js/lib/ckeditor/plugins/util.test.ts
@@ -389,7 +389,7 @@ describe("Shortcode", () => {
       ])
     })
 
-    it('captures closing and opening shortcodes', () => {
+    it("captures closing and opening shortcodes", () => {
       const regex = Shortcode.regex("some_shortcode", false)
       const text = `
       a {{< some_shortcode xyz >}} b
@@ -398,16 +398,17 @@ describe("Shortcode", () => {
       `
       const match = text.match(regex)
       expect(match).toStrictEqual([
-        '{{< some_shortcode xyz >}}',
-        '{{< /some_shortcode >}}',
-        '{{</ some_shortcode >}}'
+        "{{< some_shortcode xyz >}}",
+        "{{< /some_shortcode >}}",
+        "{{</ some_shortcode >}}"
       ])
     })
 
     it.each([
       {
-        name:     "some_shortcode",
-        text:     "a {{< some_shortcode xyz >}} b {{< some_shortcode_two 123 >}} {{< /some_shortcode xyz >}}",
+        name: "some_shortcode",
+        text:
+          "a {{< some_shortcode xyz >}} b {{< some_shortcode_two 123 >}} {{< /some_shortcode xyz >}}",
         expected: ["{{< some_shortcode xyz >}}", "{{< /some_shortcode xyz >}}"]
       },
       {
@@ -426,6 +427,13 @@ describe("Shortcode", () => {
       const text = 'a {{< shortcode "cat \\" >}}" >}} b'
       const match = text.match(regex)
       expect(match).toStrictEqual(['{{< shortcode "cat \\" >}}" >}}'])
+    })
+
+    it("can take a regex as name parameter", () => {
+      const regex = Shortcode.regex(/cat|dog/, false)
+      const text = "a {{< cat meow >}} {{< dog woof >}} {{< dragon roar >}}  b"
+      const match = text.match(regex)
+      expect(match).toStrictEqual(["{{< cat meow >}}", "{{< dog woof >}}"])
     })
   })
 })

--- a/static/js/lib/ckeditor/plugins/util.test.ts
+++ b/static/js/lib/ckeditor/plugins/util.test.ts
@@ -46,15 +46,15 @@ describe("unescapeStringQuotedWith", () => {
 })
 
 describe("Shortcode", () => {
-  describe("Shortcode.parse", () => {
+  describe("Shortcode.fromString", () => {
     it("parses shortcodes with named params", () => {
       const text =
-        '{{< some_shortcode cool_arg="cats and dogs" href_uuid=uuid456 >}}'
+        '{{< some_shortcode param-with-dash="cats and dogs" with_underscore=uuid456 >}}'
       const result = Shortcode.fromString(text)
 
       const params = [
-        { name: "cool_arg", value: "cats and dogs" },
-        { name: "href_uuid", value: "uuid456" }
+        { name: "param-with-dash", value: "cats and dogs" },
+        { name: "with_underscore", value: "uuid456" }
       ].map(makeParams)
       expect(result).toStrictEqual(
         new Shortcode("some_shortcode", params, false)

--- a/static/js/lib/ckeditor/plugins/util.ts
+++ b/static/js/lib/ckeditor/plugins/util.ts
@@ -244,14 +244,15 @@ export class Shortcode {
    * Returns a global regex that matches shortcodes of given name. Useful for
    * use in Showdown rules.
    */
-  static regex(name: string, isPercentDelimited: boolean) {
+  static regex(name: string | RegExp, isPercentDelimited: boolean) {
     const opener = isPercentDelimited ? "{{%" : "{{<"
     const closer = isPercentDelimited ? "%}}" : ">}}"
     const regex = new RegExp(
       [
         opener,
         Shortcode.IS_CLOSING_REGEXP.source,
-        String.raw`${name}\s`,
+        name instanceof RegExp ? `(${name.source})` : name,
+        String.raw`\s`,
         /**
          * Non-greedily capture anything up until the closer. Except if there is
          * a non-escaped quotation mark, then there must be another.

--- a/static/js/lib/ckeditor/plugins/util.ts
+++ b/static/js/lib/ckeditor/plugins/util.ts
@@ -102,14 +102,18 @@ export class Shortcode {
 
   isPercentDelimited: boolean
 
+  isClosing: boolean
+
   constructor(
     name: string,
     params: ShortcodeParam[],
-    isPercentDelimited = false
+    isPercentDelimited = false,
+    isClosing = false
   ) {
     this.name = name
     this.params = params
     this.isPercentDelimited = isPercentDelimited
+    this.isClosing = isClosing
 
     const hasPositionalParams = params.some(p => p.name === undefined)
     const hasNamedParams = params.some(p => p.name !== undefined)
@@ -127,12 +131,15 @@ export class Shortcode {
    */
   toHugo() {
     const stringifiedArgs = this.params.map(p => p.toHugo())
-    const interior = [this.name, ...stringifiedArgs].join(" ")
+    const name = this.isClosing ? `/${this.name}` : this.name
+    const interior = [name, ...stringifiedArgs].join(" ")
     if (this.isPercentDelimited) {
       return `{{% ${interior} %}}`
     }
     return `{{< ${interior} >}}`
   }
+
+  private static IS_CLOSING_REGEXP = /\s*(?<isClosing>\/)?\s*/
 
   /**
    * Regexp used for matching individual shortcode arguments.
@@ -156,9 +163,15 @@ export class Shortcode {
   static fromString(s: string): Shortcode {
     Shortcode.heuristicValidation(s)
     const isPercentDelmited = s.startsWith("{{%") && s.endsWith("%}}")
-    const [nameMatch, ...argMatches] = s
-      .slice(3, -3)
-      .matchAll(Shortcode.ARG_REGEXP)
+    const interior = s.slice(3, -3)
+    const isClosingMatch = interior.match(Shortcode.IS_CLOSING_REGEXP)
+    // IS_CLOSING_REGEXP will always match, hence the non-null assertion !
+    const isClosing = isClosingMatch!.groups!.isClosing === "/"
+    const nameAndArgs = interior.slice(isClosingMatch![0].length)
+
+    const [nameMatch, ...argMatches] = nameAndArgs.matchAll(
+      Shortcode.ARG_REGEXP
+    )
     const name = Shortcode.getArgMatchValue(nameMatch)
     const params = argMatches.map(match => {
       return new ShortcodeParam(
@@ -167,7 +180,7 @@ export class Shortcode {
       )
     })
 
-    return new Shortcode(name, params, isPercentDelmited)
+    return new Shortcode(name, params, isPercentDelmited, isClosing)
   }
 
   /**
@@ -237,7 +250,8 @@ export class Shortcode {
     const regex = new RegExp(
       [
         opener,
-        String.raw`\s${name}\s`,
+        Shortcode.IS_CLOSING_REGEXP.source,
+        String.raw`${name}\s`,
         /**
          * Non-greedily capture anything up until the closer. Except if there is
          * a non-escaped quotation mark, then there must be another.

--- a/static/js/lib/ckeditor/plugins/util.ts
+++ b/static/js/lib/ckeditor/plugins/util.ts
@@ -146,7 +146,7 @@ export class Shortcode {
    */
   private static ARG_REGEXP = new RegExp(
     [
-      /((?<name>[a-zA-Z_]+)=)?/.source,
+      /((?<name>[a-zA-Z\-_]+)=)?/.source,
       "(",
       /("(?<qvalue>.*?)(?<!\\)")/.source,
       "|",


### PR DESCRIPTION
This builds on #1347 so waiting for that to be reviewed first.

#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1317 

#### What's this PR do?
This improves the LegacyShortcodes plugin for CKEditor. "Legacy" Shortcodes are shortcodes that cannot be edited or created in Studio, i.e., only exist due to the migration of legacy content. Alice did some work so that we could safely edit pages containing such legacy shortcodes. This PR uses the some of the work from #1347  to improve upon this in two ways:
1. Some legacy shortcodes included shortocdes inside shortcodes (see image gallery item below)
2. Makes closing shortcodes a bit more flexible. The old code expected `{{< /shortcode-name...`. But some shortcodes, particularly image-gallery-item, used `{{</ shortcode-name`, ie with no space between "<" and "/". _Hugo documentation uses the first form, but Hugo itself tolerates both forms as closing shrotcode tags._

Both changes can be seen the screenshots below:

Before / After:
<img width="300" alt="Screen Shot 2022-05-16 at 12 03 46 PM" src="https://user-images.githubusercontent.com/9010790/168635881-bfb1d5d7-8aae-4e58-bf57-d09c6b8bfd19.png"> / <img width="300" alt="Screen Shot 2022-05-16 at 12 03 32 PM" src="https://user-images.githubusercontent.com/9010790/168635910-a1c3f007-c139-4e80-9027-62a21d1f7261.png">



#### How should this be manually tested?
Manually insert some legacy shortcodes into a content page and check that the page (but not the shortcodes themselves) can still be edited safely. The shortcode parameters should not change when editing. _Note for testing: the actual argument values don't need to be valid for those shortcodes since studio doesn't use the values._

For example:
```

Cyclosilicates
--------------
{{< image-gallery id="8d434783-38e4-6c38-89ad-01e859532b7e_nanogallery2" baseUrl="/courses/12-108-structure-of-earth-materials-fall-2004/" >}}
{{< image-gallery-item href="2237ca98fc40c772cac4af3df1e8635f_lab2-17.jpg" data-ngdesc="Beryl: Be3Al2Si6O18. Courtesy of OCW." text="Beryl: Be{{< sub 3 >}}Al{{< sub 2 >}}Si{{< sub 6 >}}O{{< sub 18 >}}." >}}
{{< image-gallery-item href="81ba381fade05dbad91194b41151d575_lab2-18.jpg" data-ngdesc="Tourmaline single crystal and tourmalines in quartz: NaMg3Al5B3Si6O27(OH)4. Courtesy of OCW." text="Tourmaline single crystal and tourmalines in quartz: NaMg{{< sub 3 >}}Al{{< sub 5 >}}B{{< sub 3 >}}Si{{< sub 6 >}}O{{< sub 27 >}}(OH){{< sub 4 >}}." >}}
{{< image-gallery-item href="1d7abc15a62bbec93420b7dcfa6ec674_lab2-19.jpg" data-ngdesc="Radiating acicular tourmaline crystals and tourmaline crystal in quartz: NaMg3Al5B3Si6O27(OH)4." text="Radiating acicular tourmaline crystals and tourmaline crystal in quartz: NaMg{{< sub 3 >}}Al{{< sub 5 >}}B{{< sub 3 >}}Si{{< sub 6 >}}O{{< sub 27 >}}(OH){{< sub 4 >}}." >}}
{{</ image-gallery >}}
```