### PR TITLE
update generate_item_metadata to optionally use config default value

### DIFF
--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -359,7 +359,8 @@ def create_gdrive_resource_content(drive_file: DriveFile):
                 ),
             )
             resource_type_fields = {
-                field: resource_type for field in settings.RESOURCE_TYPE_FIELDS
+                "file_type": drive_file.mime_type,
+                **{field: resource_type for field in settings.RESOURCE_TYPE_FIELDS},
             }
             resource = WebsiteContent.objects.create(
                 website=drive_file.website,
@@ -375,8 +376,8 @@ def create_gdrive_resource_content(drive_file: DriveFile):
                     ).generate_item_metadata(
                         CONTENT_TYPE_RESOURCE,
                         cls=WebsiteContent,
-                        file_type=drive_file.mime_type,
-                        **resource_type_fields,
+                        use_defaults=True,
+                        values=resource_type_fields,
                     )
                 },
             )

--- a/gdrive_sync/api_test.py
+++ b/gdrive_sync/api_test.py
@@ -498,6 +498,7 @@ def test_create_gdrive_resource_content(mime_type, mock_get_s3_content_type):
         assert content.metadata["resourcetype"] == RESOURCE_TYPE_DOCUMENT
         assert content.metadata["file_type"] == mime_type
         assert content.metadata["image"] == ""
+        assert content.metadata["license"] == "some_default_license"
         drive_file.refresh_from_db()
         assert drive_file.resource == content
 

--- a/gdrive_sync/api_test.py
+++ b/gdrive_sync/api_test.py
@@ -498,7 +498,7 @@ def test_create_gdrive_resource_content(mime_type, mock_get_s3_content_type):
         assert content.metadata["resourcetype"] == RESOURCE_TYPE_DOCUMENT
         assert content.metadata["file_type"] == mime_type
         assert content.metadata["image"] == ""
-        assert content.metadata["license"] == "some_default_license"
+        assert content.metadata["license"] == "default_license_specificed_in_config"
         drive_file.refresh_from_db()
         assert drive_file.resource == content
 

--- a/localdev/configs/basic-site-config.yml
+++ b/localdev/configs/basic-site-config.yml
@@ -35,3 +35,4 @@ collections:
       - {"label": "Image", "name": "image", "widget": "file", "required": false}
       - {"label": "Resource Type", "name": "resourcetype", "widget": "select", "required": false}
       - {"label": "File Type", "name": "file_type", "widget": "string", "required": false}
+      - {"label": "License", "name": "license", "widget": "string", "required": true, "default": "some_default_license"}

--- a/localdev/configs/basic-site-config.yml
+++ b/localdev/configs/basic-site-config.yml
@@ -35,4 +35,4 @@ collections:
       - {"label": "Image", "name": "image", "widget": "file", "required": false}
       - {"label": "Resource Type", "name": "resourcetype", "widget": "select", "required": false}
       - {"label": "File Type", "name": "file_type", "widget": "string", "required": false}
-      - {"label": "License", "name": "license", "widget": "string", "required": true, "default": "some_default_license"}
+      - {"label": "License", "name": "license", "widget": "string", "required": true, "default": "default_license_specificed_in_config"}

--- a/static/js/resources/basic-site-config.json
+++ b/static/js/resources/basic-site-config.json
@@ -78,7 +78,7 @@
           "widget": "string"
         },
         {
-          "default": "some_default_license",
+          "default": "default_license_specificed_in_config",
           "label": "License",
           "name": "license",
           "required": true,

--- a/static/js/resources/basic-site-config.json
+++ b/static/js/resources/basic-site-config.json
@@ -76,6 +76,13 @@
           "name": "file_type",
           "required": false,
           "widget": "string"
+        },
+        {
+          "default": "some_default_license",
+          "label": "License",
+          "name": "license",
+          "required": true,
+          "widget": "string"
         }
       ],
       "folder": "content/resource",

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -275,6 +275,7 @@ def test_update_youtube_statuses(
                 },
                 "video_metadata": {"youtube_id": video_file.destination_id},
                 "image": "",
+                "license": "default_license_specificed_in_config",
             }
     else:
         mock_youtube.assert_not_called()

