### PR TITLE
Option to delete existing pipelines in management commands

### DIFF
--- a/content_sync/api.py
+++ b/content_sync/api.py
@@ -36,11 +36,11 @@ def get_sync_backend(website: Website) -> BaseSyncBackend:
 
 
 @is_publish_pipeline_enabled
-def get_general_pipeline(api: Optional[object] = None) -> BasePipeline:
+def get_pipeline_api() -> BasePipeline:
     """ Get the base backend pipeline """
     return import_string(
-        f"content_sync.pipelines.{settings.CONTENT_SYNC_PIPELINE_BACKEND}.GeneralPipeline"
-    )(api=api)
+        f"content_sync.pipelines.{settings.CONTENT_SYNC_PIPELINE_BACKEND}.PipelineApi"
+    )()
 
 
 @is_publish_pipeline_enabled

--- a/content_sync/api.py
+++ b/content_sync/api.py
@@ -36,7 +36,15 @@ def get_sync_backend(website: Website) -> BaseSyncBackend:
 
 
 @is_publish_pipeline_enabled
-def get_sync_pipeline(website: Website, api: Optional[object] = None) -> BasePipeline:
+def get_general_pipeline(api: Optional[object] = None) -> BasePipeline:
+    """ Get the base backend pipeline """
+    return import_string(
+        f"content_sync.pipelines.{settings.CONTENT_SYNC_PIPELINE_BACKEND}.GeneralPipeline"
+    )(api=api)
+
+
+@is_publish_pipeline_enabled
+def get_site_pipeline(website: Website, api: Optional[object] = None) -> BasePipeline:
     """ Get the configured sync publishing pipeline """
     return import_string(
         f"content_sync.pipelines.{settings.CONTENT_SYNC_PIPELINE_BACKEND}.SitePipeline"
@@ -129,7 +137,7 @@ def publish_website(  # pylint: disable=too-many-arguments
             backend.merge_backend_live()
 
         if trigger_pipeline and settings.CONTENT_SYNC_PIPELINE_BACKEND:
-            pipeline = get_sync_pipeline(website, api=pipeline_api)
+            pipeline = get_site_pipeline(website, api=pipeline_api)
             # Always upsert pipeline in case the site url path changed,
             # unless it's been published to production (url path permanent).
             if not website.publish_date:

--- a/content_sync/api_test.py
+++ b/content_sync/api_test.py
@@ -23,7 +23,7 @@ def mock_api_funcs(settings, mocker):
     settings.CONTENT_SYNC_PIPELINE_BACKEND = "concourse"
     return SimpleNamespace(
         mock_get_backend=mocker.patch("content_sync.api.get_sync_backend"),
-        mock_get_pipeline=mocker.patch("content_sync.api.get_sync_pipeline"),
+        mock_get_pipeline=mocker.patch("content_sync.api.get_site_pipeline"),
         mock_import_string=mocker.patch("content_sync.api.import_string"),
     )
 
@@ -185,12 +185,21 @@ def test_sync_github_website_starters(mocker):
 
 
 @pytest.mark.parametrize("pipeline_api", [None, {}])
-def test_get_sync_pipeline(settings, mocker, pipeline_api):
-    """ Verify that get_sync_pipeline() imports the pipeline class based on settings.py """
+def test_get_general_pipeline(settings, mocker, pipeline_api):
+    """ Verify that get_general_pipeline() imports the pipeline class based on settings.py """
+    settings.CONTENT_SYNC_PIPELINE_BACKEND = "concourse"
+    import_string_mock = mocker.patch("content_sync.pipelines.concourse.GeneralPipeline")
+    api.get_general_pipeline(api=pipeline_api)
+    import_string_mock.assert_any_call(api=pipeline_api)
+
+
+@pytest.mark.parametrize("pipeline_api", [None, {}])
+def test_get_site_pipeline(settings, mocker, pipeline_api):
+    """ Verify that get_site_pipeline() imports the pipeline class based on settings.py """
     settings.CONTENT_SYNC_PIPELINE_BACKEND = "concourse"
     import_string_mock = mocker.patch("content_sync.pipelines.concourse.SitePipeline")
     website = WebsiteFactory.create()
-    api.get_sync_pipeline(website, api=pipeline_api)
+    api.get_site_pipeline(website, api=pipeline_api)
     import_string_mock.assert_any_call(website, api=pipeline_api)
 
 
@@ -288,7 +297,13 @@ def test_get_theme_assets_pipeline_no_backend(settings):
     assert api.get_theme_assets_pipeline() is None
 
 
-def test_get_sync_pipeline_no_backend(settings):
-    """get_sync_pipeline should return None if no backend is specified"""
+def test_get_site_pipeline_no_backend(settings):
+    """get_site_pipeline should return None if no backend is specified"""
     settings.CONTENT_SYNC_PIPELINE_BACKEND = None
-    assert api.get_sync_pipeline(WebsiteFactory.create()) is None
+    assert api.get_site_pipeline(WebsiteFactory.create()) is None
+
+
+def test_get_general_pipeline_no_backend(settings):
+    """get_general_pipeline should return None if no backend is specified"""
+    settings.CONTENT_SYNC_PIPELINE_BACKEND = None
+    assert api.get_general_pipeline() is None

--- a/content_sync/api_test.py
+++ b/content_sync/api_test.py
@@ -184,13 +184,12 @@ def test_sync_github_website_starters(mocker):
     mock_task.assert_called_once_with(*args, **kwargs)
 
 
-@pytest.mark.parametrize("pipeline_api", [None, {}])
-def test_get_general_pipeline(settings, mocker, pipeline_api):
-    """ Verify that get_general_pipeline() imports the pipeline class based on settings.py """
+def test_get_pipeline_api(settings, mocker):
+    """ Verify that get_pipeline_api() imports the pipeline api class based on settings.py """
     settings.CONTENT_SYNC_PIPELINE_BACKEND = "concourse"
-    import_string_mock = mocker.patch("content_sync.pipelines.concourse.GeneralPipeline")
-    api.get_general_pipeline(api=pipeline_api)
-    import_string_mock.assert_any_call(api=pipeline_api)
+    import_string_mock = mocker.patch("content_sync.pipelines.concourse.PipelineApi")
+    api.get_pipeline_api()
+    import_string_mock.assert_called_once_with()
 
 
 @pytest.mark.parametrize("pipeline_api", [None, {}])
@@ -303,7 +302,7 @@ def test_get_site_pipeline_no_backend(settings):
     assert api.get_site_pipeline(WebsiteFactory.create()) is None
 
 
-def test_get_general_pipeline_no_backend(settings):
+def test_get_pipeline_api_no_backend(settings):
     """get_general_pipeline should return None if no backend is specified"""
     settings.CONTENT_SYNC_PIPELINE_BACKEND = None
-    assert api.get_general_pipeline() is None
+    assert api.get_pipeline_api() is None

--- a/content_sync/management/commands/backpopulate_pipelines.py
+++ b/content_sync/management/commands/backpopulate_pipelines.py
@@ -60,8 +60,8 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "-d",
-            "--delete",
-            dest="delete",
+            "--delete-all",
+            dest="delete_all",
             action="store_true",
             help="Delete all existing site pipelines first",
         )
@@ -81,9 +81,9 @@ class Command(BaseCommand):
         create_backend = options["create_backend"]
         is_verbose = options["verbosity"] > 1
         unpause = options["unpause"]
-        delete = options["delete"]
+        delete_all = options["delete_all"]
 
-        if delete:
+        if delete_all:
             self.stdout.write("Deleting all existing site pipelines first")
             api = get_pipeline_api()
             if api:

--- a/content_sync/management/commands/backpopulate_pipelines.py
+++ b/content_sync/management/commands/backpopulate_pipelines.py
@@ -90,7 +90,7 @@ class Command(BaseCommand):
                 api.delete_pipelines(names=[VERSION_LIVE, VERSION_DRAFT])
                 self.stdout.write("Deleted all site pipelines")
             else:
-                self.stdout.error("No general pipeline configured")
+                self.stdout.error("No pipeline api configured")
 
         if filter_str:
             website_qset = Website.objects.filter(

--- a/content_sync/management/commands/backpopulate_pipelines.py
+++ b/content_sync/management/commands/backpopulate_pipelines.py
@@ -1,11 +1,11 @@
 """ Backpopulate website pipelines"""
-from content_sync.constants import VERSION_LIVE, VERSION_DRAFT
 from django.conf import settings
 from django.core.management import BaseCommand, CommandError
 from django.db.models import Q
 from mitol.common.utils.datetime import now_in_utc
 
-from content_sync.api import get_general_pipeline
+from content_sync.api import get_pipeline_api
+from content_sync.constants import VERSION_DRAFT, VERSION_LIVE
 from content_sync.tasks import upsert_pipelines
 from websites.models import Website
 
@@ -85,9 +85,9 @@ class Command(BaseCommand):
 
         if delete:
             self.stdout.write("Deleting all existing site pipelines first")
-            base_pipeline = get_general_pipeline()
-            if base_pipeline:
-                base_pipeline.delete_pipelines(names=[VERSION_LIVE, VERSION_DRAFT])
+            api = get_pipeline_api()
+            if api:
+                api.delete_pipelines(names=[VERSION_LIVE, VERSION_DRAFT])
                 self.stdout.write("Deleted all site pipelines")
             else:
                 self.stdout.error("No general pipeline configured")

--- a/content_sync/management/commands/upsert_mass_build_pipeline.py
+++ b/content_sync/management/commands/upsert_mass_build_pipeline.py
@@ -23,8 +23,8 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "-d",
-            "--delete",
-            dest="delete",
+            "--delete-all",
+            dest="delete_all",
             action="store_true",
             help="Delete existing mass publish pipelines first",
         )
@@ -38,10 +38,10 @@ class Command(BaseCommand):
         self.stdout.write("Creating mass build pipelines")
 
         unpause = options["unpause"]
-        delete = options["delete"]
+        delete_all = options["delete_all"]
         start = now_in_utc()
 
-        if delete:
+        if delete_all:
             self.stdout.write("Deleting existing mass build pipelines first")
             api = get_pipeline_api()
             if api:

--- a/content_sync/management/commands/upsert_mass_build_pipeline.py
+++ b/content_sync/management/commands/upsert_mass_build_pipeline.py
@@ -3,8 +3,9 @@ from django.conf import settings
 from django.core.management import BaseCommand, CommandError
 from mitol.common.utils.datetime import now_in_utc
 
-from content_sync.api import get_mass_build_sites_pipeline
+from content_sync.api import get_mass_build_sites_pipeline, get_pipeline_api
 from content_sync.constants import VERSION_DRAFT, VERSION_LIVE
+from content_sync.pipelines.base import BaseMassBuildSitesPipeline
 
 
 class Command(BaseCommand):
@@ -20,6 +21,13 @@ class Command(BaseCommand):
             action="store_true",
             help="Unpause the pipelines after creating/updating them",
         )
