### PR TITLE
Added slack notifications on_failure cases to the individual site pipelines.

### DIFF
--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -92,7 +92,7 @@ jobs:
                       "version": "((pipeline_name))",
                       "status": "errored"
                     }
-            - put: slack-webook
+            - put: slack-webhook
               timeout: 1m
               params:
                 alert_type: failed
@@ -131,7 +131,7 @@ jobs:
                       "version": "((pipeline_name))",
                       "status": "errored"
                     }
-            - put: slack-webook
+            - put: slack-webhook
               timeout: 1m
               params:
                 alert_type: failed
@@ -151,7 +151,7 @@ jobs:
                       "version": "((pipeline_name))",
                       "status": "errored"
                     }
-            - put: slack-webook
+            - put: slack-webhook
               timeout: 1m
               params:
                 alert_type: failed
@@ -199,7 +199,7 @@ jobs:
                       "version": "((pipeline_name))",
                       "status": "errored"
                     }
-            - put: slack-webook
+            - put: slack-webhook
               timeout: 1m
               params:
                 alert_type: failed
@@ -233,7 +233,7 @@ jobs:
                       "version": "((pipeline_name))",
                       "status": "errored"
                     }
-            - put: slack-webook
+            - put: slack-webhook
               timeout: 1m
               params:
                 alert_type: failed
@@ -289,7 +289,7 @@ jobs:
                       "version": "((pipeline_name))",
                       "status": "errored"
                     }
-            - put: slack-webook
+            - put: slack-webhook
               timeout: 1m
               params:
                 alert_type: failed

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -10,6 +10,11 @@ resource_types:
     source:
       repository: governmentpaas/s3-resource
       tag: latest
+  - name: slack-alert
+    type: docker-image
+    source:
+      repository: arbourd/concourse-slack-alert-resource
+      tag: v0.15.0
 resources:
   - name: webpack-json
     type: s3-resource-iam
@@ -54,6 +59,12 @@ resources:
         headers:
           Content-Type: "application/json"
         out_only: true
+  - name: slack-webhook
+    type: slack-alert
+    check_every: never
+    source:
+      url: ((slack-url))
+      disabled: false
 jobs:
   - name: build-ocw-site
     serial: true
@@ -72,55 +83,79 @@ jobs:
         trigger: false
         on_failure:
           try:
-            put: ocw-studio-webhook
-            timeout: 1m
-            params:
-                text: |
-                  {
-                    "version": "((pipeline_name))",
-                    "status": "errored"
-                  }
+            do:
+            - put: ocw-studio-webhook
+              timeout: 1m
+              params:
+                  text: |
+                    {
+                      "version": "((pipeline_name))",
+                      "status": "errored"
+                    }
+            - put: slack-webook
+              timeout: 1m
+              params:
+                alert_type: failed
+                text: "Failed to get webpack-json"
       - get: ocw-hugo-themes
         trigger: false
         timeout: 5m
         on_failure:
           try:
-            put: ocw-studio-webhook
-            timeout: 1m
-            params:
-                text: |
-                  {
-                    "version": "((pipeline_name))",
-                    "status": "errored"
-                  }
+            do:
+            - put: ocw-studio-webhook
+              timeout: 1m
+              params:
+                  text: |
+                    {
+                      "version": "((pipeline_name))",
+                      "status": "errored"
+                    }
+            - put: slack-webhook
+              timeout: 1m
+              params:
+                alert_type: failed
+                text: "Failed to get ocw-hugo-themes"
       - get: ocw-hugo-projects
         trigger: false
         timeout: 5m
         attempts: 3
         on_failure:
           try:
-            put: ocw-studio-webhook
-            timeout: 1m
-            params:
-                text: |
-                  {
-                    "version": "((pipeline_name))",
-                    "status": "errored"
-                  }
+            do:
+            - put: ocw-studio-webhook
+              timeout: 1m
+              params:
+                  text: |
+                    {
+                      "version": "((pipeline_name))",
+                      "status": "errored"
+                    }
+            - put: slack-webook
+              timeout: 1m
+              params:
+                alert_type: failed
+                text: "Failed to get ocw-hugo-projects"
       - get: course-markdown
         trigger: false
         timeout: 5m
         attempts: 3
         on_failure:
           try:
