### PR TITLE
make markdown editor minimal by default

### DIFF
--- a/localdev/configs/ocw-course-site-config.yml
+++ b/localdev/configs/ocw-course-site-config.yml
@@ -6,6 +6,12 @@ collections:
     label: Pages
     name: page
     fields:
+      - label: Draft
+        name: draft
+        required: true
+        widget: boolean
+        help: Enable this setting to prevent publishing in production
+
       - label: Title
         name: title
         widget: string
@@ -14,9 +20,11 @@ collections:
       - label: Body
         name: body
         widget: markdown
+        minimal: false
         link:
           - resource
           - page
+          - video_gallery
         embed:
           - resource
 
@@ -25,9 +33,27 @@ collections:
     label: "Video Gallery"
     name: video_gallery
     fields:
-      - label: "Description"
-        name: "description"
-        widget: "markdown"
+      - label: Draft
+        name: draft
+        required: true
+        widget: boolean
+        help: Enable this setting to prevent publishing in production
+
+      - label: Title
+        name: title
+        widget: string
+        required: true
+
+      - label: Body
+        name: body
+        widget: markdown
+        minimal: false
+        link:
+          - resource
+          - page
+        embed:
+          - resource
+
       - label: Videos
         name: videos
         widget: relation
@@ -45,14 +71,32 @@ collections:
     label: Resources
     name: resource
     fields:
+      - label: Draft
+        name: draft
+        required: true
+        widget: boolean
+        help: Enable this setting to prevent publishing in production
+
       - label: Title
         name: title
         required: true
         widget: string
+        help: If this is a video, this will be published as the YouTube title
       - label: Description
         name: description
         widget: markdown
-        minimal: true
+      - label: Body
+        name: body
+        widget: markdown
+        minimal: false
+        link:
+          - resource
+          - page
+        embed:
+          - resource
+        help: >
+          The body of the resource page, displayed below
+          the page title and above the resource
       - label: Resource Type
         name: resourcetype
         required: true
@@ -73,49 +117,50 @@ collections:
         widget: select
         multiple: true
         options:
-          - 'Activity Assignments'
-          - 'Activity Assignments with Examples'
-          - 'Competition Videos'
-          - 'Course Introduction'
-          - 'Demonstration Audio'
-          - 'Demonstration Videos'
-          - 'Design Assignments'
-          - 'Design Assignments with Examples'
-          - 'Exam Materials'
+          - "Activity Assignments"
+          - "Activity Assignments with Examples"
+          - "Competition Videos"
+          - "Course Introduction"
+          - "Demonstration Audio"
+          - "Demonstration Videos"
+          - "Design Assignments"
+          - "Design Assignments with Examples"
+          - "Exam Materials"
           - Exams
-          - 'Exams with Solutions'
-          - 'Image Gallery'
+          - "Exams with Solutions"
+          - "Image Gallery"
+          - "Instructor Insights"
           - Labs
-          - 'Lecture Audio'
-          - 'Lecture Notes'
-          - 'Lecture Videos'
-          - 'Media Assignments'
-          - 'Media Assignments with Examples'
-          - 'Multiple Assignment Types'
-          - 'Multiple Assignment Types with Solutions'
+          - "Lecture Audio"
+          - "Lecture Notes"
+          - "Lecture Videos"
+          - "Media Assignments"
+          - "Media Assignments with Examples"
+          - "Multiple Assignment Types"
+          - "Multiple Assignment Types with Solutions"
           - Music
-          - 'Online Textbook'
-          - 'Other Audio'
-          - 'Other Video'
-          - 'Presentation Assignments'
-          - 'Presentation Assignments with Examples'
-          - 'Problem Sets'
-          - 'Problem Sets with Solutions'
-          - 'Programming Assignments'
-          - 'Programming Assignments with Examples'
+          - "Online Textbook"
+          - "Other Audio"
+          - "Other Video"
+          - "Presentation Assignments"
+          - "Presentation Assignments with Examples"
+          - "Problem Sets"
+          - "Problem Sets with Solutions"
+          - "Programming Assignments"
+          - "Programming Assignments with Examples"
           - Projects
-          - 'Projects with Examples'
+          - "Projects with Examples"
           - Readings
-          - 'Recitation Videos'
-          - 'Simulation Videos'
+          - "Recitation Videos"
+          - "Simulation Videos"
           - Simulations
           - Tools
-          - 'Tutorial Videos'
-          - 'Video Materials'
+          - "Tutorial Videos"
+          - "Video Materials"
           - Videos
-          - 'Workshop Videos'
-          - 'Written Assignments'
-          - 'Written Assignments with Examples'
+          - "Workshop Videos"
+          - "Written Assignments"
+          - "Written Assignments with Examples"
       - label: License
         name: license
         options:
@@ -142,39 +187,46 @@ collections:
             widget: string
           - label: Caption
             name: caption