--- a/websites/management/commands/update_content_metadata.py
+++ b/websites/management/commands/update_content_metadata.py
@@ -25,6 +25,13 @@ class Command(BaseCommand):
             help="Only update metadata of this_type (default = resource)",
         )
         parser.add_argument(
+            "-ud",
+            "--use-defaults",
+            dest="use_defaults",
+            action="store_true",
+            help="Use default config values for metadata values that do not currently exist",
+        )
+        parser.add_argument(
             "-f",
             "--filter",
             dest="filter",
@@ -45,6 +52,7 @@ class Command(BaseCommand):
         starter_str = options["starter"]
         source_str = options["source"]
         type_str = options["type"]
+        use_defaults = options["use_defaults"]
 
         content_qset = WebsiteContent.objects.filter(
             website__starter__slug=starter_str, type=type_str
@@ -63,7 +71,9 @@ class Command(BaseCommand):
 
         base_metadata = SiteConfig(
             WebsiteStarter.objects.get(slug=starter_str).config
-        ).generate_item_metadata(type_str, cls=WebsiteContent)
+        ).generate_item_metadata(
+            type_str, cls=WebsiteContent, use_defaults=use_defaults
+        )
         with transaction.atomic():
             for content in content_qset.iterator():
                 if set(base_metadata.keys()).symmetric_difference(

--- a/websites/site_config_api.py
+++ b/websites/site_config_api.py
@@ -117,11 +117,16 @@ class SiteConfig:
         return None
 
     def generate_item_metadata(
-        self, name: str, cls: object = None, use_defaults=False, values: Dict = {}
+        self,
+        name: str,
+        cls: object = None,
+        use_defaults=False,
+        values: Optional[Dict] = None,
     ) -> Dict:
         """Generate a metadata dict with blank keys for the specified item. If
         use_defaults is True, fill the keys with default values from config.
         """
+        values = values or {}
         item_dict = {}
         item = self.find_item_by_name(name)
 

--- a/websites/site_config_api_test.py
+++ b/websites/site_config_api_test.py
@@ -168,7 +168,7 @@ def test_find_file_field(basic_site_config, content_type, field_name):
 @pytest.mark.parametrize("file_type", [None, "image/png"])
 @pytest.mark.parametrize("use_defaults", [True, False])
 @pytest.mark.parametrize("values", [True, False])
-def test_generate_item_metadata(
+def test_generate_item_metadata(  # pylint: disable=too-many-arguments
     parsed_site_config, cls, resource_type, file_type, use_defaults, values
 ):
     """generate_item_metadata should return the expected dict"""

--- a/websites/site_config_api_test.py
+++ b/websites/site_config_api_test.py
@@ -166,18 +166,20 @@ def test_find_file_field(basic_site_config, content_type, field_name):
 @pytest.mark.parametrize("cls", [None, WebsiteContent])
 @pytest.mark.parametrize("resource_type", [None, "Image"])
 @pytest.mark.parametrize("file_type", [None, "image/png"])
-@pytest.mark.parametrize("with_kwargs", [True, False])
+@pytest.mark.parametrize("use_defaults", [True, False])
+@pytest.mark.parametrize("values", [True, False])
 def test_generate_item_metadata(
-    parsed_site_config, cls, resource_type, file_type, with_kwargs
+    parsed_site_config, cls, resource_type, file_type, use_defaults, values
 ):
     """generate_item_metadata should return the expected dict"""
     class_data = {} if cls else {"title": "", "file": ""}
+    default_license = "https://creativecommons.org/licenses/by-nc-sa/4.0/"
     expected_data = {
         "description": "",
-        "resourcetype": (resource_type or "") if with_kwargs else "",
-        "file_type": (file_type or "") if with_kwargs else "",
+        "resourcetype": (resource_type or "") if values else "",
+        "file_type": (file_type or "") if values else "",
         "learning_resource_types": [],
-        "license": "",
+        "license": default_license if use_defaults else "",
         "image_metadata": {"image-alt": "", "caption": "", "credit": ""},
         "video_metadata": {"youtube_id": "", "video_speakers": "", "video_tags": ""},
         "video_files": {
@@ -188,9 +190,10 @@ def test_generate_item_metadata(
         **class_data,
     }
     site_config = SiteConfig(parsed_site_config)
-    kwargs = (
-        {"resourcetype": resource_type, "file_type": file_type} if with_kwargs else {}
-    )
+    values = {"resourcetype": resource_type, "file_type": file_type} if values else {}
     assert (
-        site_config.generate_item_metadata("resource", cls, **kwargs) == expected_data
+        site_config.generate_item_metadata(
+            "resource", cls, use_defaults=use_defaults, values=values
+        )
+        == expected_data
     )


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1343 

#### What's this PR do?
This PR changes `create_gdrive_resource_content` to set default metadata values based on default field values in the config; these field values would be populated in a form when creating a new item on the frontend.

#### How should this be manually tested?
Create a gdrive resource and verify that the license is set. _No other resource fields currently have a default._