-            put: ocw-studio-webhook
-            timeout: 1m
-            params:
-                text: |
-                  {
-                    "version": "((pipeline_name))",
-                    "status": "errored"
-                  }
+            do:
+            - put: ocw-studio-webhook
+              timeout: 1m
+              params:
+                  text: |
+                    {
+                      "version": "((pipeline_name))",
+                      "status": "errored"
+                    }
+            - put: slack-webook
+              timeout: 1m
+              params:
+                alert_type: failed
+                text: "Failed to get course-markdown"
       - task: build-course-task
         timeout: 20m
         attempts: 3
@@ -154,15 +189,21 @@ jobs:
               hugo --config ../ocw-hugo-projects/((config-slug))/config.yaml --baseUrl /((base-url)) --themesDir ../ocw-hugo-themes/ ((build-drafts))
         on_failure:
           try:
-            put: ocw-studio-webhook
-            timeout: 1m
-            attempts: 3
-            params:
-                text: |
-                  {
-                    "version": "((pipeline_name))",
-                    "status": "errored"
-                  }
+            do:
+            - put: ocw-studio-webhook
+              timeout: 1m
+              attempts: 3
+              params:
+                  text: |
+                    {
+                      "version": "((pipeline_name))",
+                      "status": "errored"
+                    }
+            - put: slack-webook
+              timeout: 1m
+              params:
+                alert_type: failed
+                text: "Failed on build-course-task"
       - task: copy-s3-buckets
         timeout: 20m
         attempts: 3
@@ -182,15 +223,21 @@ jobs:
               aws s3 sync course-markdown/public s3://((ocw-bucket))/((base-url)) --metadata site-id=((site-name))
         on_failure:
           try:
-            put: ocw-studio-webhook
-            timeout: 1m
-            attempts: 3
-            params:
-                text: |
-                  {
-                    "version": "((pipeline_name))",
-                    "status": "errored"
-                  }
+            do:
+            - put: ocw-studio-webhook
+              timeout: 1m
+              attempts: 3
+              params:
+                  text: |
+                    {
+                      "version": "((pipeline_name))",
+                      "status": "errored"
+                    }
+            - put: slack-webook
+              timeout: 1m
+              params:
+                alert_type: failed
+                text: "Failed on copy-s3-buckets"
       - task: clear-cdn-cache
         timeout: 5m
         attempts: 3
@@ -232,12 +279,18 @@ jobs:
                     }
         on_failure:
           try:
-            put: ocw-studio-webhook
-            timeout: 1m
-            attempts: 3
-            params:
-                text: |
-                  {
-                    "version": "((pipeline_name))",
-                    "status": "errored"
-                  }
+            do:
+            - put: ocw-studio-webhook
+              timeout: 1m
+              attempts: 3
+              params:
+                  text: |
+                    {
+                      "version": "((pipeline_name))",
+                      "status": "errored"
+                    }
+            - put: slack-webook
+              timeout: 1m
+              params:
+                alert_type: failed
+                text: "Failed on clear-cdn-cache"


### PR DESCRIPTION
Added slack notifications on_failure cases to the individual site pipelines.
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling - N/A
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code - N/A
- [ ] Testing
  - [X] Code is tested 
  - [X] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json` - N/A
  - [ ] New settings have reasonable development defaults, if applicable - N/A
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments - N/A

#### What are the relevant tickets?
#1323 

#### What's this PR do?
This will add slack notifications to #ocw-publish-notifications and #ocw-publish-notifications-rc channels when the pipeline fails. The notifications include a short description of the nature of the failure as well as a link directly to the job that failed. There are no notifications sent when the job is successful.

#### How should this be manually tested?
Will test in QA by creating the 'slack-url' key in vault and then working with someone in dev to repopulate the pipeline definitions. 

Repeat the procedure to production.

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