-            widget: string
+            widget: markdown
           - label: Credit
             name: credit
-            widget: text
+            widget: markdown
       # show the sections below only if the type of resource is "Video"
       - label: Video Metadata
         name: video_metadata
         widget: object
-        condition: {field: resourcetype, equals: Video}
+        condition: { field: resourcetype, equals: Video }
+        help: These fields will be published to YouTube
         fields:
-        - label: Youtube ID
-          name: youtube_id
-          widget: string
-        - label: Youtube Speakers
-          name: video_speakers
-          widget: string
-        - label: Youtube Tags (comma separated; max 100 characters)
-          name: video_tags
-          widget: text
+          - label: Youtube ID
+            name: youtube_id
+            widget: string
+          - label: Youtube Description
+            name: youtube_description
+            widget: text
+          - label: Youtube Speakers
+            name: video_speakers
+            widget: string
+          - label: Youtube Tags (comma separated; max 100 characters)
+            name: video_tags
+            widget: text
       - label: Video Files
         name: video_files
         widget: object
-        condition: {field: resourcetype, equals: Video}
+        condition: { field: resourcetype, equals: Video }
+        help: >
+          Internal YouTube fields, don't edit
+          unless you know what you're doing
         fields:
-        - label: Video Thumbnail URL
-          name: video_thumbnail_file
-          widget: string
-        - label: Video Captions (WebVTT) URL
-          name: video_captions_file
-          widget: string
-        - label: Video Transcript (PDF) URL
-          name: video_transcript_file
-          widget: string
+          - label: Video Thumbnail URL
+            name: video_thumbnail_file
+            widget: string
+          - label: Video Captions (WebVTT) URL
+            name: video_captions_file
+            widget: string
+          - label: Video Transcript (PDF) URL
+            name: video_transcript_file
+            widget: string
 
   - category: Settings
     name: metadata
@@ -223,31 +275,31 @@ collections:
             multiple: true
             name: "department_numbers"
             options:
-              - '1'
-              - '2'
-              - '3'
-              - '4'
-              - '5'
-              - '6'
-              - '7'
-              - '8'
-              - '9'
-              - '10'
-              - '11'
-              - '12'
-              - '14'
-              - '15'
-              - '16'
-              - '17'
-              - '18'
-              - '20'
+              - "1"
+              - "2"
+              - "3"
+              - "4"
+              - "5"
+              - "6"
+              - "7"
+              - "8"
+              - "9"
+              - "10"
+              - "11"
+              - "12"
+              - "14"
+              - "15"
+              - "16"
+              - "17"
+              - "18"
+              - "20"
               - 21A
               - 21G
               - 21H
               - 21L
               - 21M
-              - '22'
-              - '24'
+              - "22"
+              - "24"
               - CC
               - CMS-W
               - EC
@@ -265,9 +317,9 @@ collections:
             name: "level"
             multiple: true
             options:
-              - 'Undergraduate'
-              - 'Graduate'
-              - 'Non Credit'
+              - "Undergraduate"
+              - "Graduate"
+              - "Non Credit"
             widget: "select"
           - label: "Term"
             name: "term"
@@ -285,49 +337,50 @@ collections:
             widget: select
             multiple: true
             options:
-              - 'Activity Assignments'
-              - 'Activity Assignments with Examples'
-              - 'Competition Videos'
-              - 'Course Introduction'
-              - 'Demonstration Audio'
-              - 'Demonstration Videos'
-              - 'Design Assignments'
-              - 'Design Assignments with Examples'
-              - 'Exam Materials'
+              - "Activity Assignments"
+              - "Activity Assignments with Examples"
+              - "Competition Videos"
+              - "Course Introduction"
+              - "Demonstration Audio"
+              - "Demonstration Videos"
+              - "Design Assignments"
+              - "Design Assignments with Examples"
+              - "Exam Materials"
               - Exams
-              - 'Exams with Solutions'
-              - 'Image Gallery'
+              - "Exams with Solutions"
+              - "Image Gallery"
+              - "Instructor Insights"
               - Labs
-              - 'Lecture Audio'
-              - 'Lecture Notes'
-              - 'Lecture Videos'
-              - 'Media Assignments'
-              - 'Media Assignments with Examples'
-              - 'Multiple Assignment Types'
-              - 'Multiple Assignment Types with Solutions'
+              - "Lecture Audio"
+              - "Lecture Notes"
+              - "Lecture Videos"
+              - "Media Assignments"
+              - "Media Assignments with Examples"
+              - "Multiple Assignment Types"
+              - "Multiple Assignment Types with Solutions"
               - Music