+        parser.add_argument(
+            "-d",
+            "--delete",
+            dest="delete",
+            action="store_true",
+            help="Delete existing mass publish pipelines first",
+        )
 
     def handle(self, *args, **options):
 
@@ -30,8 +38,18 @@ class Command(BaseCommand):
         self.stdout.write("Creating mass build pipelines")
 
         unpause = options["unpause"]
-
+        delete = options["delete"]
         start = now_in_utc()
+
+        if delete:
+            self.stdout.write("Deleting existing mass build pipelines first")
+            api = get_pipeline_api()
+            if api:
+                api.delete_pipelines(names=[BaseMassBuildSitesPipeline.PIPELINE_NAME])
+                self.stdout.write("Deleted all mass build pipelines")
+            else:
+                self.stdout.error("No pipeline api configured")
+
         for version in (VERSION_DRAFT, VERSION_LIVE):
             pipeline = get_mass_build_sites_pipeline(version)
             pipeline.upsert_pipeline()

--- a/content_sync/management/commands/upsert_site_removal_pipeline.py
+++ b/content_sync/management/commands/upsert_site_removal_pipeline.py
@@ -22,8 +22,8 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "-d",
-            "--delete",
-            dest="delete",
+            "--delete-all",
+            dest="delete_all",
             action="store_true",
             help="Delete existing site removal pipelines first",
         )
