### PR TITLE
Show proper urls on the Publish Drawer

### DIFF
--- a/static/js/components/forms/PublishForm.test.tsx
+++ b/static/js/components/forms/PublishForm.test.tsx
@@ -104,6 +104,17 @@ describe("PublishForm", () => {
     }
   )
 
+  it("shows a text-only live url for unpublished site", () => {
+    website.publish_date = null
+    website.url_path = "courses/my-url-fall-2028"
+    const form = renderInnerForm(
+      { isSubmitting: false, status: "whatever" },
+      { option: PUBLISH_OPTION_PRODUCTION }
+    )
+    //expect(form.find("a").exists()).toBeFalsy()
+    expect(form.find("span").text()).toEqual(`${website.live_url}`)
+  })
+
   describe("validation", () => {
     it("rejects an empty url", async () => {
       try {

--- a/static/js/components/forms/PublishForm.tsx
+++ b/static/js/components/forms/PublishForm.tsx
@@ -64,9 +64,13 @@ export const PublishForm: React.FC<Props> = ({
             <div className="form-group">
               <label htmlFor="url_path">URL: </label>{" "}
               {website.url_path ? (
-                <a href={website.draft_url} target="_blank" rel="noreferrer">
-                  {website.draft_url}{" "}
-                </a>
+                website.publish_date || option === PUBLISH_OPTION_STAGING ? (
+                  <a href={fullUrl} target="_blank" rel="noreferrer">
+                    {fullUrl}{" "}
+                  </a>
+                ) : (
+                  <span>{`${fullUrl}`}</span>
+                )
               ) : (
                 <span>{`${partialUrl}`}</span>
               )}

--- a/static/js/components/forms/PublishForm.tsx
+++ b/static/js/components/forms/PublishForm.tsx
@@ -64,7 +64,9 @@ export const PublishForm: React.FC<Props> = ({
             <div className="form-group">
               <label htmlFor="url_path">URL: </label>{" "}
               {website.url_path ? (
-                <a href={website.draft_url}>{website.draft_url}</a>
+                <a href={website.draft_url} target="_blank" rel="noreferrer">
+                  {website.draft_url}{" "}
+                </a>
               ) : (
                 <span>{`${partialUrl}`}</span>
               )}

--- a/websites/models.py
+++ b/websites/models.py
@@ -202,7 +202,7 @@ class Website(TimestampedModel):
             else settings.OCW_STUDIO_DRAFT_URL
         )
         url_path = self.url_path
-        if url_path:
+        if url_path and self.name != settings.ROOT_WEBSITE_NAME:
             return urljoin(base_url, url_path)
         else:
             return urljoin(base_url, self.get_site_root_path())

--- a/websites/models_test.py
+++ b/websites/models_test.py
@@ -1,6 +1,4 @@
 """ Website models tests """
-from urllib.parse import urljoin
-
 import pytest
 from django.core.files.uploadedfile import SimpleUploadedFile
 from mitol.common.utils import now_in_utc
@@ -204,7 +202,9 @@ def test_website_get_full_url(
     starter.save()
     settings.ROOT_WEBSITE_NAME = name if is_home else "test-home"
     website = WebsiteFactory.create(name=name, starter=starter, url_path=expected_path)
-    assert website.get_full_url(version) == urljoin(expected_domain, expected_path)
+    assert website.get_full_url(version) == "/".join(
+        section for section in [expected_domain, expected_path] if section
+    )
 
 
 def test_website_get_full_url_no_starter():


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #1376 
Closes #1379

#### What's this PR do?
Sets the full url for the ocw-www home page properly.
Shows the live URL as non-linking text when publishing to production for the first time.

#### How should this be manually tested?
- Go to `http://localhost:8043/sites/ocw-www` and open the publish drawer.  Observe the link and click on it to verify it goes to the right place, and does so in a new browser tab.
- Create a new site.  Open the publish drawer, select a url path, publish to draft (it will fail, that's ok).  Open the publish drawer again, click the link above the URL field, it should open in a new drawer.
- Open the publish drawer, choose production this time.  The URL above the input field should be the live URL, not draft, but text only - no link
- In django admin, set `publish_date` to some value for the above site.  Go back to the publish drawer, now the live url should be a working link.