-              - 'Online Textbook'
-              - 'Other Audio'
-              - 'Other Video'
-              - 'Presentation Assignments'
-              - 'Presentation Assignments with Examples'
-              - 'Problem Sets'
-              - 'Problem Sets with Solutions'
-              - 'Programming Assignments'
-              - 'Programming Assignments with Examples'
+              - "Online Textbook"
+              - "Other Audio"
+              - "Other Video"
+              - "Presentation Assignments"
+              - "Presentation Assignments with Examples"
+              - "Problem Sets"
+              - "Problem Sets with Solutions"
+              - "Programming Assignments"
+              - "Programming Assignments with Examples"
               - Projects
-              - 'Projects with Examples'
+              - "Projects with Examples"
               - Readings
-              - 'Recitation Videos'
-              - 'Simulation Videos'
+              - "Recitation Videos"
+              - "Simulation Videos"
               - Simulations
               - Tools
-              - 'Tutorial Videos'
-              - 'Video Materials'
+              - "Tutorial Videos"
+              - "Video Materials"
               - Videos
-              - 'Workshop Videos'
-              - 'Written Assignments'
-              - 'Written Assignments with Examples'
+              - "Workshop Videos"
+              - "Written Assignments"
+              - "Written Assignments with Examples"
           - label: Instructors
             name: instructors
             widget: relation
@@ -344,35 +397,35 @@ collections:
               - { label: "Speciality", name: "speciality" }
             options_map:
               Business:
-                Accounting: [ ]
-                Business Ethics: [ ]
-                Entrepreneurship: [ ]
-                Finance: [ ]
-                Globalization: [ ]
-                Health Care Management: [ ]
-                Industrial Relations and Human Resource Management: [ ]
-                Information Technology: [ ]
-                Innovation: [ ]
-                Leadership: [ ]
-                Management: [ ]
-                Marketing: [ ]
-                Operations Management: [ ]
-                Organizational Behavior: [ ]
-                Project Management: [ ]
-                Real Estate: [ ]
-                Supply Chain Management: [ ]
+                Accounting: []
+                Business Ethics: []
+                Entrepreneurship: []
+                Finance: []
+                Globalization: []
+                Health Care Management: []
+                Industrial Relations and Human Resource Management: []
+                Information Technology: []
+                Innovation: []
+                Leadership: []
+                Management: []
+                Marketing: []
+                Operations Management: []
+                Organizational Behavior: []
+                Project Management: []
+                Real Estate: []
+                Supply Chain Management: []
               Energy:
-                Buildings: [ ]
-                Climate: [ ]
-                Combustion: [ ]
-                Electricity: [ ]
-                Fossil Fuels: [ ]
-                Fuel Cells: [ ]
-                Hydrogen and Alternatives: [ ]
-                Nuclear: [ ]
-                Renewables: [ ]
-                Technology: [ ]
-                Transportation: [ ]
+                Buildings: []
+                Climate: []
+                Combustion: []
+                Electricity: []
+                Fossil Fuels: []
+                Fuel Cells: []
+                Hydrogen and Alternatives: []
+                Nuclear: []
+                Renewables: []
+                Technology: []
+                Transportation: []
               Engineering:
                 Aerospace Engineering:
                   - Astrodynamics
@@ -439,7 +492,7 @@ collections:
                   - Solid Mechanics
                   - Mechanical Design
                   - Dynamics and Control
-                Nanotechnology: [ ]
+                Nanotechnology: []
                 Nuclear Engineering:
                   - Nuclear Systems, Policy, and Economics
                   - Radiological Engineering
@@ -462,8 +515,8 @@ collections:
                   - Environmental Design
                   - Architectural History and Criticism
                   - Architectural Engineering
-                Art History: [ ]
-                Game Design: [ ]
+                Art History: []
+                Game Design: []
                 Media Studies:
                   - Digital Media
                 Music:
@@ -479,27 +532,27 @@ collections:
                   - Film and Video
                   - Graphic Design
               Health and Medicine:
-                Anatomy and Physiology: [ ]
-                Biomedical Enterprise: [ ]
-                Biomedical Instrumentation: [ ]
-                Biomedical Signal and Image Processing: [ ]
-                Biomedicine: [ ]
-                Cancer: [ ]
-                Cellular and Molecular Medicine: [ ]
-                Epidemiology: [ ]
-                Functional Genomics: [ ]
-                Health and Exercise Science: [ ]
-                Immunology: [ ]
-                Medical Imaging: [ ]
-                Mental Health: [ ]
-                Pathology and Pathophysiology: [ ]
-                Pharmacology and Toxicology: [ ]
-                Physical Education and Recreation: [ ]
-                Public Health: [ ]
-                Sensory-Neural Systems: [ ]
-                Social Medicine: [ ]
-                Spectroscopy: [ ]
-                Speech Pathology: [ ]
+                Anatomy and Physiology: []
+                Biomedical Enterprise: []
+                Biomedical Instrumentation: []
+                Biomedical Signal and Image Processing: []
+                Biomedicine: []
+                Cancer: []
+                Cellular and Molecular Medicine: []
+                Epidemiology: []
+                Functional Genomics: []
+                Health and Exercise Science: []
+                Immunology: []
+                Medical Imaging: []
+                Mental Health: []
+                Pathology and Pathophysiology: []
+                Pharmacology and Toxicology: []
+                Physical Education and Recreation: []
+                Public Health: []
+                Sensory-Neural Systems: []
+                Social Medicine: []
+                Spectroscopy: []
+                Speech Pathology: []
               Humanities:
                 History:
                   - European History
