### PR TITLE
courses short_id shown in course list

### DIFF
--- a/static/js/components/widgets/RelationField.test.tsx
+++ b/static/js/components/widgets/RelationField.test.tsx
@@ -103,7 +103,7 @@ describe("RelationField", () => {
 
     websites = makeWebsites()
     useWebsiteSelectOptions.mockReturnValue({
-      options:     formatWebsiteOptions(websites, "title", "short_id", "name"),
+      options:     formatWebsiteOptions(websites, "title", "", "name"),
       loadOptions: jest.fn()
     })
   })

--- a/static/js/components/widgets/RelationField.test.tsx
+++ b/static/js/components/widgets/RelationField.test.tsx
@@ -103,7 +103,7 @@ describe("RelationField", () => {
 
     websites = makeWebsites()
     useWebsiteSelectOptions.mockReturnValue({
-      options:     formatWebsiteOptions(websites, "title", "name"),
+      options:     formatWebsiteOptions(websites, "title", "short_id", "name"),
       loadOptions: jest.fn()
     })
   })
@@ -193,7 +193,7 @@ describe("RelationField", () => {
           .find("SelectField")
           .at(0)
           .prop("defaultOptions")
-      ).toEqual(formatWebsiteOptions(websites, "title", "name"))
+      ).toEqual(formatWebsiteOptions(websites, "title", "", "name"))
     })
 
     it.each(["ocw-www", null])(

--- a/static/js/components/widgets/RelationField.test.tsx
+++ b/static/js/components/widgets/RelationField.test.tsx
@@ -103,7 +103,7 @@ describe("RelationField", () => {
 
     websites = makeWebsites()
     useWebsiteSelectOptions.mockReturnValue({
-      options:     formatWebsiteOptions(websites, "name"),
+      options:     formatWebsiteOptions(websites, "title", "name"),
       loadOptions: jest.fn()
     })
   })
@@ -193,7 +193,7 @@ describe("RelationField", () => {
           .find("SelectField")
           .at(0)
           .prop("defaultOptions")
-      ).toEqual(formatWebsiteOptions(websites, "name"))
+      ).toEqual(formatWebsiteOptions(websites, "title", "name"))
     })
 
     it.each(["ocw-www", null])(

--- a/static/js/components/widgets/RelationField.tsx
+++ b/static/js/components/widgets/RelationField.tsx
@@ -119,7 +119,7 @@ export default function RelationField(props: Props): JSX.Element {
   const {
     options: websiteOptions,
     loadOptions: loadWebsiteOptions
-  } = useWebsiteSelectOptions("title", "name")
+  } = useWebsiteSelectOptions("title", "short_id", "name")
   const [focusedWebsite, setFocusedWebsite] = useState<string | null>(null)
   const setFocusedWebsiteCB = useCallback(
     (event: ChangeEvent<HTMLSelectElement>) => {

--- a/static/js/components/widgets/RelationField.tsx
+++ b/static/js/components/widgets/RelationField.tsx
@@ -119,7 +119,7 @@ export default function RelationField(props: Props): JSX.Element {
   const {
     options: websiteOptions,
     loadOptions: loadWebsiteOptions
-  } = useWebsiteSelectOptions("title", "short_id", "name")
+  } = useWebsiteSelectOptions("title", "", "name")
   const [focusedWebsite, setFocusedWebsite] = useState<string | null>(null)
   const setFocusedWebsiteCB = useCallback(
     (event: ChangeEvent<HTMLSelectElement>) => {

--- a/static/js/components/widgets/RelationField.tsx
+++ b/static/js/components/widgets/RelationField.tsx
@@ -119,7 +119,7 @@ export default function RelationField(props: Props): JSX.Element {
   const {
     options: websiteOptions,
     loadOptions: loadWebsiteOptions
-  } = useWebsiteSelectOptions("name")
+  } = useWebsiteSelectOptions("title", "name")
   const [focusedWebsite, setFocusedWebsite] = useState<string | null>(null)
   const setFocusedWebsiteCB = useCallback(
     (event: ChangeEvent<HTMLSelectElement>) => {

--- a/static/js/components/widgets/WebsiteCollectionField.test.tsx
+++ b/static/js/components/widgets/WebsiteCollectionField.test.tsx
@@ -34,7 +34,8 @@ describe("WebsiteCollectionField", () => {
       value: []
     })
     websites = makeWebsites()
-    websiteOptions = websiteHooks.formatWebsiteOptions(websites, "name")
+    websiteOptions = formatWebsiteOptions(websites, "title", "name")
+    // @ts-ignore
     useWebsiteSelectOptions.mockReturnValue({
       options:     websiteOptions,
       loadOptions: jest.fn()
@@ -47,7 +48,7 @@ describe("WebsiteCollectionField", () => {
 
   it("should pass published=true to the useWebsiteSelectOptions", async () => {
     await render()
-    expect(useWebsiteSelectOptions).toHaveBeenCalledWith("url_path", true)
+    expect(useWebsiteSelectOptions).toBeCalledWith("short_id", "url_path", true)
   })
 
   it("should pass things down to SortableSelect", async () => {

--- a/static/js/components/widgets/WebsiteCollectionField.test.tsx
+++ b/static/js/components/widgets/WebsiteCollectionField.test.tsx
@@ -14,6 +14,7 @@ jest.mock("../../hooks/websites", () => ({
   ...jest.requireActual("../../hooks/websites"),
   useWebsiteSelectOptions: jest.fn()
 }))
+const { formatWebsiteOptions } = websiteHooks
 const useWebsiteSelectOptions = jest.mocked(
   websiteHooks.useWebsiteSelectOptions
 )
@@ -34,8 +35,7 @@ describe("WebsiteCollectionField", () => {
       value: []
     })
     websites = makeWebsites()
-    websiteOptions = formatWebsiteOptions(websites, "title", "name")
-    // @ts-ignore
+    websiteOptions = formatWebsiteOptions(websites, "title", "short_id", "name")
     useWebsiteSelectOptions.mockReturnValue({
       options:     websiteOptions,
       loadOptions: jest.fn()
@@ -48,7 +48,12 @@ describe("WebsiteCollectionField", () => {
 
   it("should pass published=true to the useWebsiteSelectOptions", async () => {
     await render()
-    expect(useWebsiteSelectOptions).toBeCalledWith("short_id", "url_path", true)
+    expect(useWebsiteSelectOptions).toHaveBeenCalledWith(
+      "title",
+      "short_id",
+      "url_path",
+      true
+    )
   })
 
   it("should pass things down to SortableSelect", async () => {

--- a/static/js/components/widgets/WebsiteCollectionField.test.tsx
+++ b/static/js/components/widgets/WebsiteCollectionField.test.tsx
@@ -14,7 +14,7 @@ jest.mock("../../hooks/websites", () => ({
   ...jest.requireActual("../../hooks/websites"),
   useWebsiteSelectOptions: jest.fn()
 }))
-const { formatWebsiteOptions } = websiteHooks
+
 const useWebsiteSelectOptions = jest.mocked(
   websiteHooks.useWebsiteSelectOptions
 )
@@ -35,7 +35,12 @@ describe("WebsiteCollectionField", () => {
       value: []
     })
     websites = makeWebsites()
-    websiteOptions = formatWebsiteOptions(websites, "title", "short_id", "name")
+    websiteOptions = websiteHooks.formatWebsiteOptions(
+      websites,
+      "title",
+      "short_id",
+      "name"
+    )
     useWebsiteSelectOptions.mockReturnValue({
       options:     websiteOptions,
       loadOptions: jest.fn()

--- a/static/js/components/widgets/WebsiteCollectionField.test.tsx
+++ b/static/js/components/widgets/WebsiteCollectionField.test.tsx
@@ -38,7 +38,7 @@ describe("WebsiteCollectionField", () => {
     websiteOptions = websiteHooks.formatWebsiteOptions(
       websites,
       "title",
-      "short_id",
+      "",
       "name"
     )
     useWebsiteSelectOptions.mockReturnValue({

--- a/static/js/components/widgets/WebsiteCollectionField.tsx
+++ b/static/js/components/widgets/WebsiteCollectionField.tsx
@@ -36,22 +36,29 @@ export default function WebsiteCollectionField(props: Props): JSX.Element {
     [onChange, websiteMap, name]
   )
 
+  const optionsWithoutShortID = useWebsiteSelectOptions(
+    "title",
+    "",
+    "url_path",
+    true
+  ).options
+
+  useEffect(() => {
+    setWebsiteMap(cur => {
+      const newMap = new Map(cur)
+      optionsWithoutShortID.forEach(({ value, label }) => {
+        newMap.set(value, label)
+      })
+      return newMap
+    })
+  }, [optionsWithoutShortID, setWebsiteMap])
+
   const { options, loadOptions } = useWebsiteSelectOptions(
     "title",
     "short_id",
     "url_path",
     true
   )
-
-  useEffect(() => {
-    setWebsiteMap(cur => {
-      const newMap = new Map(cur)
-      options.forEach(({ value, label }) => {
-        newMap.set(value, label)
-      })
-      return newMap
-    })
-  }, [options, setWebsiteMap])
 
   const isOptionDisabled = useCallback(
     (option: Option) => {

--- a/static/js/components/widgets/WebsiteCollectionField.tsx
+++ b/static/js/components/widgets/WebsiteCollectionField.tsx
@@ -37,6 +37,7 @@ export default function WebsiteCollectionField(props: Props): JSX.Element {
   )
 
   const { options, loadOptions } = useWebsiteSelectOptions(
+    "title",
     "short_id",
     "url_path",
     true

--- a/static/js/components/widgets/WebsiteCollectionField.tsx
+++ b/static/js/components/widgets/WebsiteCollectionField.tsx
@@ -36,7 +36,11 @@ export default function WebsiteCollectionField(props: Props): JSX.Element {
     [onChange, websiteMap, name]
   )
 
-  const { options, loadOptions } = useWebsiteSelectOptions("url_path", true)
+  const { options, loadOptions } = useWebsiteSelectOptions(
+    "short_id",
+    "url_path",
+    true
+  )
 
   useEffect(() => {
     setWebsiteMap(cur => {

--- a/static/js/hooks/websites.test.ts
+++ b/static/js/hooks/websites.test.ts
@@ -45,6 +45,25 @@ describe("website hooks", () => {
         { credentials: "include" }
       )
       expect(result.current.options).toEqual(
+        formatWebsiteOptions(websites, "title", "", "uuid")
+      )
+    })
+
+    it("should fetch options with additional Label on startup by default", async () => {
+      const { result, waitForNextUpdate } = renderHook(() =>
+        useWebsiteSelectOptions("title", "short_id", "uuid")
+      )
+      await act(async () => {
+        await waitForNextUpdate()
+      })
+      expect(global.fetch).toHaveBeenCalledWith(
+        siteApiListingUrl
+          .query({ offset: 0 })
+          .param({ search: "" })
+          .toString(),
+        { credentials: "include" }
+      )
+      expect(result.current.options).toEqual(
         formatWebsiteOptions(websites, "title", "short_id", "uuid")
       )
     })
@@ -55,7 +74,7 @@ describe("website hooks", () => {
         published
       )} if you pass the option`, async () => {
         const { waitForNextUpdate } = renderHook(() =>
-          useWebsiteSelectOptions("title", "short_id", "uuid", published)
+          useWebsiteSelectOptions("title", "", "uuid", published)
         )
         await act(async () => {
           await waitForNextUpdate()
@@ -88,7 +107,7 @@ describe("website hooks", () => {
         { credentials: "include" }
       )
       expect(cb).toHaveBeenCalledWith(
-        formatWebsiteOptions(websites, "title", "short_id", "uuid")
+        formatWebsiteOptions(websites, "title", "", "uuid")
       )
     })
   })

--- a/static/js/hooks/websites.test.ts
+++ b/static/js/hooks/websites.test.ts
@@ -45,7 +45,7 @@ describe("website hooks", () => {
         { credentials: "include" }
       )
       expect(result.current.options).toEqual(
-        formatWebsiteOptions(websites, "title", "uuid")
+        formatWebsiteOptions(websites, "title", "short_id", "uuid")
       )
     })
 
@@ -55,7 +55,7 @@ describe("website hooks", () => {
         published
       )} if you pass the option`, async () => {
         const { waitForNextUpdate } = renderHook(() =>
-          useWebsiteSelectOptions("title", "uuid", published)
+          useWebsiteSelectOptions("title", "short_id", "uuid", published)
         )
         await act(async () => {
           await waitForNextUpdate()
@@ -87,7 +87,9 @@ describe("website hooks", () => {
           .toString(),
         { credentials: "include" }
       )
-      expect(cb).toBeCalledWith(formatWebsiteOptions(websites, "title", "uuid"))
+      expect(cb).toHaveBeenCalledWith(
+        formatWebsiteOptions(websites, "title", "short_id", "uuid")
+      )
     })
   })
 })

--- a/static/js/hooks/websites.test.ts
+++ b/static/js/hooks/websites.test.ts
@@ -45,7 +45,7 @@ describe("website hooks", () => {
         { credentials: "include" }
       )
       expect(result.current.options).toEqual(
-        formatWebsiteOptions(websites, "uuid")
+        formatWebsiteOptions(websites, "title", "uuid")
       )
     })
 
@@ -55,7 +55,7 @@ describe("website hooks", () => {
         published
       )} if you pass the option`, async () => {
         const { waitForNextUpdate } = renderHook(() =>
-          useWebsiteSelectOptions("uuid", published)
+          useWebsiteSelectOptions("title", "uuid", published)
         )
         await act(async () => {
           await waitForNextUpdate()
@@ -87,7 +87,7 @@ describe("website hooks", () => {
           .toString(),
         { credentials: "include" }
       )
-      expect(cb).toHaveBeenCalledWith(formatWebsiteOptions(websites, "uuid"))
+      expect(cb).toBeCalledWith(formatWebsiteOptions(websites, "title", "uuid"))
     })
   })
 })

--- a/static/js/hooks/websites.ts
+++ b/static/js/hooks/websites.ts
@@ -71,7 +71,7 @@ export const formatWebsiteOptions = (
 ): Option[] =>
   websites.map(website => ({
     label: additionalLabelField ?
-      `${website[labelField]} (${website["short_id"]})` :
+      `${website[labelField]} (${website[additionalLabelField]})` :
       website[labelField],
     value: website[valueField]
   }))

--- a/static/js/hooks/websites.ts
+++ b/static/js/hooks/websites.ts
@@ -54,15 +54,19 @@ export function useWebsiteContent(
  * Format an array of Website objects into an array of Option
  * objects, which can be passed to a Select field.
  *
+ * The `labelField` argument indicates what field of the Website
+ * you'd like to show to the user.
+ *
  * The `valueField` argument indicates what field on the Website
  * you'd like to use for a user-readable label.
  */
 export const formatWebsiteOptions = (
   websites: Website[],
+  labelField: string,
   valueField: string
 ): Option[] =>
   websites.map(website => ({
-    label: website.title,
+    label: website[labelField],
     value: website[valueField]
   }))
 
@@ -82,6 +86,7 @@ interface ReturnProps {
  * which can be used to fetch new options.
  */
 export function useWebsiteSelectOptions(
+  labelField = "title",
   valueField = "uuid",
   published: boolean | undefined = undefined
 ): ReturnProps {
@@ -114,7 +119,7 @@ export function useWebsiteSelectOptions(
       }
       const json: WebsiteListingResponse = await response.json()
       const { results } = json
-      const options = formatWebsiteOptions(results, valueField)
+      const options = formatWebsiteOptions(results, labelField, valueField)
       setOptions(current =>
         uniqBy(option => option.value, [...current, ...options])
       )
@@ -122,7 +127,7 @@ export function useWebsiteSelectOptions(
         callback(options)
       }
     },
-    [setOptions, valueField, published]
+    [setOptions, labelField, valueField, published]
   )
 
   // on startup we want to fetch options initially so defaultOptions can

--- a/static/js/hooks/websites.ts
+++ b/static/js/hooks/websites.ts
@@ -57,16 +57,22 @@ export function useWebsiteContent(
  * The `labelField` argument indicates what field of the Website
  * you'd like to show to the user.
  *
+ * The `additionalLabelField` argument indicates the field of the Website
+ * shown in brackets next to `labelField`. Only shown if its not empty.
+ *
  * The `valueField` argument indicates what field on the Website
  * you'd like to use for a user-readable label.
  */
 export const formatWebsiteOptions = (
   websites: Website[],
   labelField: string,
+  additionalLabelField: string,
   valueField: string
 ): Option[] =>
   websites.map(website => ({
-    label: website[labelField],
+    label: additionalLabelField ?
+      `${website[labelField]} (${website["short_id"]})` :
+      website[labelField],
     value: website[valueField]
   }))
 
@@ -87,6 +93,7 @@ interface ReturnProps {
  */
 export function useWebsiteSelectOptions(
   labelField = "title",
+  additionalLabelField = "",
   valueField = "uuid",
   published: boolean | undefined = undefined
 ): ReturnProps {
@@ -119,7 +126,12 @@ export function useWebsiteSelectOptions(
       }
       const json: WebsiteListingResponse = await response.json()
       const { results } = json
-      const options = formatWebsiteOptions(results, labelField, valueField)
+      const options = formatWebsiteOptions(
+        results,
+        labelField,
+        additionalLabelField,
+        valueField
+      )
       setOptions(current =>
         uniqBy(option => option.value, [...current, ...options])
       )
@@ -127,7 +139,7 @@ export function useWebsiteSelectOptions(
         callback(options)
       }
     },
-    [setOptions, labelField, valueField, published]
+    [setOptions, labelField, additionalLabelField, valueField, published]
   )
 
   // on startup we want to fetch options initially so defaultOptions can


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/393

#### What's this PR do?
- Adds `short_id` in brackets next to `title` in the courses dropdown while adding/editing course lists so the user doesn't see duplicate listings. 

#### How should this be manually tested?
- Checkout this branch.
- In `/sites`, go to `ocw-www`
- Add a new course list or edit an existing one.
- Open the courses dropdown and verify that the format is `title (short_id)`
- Select course(s).
- Save the course list and verify that the course list is successfully saved.

#### Screenshots 
<img width="412" alt="image" src="https://user-images.githubusercontent.com/93309234/220926116-9a5611a8-dff4-4cfe-ac8b-3e5c2cf3bf82.png">

<img width="524" alt="image" src="https://user-images.githubusercontent.com/93309234/220926200-5fc741e3-69a4-4d36-a256-2a96a308e24c.png">



#### Related Issue:
https://github.com/mitodl/ocw-studio/issues/1265