### PR TITLE
make markdown editor minimal by default

### DIFF
--- a/static/js/lib/site_content.test.ts
+++ b/static/js/lib/site_content.test.ts
@@ -422,14 +422,23 @@ describe("site_content", () => {
     it("should grab the markdown props for a markdown widget", () => {
       const field = makeWebsiteConfigField({
         widget:  WidgetVariant.Markdown,
-        minimal: true,
+        minimal: false,
         link:    ["resource", "page"],
         embed:   ["resource"]
       })
       expect(widgetExtraProps(field)).toStrictEqual({
-        minimal: true,
+        minimal: false,
         link:    ["resource", "page"],
         embed:   ["resource"]
+      })
+    })
+
+    it("sets minimal = true for markdown fields by default", () => {
+      const field = makeWebsiteConfigField({ widget: WidgetVariant.Markdown })
+      expect(widgetExtraProps(field)).toStrictEqual({
+        minimal: true,
+        link:    [],
+        embed:   []
       })
     })
 

--- a/static/js/lib/site_content.ts
+++ b/static/js/lib/site_content.ts
@@ -96,7 +96,7 @@ export function widgetExtraProps(field: ConfigField): Record<string, any> {
     return pick(SELECT_EXTRA_PROPS, field)
   case WidgetVariant.Markdown:
     return {
-      minimal: field.minimal ?? false,
+      minimal: field.minimal ?? true,
       link:    field.link ?? [],
       embed:   field.embed ?? []
     }


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1277 

#### What's this PR do?
Updates the frontend code to use `minimal=true` the default for markdown widget.

#### How should this be manually tested?
1. Use the course config from https://github.com/mitodl/ocw-hugo-projects/pull/182
2. View any widget markdown widget for which `minimal` is not specified. A good example is Resource description. Verify that it is minimal (i.e., no tables, no code blocks, etc.)
3. Check that widgets for which minimal=false are still full, e.g., page bodies or resource bodies.