@@ -556,19 +609,19 @@ collections:
                   - Metaphysics
                   - Ethics
                   - Logic
-                Religion: [ ]
+                Religion: []
               Mathematics:
-                Algebra and Number Theory: [ ]
-                Applied Mathematics: [ ]
-                Calculus: [ ]
-                Computation: [ ]
-                Differential Equations: [ ]
-                Discrete Mathematics: [ ]
-                Linear Algebra: [ ]
-                Mathematical Analysis: [ ]
-                Mathematical Logic: [ ]
-                Probability and Statistics: [ ]
-                Topology and Geometry: [ ]
+                Algebra and Number Theory: []
+                Applied Mathematics: []
+                Calculus: []
+                Computation: []
+                Differential Equations: []
+                Discrete Mathematics: []
+                Linear Algebra: []
+                Mathematical Analysis: []
+                Mathematical Logic: []
+                Probability and Statistics: []
+                Topology and Geometry: []
               Science:
                 Biology:
                   - Stem Cells
@@ -591,7 +644,7 @@ collections:
                   - Physical Chemistry
                   - Organic Chemistry
                   - Inorganic Chemistry
-                Cognitive Science: [ ]
+                Cognitive Science: []
                 Earth Science:
                   - Planetary Science
                   - Geology
@@ -622,8 +675,8 @@ collections:
                   - Ethnography
                   - Social Anthropology
                   - Biological Anthropology
-                Archaeology: [ ]
-                Communication: [ ]
+                Archaeology: []
+                Communication: []
                 Economics:
                   - Industrial Organization
                   - Political Economy
@@ -636,14 +689,14 @@ collections:
                   - Labor Economics
                   - International Economics
                   - Econometrics
-                Game Theory: [ ]
-                Geography: [ ]
-                Legal Studies: [ ]
+                Game Theory: []
+                Geography: []
+                Legal Studies: []
                 Political Science:
                   - American Politics
                   - International Relations
                   - Comparative Politics
-                Psychology: [ ]
+                Psychology: []
                 Public Administration:
                   - Environmental Policy
                   - Social Welfare
@@ -661,24 +714,25 @@ collections:
                   - Urban Planning
                   - Transportation Planning
               Society:
-                African American Studies: [ ]
-                Asian Studies: [ ]
-                European and Russian Studies: [ ]
-                Gender Studies: [ ]
-                Global Poverty: [ ]
-                Indigenous Studies: [ ]
-                Latin and Caribbean Studies: [ ]
-                Middle Eastern Studies: [ ]
-                The Developing World: [ ]
-                Women's Studies: [ ]
+                African American Studies: []
+                Asian Studies: []
+                European and Russian Studies: []
+                Gender Studies: []
+                Global Poverty: []
+                Indigenous Studies: []
+                Latin and Caribbean Studies: []
+                Middle Eastern Studies: []
+                The Developing World: []
+                Women's Studies: []
               Teaching and Education:
-                Curriculum and Teaching: [ ]
-                Education Policy: [ ]
-                Educational Technology: [ ]
-                Higher Education: [ ]
+                Curriculum and Teaching: []
+                Education Policy: []
+                Educational Technology: []
+                Higher Education: []
           - label: "Legacy UID"
             name: "legacy_uid"
             widget: "hidden"
+
   - category: Settings
     label: Menu
     name: menu
@@ -687,8 +741,4 @@ collections:
         name: navmenu
         label: Navigation Menu
         fields:
-          - {
-            "label": "Menu",
-            "name": "leftnav",
-            "widget": "menu",
-          }
+          - { "label": "Menu", "name": "leftnav", "widget": "menu" }

--- a/localdev/configs/ocw-www.yml
+++ b/localdev/configs/ocw-www.yml
@@ -3,9 +3,15 @@ root-url-path: ""
 collections:
   - category: Content
     folder: content/pages
-    label: Page
-    name: pages
+    label: Pages
+    name: page
     fields:
+      - label: Draft
+        name: draft
+        required: true
+        widget: boolean
+        help: Enable this setting to prevent publishing in production
+
       - label: Title
         name: title
         widget: string
@@ -14,15 +20,35 @@ collections:
       - label: Body
         name: body
         widget: markdown
+        minimal: false
         link:
-          - course-collection
+          - course_collections
           - resource_collections
