### PR TITLE
Management command & github api tweak to ensure checksums are current

### DIFF
--- a/content_sync/apis/github.py
+++ b/content_sync/apis/github.py
@@ -327,10 +327,10 @@ class GithubApiWrapper:
 
         for sync_state in unsynced_states.iterator():
             content = sync_state.content
-            current_checksum = content.calculate_checksum()
             filepath = get_destination_filepath(content, self.site_config)
             if not filepath:
                 continue
+            current_checksum = content.calculate_checksum()
             if sync_state.current_checksum != current_checksum:
                 # sync_state.current_checksum is out of date
                 sync_state.current_checksum = current_checksum

--- a/content_sync/management/commands/update_checksums.py
+++ b/content_sync/management/commands/update_checksums.py
@@ -1,0 +1,76 @@
+"""Modify any ContentSyncState.current_checksum values that are out of date"""
+import json
+import logging
+
+from django.core.management import BaseCommand
+from django.core.paginator import Paginator
+from django.db.models import Q
+from tqdm import tqdm
+
+from content_sync.models import ContentSyncState
+
+
+log = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Modify any ContentSyncState.current_checksum values that are out of date
+    """
+
+    help = __doc__
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--filter-json",
+            dest="filter_json",
+            default=None,
+            help="If specified, only process sync states for websites specified in a JSON file",
+        )
+        parser.add_argument(
+            "-f",
+            "--filter",
+            dest="filter",
+            default="",
+            help="If specified, only process sync states for websites with matching names or short_ids",
+        )
+
+    def handle(self, *args, **options):
+        """
+        Iterate through all ContentSyncState objects, calculate checksum, and
+        assign to current_checksum value if different.
+        """
+        sync_states = (
+            ContentSyncState.objects.all().prefetch_related("content").order_by("id")
+        )
+        filter_json = options["filter_json"]
+        if filter_json:
+            with open(filter_json) as input_file:
+                filter_list = json.load(input_file)
+        else:
+            filter_list = [
+                name.strip() for name in options["filter"].split(",") if name
+            ]
+        if filter_list:
+            sync_states = sync_states.filter(
+                Q(content__website__name__in=filter_list)
+                | Q(content__website__short_id__in=filter_list)
+            )
+
+        page_size = 100
+        pages = Paginator(sync_states, page_size)
+        num_updated = 0
+        self.stdout.write(
+            f"Comparing checksums for {sync_states.count()} ContentSyncState objects"
+        )
+        with tqdm(total=pages.count) as progress:
+            for page in pages:
+                for sync_state in page:
+                    checksum = sync_state.content.calculate_checksum()
+                    if checksum != sync_state.current_checksum:
+                        sync_state.current_checksum = checksum
+                        sync_state.save()
+                        num_updated += 1
+                    progress.update()
+
+        self.stdout.write(f"ContentSyncStates updated: {num_updated}")

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -131,15 +131,11 @@ class WebsiteUrlSerializer(serializers.ModelSerializer):
         return value
 
     def update(self, instance, validated_data):
-        """ Update the website url_path"""
+        """Update the website url_path"""
         url_path = validated_data.get("url_path")
         with transaction.atomic():
             instance.url_path = instance.assemble_full_url_path(url_path)
             instance.save()
-            # Force a backend resync of all associated content with file paths
-            ContentSyncState.objects.filter(
-                content__in=instance.websitecontent_set.filter(file__isnull=False)
-            ).update(synced_checksum=None)
 
     class Meta:
         model = Website

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -14,7 +14,6 @@ from rest_framework.exceptions import ValidationError
 
 from content_sync.api import create_website_backend, update_website_backend
 from content_sync.constants import VERSION_DRAFT, VERSION_LIVE
-from content_sync.models import ContentSyncState
 from gdrive_sync.api import gdrive_root_url, is_gdrive_enabled
 from gdrive_sync.tasks import create_gdrive_folders
 from main.serializers import RequestUserSerializerMixin


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #1387

#### What's this PR do?
Adds a management command to update any out-of-date `ContentSyncState.current_checksum` values
Modifies the `GithubApiWrapper.upsert_content_files_for_user` function to skip any files whose calculated checksum is the same as the `synced checksum` (and update the `current_checksum` to match).

#### How should this be manually tested?
On master branch:
- Create a site and some content.
- In a shell or django admin, set the `current_checksum` value for one of the site content's `ContentSyncState` objects to "fake"
- Publish the site.  Check the repo commits on the main branch, there will be a commit with 0 files.

On this branch:
- Publish the site again.  Check the repo commits on the main branch, there should not be an additional commit with 0 files.
- Check the `WebsiteContent.current_checksum` value for the object you manually modified earlier, it should now be the same value as the synced_checksum value.
- Run `manage.py update_checksums`, it should complete without errors and maybe find some more `ContentSyncState` objects with out of date checksums that it will update.
