### PR TITLE
Show publishing api errors in publishing drawer

### DIFF
--- a/static/js/components/PublishDrawer.test.tsx
+++ b/static/js/components/PublishDrawer.test.tsx
@@ -252,50 +252,6 @@ describe("PublishDrawer", () => {
           })
         })
 
-        it("renders an error message if the publish didn't work", async () => {
-          const actionStub = helper.mockPostRequest(
-            siteApiActionUrl
-              .param({
-                name:   website.name,
-                action: api
-              })
-              .toString(),
-            {},
-            500
-          )
-          const { wrapper } = await render()
-          await act(async () => {
-            const onChange = wrapper.find(`#publish-${action}`).prop("onChange")
-            // @ts-expect-error
-            onChange({ target: { checked: true } })
-          })
-          wrapper.update()
-          await act(async () => {
-            wrapper
-              .find("PublishForm")
-              .find(".btn-publish")
-              .simulate("submit")
-          })
-          wrapper.update()
-          expect(wrapper.find(".publish-option-description").text()).toContain(
-            "There was an error publishing the site."
-          )
-          sinon.assert.calledOnceWithExactly(
-            actionStub,
-            `/api/websites/${website.name}/${api}/`,
-            "POST",
-            {
-              body: {
-                url_path: website.url_path
-              },
-              headers:     { "X-CSRFTOKEN": "" },
-              credentials: undefined
-            }
-          )
-          sinon.assert.notCalled(refreshWebsiteStub)
-          sinon.assert.notCalled(toggleVisibilityStub)
-        })
-
         it("publish button sends the expected request", async () => {
           const actionStub = helper.mockPostRequest(
             siteApiActionUrl

--- a/static/js/components/PublishDrawer.test.tsx
+++ b/static/js/components/PublishDrawer.test.tsx
@@ -109,13 +109,13 @@ describe("PublishDrawer", () => {
         it("renders the date and url", async () => {
           const { wrapper } = await render()
           await act(async () => {
-            // @ts-ignore
+            // @ts-expect-error
             wrapper
               .find("input[type='radio']")
-              // @ts-ignore
+              // @ts-expect-error
               .at(idx)
-              // @ts-ignore
-              .prop("onChange")()
+              // @ts-expect-error
+              .prop("onChange")({ target: { checked: true } })
           })
           wrapper.update()
           expect(wrapper.find(".publish-option-description").text()).toContain(
@@ -137,13 +137,13 @@ describe("PublishDrawer", () => {
         it("renders the publish status", async () => {
           const { wrapper } = await render()
           await act(async () => {
-            // @ts-ignore
+            // @ts-expect-error
             wrapper
               .find("input[type='radio']")
-              // @ts-ignore
+              // @ts-expect-error
               .at(idx)
-              // @ts-ignore
-              .prop("onChange")()
+              // @ts-expect-error
+              .prop("onChange")({ target: { checked: true } })
           })
           wrapper.update()
           expect(wrapper.find("PublishStatusIndicator").prop("status")).toBe(
@@ -161,13 +161,13 @@ describe("PublishDrawer", () => {
           website[publishDateField] = null
           const { wrapper } = await render()
           await act(async () => {
-            // @ts-ignore
+            // @ts-expect-error
             wrapper
               .find("input[type='radio']")
-              // @ts-ignore
+              // @ts-expect-error
               .at(idx)
-              // @ts-ignore
-              .prop("onChange")()
+              // @ts-expect-error
+              .prop("onChange")({ target: { checked: true } })
           })
           wrapper.update()
           expect(wrapper.find(".publish-option-description").text()).toContain(
@@ -178,20 +178,19 @@ describe("PublishDrawer", () => {
         it("has an option with the right label", async () => {
           const { wrapper } = await render()
           await act(async () => {
-            // @ts-ignore
+            // @ts-expect-error
             wrapper
               .find("input[type='radio']")
-              // @ts-ignore
+              // @ts-expect-error
               .at(idx)
-              // @ts-ignore
-              .prop("onChange")()
+              // @ts-expect-error
+              .prop("onChange")({ target: { checked: true } })
           })
           wrapper.update()
-          // @ts-ignore
           expect(
             wrapper
               .find(".publish-option label")
-              // @ts-ignore
+              // @ts-expect-error
               .at(idx)
               .text()
           ).toBe(label)
@@ -201,8 +200,9 @@ describe("PublishDrawer", () => {
           website[unpublishedField] = false
           const { wrapper } = await render()
           await act(async () => {
-            // @ts-ignore
-            wrapper.find(`#publish-${action}`).prop("onChange")()
+            const onChange = wrapper.find(`#publish-${action}`).prop("onChange")
+            // @ts-expect-error
+            onChange(({target: { checked: true }}))
           })
           wrapper.update()
           expect(wrapper.find(".btn-publish").prop("disabled")).toBe(true)
@@ -220,8 +220,9 @@ describe("PublishDrawer", () => {
           website[unpublishedField] = true
           const { wrapper } = await render()
           await act(async () => {
-            // @ts-ignore
-            wrapper.find(`#publish-${action}`).prop("onChange")()
+            const onChange = wrapper.find(`#publish-${action}`).prop("onChange")
+            // @ts-expect-error
+            onChange(({target: { checked: true }}))
           })
           wrapper.update()
           expect(wrapper.find(".publish-option-description").text()).toContain(
@@ -255,12 +256,12 @@ describe("PublishDrawer", () => {
           )
           const { wrapper } = await render()
           await act(async () => {
-            // @ts-ignore
-            wrapper.find(`#publish-${action}`).prop("onChange")()
+            const onChange = wrapper.find(`#publish-${action}`).prop("onChange")
+            // @ts-expect-error
+            onChange(({target: { checked: true }}))
           })
           wrapper.update()
           await act(async () => {
-            // @ts-ignore
             wrapper
               .find("PublishForm")
               .find(".btn-publish")
@@ -300,8 +301,9 @@ describe("PublishDrawer", () => {
           )
           const { wrapper } = await render()
           await act(async () => {
-            // @ts-ignore
-            wrapper.find(`#publish-${action}`).prop("onChange")()
+            const onChange = wrapper.find(`#publish-${action}`).prop("onChange")
+            // @ts-expect-error
+            onChange(({target: { checked: true }}))
           })
           wrapper.update()
           expect(
@@ -311,7 +313,6 @@ describe("PublishDrawer", () => {
               .prop("disabled")
           ).toBeFalsy()
           await act(async () => {
-            // @ts-ignore
             wrapper
               .find("PublishForm")
               .find(".btn-publish")

--- a/static/js/components/PublishDrawer.tsx
+++ b/static/js/components/PublishDrawer.tsx
@@ -1,13 +1,12 @@
 import React, { useState } from "react"
 import { Modal, ModalBody, ModalHeader } from "reactstrap"
-import { useStore } from "react-redux"
 import { useMutation } from "redux-query-react"
 import { requestAsync } from "redux-query"
 import moment from "moment"
 import { isEmpty } from "ramda"
 
 import {
-  websiteAction,
+  websitePublishAction,
   websiteDetailRequest,
   WebsitePublishPayload
 } from "../query-configs/websites"
@@ -16,7 +15,127 @@ import PublishStatusIndicator from "./PublishStatusIndicator"
 
 import { Website } from "../types/websites"
 import { PublishForm } from "./forms/PublishForm"
-import { PUBLISH_OPTION_PRODUCTION, PUBLISH_OPTION_STAGING } from "../constants"
+import { PublishingEnv, PublishStatus } from "../constants"
+import { useAppDispatch } from "../hooks/redux"
+
+interface PublishingOptionProps {
+  website: Website
+  publishingEnv: PublishingEnv
+  selected: boolean
+  onSelect: (publishingEnv: PublishingEnv) => void
+  onPublishSuccess: () => void
+}
+interface PublishingInfo {
+  date: string | null
+  status: PublishStatus | null
+  hasUnpublishedChanges: boolean
+  envLabel: string
+}
+
+const getPublishingInfo = (
+  website: Website,
+  publishingEnv: PublishingEnv
+): PublishingInfo => {
+  if (publishingEnv === PublishingEnv.Staging) {
+    return {
+      envLabel:              "Staging",
+      date:                  website.draft_publish_date,
+      status:                website.draft_publish_status,
+      hasUnpublishedChanges: website.has_unpublished_draft
+    }
+  }
+  if (publishingEnv === PublishingEnv.Production) {
+    return {
+      envLabel:              "Production",
+      date:                  website.publish_date,
+      status:                website.live_publish_status,
+      hasUnpublishedChanges: website.has_unpublished_live
+    }
+  }
+  throw new Error("Invalid PublishingEnv")
+}
+
+const PublishingOption: React.FC<PublishingOptionProps> = props => {
+  const { publishingEnv, selected, onSelect, website, onPublishSuccess } = props
+  const publishingInfo = getPublishingInfo(website, publishingEnv)
+  const [error, setError] = useState<null | Record<string, string>>(null)
+
+  const [
+    { isPending },
+    publish
+  ] = useMutation((payload: WebsitePublishPayload) =>
+    websitePublishAction(website.name, publishingEnv, payload)
+  )
+
+  const handlePublish = async (payload: WebsitePublishPayload) => {
+    setError(null)
+    if (isPending) {
+      return
+    }
+    const response = await publish(payload)
+    if (!response) {
+      return
+    } else {
+      if (isErrorStatusCode(response.status)) {
+        setError(response.body)
+      } else {
+        onPublishSuccess()
+      }
+    }
+  }
+
+  return (
+    <div className="publish-option my-2">
+      <div className="d-flex flex-direction-row align-items-center">
+        <input
+          type="radio"
+          id={`publish-${publishingEnv}`}
+          value={publishingEnv}
+          checked={selected}
+          onChange={e => {
+            if (e.target.checked) {
+              onSelect(publishingEnv)
+            }
+          }}
+        />{" "}
+        <label htmlFor={`publish-${publishingEnv}`}>
+          {publishingInfo.envLabel}
+        </label>
+      </div>
+      {selected && (
+        <div className="publish-option-description">
+          Last updated:{" "}
+          {publishingInfo.date ?
+            moment(publishingInfo.date).format("dddd, MMMM D h:mma ZZ") :
+            "never published"}
+          <br />
+          {publishingInfo.hasUnpublishedChanges && (
+            <>
+              <strong>You have unpublished changes.</strong>
+              <br />
+            </>
+          )}
+          {error && (
+            <>
+              <strong className="text-danger">
+                We apologize, there was an error publishing the site. Please try
+                again in a few minutes.
+              </strong>
+              <br />
+            </>
+          )}
+          <PublishForm
+            onSubmit={handlePublish}
+            disabled={!publishingInfo.hasUnpublishedChanges}
+            website={website}
+            option={publishingEnv}
+          />
+          <PublishStatusIndicator status={publishingInfo.status} />
+        </div>
+      )}
+    </div>
+  )
+}
 
 type Props = {
   visibility: boolean
@@ -25,126 +144,17 @@ type Props = {
 }
 export default function PublishDrawer(props: Props): JSX.Element {
   const { visibility, toggleVisibility, website } = props
+  const dispatch = useAppDispatch()
+  const [selectedEnv, setSelectedEnv] = useState(PublishingEnv.Staging)
 
-  const [
-    { isPending: previewIsPending },
-    previewWebsite
-  ] = useMutation((payload: WebsitePublishPayload) =>
-    websiteAction(website.name, "preview", payload)
-  )
-
-  const [
-    { isPending: publishIsPending },
-    publishWebsite
-  ] = useMutation((payload: WebsitePublishPayload) =>
-    websiteAction(website.name, "publish", payload)
-  )
-  const store = useStore()
-  const [publishOption, setPublishOption] = useState<string>(
-    PUBLISH_OPTION_STAGING
-  )
-  const [errorStaging, setErrorStaging] = useState<boolean>(false)
-  const [errorProduction, setErrorProduction] = useState<boolean>(false)
-
-  const onPreview = async (payload: WebsitePublishPayload) => {
-    setErrorStaging(false)
-    if (previewIsPending) {
-      return
-    }
-    const response = await previewWebsite(payload)
-    if (!response) {
-      return
-    } else {
-      if (isErrorStatusCode(response.status)) {
-        setErrorStaging(true)
-      } else {
-        // refresh
-        toggleVisibility()
-        await store.dispatch(requestAsync(websiteDetailRequest(website.name)))
-      }
-    }
+  const onPublishSuccess = async () => {
+    toggleVisibility()
+    await dispatch(requestAsync(websiteDetailRequest(website.name)))
   }
 
-  const onPublish = async (payload: WebsitePublishPayload) => {
-    setErrorProduction(false)
-    if (publishIsPending) {
-      return
-    }
-    const response = await publishWebsite(payload)
-    if (!response) {
-      return
-    } else {
-      if (isErrorStatusCode(response.status)) {
-        setErrorProduction(true)
-      } else {
-        // refresh
-        toggleVisibility()
-        store.dispatch(requestAsync(websiteDetailRequest(website.name)))
-      }
-    }
-  }
-
-  const renderOption = (option: string) => {
-    const isStaging = option === PUBLISH_OPTION_STAGING
-    const label = isStaging ? "Staging" : "Production"
-    const publish = isStaging ? onPreview : onPublish
-    const error = isStaging ? errorStaging : errorProduction
-    const publishDate = isStaging ?
-      website.draft_publish_date :
-      website.publish_date
-    const hasUnpublishedChanges = isStaging ?
-      website.has_unpublished_draft :
-      website.has_unpublished_live
-    const publishStatus = isStaging ?
-      website.draft_publish_status :
-      website.live_publish_status
-
-    return (
-      <div className="publish-option my-2">
-        <div className="d-flex flex-direction-row align-items-center">
-          <input
-            type="radio"
-            id={`publish-${option}`}
-            value={option}
-            checked={publishOption === option}
-            onChange={() => setPublishOption(option)}
-          />{" "}
-          <label htmlFor={`publish-${option}`}>{label}</label>
-        </div>
-        {publishOption === option ? (
-          <div className="publish-option-description">
-            Last updated:{" "}
-            {publishDate ?
-              moment(publishDate).format("dddd, MMMM D h:mma ZZ") :
-              "never published"}
-            <br />
-            {hasUnpublishedChanges ? (
-              <>
-                <strong>You have unpublished changes.</strong>
-                <br />
-              </>
-            ) : null}
-            {error ? (
-              <>
-                <strong className="text-danger">
-                  We apologize, there was an error publishing the site. Please
-                  try again in a few minutes.
-                </strong>
-                <br />
-              </>
-            ) : null}
-            <PublishForm
-              onSubmit={publish}
-              disabled={!hasUnpublishedChanges}
-              website={website}
-              option={option}
-            ></PublishForm>
-            <PublishStatusIndicator status={publishStatus} />
-          </div>
-        ) : null}
-      </div>
-    )
-  }
+  const userEnvs = website.is_admin ?
+    [PublishingEnv.Staging, PublishingEnv.Production] :
+    [PublishingEnv.Staging]
 
   return (
     <Modal
@@ -154,9 +164,17 @@ export default function PublishDrawer(props: Props): JSX.Element {
     >
       <ModalHeader toggle={toggleVisibility}>Publish your site</ModalHeader>
       <ModalBody>
-        {renderOption(PUBLISH_OPTION_STAGING)}
-        {website.is_admin ? renderOption(PUBLISH_OPTION_PRODUCTION) : null}
-        {website.content_warnings && !isEmpty(website.content_warnings) ? (
+        {userEnvs.map(publishingEnv => (
+          <PublishingOption
+            key={publishingEnv}
+            website={website}
+            publishingEnv={publishingEnv}
+            selected={selectedEnv === publishingEnv}
+            onPublishSuccess={onPublishSuccess}
+            onSelect={setSelectedEnv}
+          />
+        ))}
+        {website.content_warnings && !isEmpty(website.content_warnings) && (
           <div className="publish-warnings pt-2">
             <strong className="text-danger">
               This site has issues that could affect publishing output.
@@ -167,7 +185,7 @@ export default function PublishDrawer(props: Props): JSX.Element {
               ))}
             </ul>
           </div>
-        ) : null}
+        )}
       </ModalBody>
     </Modal>
   )

--- a/static/js/components/forms/PublishForm.test.tsx
+++ b/static/js/components/forms/PublishForm.test.tsx
@@ -3,7 +3,7 @@ import sinon, { SinonStub } from "sinon"
 import { shallow } from "enzyme"
 import { ValidationError } from "yup"
 
-import { PublishForm, websiteUrlValidation } from "./PublishForm"
+import PublishForm, { websiteUrlValidation } from "./PublishForm"
 import { PublishingEnv } from "../../constants"
 import { assertInstanceOf, defaultFormikChildProps } from "../../test_util"
 import { makeWebsiteDetail } from "../../util/factories/websites"

--- a/static/js/components/forms/PublishForm.test.tsx
+++ b/static/js/components/forms/PublishForm.test.tsx
@@ -5,8 +5,7 @@ import { ValidationError } from "yup"
 
 import { PublishForm, websiteUrlValidation } from "./PublishForm"
 import {
-  PUBLISH_OPTION_PRODUCTION,
-  PUBLISH_OPTION_STAGING
+  PublishingEnv
 } from "../../constants"
 import { assertInstanceOf, defaultFormikChildProps } from "../../test_util"
 import { makeWebsiteDetail } from "../../util/factories/websites"
@@ -21,7 +20,7 @@ describe("PublishForm", () => {
         onSubmit={onSubmitStub}
         disabled={false}
         website={website}
-        option={PUBLISH_OPTION_STAGING}
+        option={PublishingEnv.Staging}
         {...props}
       />
     )
@@ -83,7 +82,7 @@ describe("PublishForm", () => {
     ).toBeTruthy()
   })
 
-  it.each([PUBLISH_OPTION_STAGING, PUBLISH_OPTION_PRODUCTION])(
+  it.each([PublishingEnv.Staging, PublishingEnv.Production])(
     "shows a URL link instead of a field if website is published",
     option => {
       website.publish_date = "2020-01-01"
@@ -99,7 +98,7 @@ describe("PublishForm", () => {
           .exists()
       ).toBeFalsy()
       expect(form.find("a").prop("href")).toEqual(
-        option === PUBLISH_OPTION_STAGING ? website.draft_url : website.live_url
+        option === PublishingEnv.Staging ? website.draft_url : website.live_url
       )
     }
   )
@@ -109,7 +108,7 @@ describe("PublishForm", () => {
     website.url_path = "courses/my-url-fall-2028"
     const form = renderInnerForm(
       { isSubmitting: false, status: "whatever" },
-      { option: PUBLISH_OPTION_PRODUCTION }
+      { option: PublishingEnv.Production }
     )
     //expect(form.find("a").exists()).toBeFalsy()
     expect(form.find("span").text()).toEqual(`${website.live_url}`)

--- a/static/js/components/forms/PublishForm.test.tsx
+++ b/static/js/components/forms/PublishForm.test.tsx
@@ -4,9 +4,7 @@ import { shallow } from "enzyme"
 import { ValidationError } from "yup"
 
 import { PublishForm, websiteUrlValidation } from "./PublishForm"
-import {
-  PublishingEnv
-} from "../../constants"
+import { PublishingEnv } from "../../constants"
 import { assertInstanceOf, defaultFormikChildProps } from "../../test_util"
 import { makeWebsiteDetail } from "../../util/factories/websites"
 

--- a/static/js/components/forms/PublishForm.tsx
+++ b/static/js/components/forms/PublishForm.tsx
@@ -11,11 +11,13 @@ export interface SiteFormValues {
   url_path: string // eslint-disable-line camelcase
 }
 
+export type OnSubmitPublish = (
+  values: SiteFormValues,
+  formikHelpers: FormikHelpers<SiteFormValues>
+) => void
+
 type Props = {
-  onSubmit: (
-    values: SiteFormValues,
-    formikHelpers: FormikHelpers<SiteFormValues>
-  ) => void
+  onSubmit: OnSubmitPublish
   website: Website
   option: string
   disabled: boolean
@@ -33,7 +35,7 @@ export const websiteUrlValidation = yup.object().shape({
     )
 })
 
-export const PublishForm: React.FC<Props> = ({
+const PublishForm: React.FC<Props> = ({
   onSubmit,
   website,
   disabled,
@@ -85,7 +87,7 @@ export const PublishForm: React.FC<Props> = ({
               <br />
             </div>
           )}
-          <div className="form-group d-flex justify-content-end">
+          <div className="form-group d-flex justify-content-between flex-row-reverse align-items-center">
             <button
               type="submit"
               className="btn btn-publish cyan-button-outline d-flex flex-direction-row align-items-center"
@@ -93,13 +95,17 @@ export const PublishForm: React.FC<Props> = ({
             >
               Publish
             </button>
+            {status && (
+              // Status is being used to store non-field errors
+              <div className="form-error">
+                <strong>{status}</strong>
+              </div>
+            )}
           </div>
-          {status && (
-            // Status is being used to store non-field errors
-            <div className="form-error">{status}</div>
-          )}
         </Form>
       )}
     </Formik>
   )
 }
+
+export default PublishForm

--- a/static/js/components/forms/PublishForm.tsx
+++ b/static/js/components/forms/PublishForm.tsx
@@ -5,7 +5,7 @@ import * as yup from "yup"
 import { FormError } from "./FormError"
 
 import { Website } from "../../types/websites"
-import { PUBLISH_OPTION_STAGING } from "../../constants"
+import { PublishingEnv } from "../../constants"
 
 export interface SiteFormValues {
   url_path: string // eslint-disable-line camelcase
@@ -47,7 +47,7 @@ export const PublishForm: React.FC<Props> = ({
   }
 
   const fullUrl =
-    option === PUBLISH_OPTION_STAGING ? website.draft_url : website.live_url
+    option === PublishingEnv.Staging ? website.draft_url : website.live_url
   const partialUrl = website.url_path ?
     fullUrl.slice(0, fullUrl.lastIndexOf("/")) :
     fullUrl
@@ -64,7 +64,7 @@ export const PublishForm: React.FC<Props> = ({
             <div className="form-group">
               <label htmlFor="url_path">URL: </label>{" "}
               {website.url_path ? (
-                website.publish_date || option === PUBLISH_OPTION_STAGING ? (
+                website.publish_date || option === PublishingEnv.Staging ? (
                   <a href={fullUrl} target="_blank" rel="noreferrer">
                     {fullUrl}{" "}
                   </a>

--- a/static/js/constants.ts
+++ b/static/js/constants.ts
@@ -199,11 +199,13 @@ export const GOOGLE_DRIVE_SYNC_PROCESSING_STATES = [
 
 export const IS_A_REQUIRED_FIELD = "is a required field"
 
-export const PUBLISH_OPTION_STAGING = "staging"
-export const PUBLISH_OPTION_PRODUCTION = "production"
-
 export enum WebsiteStarterStatus {
   Default = "default",
   Active = "active",
   Inactive = "inactive"
+}
+
+export enum PublishingEnv {
+  Staging = "staging",
+  Production = "production"
 }

--- a/static/js/query-configs/websites.ts
+++ b/static/js/query-configs/websites.ts
@@ -40,6 +40,7 @@ import {
   WebsiteStarter,
   WebsiteStatus
 } from "../types/websites"
+import { PublishingEnv } from "../constants"
 
 export type WebsiteDetails = Record<string, Website>
 
@@ -158,20 +159,24 @@ export const websiteMutation = (payload: NewWebsitePayload): QueryConfig => ({
   }
 })
 
-export const websiteAction = (
+export const websitePublishAction = (
   name: string,
-  action: string,
+  publishingEnv: PublishingEnv,
   payload: WebsitePublishPayload
-): QueryConfig => ({
-  url:     siteApiActionUrl.param({ name, action }).toString(),
-  options: {
-    method:  "POST",
-    headers: {
-      "X-CSRFTOKEN": getCookie("csrftoken") || ""
-    }
-  },
-  body: payload
-})
+): QueryConfig => {
+  const action =
+    publishingEnv === PublishingEnv.Production ? "publish" : "preview"
+  return {
+    url:     siteApiActionUrl.param({ name, action }).toString(),
+    options: {
+      method:  "POST",
+      headers: {
+        "X-CSRFTOKEN": getCookie("csrftoken") || ""
+      }
+    },
+    body: payload
+  }
+}
 
 export const websiteStartersRequest = (): QueryConfig => ({
   url:       startersApi.toString(),

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -126,7 +126,9 @@ class WebsiteUrlSerializer(serializers.ModelSerializer):
             .exclude(pk=self.instance.pk)
             .exists()
         ):
-            raise serializers.ValidationError("The given website URL is already in use.")
+            raise serializers.ValidationError(
+                "The given website URL is already in use."
+            )
         return value
 
     def update(self, instance, validated_data):

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -126,7 +126,7 @@ class WebsiteUrlSerializer(serializers.ModelSerializer):
             .exclude(pk=self.instance.pk)
             .exists()
         ):
-            raise serializers.ValidationError("The website URL is not unique")
+            raise serializers.ValidationError("The given website URL is already in use.")
         return value
 
     def update(self, instance, validated_data):

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -703,7 +703,9 @@ def test_website_url_serializer_duplicate_url_path(ocw_site, parsed_site_config)
     data = {"url_path": new_url_path}
     serializer = WebsiteUrlSerializer(ocw_site, data)
     assert serializer.is_valid() is False
-    assert serializer.errors.get("url_path") == ["The given website URL is already in use."]
+    assert serializer.errors.get("url_path") == [
+        "The given website URL is already in use."
+    ]
 
 
 def test_website_url_serializer_url_path_published(ocw_site):

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -703,7 +703,7 @@ def test_website_url_serializer_duplicate_url_path(ocw_site, parsed_site_config)
     data = {"url_path": new_url_path}
     serializer = WebsiteUrlSerializer(ocw_site, data)
     assert serializer.is_valid() is False
-    assert serializer.errors.get("url_path") == ["The website URL is not unique"]
+    assert serializer.errors.get("url_path") == ["The given website URL is already in use."]
 
 
 def test_website_url_serializer_url_path_published(ocw_site):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1366 

#### What's this PR do?
This PR adds field-specific error messages to the publishing drawer, building on #1316 

#### How should this be manually tested?
1. Create a new site
2. Try to publish the site using a url that is already in use
3. You should see a specific error near the error field.
4. If you want to check that generic / unexpected errors only show the "overall" error message... I am not sure the best way to trigger that. You could change the publishing URL in `websitePublishAction` code from `"preview"` to something invalid.

#### Screenshots (if appropriate)
Before / After
<img width="350" alt="Screen Shot 2022-05-19 at 1 48 04 PM" src="https://user-images.githubusercontent.com/9010790/169367878-82d0b620-a1bd-447b-b461-1198ce03b0b7.png"> <img width="350" alt="Screen Shot 2022-05-19 at 1 46 54 PM" src="https://user-images.githubusercontent.com/9010790/169367904-d87510e0-533e-4f38-9606-8e396b30d722.png">