+          - resource
+          - page
+        embed:
+          - resource
 
   - category: Content
     folder: content/resource_collections
     label: "Resource Collections"
     name: "resource_collections"
     fields:
+      - label: Draft
+        name: draft
+        required: true
+        widget: boolean
+        help: Enable this setting to prevent publishing in production
+
+      - label: Title
+        name: title
+        widget: string
+        required: true
+
+      - label: Description
+        name: description
+        widget: markdown
+
       - widget: relation
         name: resources
         label: Resources
@@ -32,41 +58,16 @@ collections:
         sortable: true
 
   - category: Content
-    folder: content/collections
-    label: "Course Collections"
-    name: course-collection
-    fields:
-      - label: "Description"
-        name: "description"
-        widget: "markdown"
-      - label: Cover Image
-        name: cover-image
-        widget: relation
-        collection: resource
-        display_field: title
-        multiple: false
-        filter:
-          field: "filetype"
-          filter_type: "equals"
-          value: "Image"
-
-      - label: Featured Courses
-        name: featured-courses
-        widget: website-collection
-
-      - label: Course Lists
-        name: courselists
-        widget: relation
-        multiple: true
-        collection: course-lists
-        display_field: title
-        sortable: true
-
-  - category: Content
     folder: content/course-lists
     label: "Course Lists"
     name: "course-lists"
     fields:
+      - label: Draft
+        name: draft
+        required: true
+        widget: boolean
+        help: Enable this setting to prevent publishing in production
+
       - label: Title
         name: title
         widget: string
@@ -81,10 +82,51 @@ collections:
         widget: website-collection
 
   - category: Content
+    folder: content/collections
+    label: "Course Collections"
+    name: "course-collection"
+    fields:
+      - label: "Description"
+        name: "description"
+        widget: "markdown"
+      - label: Cover Image
+        name: cover-image
+        widget: relation
+        collection: resource
+        display_field: title
+        multiple: false
+        filter:
+          field: "resourcetype"
+          filter_type: "equals"
+          value: "Image"
+
+      - label: Featured Courses List
+        name: featured-courses
+        widget: relation
+        multiple: false
+        collection: course-lists
+        display_field: title
+        sortable: false
+
+      - label: Course Lists
+        name: courselists
+        widget: relation
+        multiple: true
+        collection: course-lists
+        display_field: title
+        sortable: true
+
+  - category: Content
     folder: content/promos
     label: Promo
     name: promos
     fields:
+      - label: Draft
+        name: draft
+        required: true
+        widget: boolean
+        help: Enable this setting to prevent publishing in production
+
       - label: Title
         name: title
         widget: string
@@ -107,11 +149,12 @@ collections:
         widget: relation
         collection: resource
         display_field: title
+        required: true
         multiple: false
         min: 1
         max: 1
         filter:
-          field: "filetype"
+          field: "resourcetype"
           filter_type: "equals"
           value: "Image"
 
@@ -120,6 +163,12 @@ collections:
     label: Notification
     name: notifications
     fields:
+      - label: Draft
+        name: draft
+        required: true
+        widget: boolean
+        help: Enable this setting to prevent publishing in production
+
       - label: Title
         name: title
         widget: string
@@ -128,7 +177,6 @@ collections:
       - label: Body
         name: body
         widget: markdown
-        minimal: true
 
       - label: Headless
         name: headless
@@ -136,10 +184,16 @@ collections:
         default: true
 
   - category: Content
-    folder: content/testimonials
-    label: Testimonial
-    name: testimonials
+    folder: content/stories
+    label: Stories
+    name: stories
     fields:
+      - label: Draft
+        name: draft
+        required: true
+        widget: boolean
+        help: Enable this setting to prevent publishing in production
+
       - label: Title
         name: title
         widget: string
@@ -166,7 +220,7 @@ collections:
         min: 1
         max: 1
         filter:
-          field: "filetype"
+          field: "resourcetype"
           filter_type: "equals"
           value: "Image"
 
@@ -177,12 +231,19 @@ collections:
       - label: Body
         name: body
         widget: markdown
+        minimal: false
 
   - category: Content
     folder: content/resources
     label: Resources
     name: resource
     fields:
+      - label: Draft
+        name: draft
+        required: true
+        widget: boolean
+        help: Enable this setting to prevent publishing in production
+
       - label: Title
         name: title
         required: true
@@ -190,9 +251,8 @@ collections:
       - label: Description
         name: description
         widget: markdown
-        minimal: true
-      - label: File Type
-        name: filetype
+      - label: Resource Type
+        name: resourcetype
         required: true
         widget: select
         options:
@@ -208,7 +268,7 @@ collections:
       - label: Image Metadata
         name: metadata
         widget: object
-        condition: { field: filetype, equals: Image }
+        condition: { field: resourcetype, equals: Image }
         fields:
           - label: ALT text
             name: image_alt
