### PR TITLE
Always set publish fields in publish_website function

### DIFF
--- a/content_sync/api.py
+++ b/content_sync/api.py
@@ -141,18 +141,13 @@ def publish_website(  # pylint: disable=too-many-arguments
             }
         else:
             update_kwargs = {}
-        if (
-            getattr(website, f"{version}_publish_status") != PUBLISH_STATUS_NOT_STARTED
-            or getattr(website, f"{version}_publish_status_updated_on") is None
-        ):
-            # Need to update additional fields
-            update_kwargs = {
-                f"{version}_publish_status": PUBLISH_STATUS_NOT_STARTED,
-                f"{version}_publish_status_updated_on": now_in_utc(),
-                f"{version}_last_published_by": None,
-                f"has_unpublished_{version}": False,
-                **update_kwargs,
-            }
+        # Need to update additional fields
+        update_kwargs = {
+            f"{version}_publish_status": PUBLISH_STATUS_NOT_STARTED,
+            f"{version}_publish_status_updated_on": now_in_utc(),
+            f"has_unpublished_{version}": False,
+            **update_kwargs,
+        }
     except:  # pylint:disable=bare-except
         update_kwargs = {
             f"{version}_publish_status": PUBLISH_STATUS_ERRORED,
@@ -161,6 +156,7 @@ def publish_website(  # pylint: disable=too-many-arguments
         }
         raise
     finally:
+        log.error(update_kwargs)
         Website.objects.filter(name=name).update(**update_kwargs)
 
 

--- a/content_sync/api.py
+++ b/content_sync/api.py
@@ -156,7 +156,6 @@ def publish_website(  # pylint: disable=too-many-arguments
         }
         raise
     finally:
-        log.error(update_kwargs)
         Website.objects.filter(name=name).update(**update_kwargs)
 
 

--- a/content_sync/api_test.py
+++ b/content_sync/api_test.py
@@ -217,6 +217,7 @@ def test_publish_website(  # pylint:disable=redefined-outer-name,too-many-argume
     settings.PREPUBLISH_ACTIONS = prepublish_actions
     website = WebsiteFactory.create(publish_date=publish_date)
     setattr(website, f"{version}_publish_status", status)
+    setattr(website, f"has_unpublished_{version}", status == PUBLISH_STATUS_NOT_STARTED)
     if status:
         setattr(website, f"{version}_publish_status_updated_on", now_in_utc())
     website.save()
@@ -253,9 +254,7 @@ def test_publish_website(  # pylint:disable=redefined-outer-name,too-many-argume
         pipeline.unpause_pipeline.assert_not_called()
         assert getattr(website, f"latest_build_id_{version}") is None
     assert getattr(website, f"{version}_publish_status") == PUBLISH_STATUS_NOT_STARTED
-    assert getattr(website, f"has_unpublished_{version}") is (
-        status == PUBLISH_STATUS_NOT_STARTED
-    )
+    assert getattr(website, f"has_unpublished_{version}") is False
     assert getattr(website, f"{version}_last_published_by") is None
     assert getattr(website, f"{version}_publish_status_updated_on") is not None
     if len(prepublish_actions) > 0 and prepublish:


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes #1372

#### What's this PR do?
Always set the `publish_status_*` and `has_unpublished_*` fields when running the `publish_website` function.  

#### How should this be manually tested?
Tests should pass.
Run this in a shell for a site with recent changes, then verify that `has_unpublished_draft` is `False`:
```python
from content_sync.api import *
publish_website(<website.name>, "draft", prepublish=False, trigger_pipeline=False)
```

