### PR TITLE
treat shortcodes in resource link text as literal text

### DIFF
--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
@@ -106,7 +106,7 @@ describe("ResourceLink plugin", () => {
     )
   })
 
-  it("Escapes shortcodes in the link text", async () => {
+  it("Treats legacy shortcodes in link text as literal text", async () => {
     const editor = await getEditor("")
     const md = 'Dogs {{% resource_link "uuid123" "{{< sup 2 >}}" %}} Woof'
     const html = `<p>Dogs <a class="resource-link" data-uuid="${encode(

--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
@@ -10,11 +10,13 @@ import ResourceLinkMarkdownSyntax, {
   encodeShortcodeArgs as encode
 } from "./ResourceLinkMarkdownSyntax"
 import Paragraph from "@ckeditor/ckeditor5-paragraph/src/paragraph"
+import LegacyShortcodes from "./LegacyShortcodes"
 
 const getEditor = createTestEditor([
   Paragraph,
   ResourceLink,
   ResourceLinkMarkdownSyntax,
+  LegacyShortcodes,
   Markdown
 ])
 
@@ -102,5 +104,14 @@ describe("ResourceLink plugin", () => {
         "uuid123"
       )}">bark bark</a> Woof</p>`
     )
+  })
+
+  it("Escapes shortcodes in the link text", async () => {
+    const editor = await getEditor("")
+    const md = 'Dogs {{% resource_link "uuid123" "{{< sup 2 >}}" %}} Woof'
+    const html = `<p>Dogs <a class="resource-link" data-uuid="${encode(
+      "uuid123"
+    )}">{{&lt; sup 2 &gt;}}</a> Woof</p>`
+    markdownTest(editor, md, html)
   })
 })

--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
@@ -9,7 +9,7 @@ import {
   RESOURCE_LINK_CKEDITOR_CLASS,
   RESOURCE_LINK
 } from "@mitodl/ckeditor5-resource-link/src/constants"
-import { Shortcode } from "./util"
+import { Shortcode, escapeShortcodes } from "./util"
 
 export const encodeShortcodeArgs = (...args: (string | undefined)[]) =>
   encodeURIComponent(JSON.stringify(args))
@@ -52,7 +52,7 @@ export default class ResourceLinkMarkdownSyntax extends MarkdownSyntaxPlugin {
           replace: (s: string) => {
             const shortcode = Shortcode.fromString(s)
             const uuid = shortcode.get(0)
-            const text = shortcode.get(1)
+            const text = escapeShortcodes(shortcode.get(1) ?? "")
             const fragment = shortcode.get(2)
             const encoded = fragment ?
               encodeShortcodeArgs(uuid, fragment) :

--- a/static/js/lib/ckeditor/plugins/util.ts
+++ b/static/js/lib/ckeditor/plugins/util.ts
@@ -315,3 +315,20 @@ export const makeHtmlString = (
     })
   return `<${tagName} ${attrAssignments.join(" ")}></${tagName}>`
 }
+
+/**
+ * Escape shortcode delimiters, e.g., `"{{<"` --> `"{{\<"`.
+ *
+ * This is something of a workaround for when we do NOT want shortcode-esque
+ * text to be considered a shortcode, for example the `sup` group in
+ * `'{{% resource_link uuid "{{< sup 2 > }}" %}}'`. Hugo will display this sup
+ * as literal text, so Studio should, too.
+ *
+ * By escaping `<` or `{` in the shortcode delimiter, we prevent the text from
+ * triggering shortcode-related code, e.g., Showdown extensions. Markdown allows
+ * optionally escaping these characters, so there is no affect on the rendered
+ * HTML.
+ */
+export const escapeShortcodes = (text: string) => {
+  return text.replace(/{{</g, "{{\\<").replace("{{%", "{\\{%")
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
 
#### What are the relevant tickets?
#1280 

#### What's this PR do?
Ensures that shortcodes inside resource_link text do not trigger the LegacyShortcodes plugin.

#### How should this be manually tested?
1. Add a resource link with with a legacy shortcode in its text, e.g., `{{% resource_link uuid "Helo {{< sup 2 >}} bye"%}}`
2. Ensure the page can be edited without unintended edits to the link text. _In the example above, you should be able to edit the `{{< sup 2 >}}` since it is not really a shortcode, it's just text.

### Screenshots

Before/After
 <img width="300" alt="Screen Shot 2022-05-17 at 11 38 05 AM" src="https://user-images.githubusercontent.com/9010790/168851870-ae673ce2-cb27-4e92-9012-e128930de035.png"><img width="300" alt="Screen Shot 2022-05-17 at 11 37 49 AM" src="https://user-images.githubusercontent.com/9010790/168851869-6750d667-e0fd-4423-8eaf-f9dee608fbaf.png">

