### PR TITLE
allow setting link / embed on minimal markdown editor

### DIFF
--- a/static/js/components/widgets/MarkdownEditor.tsx
+++ b/static/js/components/widgets/MarkdownEditor.tsx
@@ -92,8 +92,24 @@ export default function MarkdownEditor(props: Props): JSX.Element {
   )
 
   const editorConfig = useMemo(() => {
+    const toolbarItemsFilter = (item: string): boolean => {
+      if (item === ADD_RESOURCE_LINK) {
+        return link.length > 0
+      }
+      if (item === ADD_RESOURCE_EMBED) {
+        return embed.length > 0
+      }
+      return true
+    }
+
     if (minimal) {
-      return MinimalEditorConfig
+      return {
+        ...MinimalEditorConfig,
+        toolbar: {
+          ...MinimalEditorConfig.toolbar,
+          items: MinimalEditorConfig.toolbar.items.filter(toolbarItemsFilter)
+        }
+      }
     } else {
       // this render function is stuck into the editor config
       // our ResourceEmbed plugin can pull the callback out,
@@ -106,15 +122,7 @@ export default function MarkdownEditor(props: Props): JSX.Element {
         },
         toolbar: {
           ...FullEditorConfig.toolbar,
-          items: FullEditorConfig.toolbar.items.filter(item => {
-            if (item === ADD_RESOURCE_LINK) {
-              return link.length > 0
-            }
-            if (item === ADD_RESOURCE_EMBED) {
-              return embed.length > 0
-            }
-            return true
-          })
+          items: FullEditorConfig.toolbar.items.filter(toolbarItemsFilter)
         }
       }
     }

--- a/static/js/components/widgets/MarkdownEditor.tsx
+++ b/static/js/components/widgets/MarkdownEditor.tsx
@@ -105,6 +105,10 @@ export default function MarkdownEditor(props: Props): JSX.Element {
     if (minimal) {
       return {
         ...MinimalEditorConfig,
+        [CKEDITOR_RESOURCE_UTILS]: {
+          renderResource,
+          openResourcePicker
+        },
         toolbar: {
           ...MinimalEditorConfig.toolbar,
           items: MinimalEditorConfig.toolbar.items.filter(toolbarItemsFilter)

--- a/static/js/lib/ckeditor/CKEditor.ts
+++ b/static/js/lib/ckeditor/CKEditor.ts
@@ -162,7 +162,9 @@ export const MinimalEditorConfig = {
       "numberedList",
       "blockQuote",
       "undo",
-      "redo"
+      "redo",
+      ADD_RESOURCE_LINK,
+      ADD_RESOURCE_EMBED
     ]
   },
   language: "en"

--- a/static/js/lib/ckeditor/CKEditor.ts
+++ b/static/js/lib/ckeditor/CKEditor.ts
@@ -148,12 +148,12 @@ export const MinimalEditorConfig = {
     LinkPlugin,
     ListPlugin,
     ParagraphPlugin,
-    MarkdownListSyntax,
-    Markdown,
     ResourceEmbed,
     ResourcePicker,
     ResourceLink,
     ResourceLinkMarkdownSyntax,
+    MarkdownListSyntax,
+    Markdown,
     LegacyShortcodes
   ],
   toolbar: {

--- a/static/js/lib/ckeditor/CKEditor.ts
+++ b/static/js/lib/ckeditor/CKEditor.ts
@@ -149,7 +149,12 @@ export const MinimalEditorConfig = {
     ListPlugin,
     ParagraphPlugin,
     MarkdownListSyntax,
-    Markdown
+    Markdown,
+    ResourceEmbed,
+    ResourcePicker,
+    ResourceLink,
+    ResourceLinkMarkdownSyntax,
+    LegacyShortcodes
   ],
   toolbar: {
     items: [


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Prerequisite for https://github.com/mitodl/ocw-hugo-projects/issues/185

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/112, we added a "minimal" configuration for CKEditor.  Markdown fields in starter configurations that specify `minimal: true` utilize this config and it hides things like the table controls.  In https://github.com/mitodl/ocw-studio/pull/560, we added the ability to link to resources in the markdown editor.  Currently, you cannot set `minimal: true` and also set the `link` or `embed` properties to allow linking / embedding of pages / resources / whatever inside a markdown editor with `minimal: true`.  This PR changes that behavior so that if both `minimal: true` and `link` or `embed` are set, the markdown editor is initialized with the minimal configuration, but also the link and embed controls specified in the configuration.

#### How should this be manually tested?
 - Clone `ocw-hugo-projects` locally on the `cg/body-description` branch
 - Spin up `ocw-studio` locally on this branch, making sure you are set up to publish to a test organization of your choice
 - If you do not already have a superuser, create one and go to Django admin
 - Inside Django admin, pull up the `ocw-www` and `ocw-course` starters
 - Paste in the contents of the respective starters from your locally cloned `ocw-hugo-projects` on the `cg/body-description` branch
 - If you do not already have test sites created for `ocw-www` and `ocw-course`, create them and add at least one resource to each
 - Open up each resource for editing, and in the description markdown editor you should **not** see the insert table button, but you **should** see the "Add link" button
 - Add a link to a resource or page to your test resource descriptions and save
 - Re-open the resources and ensure that the links are still there
 - Publish your test course to your test org and view the output, make sure you see the `resource_link` written into the markdown for the resource you added the link to in the markdown body