@@ -226,6 +286,12 @@ collections:
     name: instructor
     slug: text_id
     fields:
+      - label: Draft
+        name: draft
+        required: true
+        widget: boolean
+        help: Enable this setting to prevent publishing in production
+
       - label: First name
         name: first_name
         widget: string
@@ -259,8 +325,4 @@ collections:
         name: navmenu
         label: Navigation Menu
         fields:
-          - {
-            "label": "Menu",
-            "name": "mainmenu",
-            "widget": "menu",
-          }
+          - { "label": "Menu", "name": "mainmenu", "widget": "menu" }

--- a/static/js/lib/site_content.test.ts
+++ b/static/js/lib/site_content.test.ts
@@ -422,14 +422,23 @@ describe("site_content", () => {
     it("should grab the markdown props for a markdown widget", () => {
       const field = makeWebsiteConfigField({
         widget:  WidgetVariant.Markdown,
-        minimal: true,
+        minimal: false,
         link:    ["resource", "page"],
         embed:   ["resource"]
       })
       expect(widgetExtraProps(field)).toStrictEqual({
-        minimal: true,
+        minimal: false,
         link:    ["resource", "page"],
         embed:   ["resource"]
+      })
+    })
+
+    it("sets minimal = true for markdown fields by default", () => {
+      const field = makeWebsiteConfigField({ widget: WidgetVariant.Markdown })
+      expect(widgetExtraProps(field)).toStrictEqual({
+        minimal: true,
+        link:    [],
+        embed:   []
       })
     })
 

--- a/static/js/lib/site_content.ts
+++ b/static/js/lib/site_content.ts
@@ -96,7 +96,7 @@ export function widgetExtraProps(field: ConfigField): Record<string, any> {
     return pick(SELECT_EXTRA_PROPS, field)
   case WidgetVariant.Markdown:
     return {
-      minimal: field.minimal ?? false,
+      minimal: field.minimal ?? true,
       link:    field.link ?? [],
       embed:   field.embed ?? []
     }

--- a/static/js/resources/ocw-course-site-config.json
+++ b/static/js/resources/ocw-course-site-config.json
@@ -4,6 +4,48 @@
       "category": "Content",
       "fields": [
         {
+          "help": "Enable this setting to prevent publishing in production",
+          "label": "Draft",
+          "name": "draft",
+          "required": true,
+          "widget": "boolean"
+        },
+        {
+          "label": "Title",
+          "name": "title",
+          "required": true,
+          "widget": "string"
+        },
+        {
+          "embed": [
+            "resource"
+          ],
+          "label": "Body",
+          "link": [
+            "resource",
+            "page",
+            "video_gallery"
+          ],
+          "minimal": false,
+          "name": "body",
+          "widget": "markdown"
+        }
+      ],
+      "folder": "content/pages",
+      "label": "Pages",
+      "name": "page"
+    },
+    {
+      "category": "Content",
+      "fields": [
+        {
+          "help": "Enable this setting to prevent publishing in production",
+          "label": "Draft",
+          "name": "draft",
+          "required": true,
+          "widget": "boolean"
+        },
+        {
           "label": "Title",
           "name": "title",
           "required": true,
@@ -18,20 +60,8 @@
             "resource",
             "page"
           ],
+          "minimal": false,
           "name": "body",
-          "widget": "markdown"
-        }
-      ],
-      "folder": "content/pages",
-      "label": "Pages",
-      "name": "page"
-    },
-    {
-      "category": "Content",
-      "fields": [
-        {
-          "label": "Description",
-          "name": "description",
           "widget": "markdown"
         },
         {
@@ -57,6 +87,14 @@
       "category": "Content",
       "fields": [
         {
+          "help": "Enable this setting to prevent publishing in production",
+          "label": "Draft",
+          "name": "draft",
+          "required": true,
+          "widget": "boolean"
+        },
+        {
+          "help": "If this is a video, this will be published as the YouTube title",
           "label": "Title",
           "name": "title",
           "required": true,
@@ -64,8 +102,21 @@
         },
         {
           "label": "Description",
-          "minimal": true,
           "name": "description",
+          "widget": "markdown"
+        },
+        {
+          "embed": [
+            "resource"
+          ],
+          "help": "The body of the resource page, displayed below the page title and above the resource\n",
+          "label": "Body",
+          "link": [
+            "resource",
+            "page"
+          ],
+          "minimal": false,
+          "name": "body",
           "widget": "markdown"
         },
         {
@@ -107,6 +158,7 @@
             "Exams",
             "Exams with Solutions",
             "Image Gallery",
+            "Instructor Insights",
             "Labs",
             "Lecture Audio",
             "Lecture Notes",
@@ -180,12 +232,12 @@
             {
               "label": "Caption",
               "name": "caption",
-              "widget": "string"
+              "widget": "markdown"
             },
             {
               "label": "Credit",
               "name": "credit",
-              "widget": "text"
+              "widget": "markdown"
             }
           ],
           "label": "Image Metadata",
@@ -204,6 +256,11 @@
               "widget": "string"
             },
             {
+              "label": "Youtube Description",
+              "name": "youtube_description",
+              "widget": "text"
+            },
+            {
               "label": "Youtube Speakers",
               "name": "video_speakers",
               "widget": "string"
@@ -214,6 +271,7 @@
               "widget": "text"
             }
           ],
+          "help": "These fields will be published to YouTube",
           "label": "Video Metadata",
           "name": "video_metadata",
           "widget": "object"
@@ -240,6 +298,7 @@
               "widget": "string"
             }
           ],
+          "help": "Internal YouTube fields, don't edit unless you know what you're doing\n",
           "label": "Video Files",
           "name": "video_files",
           "widget": "object"
@@ -392,6 +451,7 @@
                 "Exams",
                 "Exams with Solutions",
                 "Image Gallery",
+                "Instructor Insights",
                 "Labs",
                 "Lecture Audio",
                 "Lecture Notes",

--- a/static/js/resources/ocw-www.json
+++ b/static/js/resources/ocw-www.json
@@ -4,28 +4,59 @@
       "category": "Content",
       "fields": [
         {
+          "help": "Enable this setting to prevent publishing in production",
+          "label": "Draft",
+          "name": "draft",
+          "required": true,
+          "widget": "boolean"
+        },
+        {
           "label": "Title",
           "name": "title",
           "required": true,
           "widget": "string"
         },
         {
+          "embed": [
+            "resource"
+          ],
           "label": "Body",
           "link": [
-            "course-collection",
-            "resource_collections"
+            "course_collections",
+            "resource_collections",
+            "resource",
+            "page"
           ],
+          "minimal": false,
           "name": "body",
           "widget": "markdown"
         }
       ],
       "folder": "content/pages",
-      "label": "Page",
-      "name": "pages"
+      "label": "Pages",
+      "name": "page"
     },
     {
       "category": "Content",
       "fields": [
+        {
+          "help": "Enable this setting to prevent publishing in production",
+          "label": "Draft",
+          "name": "draft",
+          "required": true,
+          "widget": "boolean"
+        },
+        {
+          "label": "Title",
+          "name": "title",
+          "required": true,
+          "widget": "string"
+        },
+        {
+          "label": "Description",
+          "name": "description",
+          "widget": "markdown"
+        },
         {
           "collection": "resource",
           "cross_site": true,
@@ -44,45 +75,12 @@
       "category": "Content",
       "fields": [
         {
-          "label": "Description",
-          "name": "description",
-          "widget": "markdown"
+          "help": "Enable this setting to prevent publishing in production",
+          "label": "Draft",
+          "name": "draft",
+          "required": true,
+          "widget": "boolean"
         },
-        {
-          "collection": "resource",
-          "display_field": "title",
-          "filter": {
-            "field": "filetype",
-            "filter_type": "equals",
-            "value": "Image"
-          },
-          "label": "Cover Image",
-          "multiple": false,
-          "name": "cover-image",
-          "widget": "relation"
-        },
-        {
-          "label": "Featured Courses",
-          "name": "featured-courses",
-          "widget": "website-collection"
-        },
-        {
-          "collection": "course-lists",
-          "display_field": "title",
-          "label": "Course Lists",
-          "multiple": true,
-          "name": "courselists",
-          "sortable": true,
-          "widget": "relation"
-        }
-      ],
-      "folder": "content/collections",
-      "label": "Course Collections",
-      "name": "course-collection"
-    },
-    {
-      "category": "Content",
-      "fields": [
         {
           "label": "Title",
           "name": "title",
@@ -108,6 +106,57 @@
       "category": "Content",
       "fields": [
         {
+          "label": "Description",
+          "name": "description",
+          "widget": "markdown"
+        },
+        {
+          "collection": "resource",
+          "display_field": "title",
+          "filter": {
+            "field": "resourcetype",
+            "filter_type": "equals",
+            "value": "Image"
+          },
+          "label": "Cover Image",
+          "multiple": false,
+          "name": "cover-image",
+          "widget": "relation"
+        },
+        {
+          "collection": "course-lists",
+          "display_field": "title",
+          "label": "Featured Courses List",
+          "multiple": false,
+          "name": "featured-courses",
+          "sortable": false,
+          "widget": "relation"
+        },
+        {
+          "collection": "course-lists",
+          "display_field": "title",
+          "label": "Course Lists",
+          "multiple": true,
+          "name": "courselists",
+          "sortable": true,
+          "widget": "relation"
+        }
+      ],
+      "folder": "content/collections",
+      "label": "Course Collections",
+      "name": "course-collection"
+    },
+    {
+      "category": "Content",
+      "fields": [
+        {
+          "help": "Enable this setting to prevent publishing in production",
+          "label": "Draft",
+          "name": "draft",
+          "required": true,
+          "widget": "boolean"
+        },
+        {
           "label": "Title",
           "name": "title",
           "required": true,
@@ -132,7 +181,7 @@
           "collection": "resource",
           "display_field": "title",
           "filter": {
-            "field": "filetype",
+            "field": "resourcetype",
             "filter_type": "equals",
             "value": "Image"
           },
@@ -141,6 +190,7 @@
           "min": 1,
           "multiple": false,
           "name": "image",
+          "required": true,
           "widget": "relation"
         }
       ],
@@ -152,6 +202,13 @@
       "category": "Content",
       "fields": [
         {
+          "help": "Enable this setting to prevent publishing in production",
+          "label": "Draft",
+          "name": "draft",
+          "required": true,
+          "widget": "boolean"
+        },
+        {
           "label": "Title",
           "name": "title",
           "required": true,
@@ -159,7 +216,6 @@
         },
         {
           "label": "Body",
-          "minimal": true,
           "name": "body",
           "widget": "markdown"
         },
@@ -177,6 +233,13 @@
     {
       "category": "Content",
       "fields": [
+        {
+          "help": "Enable this setting to prevent publishing in production",
+          "label": "Draft",
+          "name": "draft",
+          "required": true,
+          "widget": "boolean"
+        },
         {
           "label": "Title",
           "name": "title",
@@ -202,7 +265,7 @@
           "collection": "resource",
           "display_field": "title",
           "filter": {
-            "field": "filetype",
+            "field": "resourcetype",
             "filter_type": "equals",
             "value": "Image"
           },
@@ -220,17 +283,25 @@
         },
         {
           "label": "Body",
+          "minimal": false,
           "name": "body",
           "widget": "markdown"
         }
       ],
-      "folder": "content/testimonials",
-      "label": "Testimonial",
-      "name": "testimonials"
+      "folder": "content/stories",
+      "label": "Stories",
+      "name": "stories"
     },
     {
       "category": "Content",
       "fields": [
+        {
+          "help": "Enable this setting to prevent publishing in production",
+          "label": "Draft",
+          "name": "draft",
+          "required": true,
+          "widget": "boolean"
+        },
         {
           "label": "Title",
           "name": "title",
@@ -239,13 +310,12 @@
         },
         {
           "label": "Description",
-          "minimal": true,
           "name": "description",
           "widget": "markdown"
         },
         {
-          "label": "File Type",
-          "name": "filetype",
+          "label": "Resource Type",
+          "name": "resourcetype",
           "options": [
             "Image",
             "Video",
@@ -263,7 +333,7 @@
         {
           "condition": {
             "equals": "Image",
-            "field": "filetype"
+            "field": "resourcetype"
           },
           "fields": [
             {
@@ -294,6 +364,13 @@
     {
       "category": "Content",
       "fields": [
+        {
+          "help": "Enable this setting to prevent publishing in production",
+          "label": "Draft",
+          "name": "draft",
+          "required": true,
+          "widget": "boolean"
+        },
         {
           "label": "First name",
           "name": "first_name",

--- a/websites/site_config_api_test.py
+++ b/websites/site_config_api_test.py
@@ -174,12 +174,19 @@ def test_generate_item_metadata(
     class_data = {} if cls else {"title": "", "file": ""}
     expected_data = {
         "description": "",
+        "body": "",
+        "draft": "",
         "resourcetype": (resource_type or "") if with_kwargs else "",
         "file_type": (file_type or "") if with_kwargs else "",
         "learning_resource_types": [],
         "license": "",
         "image_metadata": {"image-alt": "", "caption": "", "credit": ""},
-        "video_metadata": {"youtube_id": "", "video_speakers": "", "video_tags": ""},
+        "video_metadata": {
+            "youtube_id": "",
+            "video_speakers": "",
+            "video_tags": "",
+            "youtube_description": "",
+        },
         "video_files": {
             "video_thumbnail_file": "",
             "video_captions_file": "",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1277 

#### What's this PR do?
1. Updates the frontend code to use `minimal=true` the default for markdown widget.
2. Syncs the studio configs with https://github.com/mitodl/ocw-hugo-projects/pull/182 _doing this manually was no fun and it seems like maybe we haven't done it recently. I think we've talked about just pulling in the configs for running tests? I will start a discussion_

#### How should this be manually tested?
1. Use the course config from https://github.com/mitodl/ocw-hugo-projects/pull/182
2. View any widget markdown widget for which `minimal` is not specified. A good example is Resource description. Verify that it is minimal (i.e., no tables, no code blocks, etc.)
3. Check that widgets for which minimal=false are still full, e.g., page bodies or resource bodies.