@@ -37,10 +37,10 @@ class Command(BaseCommand):
         self.stdout.write("Creating unpublished sites removal pipeline")
 
         unpause = options["unpause"]
-        delete = options["delete"]
+        delete_all = options["delete_all"]
         start = now_in_utc()
 
-        if delete:
+        if delete_all:
             self.stdout.write(
                 "Delete existing unpublished sites removal pipeline first"
             )

--- a/content_sync/management/commands/upsert_theme_assets_pipeline.py
+++ b/content_sync/management/commands/upsert_theme_assets_pipeline.py
@@ -1,9 +1,10 @@
 """ Management command for backpopulating the theme pipeline """
 from django.conf import settings
 from django.core.management import BaseCommand, CommandError
-from django.db.models import Q
 from mitol.common.utils.datetime import now_in_utc
 
+from content_sync.api import get_pipeline_api
+from content_sync.pipelines.base import BaseThemeAssetsPipeline
 from content_sync.tasks import upsert_theme_assets_pipeline
 
 
@@ -20,6 +21,13 @@ class Command(BaseCommand):
             action="store_true",
             help="Unpause the pipelines after creating/updating them",
         )
+        parser.add_argument(
+            "-d",
+            "--delete",
+            dest="delete",
+            action="store_true",
+            help="Delete existing theme assets pipelines first",
+        )
 
     def handle(self, *args, **options):
 
@@ -31,15 +39,26 @@ class Command(BaseCommand):
 
         is_verbose = options["verbosity"] > 1
         unpause = options["unpause"]
+        delete = options["delete"]
 
         if is_verbose:
             self.stdout.write(f"Upserting theme assets pipeline")
 
         start = now_in_utc()
+
+        if delete:
+            self.stdout.write(
+                "Delete existing unpublished sites removal pipeline first"
+            )
+            api = get_pipeline_api()
+            if api:
+                api.delete_pipelines(names=[BaseThemeAssetsPipeline.PIPELINE_NAME])
+                self.stdout.write("Deleted unpublished sites removal pipeline")
+            else:
+                self.stdout.error("No pipeline api configured")
+
         task = upsert_theme_assets_pipeline.delay(unpause=unpause)
-
         self.stdout.write(f"Started celery task {task} to upsert theme assets pipeline")
-
         self.stdout.write("Waiting on task...")
 
         result = task.get()

--- a/content_sync/management/commands/upsert_theme_assets_pipeline.py
+++ b/content_sync/management/commands/upsert_theme_assets_pipeline.py
@@ -23,8 +23,8 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "-d",
-            "--delete",
-            dest="delete",
+            "--delete-all",
+            dest="delete_all",
             action="store_true",
             help="Delete existing theme assets pipelines first",
         )
@@ -39,14 +39,14 @@ class Command(BaseCommand):
 
         is_verbose = options["verbosity"] > 1
         unpause = options["unpause"]
-        delete = options["delete"]
+        delete_all = options["delete_all"]
 
         if is_verbose:
             self.stdout.write(f"Upserting theme assets pipeline")
 
         start = now_in_utc()
 
-        if delete:
+        if delete_all:
             self.stdout.write("Delete existing theme assets pipelines first")
             api = get_pipeline_api()
             if api:

--- a/content_sync/management/commands/upsert_theme_assets_pipeline.py
+++ b/content_sync/management/commands/upsert_theme_assets_pipeline.py
@@ -47,13 +47,11 @@ class Command(BaseCommand):
         start = now_in_utc()
 
         if delete:
-            self.stdout.write(
-                "Delete existing unpublished sites removal pipeline first"
-            )
+            self.stdout.write("Delete existing theme assets pipelines first")
             api = get_pipeline_api()
             if api:
                 api.delete_pipelines(names=[BaseThemeAssetsPipeline.PIPELINE_NAME])
-                self.stdout.write("Deleted unpublished sites removal pipeline")
+                self.stdout.write("Deleted theme assets pipeline")
             else:
                 self.stdout.error("No pipeline api configured")
 

--- a/content_sync/pipelines/base.py
+++ b/content_sync/pipelines/base.py
@@ -1,5 +1,20 @@
 """ Sync abstract base """
 import abc
+from typing import List
+
+
+class BasePipelineApi(abc.ABC):
+    """ Base class for a pipeline API"""
+
+    @abc.abstractmethod
+    def list_pipelines(self, names: List[str] = None):
+        """Retrieve a list of pipelines"""
+        ...
+
+    @abc.abstractmethod
+    def delete_pipelines(self, names: List[str] = None):
+        """Delete a list of pipelines"""
+        ...
 
 
 class BasePipeline(abc.ABC):
@@ -46,20 +61,6 @@ class BasePipeline(abc.ABC):
     def pause_pipeline(self, pipeline_name: str):
         """
         Called to pause a website pipeline.
-        """
-        ...
-
-    @abc.abstractmethod
-    def delete_pipelines(self, **kwargs):
-        """
-        Called to delete pipelines.
-        """
-        ...
-
-    @abc.abstractmethod
-    def list_pipelines(self, **kwargs):
-        """
-        Called to list pipelines.
         """
         ...
 

--- a/content_sync/pipelines/base.py
+++ b/content_sync/pipelines/base.py
@@ -49,6 +49,24 @@ class BasePipeline(abc.ABC):
         """
         ...
 
+    @abc.abstractmethod
+    def delete_pipelines(self, **kwargs):
+        """
+        Called to delete pipelines.
+        """
+        ...
+
+    @abc.abstractmethod
+    def list_pipelines(self, **kwargs):
+        """
+        Called to list pipelines.
+        """
+        ...
+
+
+class BaseGeneralPipeline(BasePipeline):
+    """ Base class for general pipelines """
+
 
 class BaseSitePipeline(BasePipeline):
     """ Base class for site-specific publishing """

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -109,7 +109,7 @@ def test_api_get_with_headers(mocker, mock_auth, stream, iterator):
     mock_text = '[{"test": "output"}]' if iterator else '{"test": "output"}'
     stream_output = ["yielded"]
     mocker.patch(
-        "content_sync.pipelines.concourse.BaseConcourseApi.iter_sse_stream",
+        "content_sync.pipelines.concourse.Api.iter_sse_stream",
         return_value=stream_output,
     )
     mock_response = mocker.Mock(
@@ -138,7 +138,7 @@ def test_api_put(mocker, mock_auth, headers, status_code, ok_response):
         status_code=status_code, headers={"X-Test": "header_value"}
     )
     mocker.patch(
-        "content_sync.pipelines.concourse.BaseConcourseApi._is_response_ok",
+        "content_sync.pipelines.concourse.Api._is_response_ok",
         return_value=ok_response,
     )
     mock_put = mocker.patch(
@@ -170,7 +170,7 @@ def test_api_delete(mocker, mock_auth, status_code, ok_response):
         status_code=status_code, headers={"X-Test": "header_value"}
     )
     mocker.patch(
-        "content_sync.pipelines.concourse.BaseConcourseApi._is_response_ok",
+        "content_sync.pipelines.concourse.Api._is_response_ok",
         return_value=ok_response,
     )
     mock_delete = mocker.patch(
@@ -191,7 +191,7 @@ def test_get_pipelines(settings, mocker, mock_auth, names):
     """The correct list of pipelines should be returned"""
     settings.CONCOURSE_TEAM = "team1"
     mocker.patch(
-        "content_sync.pipelines.concourse.BaseConcourseApi.list_pipelines",
+        "content_sync.pipelines.concourse.Api.list_pipelines",
         return_value=PIPELINES_LIST,
     )
     api = PipelineApi()
@@ -205,7 +205,7 @@ def test_delete_pipelines(settings, mocker, mock_auth, names):
     """The correct list of pipelines should be deleted"""
     settings.CONCOURSE_TEAM = "team1"
     mocker.patch(
-        "content_sync.pipelines.concourse.BaseConcourseApi.list_pipelines",
+        "content_sync.pipelines.concourse.Api.list_pipelines",
         return_value=PIPELINES_LIST,
     )
     mock_api_delete = mocker.patch(

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -161,7 +161,7 @@ def test_api_put(mocker, mock_auth, headers, status_code, ok_response):
     assert mock_auth.call_count == 1 if ok_response else 2
 
 
-@pytest.mark.parametrize("status_code", [201, 403])
+@pytest.mark.parametrize("status_code", [200, 403])
 @pytest.mark.parametrize("ok_response", [True, False])
 def test_api_delete(mocker, mock_auth, status_code, ok_response):
     """ PipelineApi.delete function should work as expected """

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -13,11 +13,11 @@ from content_sync.pipelines.base import (
     BaseUnpublishedSiteRemovalPipeline,
 )
 from content_sync.pipelines.concourse import (
-    ConcourseApi,
     MassBuildSitesPipeline,
+    PipelineApi,
     SitePipeline,
     ThemeAssetsPipeline,
-    UnpublishedSiteRemovalPipeline, GeneralPipeline,
+    UnpublishedSiteRemovalPipeline,
 )
 from websites.constants import STARTER_SOURCE_GITHUB, STARTER_SOURCE_LOCAL
 from websites.factories import WebsiteFactory, WebsiteStarterFactory
@@ -34,53 +34,63 @@ AUTH_URLS = [
 
 
 PIPELINES_LIST = [
-    {'id': 1,
-     'name': VERSION_DRAFT,
-     'instance_vars': {'site': 'test-site-1'},
-     'paused': False,
-     'public': False,
-     'archived': False,
-     'team_name': 'team1',
-     'last_updated': 1652878975},
-    {'id': 2,
-     'name': VERSION_DRAFT,
-     'instance_vars': {'site': 'test-site-2'},
-     'paused': False,
-     'public': False,
-     'archived': False,
-     'team_name': 'team1',
-     'last_updated': 1652878976},
-    {'id': 3,
-     'name': VERSION_LIVE,
-     'instance_vars': {'site': 'test-site-1'},
-     'paused': False,
-     'public': False,
-     'archived': False,
-     'team_name': 'team1',
-     'last_updated': 1652878975},
-    {'id': 4,
-     'name': VERSION_LIVE,
-     'instance_vars': {'site': 'test-site-2'},
-     'paused': False,
-     'public': False,
-     'archived': False,
-     'team_name': 'team1',
-     'last_updated': 1652878976},
-    {'id': 5,
-     'name': "something_else",
-     'instance_vars': {'site': 'test-site-other1'},
-     'paused': False,
-     'public': False,
-     'archived': False,
-     'team_name': 'team1',
-     'last_updated': 1652878976},
+    {
+        "id": 1,
+        "name": VERSION_DRAFT,
+        "instance_vars": {"site": "test-site-1"},
+        "paused": False,
+        "public": False,
+        "archived": False,
+        "team_name": "team1",
+        "last_updated": 1652878975,
+    },
+    {
+        "id": 2,
+        "name": VERSION_DRAFT,
+        "instance_vars": {"site": "test-site-2"},
+        "paused": False,
+        "public": False,
+        "archived": False,
+        "team_name": "team1",
+        "last_updated": 1652878976,
+    },
+    {
+        "id": 3,
+        "name": VERSION_LIVE,
+        "instance_vars": {"site": "test-site-1"},
+        "paused": False,
+        "public": False,
+        "archived": False,
+        "team_name": "team1",
+        "last_updated": 1652878975,
+    },
+    {
+        "id": 4,
+        "name": VERSION_LIVE,
+        "instance_vars": {"site": "test-site-2"},
+        "paused": False,
+        "public": False,
+        "archived": False,
+        "team_name": "team1",
+        "last_updated": 1652878976,
+    },
+    {
+        "id": 5,
+        "name": "something_else",
+        "instance_vars": {"site": "test-site-other1"},
+        "paused": False,
+        "public": False,
+        "archived": False,
+        "team_name": "team1",
+        "last_updated": 1652878976,
+    },
 ]
 
 
 @pytest.fixture
 def mock_auth(mocker):
     """Mock the concourse api auth method"""
-    mocker.patch("content_sync.pipelines.concourse.ConcourseApi.auth")
+    mocker.patch("content_sync.pipelines.concourse.PipelineApi.auth")
 
 
 @pytest.fixture
@@ -95,7 +105,7 @@ def pipeline_settings(settings):
 @pytest.mark.parametrize("stream", [True, False])
 @pytest.mark.parametrize("iterator", [True, False])
 def test_api_get_with_headers(mocker, mock_auth, stream, iterator):
-    """ ConcourseApi.get_with_headers function should work as expected """
+    """ PipelineApi.get_with_headers function should work as expected """
     mock_text = '[{"test": "output"}]' if iterator else '{"test": "output"}'
     stream_output = ["yielded"]
     mocker.patch(
@@ -109,7 +119,7 @@ def test_api_get_with_headers(mocker, mock_auth, stream, iterator):
         "content_sync.pipelines.concourse.requests.get", return_value=mock_response
     )
     url_path = "/api/v1/teams/myteam/pipelines/draft/config?vars={site=mypipeline}"
-    api = ConcourseApi("http://test.edu", "test", "test", "myteam")
+    api = PipelineApi("http://test.edu", "test", "test", "myteam")
     result, headers = api.get_with_headers(url_path, stream=stream, iterator=iterator)
     mock_get.assert_called_once_with(
         f"http://test.edu{url_path}", headers=mocker.ANY, stream=stream
@@ -122,8 +132,8 @@ def test_api_get_with_headers(mocker, mock_auth, stream, iterator):
 @pytest.mark.parametrize("status_code", [200, 401])
 @pytest.mark.parametrize("ok_response", [True, False])
 def test_api_put(mocker, mock_auth, headers, status_code, ok_response):
-    """ ConcourseApi.put_with_headers function should work as expected """
-    mock_auth = mocker.patch("content_sync.pipelines.concourse.ConcourseApi.auth")
+    """ PipelineApi.put_with_headers function should work as expected """
+    mock_auth = mocker.patch("content_sync.pipelines.concourse.PipelineApi.auth")
     mock_response = mocker.Mock(
         status_code=status_code, headers={"X-Test": "header_value"}
     )
@@ -135,7 +145,7 @@ def test_api_put(mocker, mock_auth, headers, status_code, ok_response):
         "content_sync.pipelines.concourse.requests.put", return_value=mock_response
     )
     url_path = "/api/v1/teams/myteam/pipelines/draft/config?vars={site=mypipeline}"
-    api = ConcourseApi("http://test.edu", "test", "test", "myteam")
+    api = PipelineApi("http://test.edu", "test", "test", "myteam")
     data = {"test": "value"}
     assert api.put_with_headers(url_path, data=data, headers=headers) is (
         status_code == 200
@@ -149,6 +159,67 @@ def test_api_put(mocker, mock_auth, headers, status_code, ok_response):
         assert kwargs["headers"][key] == value
         assert kwargs["data"] == data
     assert mock_auth.call_count == 1 if ok_response else 2
+
+
+@pytest.mark.parametrize("status_code", [201, 403])
+@pytest.mark.parametrize("ok_response", [True, False])
+def test_api_delete(mocker, mock_auth, status_code, ok_response):
+    """ PipelineApi.delete function should work as expected """
+    mock_auth = mocker.patch("content_sync.pipelines.concourse.PipelineApi.auth")
+    mock_response = mocker.Mock(
+        status_code=status_code, headers={"X-Test": "header_value"}
+    )
+    mocker.patch(
+        "content_sync.pipelines.concourse.BaseConcourseApi._is_response_ok",
+        return_value=ok_response,
+    )
+    mock_delete = mocker.patch(
+        "content_sync.pipelines.concourse.requests.delete", return_value=mock_response
+    )
+    url_path = "/api/v1/teams/myteam/pipelines/draft?vars={site=mypipeline}"
+    api = PipelineApi("http://test.edu", "test", "test", "myteam")
+    data = {"test": "value"}
+    assert api.delete(url_path, data=data) is (status_code == 200)
+    mock_delete.assert_any_call(
+        f"http://test.edu{url_path}", data=data, headers=mocker.ANY
+    )
+    assert mock_auth.call_count == 1 if ok_response else 2
+
+
+@pytest.mark.parametrize("names", [None, [VERSION_DRAFT, VERSION_LIVE]])
+def test_get_pipelines(settings, mocker, mock_auth, names):
+    """The correct list of pipelines should be returned"""
+    settings.CONCOURSE_TEAM = "team1"
+    mocker.patch(
+        "content_sync.pipelines.concourse.BaseConcourseApi.list_pipelines",
+        return_value=PIPELINES_LIST,
+    )
+    api = PipelineApi()
+    matching_list = api.get_pipelines(names=names)
+    assert len(matching_list) == (5 if not names else 4)
+    assert matching_list == (PIPELINES_LIST if not names else PIPELINES_LIST[0:4])
+
+
+@pytest.mark.parametrize("names", [None, [VERSION_DRAFT, VERSION_LIVE]])
+def test_delete_pipelines(settings, mocker, mock_auth, names):
+    """The correct list of pipelines should be deleted"""
+    settings.CONCOURSE_TEAM = "team1"
+    mocker.patch(
+        "content_sync.pipelines.concourse.BaseConcourseApi.list_pipelines",
+        return_value=PIPELINES_LIST,
+    )
+    mock_api_delete = mocker.patch(
+        "content_sync.pipelines.concourse.PipelineApi.delete"
+    )
+    api = PipelineApi()
+    api.delete_pipelines(names=names)
+    for idx, site_pipeline in enumerate(PIPELINES_LIST):
+        if idx < 4 or names is None:
+            pipe_name = site_pipeline["name"]
+            pipe_vars = f'?vars={quote(json.dumps(site_pipeline["instance_vars"]))}'
+            mock_api_delete.assert_any_call(
+                f"/api/v1/teams/team1/pipelines/{pipe_name}{pipe_vars}"
+            )
 
 
 def test_upsert_website_pipeline_missing_settings(settings):
@@ -198,18 +269,18 @@ def test_upsert_website_pipelines(
 
     if not pipeline_exists:
         mock_get = mocker.patch(
-            "content_sync.pipelines.concourse.ConcourseApi.get_with_headers",
+            "content_sync.pipelines.concourse.PipelineApi.get_with_headers",
             side_effect=HTTPError(),
         )
     else:
         mock_get = mocker.patch(
-            "content_sync.pipelines.concourse.ConcourseApi.get_with_headers",
+            "content_sync.pipelines.concourse.PipelineApi.get_with_headers",
             return_value=({}, {"X-Concourse-Config-Version": "3"}),
         )
     mock_put_headers = mocker.patch(
-        "content_sync.pipelines.concourse.ConcourseApi.put_with_headers"
+        "content_sync.pipelines.concourse.PipelineApi.put_with_headers"
     )
-    existing_api = ConcourseApi("a", "b", "c", "d") if with_api else None
+    existing_api = PipelineApi("a", "b", "c", "d") if with_api else None
     pipeline = SitePipeline(website, api=existing_api)
     assert (pipeline.api == existing_api) is with_api
     pipeline.upsert_pipeline()
@@ -268,11 +339,11 @@ def test_upsert_pipeline_public_vs_private(
     settings.OCW_STUDIO_DRAFT_URL = "https://draft.test.edu"
     settings.OCW_STUDIO_LIVE_URL = "https://live.test.edu"
     mocker.patch(
-        "content_sync.pipelines.concourse.ConcourseApi.get_with_headers",
+        "content_sync.pipelines.concourse.PipelineApi.get_with_headers",
         return_value=(None, {"X-Concourse-Config-Version": 1}),
     )
     mock_put_headers = mocker.patch(
-        "content_sync.pipelines.concourse.ConcourseApi.put_with_headers"
+        "content_sync.pipelines.concourse.PipelineApi.put_with_headers"
     )
     starter = WebsiteStarterFactory.create(
         source=STARTER_SOURCE_GITHUB, path="https://github.com/org/repo/site"
@@ -300,10 +371,10 @@ def test_upsert_pipeline_public_vs_private(
 )
 def test_upsert_website_pipelines_invalid_starter(mocker, mock_auth, source, path):
     """A pipeline should not be upserted for invalid WebsiteStarters"""
-    mock_get = mocker.patch("content_sync.pipelines.concourse.ConcourseApi.get")
-    mock_put = mocker.patch("content_sync.pipelines.concourse.ConcourseApi.put")
+    mock_get = mocker.patch("content_sync.pipelines.concourse.PipelineApi.get")
+    mock_put = mocker.patch("content_sync.pipelines.concourse.PipelineApi.put")
     mock_put_headers = mocker.patch(
-        "content_sync.pipelines.concourse.ConcourseApi.put_with_headers"
+        "content_sync.pipelines.concourse.PipelineApi.put_with_headers"
     )
     starter = WebsiteStarterFactory.create(source=source, path=path)
     website = WebsiteFactory.create(starter=starter)
@@ -319,12 +390,12 @@ def test_trigger_pipeline_build(settings, mocker, mock_auth, version):
     """The correct requests should be made to trigger a pipeline build"""
     job_name = "build-ocw-site"
     mock_get = mocker.patch(
-        "content_sync.pipelines.concourse.ConcourseApi.get",
+        "content_sync.pipelines.concourse.PipelineApi.get",
         return_value={"config": {"jobs": [{"name": job_name}]}},
     )
     expected_build_id = 123456
     mock_post = mocker.patch(
-        "content_sync.pipelines.concourse.ConcourseApi.post",
+        "content_sync.pipelines.concourse.PipelineApi.post",
         return_value={"id": expected_build_id},
     )
     website = WebsiteFactory.create(
@@ -344,7 +415,7 @@ def test_trigger_pipeline_build(settings, mocker, mock_auth, version):
     )
     job_name = "build-theme-assets"
     mock_get = mocker.patch(
-        "content_sync.pipelines.concourse.ConcourseApi.get",
+        "content_sync.pipelines.concourse.PipelineApi.get",
         return_value={"config": {"jobs": [{"name": job_name}]}},
     )
     pipeline = ThemeAssetsPipeline()
@@ -363,7 +434,7 @@ def test_trigger_pipeline_build(settings, mocker, mock_auth, version):
 def test_pause_unpause_pipeline(settings, mocker, mock_auth, version, action):
     """pause_pipeline and unpause_pipeline should make the expected put requests"""
     settings.CONCOURSE_TEAM = "myteam"
-    mock_put = mocker.patch("content_sync.pipelines.concourse.ConcourseApi.put")
+    mock_put = mocker.patch("content_sync.pipelines.concourse.PipelineApi.put")
     website = WebsiteFactory.create(
         starter=WebsiteStarterFactory.create(
             source=STARTER_SOURCE_GITHUB, path="https://github.com/org/repo/config"
@@ -381,38 +452,12 @@ def test_pause_unpause_pipeline(settings, mocker, mock_auth, version, action):
     )
 
 
-@pytest.mark.parametrize("names", [None, [VERSION_DRAFT, VERSION_LIVE]])
-def test_list_pipelines(settings, mocker, mock_auth, names):
-    """The correct list of pipelines should be returned"""
-    settings.CONCOURSE_TEAM = "team1"
-    mocker.patch("content_sync.pipelines.concourse.ConcourseApi.list_pipelines", return_value=PIPELINES_LIST)
-    pipeline = GeneralPipeline()
-    matching_list = pipeline.list_pipelines(names=names)
-    assert len(matching_list) == (5 if not names else 4)
-    assert matching_list == (PIPELINES_LIST if not names else PIPELINES_LIST[0:4])
-
-
-@pytest.mark.parametrize("names", [None, [VERSION_DRAFT, VERSION_LIVE]])
-def test_delete_pipelines(settings, mocker, mock_auth, names):
-    """The correct list of pipelines should be deleted"""
-    settings.CONCOURSE_TEAM = "team1"
-    mocker.patch("content_sync.pipelines.concourse.ConcourseApi.list_pipelines", return_value=PIPELINES_LIST)
-    mock_api_delete = mocker.patch("content_sync.pipelines.concourse.ConcourseApi.delete")
-    pipeline = GeneralPipeline()
-    pipeline.delete_pipelines(names=names)
-    for idx, site_pipeline in enumerate(PIPELINES_LIST):
-        if idx < 4 or names is None:
-            pipe_name = PIPELINES_LIST[idx]['name']
-            pipe_vars = f'?vars={quote(json.dumps(PIPELINES_LIST[idx]["instance_vars"]))}'
-            mock_api_delete.assert_any_call(f"/api/v1/teams/team1/pipelines/{pipe_name}{pipe_vars}")
-
-
 def test_get_build_status(mocker, mock_auth):
     """Get the status of the build for the site"""
     build_id = 123456
     status = "status"
     mock_get = mocker.patch(
-        "content_sync.pipelines.concourse.ConcourseApi.get_build",
+        "content_sync.pipelines.concourse.PipelineApi.get_build",
         return_value={"status": status},
     )
     website = WebsiteFactory.create(
@@ -433,18 +478,18 @@ def test_upsert_pipeline(settings, mocker, mock_auth, pipeline_exists):
 
     if not pipeline_exists:
         mock_get = mocker.patch(
-            "content_sync.pipelines.concourse.ConcourseApi.get_with_headers",
+            "content_sync.pipelines.concourse.PipelineApi.get_with_headers",
             side_effect=HTTPError(),
         )
     else:
         mock_get = mocker.patch(
-            "content_sync.pipelines.concourse.ConcourseApi.get_with_headers",
+            "content_sync.pipelines.concourse.PipelineApi.get_with_headers",
             return_value=({}, {"X-Concourse-Config-Version": "3"}),
         )
     mock_put_headers = mocker.patch(
-        "content_sync.pipelines.concourse.ConcourseApi.put_with_headers"
+        "content_sync.pipelines.concourse.PipelineApi.put_with_headers"
     )
-    api = ConcourseApi("http://test.edu", "test", "test", "myteam")
+    api = PipelineApi("http://test.edu", "test", "test", "myteam")
     pipeline = ThemeAssetsPipeline(api)
     pipeline.upsert_pipeline()
     mock_get.assert_any_call(url_path)
@@ -482,16 +527,16 @@ def test_upsert_mass_build_pipeline(
 
     if not pipeline_exists:
         mock_get = mocker.patch(
-            "content_sync.pipelines.concourse.ConcourseApi.get_with_headers",
+            "content_sync.pipelines.concourse.PipelineApi.get_with_headers",
             side_effect=HTTPError(),
         )
     else:
         mock_get = mocker.patch(
-            "content_sync.pipelines.concourse.ConcourseApi.get_with_headers",
+            "content_sync.pipelines.concourse.PipelineApi.get_with_headers",
             return_value=({}, {"X-Concourse-Config-Version": "3"}),
         )
     mock_put_headers = mocker.patch(
-        "content_sync.pipelines.concourse.ConcourseApi.put_with_headers"
+        "content_sync.pipelines.concourse.PipelineApi.put_with_headers"
     )
     pipeline = MassBuildSitesPipeline(version)
     pipeline.upsert_pipeline()
@@ -531,16 +576,16 @@ def test_unpublished_site_removal_pipeline(
 
     if not pipeline_exists:
         mock_get = mocker.patch(
-            "content_sync.pipelines.concourse.ConcourseApi.get_with_headers",
+            "content_sync.pipelines.concourse.PipelineApi.get_with_headers",
             side_effect=HTTPError(),
         )
     else:
         mock_get = mocker.patch(
-            "content_sync.pipelines.concourse.ConcourseApi.get_with_headers",
+            "content_sync.pipelines.concourse.PipelineApi.get_with_headers",
             return_value=({}, {"X-Concourse-Config-Version": "3"}),
         )
     mock_put_headers = mocker.patch(
-        "content_sync.pipelines.concourse.ConcourseApi.put_with_headers"
+        "content_sync.pipelines.concourse.PipelineApi.put_with_headers"
     )
     pipeline = UnpublishedSiteRemovalPipeline()
     pipeline.upsert_pipeline()
@@ -583,11 +628,11 @@ def test_api_auth(
     """verify that the auth function posts to the expected url and returns the expected response"""
     settings.CONCOURSE_PASSWORD = password
     mock_skymarshal = mocker.patch(
-        "content_sync.pipelines.concourse.ConcourseApi._get_skymarshal_auth",
+        "content_sync.pipelines.concourse.PipelineApi._get_skymarshal_auth",
         return_value=auth_token,
     )
     mock_session = mocker.patch(
-        "content_sync.pipelines.concourse.ConcourseApi._set_new_session"
+        "content_sync.pipelines.concourse.PipelineApi._set_new_session"
     )
     mock_session.return_value.get.side_effect = [
         mocker.Mock(text=url, status_code=get_status) for url in [*get_urls, *get_urls]
@@ -595,7 +640,7 @@ def test_api_auth(
     mock_session.return_value.post.return_value = mocker.Mock(
         text="ok", status_code=post_status
     )
-    api = ConcourseApi(
+    api = PipelineApi(
         settings.CONCOURSE_URL,
         settings.CONCOURSE_USERNAME,
         settings.CONCOURSE_PASSWORD,

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -106,7 +106,7 @@ def upsert_website_publishing_pipeline(website_name: str):
             website_name,
         )
     else:
-        pipeline = api.get_sync_pipeline(website)
+        pipeline = api.get_site_pipeline(website)
         pipeline.upsert_pipeline()
 
 
@@ -123,7 +123,7 @@ def upsert_website_pipeline_batch(
             api.throttle_git_backend_calls(backend)
             backend.create_website_in_backend()
             backend.sync_all_content_to_backend()
-        pipeline = api.get_sync_pipeline(website, api=api_instance)
+        pipeline = api.get_site_pipeline(website, api=api_instance)
         if not api_instance:
             # Keep using the same api instance to minimize multiple authentication calls
             api_instance = pipeline.api
@@ -179,7 +179,7 @@ def trigger_mass_build(version: str) -> bool:
 def trigger_unpublished_removal(website_name: str) -> bool:
     """Trigger the unpublished site removal pipeline and pause the specified site pipeline"""
     if settings.CONTENT_SYNC_PIPELINE_BACKEND:
-        site_pipeline = api.get_sync_pipeline(Website.objects.get(name=website_name))
+        site_pipeline = api.get_site_pipeline(Website.objects.get(name=website_name))
         site_pipeline.pause_pipeline(VERSION_LIVE)
         removal_pipeline = api.get_unpublished_removal_pipeline()
         removal_pipeline.unpause()
@@ -360,7 +360,7 @@ def check_incomplete_publish_build_statuses():
             for version, update_dt, last_status in versions_to_check:
                 build_id = getattr(website, f"latest_build_id_{version}")
                 if build_id is not None:
-                    pipeline = api.get_sync_pipeline(website)
+                    pipeline = api.get_site_pipeline(website)
                     try:
                         status = pipeline.get_build_status(build_id)
                     except HTTPError as err:

--- a/content_sync/tasks_test.py
+++ b/content_sync/tasks_test.py
@@ -307,7 +307,7 @@ def test_upsert_theme_assets_pipeline(  # pylint:disable=unused-argument
 ):
     """calls upsert_theme_assets_pipeline and unpauses if asked"""
     settings.CONTENT_SYNC_PIPELINE_BACKEND = "concourse"
-    mocker.patch("content_sync.pipelines.concourse.ConcourseApi.auth")
+    mocker.patch("content_sync.pipelines.concourse.PipelineApi.auth")
     mock_pipeline_unpause = mocker.patch(
         "content_sync.pipelines.concourse.ThemeAssetsPipeline.unpause_pipeline"
     )
@@ -620,7 +620,7 @@ def test_check_incomplete_publish_build_statuses_500(settings, mocker, api_mock)
 def test_trigger_mass_build(settings, mocker, backend, version):
     """trigger_mass_build should call trigger_pipeline_build if enabled"""
     settings.CONTENT_SYNC_PIPELINE_BACKEND = backend
-    mocker.patch("content_sync.pipelines.concourse.ConcourseApi.auth")
+    mocker.patch("content_sync.pipelines.concourse.PipelineApi.auth")
     mock_pipeline_unpause = mocker.patch(
         "content_sync.pipelines.concourse.GeneralPipeline.unpause_pipeline"
     )
@@ -641,7 +641,7 @@ def test_trigger_mass_build(settings, mocker, backend, version):
 def test_trigger_unpublished_removal(settings, mocker, backend):
     """trigger_unpublished_removal should call trigger_pipeline_build if enabled"""
     settings.CONTENT_SYNC_PIPELINE_BACKEND = backend
-    mocker.patch("content_sync.pipelines.concourse.ConcourseApi.auth")
+    mocker.patch("content_sync.pipelines.concourse.PipelineApi.auth")
     mock_pipeline_unpause = mocker.patch(
         "content_sync.pipelines.concourse.BaseUnpublishedSiteRemovalPipeline.unpause_pipeline"
     )

--- a/ocw_import/management/commands/repair_dupe_repos.py
+++ b/ocw_import/management/commands/repair_dupe_repos.py
@@ -4,7 +4,7 @@ from django.db import transaction
 from github import GithubException
 from mitol.common.utils.datetime import now_in_utc
 
-from content_sync.api import get_sync_backend, get_site_pipeline
+from content_sync.api import get_site_pipeline, get_sync_backend
 from content_sync.models import ContentSyncState
 from websites.models import Website
 

--- a/ocw_import/management/commands/repair_dupe_repos.py
+++ b/ocw_import/management/commands/repair_dupe_repos.py
@@ -4,7 +4,7 @@ from django.db import transaction
 from github import GithubException
 from mitol.common.utils.datetime import now_in_utc
 
-from content_sync.api import get_sync_backend, get_sync_pipeline
+from content_sync.api import get_sync_backend, get_site_pipeline
 from content_sync.models import ContentSyncState
 from websites.models import Website
 
@@ -36,7 +36,7 @@ class Command(BaseCommand):
                     )
                     backend = get_sync_backend(website)
                     backend.sync_all_content_to_backend()
-                    get_sync_pipeline(website).upsert_pipeline()
+                    get_site_pipeline(website).upsert_pipeline()
                     for i in range(3, int(idx) + 1):
                         try:
                             backend.api.org.get_repo(f"{base_repo}-{i}").delete()


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #1391 

#### What's this PR do?
- Adds an optional parameter to all pipeline commands to delete existing pipelines first
- Modifies the concourse api, pipeline classes to support the above.

#### How should this be manually tested?
- Set up and run concourse locally as described in the README
- Run the following with and without the new `--delete` option, they all should run without errors.
`backpopulate_pipelines`
`upsert_site_removal_pipeline`
`upsert_theme_assets_pipeline`
`upsert_mass_build_pipeline`

It might be hard to notice if the pipelines are actually deleted before getting recreated, so if you want you can add a `return` line within the `if delete:` block of each command.


#### Any background context you want to provide?
There are lots of old orphaned site pipelines on RC.  One of them might be causing the draft S3 publish content to get deleted, not sure, but it would be good to remove these pipelines anyway.
