### PR TITLE
Use common mgmt command options for filtering by websites

### DIFF
--- a/content_sync/management/commands/sync_backend_to_db.py
+++ b/content_sync/management/commands/sync_backend_to_db.py
@@ -1,24 +1,20 @@
 """Syncs a website from a backend (Github, et al) to the database"""
-from django.core.management import BaseCommand
+import sys
+
 from github.GithubObject import NotSet
 
 from content_sync.api import get_sync_backend
+from main.management.commands.filter import WebsiteFilterCommand
 from websites.api import fetch_website, reset_publishing_fields
-from websites.models import Website
 
 
-class Command(BaseCommand):
+class Command(WebsiteFilterCommand):
     """Syncs a website from a backend (Github, et al) to the database"""
 
     help = __doc__
 
     def add_arguments(self, parser):
-        parser.add_argument(
-            "--website",
-            dest="website",
-            help="The uuid, name, or title of the Website that should be synced.",
-            required=True,
-        )
+        super().add_arguments(parser)
         parser.add_argument(
             "--commit",
             dest="commit",
@@ -33,25 +29,33 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        website = fetch_website(options["website"])
+        super().handle(*args, **options)
+
+        if not self.filter_list:
+            self.stdout.stderr(
+                "You must specify a website or list of websites to process, --filter or --filter-json"
+            )
+
         commit = options["commit"] or NotSet
         path = options["path"]
         confirm = (
             "Y"
             if (path is not None or commit is NotSet)
             else input(
-                "Are you sure you want to revert all files for this site to the specified commit? Y/N"
+                "Are you sure you want to revert all files for specified sites to this commit? Y/N"
             ).upper()
         )
         if confirm != "Y":
-            exit(0)
-        backend = get_sync_backend(website)
-        self.stdout.write(
-            f"Syncing content from backend to database for '{website.title}'..."
-        )
-        backend.sync_all_content_to_db(ref=commit, path=path)
-        if commit is not NotSet:
-            # Sync back to git
-            backend.sync_all_content_to_backend()
-        reset_publishing_fields(website.name)
-        self.stdout.write(f"Completed syncing from backend to database")
+            sys.exit(0)
+        for site_identifier in self.filter_list:
+            website = fetch_website(site_identifier)
+            backend = get_sync_backend(website)
+            self.stdout.write(
+                f"Syncing content from backend to database for '{website.title}'..."
+            )
+            backend.sync_all_content_to_db(ref=commit, path=path)
+            if commit is not NotSet:
+                # Sync back to git
+                backend.sync_all_content_to_backend()
+            reset_publishing_fields(website.name)
+            self.stdout.write("Completed syncing from backend to database")

--- a/content_sync/management/commands/sync_backend_to_db.py
+++ b/content_sync/management/commands/sync_backend_to_db.py
@@ -32,7 +32,7 @@ class Command(WebsiteFilterCommand):
         super().handle(*args, **options)
 
         if not self.filter_list:
-            self.stdout.stderr(
+            self.stderr.write(
                 "You must specify a website or list of websites to process, --filter or --filter-json"
             )
 

--- a/content_sync/management/commands/sync_website_to_backend.py
+++ b/content_sync/management/commands/sync_website_to_backend.py
@@ -37,24 +37,24 @@ class Command(WebsiteFilterCommand):
             self.stdout.stderr(
                 "You must specify a website or list of websites to process, --filter or --filter-json"
             )
-            for site_identifier in self.filter_list:
-                website = fetch_website(site_identifier)
-                backend = get_sync_backend(website)
-                should_create = options["force_create"]
-                should_delete = options["git_delete"]
-                if not should_create:
-                    should_create = not ContentSyncState.objects.filter(
-                        content__website=website
-                    ).exists()
-                if should_create:
-                    self.stdout.write(
-                        f"Creating website in backend for '{website.title}'..."
-                    )
-                    backend.create_website_in_backend()
+        for site_identifier in self.filter_list:
+            website = fetch_website(site_identifier)
+            backend = get_sync_backend(website)
+            should_create = options["force_create"]
+            should_delete = options["git_delete"]
+            if not should_create:
+                should_create = not ContentSyncState.objects.filter(
+                    content__website=website
+                ).exists()
+            if should_create:
                 self.stdout.write(
-                    f"Updating website content in backend for '{website.title}'..."
+                    f"Creating website in backend for '{website.title}'..."
                 )
-                backend.sync_all_content_to_backend()
-                if should_delete:
-                    backend.delete_orphaned_content_in_backend()
-                reset_publishing_fields(website.name)
+                backend.create_website_in_backend()
+            self.stdout.write(
+                f"Updating website content in backend for '{website.title}'..."
+            )
+            backend.sync_all_content_to_backend()
+            if should_delete:
+                backend.delete_orphaned_content_in_backend()
+            reset_publishing_fields(website.name)

--- a/content_sync/management/commands/sync_website_to_backend.py
+++ b/content_sync/management/commands/sync_website_to_backend.py
@@ -1,23 +1,17 @@
 """Syncs a Website and all of its contents to a backend (Github, et al)"""
-from django.core.management import BaseCommand
-
 from content_sync.api import get_sync_backend
 from content_sync.models import ContentSyncState
+from main.management.commands.filter import WebsiteFilterCommand
 from websites.api import fetch_website, reset_publishing_fields
 
 
-class Command(BaseCommand):
+class Command(WebsiteFilterCommand):
     """Syncs a Website and all of its contents to a backend (Github, et al)"""
 
     help = __doc__
 
     def add_arguments(self, parser):
-        parser.add_argument(
-            "--website",
-            dest="website",
-            help="The uuid, name, or title of the Website that should be synced.",
-            required=True,
-        )
+        super().add_arguments(parser)
         parser.add_argument(
             "--force-create",
             dest="force_create",
@@ -38,21 +32,29 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        website = fetch_website(options["website"])
-        backend = get_sync_backend(website)
-        should_create = options["force_create"]
-        should_delete = options["git_delete"]
-        if not should_create:
-            should_create = not ContentSyncState.objects.filter(
-                content__website=website
-            ).exists()
-        if should_create:
-            self.stdout.write(f"Creating website in backend for '{website.title}'...")
-            backend.create_website_in_backend()
-        self.stdout.write(
-            f"Updating website content in backend for '{website.title}'..."
-        )
-        backend.sync_all_content_to_backend()
-        if should_delete:
-            backend.delete_orphaned_content_in_backend()
-        reset_publishing_fields(website.name)
+        super().handle(*args, **options)
+        if not self.filter_list:
+            self.stdout.stderr(
+                "You must specify a website or list of websites to process, --filter or --filter-json"
+            )
+            for site_identifier in self.filter_list:
+                website = fetch_website(site_identifier)
+                backend = get_sync_backend(website)
+                should_create = options["force_create"]
+                should_delete = options["git_delete"]
+                if not should_create:
+                    should_create = not ContentSyncState.objects.filter(
+                        content__website=website
+                    ).exists()
+                if should_create:
+                    self.stdout.write(
+                        f"Creating website in backend for '{website.title}'..."
+                    )
+                    backend.create_website_in_backend()
+                self.stdout.write(
+                    f"Updating website content in backend for '{website.title}'..."
+                )
+                backend.sync_all_content_to_backend()
+                if should_delete:
+                    backend.delete_orphaned_content_in_backend()
+                reset_publishing_fields(website.name)

--- a/content_sync/management/commands/update_checksums.py
+++ b/content_sync/management/commands/update_checksums.py
@@ -8,6 +8,7 @@ from tqdm import tqdm
 from content_sync.models import ContentSyncState
 from main.management.commands.filter import WebsiteFilterCommand
 
+
 log = logging.getLogger(__name__)
 
 

--- a/content_sync/management/commands/update_checksums.py
+++ b/content_sync/management/commands/update_checksums.py
@@ -1,60 +1,37 @@
 """Modify any ContentSyncState.current_checksum values that are out of date"""
-import json
 import logging
 
-from django.core.management import BaseCommand
 from django.core.paginator import Paginator
 from django.db.models import Q
 from tqdm import tqdm
 
 from content_sync.models import ContentSyncState
-
+from main.management.commands.filter import WebsiteFilterCommand
 
 log = logging.getLogger(__name__)
 
 
-class Command(BaseCommand):
+class Command(WebsiteFilterCommand):
     """
     Modify any ContentSyncState.current_checksum values that are out of date
     """
 
     help = __doc__
 
-    def add_arguments(self, parser):
-        parser.add_argument(
-            "--filter-json",
-            dest="filter_json",
-            default=None,
-            help="If specified, only process sync states for websites specified in a JSON file",
-        )
-        parser.add_argument(
-            "-f",
-            "--filter",
-            dest="filter",
-            default="",
-            help="If specified, only process sync states for websites with matching names or short_ids",
-        )
-
     def handle(self, *args, **options):
         """
         Iterate through all ContentSyncState objects, calculate checksum, and
         assign to current_checksum value if different.
         """
+        super().handle(*args, **options)
         sync_states = (
             ContentSyncState.objects.all().prefetch_related("content").order_by("id")
         )
-        filter_json = options["filter_json"]
-        if filter_json:
-            with open(filter_json) as input_file:
-                filter_list = json.load(input_file)
-        else:
-            filter_list = [
-                name.strip() for name in options["filter"].split(",") if name
-            ]
-        if filter_list:
+
+        if self.filter_list:
             sync_states = sync_states.filter(
-                Q(content__website__name__in=filter_list)
-                | Q(content__website__short_id__in=filter_list)
+                Q(content__website__name__in=self.filter_list)
+                | Q(content__website__short_id__in=self.filter_list)
             )
 
         page_size = 100

--- a/content_sync/management/commands/upsert_mass_build_pipeline.py
+++ b/content_sync/management/commands/upsert_mass_build_pipeline.py
@@ -1,6 +1,6 @@
 """ Management command for upserting the mass build pipeline """
 from django.conf import settings
-from django.core.management import BaseCommand, CommandError
+from django.core.management import BaseCommand
 from mitol.common.utils.datetime import now_in_utc
 
 from content_sync.api import get_mass_build_sites_pipeline, get_pipeline_api

--- a/content_sync/management/commands/upsert_site_removal_pipeline.py
+++ b/content_sync/management/commands/upsert_site_removal_pipeline.py
@@ -1,6 +1,6 @@
 """ Management command for upserting the remove-unpublished-sites pipeline """
 from django.conf import settings
-from django.core.management import BaseCommand, CommandError
+from django.core.management import BaseCommand
 from mitol.common.utils.datetime import now_in_utc
 
 from content_sync.api import get_pipeline_api, get_unpublished_removal_pipeline
@@ -55,10 +55,10 @@ class Command(BaseCommand):
 
         pipeline = get_unpublished_removal_pipeline()
         pipeline.upsert_pipeline()
-        self.stdout.write(f"Created unpublished sites removal pipeline")
+        self.stdout.write("Created unpublished sites removal pipeline")
         if unpause:
             pipeline.unpause()
-            self.stdout.write(f"Unpaused unpublished sites removal pipeline")
+            self.stdout.write("Unpaused unpublished sites removal pipeline")
 
         total_seconds = (now_in_utc() - start).total_seconds()
         self.stdout.write(

--- a/content_sync/management/commands/upsert_theme_assets_pipeline.py
+++ b/content_sync/management/commands/upsert_theme_assets_pipeline.py
@@ -42,7 +42,7 @@ class Command(BaseCommand):
         delete_all = options["delete_all"]
 
         if is_verbose:
-            self.stdout.write(f"Upserting theme assets pipeline")
+            self.stdout.write("Upserting theme assets pipeline")
 
         start = now_in_utc()
 
@@ -60,7 +60,7 @@ class Command(BaseCommand):
         self.stdout.write("Waiting on task...")
 
         result = task.get()
-        if result != True:
+        if result is not True:
             raise CommandError(f"Some errors occurred: {result}")
 
         total_seconds = (now_in_utc() - start).total_seconds()

--- a/main/management/commands/filter.py
+++ b/main/management/commands/filter.py
@@ -1,0 +1,38 @@
+"""Filter options for website management commands"""
+import json
+
+from django.core.management import BaseCommand
+
+
+class WebsiteFilterCommand(BaseCommand):
+    """Common options for filtering by Website"""
+
+    filter_list = None
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--filter-json",
+            dest="filter_json",
+            default=None,
+            help="If specified, only publish courses that contain comma-delimited site names specified in a JSON file",
+        )
+        parser.add_argument(
+            "-f",
+            "--filter",
+            dest="filter",
+            default="",
+            help="If specified, only trigger website pipelines whose names are in this comma-delimited list",
+        )
+
+    def handle(self, *args, **options):
+        self.filter_list = []
+        filter_json = options["filter_json"]
+        if filter_json:
+            with open(filter_json) as input_file:
+                self.filter_list = json.load(input_file)
+        else:
+            self.filter_list = [
+                site.strip() for site in options["filter"].split(",") if site
+            ]
+        if self.filter_list and options["verbosity"] > 1:
+            self.stdout.write(f"Filtering by website: {self.filter_list}")

--- a/videos/management/commands/backpopulate_video_downloads.py
+++ b/videos/management/commands/backpopulate_video_downloads.py
@@ -46,14 +46,14 @@ class Command(WebsiteFilterCommand):
         is_verbose = options["verbosity"] > 1
 
         videos = Video.objects.all()
-        if self.site_list:
-            videos.filter(
-                Q(website__name__in=self.site_list)
-                | Q(website__short_id__in=self.site_list)
+        if self.filter_list:
+            videos = videos.filter(
+                Q(website__name__in=self.filter_list)
+                | Q(website__short_id__in=self.filter_list)
             )
 
         self.stdout.write(
-            f"Updating downloadable video files for {videos.count()} sites."
+            f"Updating downloadable video files for {videos.count()} videos."
         )
         for video in videos:
             if is_verbose:
@@ -67,7 +67,7 @@ class Command(WebsiteFilterCommand):
                     f"Error Updating video {video.source_key} for site {video.website.short_id}: {exc}"
                 )
         self.stdout.write(
-            f"Completed Updating downloadable video files for {videos.count()} sites."
+            f"Completed Updating downloadable video files for {videos.count()} videos."
         )
 
         if settings.CONTENT_SYNC_BACKEND and not options["skip_sync"]:

--- a/websites/api.py
+++ b/websites/api.py
@@ -169,11 +169,13 @@ def fetch_website(filter_value: str) -> Website:
         except ValueError:
             pass
     website_results = Website.objects.filter(
-        Q(name__iexact=filter_value) | Q(title__iexact=filter_value)
+        Q(name__iexact=filter_value)
+        | Q(title__iexact=filter_value)
+        | Q(short_id__iexact=filter_value)
     ).all()
     if len(website_results) == 0:
         raise Website.DoesNotExist(
-            f"Could not find a Website with a matching uuid, name, or title ('{filter_value}')"
+            f"Could not find a Website with a matching uuid, name, short_id, or title ('{filter_value}')"
         )
     if len(website_results) == 1:
         return website_results[0]

--- a/websites/api_test.py
+++ b/websites/api_test.py
@@ -111,6 +111,7 @@ def test_fetch_website_by_uuid(uuid_str, filter_value):
     [
         [{"title": "my test title"}, "my test title"],
         [{"name": "my test name"}, "my test name"],
+        [{"short_id": "my.test.name"}, "my.test.name"],
         [
             {"title": "05d329fd-05ca-4770-b8b2-77ad711daca9"},
             "05d329fd-05ca-4770-b8b2-77ad711daca9",

--- a/websites/management/commands/backpopulate_groups.py
+++ b/websites/management/commands/backpopulate_groups.py
@@ -13,7 +13,7 @@ class Command(WebsiteFilterCommand):
     help = "Backpopulate website groups and permissions"
 
     def add_arguments(self, parser):
-
+        super().add_arguments(parser)
         parser.add_argument(
             "--only-global",
             dest="only-global",
@@ -22,6 +22,7 @@ class Command(WebsiteFilterCommand):
         )
 
     def handle(self, *args, **options):
+        super().handle(*args, **options)
 
         self.stdout.write(f"Creating website permission groups")
         start = now_in_utc()

--- a/websites/management/commands/backpopulate_groups.py
+++ b/websites/management/commands/backpopulate_groups.py
@@ -1,25 +1,18 @@
 """ Backpopulate website groups and permissions"""
-from django.core.management import BaseCommand
 from django.db.models import Q
 from mitol.common.utils.datetime import now_in_utc
 
+from main.management.commands.filter import WebsiteFilterCommand
 from websites.models import Website
 from websites.permissions import create_global_groups, setup_website_groups_permissions
 
 
-class Command(BaseCommand):
+class Command(WebsiteFilterCommand):
     """ Backpopulate website groups and permissions """
 
     help = "Backpopulate website groups and permissions"
 
     def add_arguments(self, parser):
-        parser.add_argument(
-            "-f",
-            "--filter",
-            dest="filter",
-            default="",
-            help="If specified, only process websites that contain this filter text in their name",
-        )
 
         parser.add_argument(
             "--only-global",
@@ -33,7 +26,6 @@ class Command(BaseCommand):
         self.stdout.write(f"Creating website permission groups")
         start = now_in_utc()
 
-        filter_str = options["filter"].lower()
         is_verbose = options["verbosity"] > 1
 
         total_websites = 0
@@ -42,16 +34,17 @@ class Command(BaseCommand):
         total_owners = 0
 
         # Redo global groups too in case permissions changed
-        if not filter_str:
+        if not self.filter_list:
             created, updated = create_global_groups()
             self.stdout.write(
                 f"Global groups: created {created} groups, updated {updated} groups"
             )
 
         if not options["only-global"]:
-            if filter_str:
+            if self.filter_list:
                 website_qset = Website.objects.filter(
-                    Q(name__icontains=filter_str) | Q(title__icontains=filter_str)
+                    Q(name__in=self.filter_list)
+                    | Q(short_id__icontains=self.filter_list)
                 )
             else:
                 website_qset = Website.objects.all()

--- a/websites/management/commands/markdown_cleanup.py
+++ b/websites/management/commands/markdown_cleanup.py
@@ -7,12 +7,11 @@ from django.conf import settings
 from django.core.management.base import CommandParser
 from django.core.paginator import Paginator
 from django.db.models import Q
-
-from main.management.commands.filter import WebsiteFilterCommand
 from mitol.common.utils import now_in_utc
 from tqdm import tqdm
 
 from content_sync.tasks import sync_unsynced_websites
+from main.management.commands.filter import WebsiteFilterCommand
 from websites.management.commands.markdown_cleaning import (
     MarkdownCleanupRule,
     WebsiteContentMarkdownCleaner,

--- a/websites/management/commands/markdown_cleanup.py
+++ b/websites/management/commands/markdown_cleanup.py
@@ -50,7 +50,7 @@ class Command(WebsiteFilterCommand):
     ]
 
     def add_arguments(self, parser: CommandParser) -> None:
-        self.add_arguments(parser)
+        super().add_arguments(parser)
         aliases = [R.alias for R in self.Rules]
         parser.add_argument(
             dest="alias",
@@ -110,7 +110,7 @@ class Command(WebsiteFilterCommand):
             ) from not_found
 
     def handle(self, *args, **options):
-        self.handle(*args, **options)
+        super().handle(*args, **options)
         self.validate_options(options)
         self.do_handle(
             commit=options["commit"],

--- a/websites/management/commands/sync_content_state.py
+++ b/websites/management/commands/sync_content_state.py
@@ -1,9 +1,8 @@
 """Updates/creates content sync records for website contents"""
 from django.db.models import Q
 
-from main.management.commands.filter import WebsiteFilterCommand
-
 from content_sync.api import upsert_content_sync_state
+from main.management.commands.filter import WebsiteFilterCommand
 from websites.models import WebsiteContent
 
 

--- a/websites/management/commands/sync_content_state.py
+++ b/websites/management/commands/sync_content_state.py
@@ -1,22 +1,19 @@
 """Updates/creates content sync records for website contents"""
-from django.core.management import BaseCommand
+from django.db.models import Q
+
+from main.management.commands.filter import WebsiteFilterCommand
 
 from content_sync.api import upsert_content_sync_state
-from websites.api import fetch_website
 from websites.models import WebsiteContent
 
 
-class Command(BaseCommand):
+class Command(WebsiteFilterCommand):
     """Updates/creates content sync records for website contents"""
 
     help = __doc__
 
     def add_arguments(self, parser):
-        parser.add_argument(
-            "--website",
-            dest="website",
-            help="If provided, only update sync states for website with a matching uuid, name, or title.",
-        )
+        super().add_arguments(parser)
         parser.add_argument(
             "--content-title",
             dest="content_title",
@@ -29,15 +26,18 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        super().handle(*args, **options)
         filter_qset = {}
-        if options["website"]:
-            website = fetch_website(options["website"])
-            filter_qset["website"] = website
         if options["content_title"]:
             filter_qset["title__icontains"] = options["content_title"]
         if options["text_id"]:
             filter_qset["text_id"] = options["text_id"]
         content_qset = WebsiteContent.objects.filter(**filter_qset)
+        if self.filter_list:
+            content_qset = content_qset.filter(
+                Q(website__name__in=self.filter_list)
+                | Q(website__short_id__in=self.filter_list)
+            )
         num_records = content_qset.count()
         self.stdout.write(
             self.style.WARNING(

--- a/websites/management/commands/sync_contents_with_config.py
+++ b/websites/management/commands/sync_contents_with_config.py
@@ -4,7 +4,6 @@ import sys
 from django.db.models import Q
 
 from main.management.commands.filter import WebsiteFilterCommand
-
 from websites.models import Website, WebsiteContent, WebsiteStarter
 from websites.site_config_api import SiteConfig
 

--- a/websites/management/commands/update_content_fields.py
+++ b/websites/management/commands/update_content_fields.py
@@ -8,7 +8,6 @@ from django.db import transaction
 from django.db.models import Q
 
 from main.management.commands.filter import WebsiteFilterCommand
-
 from websites.models import WebsiteContent
 
 

--- a/websites/management/commands/update_content_fields.py
+++ b/websites/management/commands/update_content_fields.py
@@ -3,23 +3,31 @@ import re
 from argparse import ArgumentTypeError
 
 from django.core.exceptions import FieldDoesNotExist
-from django.core.management import BaseCommand, CommandError
+from django.core.management import CommandError
 from django.db import transaction
+from django.db.models import Q
+
+from main.management.commands.filter import WebsiteFilterCommand
 
 from websites.models import WebsiteContent
 
 
-class Command(BaseCommand):
+class Command(WebsiteFilterCommand):
+    """Updates multiple fields of content based on starter"""
 
     help = __doc__
 
     def _parse_data(self, data):
-        tuples = re.findall("([^\d\W]\w*)=(\S+)", data)
+        """Parse the data"""
+        tuples = re.findall(
+            "([^\d\W]\w*)=(\S+)", data
+        )  # pylint:disable=anomalous-backslash-in-string
         if not tuples:
             raise ArgumentTypeError
         return tuples[0]
 
     def add_arguments(self, parser):
+        super().add_arguments(parser)
         parser.add_argument(
             "starter",
             help="The WebsiteStarter slug to process",
@@ -44,7 +52,7 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-
+        super().handle(*args, **options)
         key_values = options.get("data")
         starter = options.get("starter")
         page_type = options.get("type")
@@ -60,8 +68,14 @@ class Command(BaseCommand):
 
         with transaction.atomic():
             try:
-                WebsiteContent.objects.filter(
+                contents = WebsiteContent.objects.filter(
                     website__starter__slug=starter, type=page_type
-                ).update(**updated_data)
+                )
+                if self.filter_list:
+                    contents = contents.filter(
+                        Q(website__name__in=self.filter_list)
+                        | Q(website__short_id__in=self.filter_list)
+                    )
+                contents.update(**updated_data)
             except FieldDoesNotExist as e:
                 raise CommandError(e)

--- a/websites/management/commands/update_content_metadata.py
+++ b/websites/management/commands/update_content_metadata.py
@@ -1,8 +1,8 @@
 """ Update content metadata for websites based on a specific starter """
 from django.db import transaction
 from django.db.models import Q
-from main.management.commands.filter import WebsiteFilterCommand
 
+from main.management.commands.filter import WebsiteFilterCommand
 from websites.models import WebsiteContent, WebsiteStarter
 from websites.site_config_api import SiteConfig
 

--- a/websites/management/commands/update_departments.py
+++ b/websites/management/commands/update_departments.py
@@ -1,15 +1,20 @@
+""" Update departments metadata for website(s)"""
 from functools import reduce
 
-from django.core.management import BaseCommand
 from django.db import transaction
 from django.db.models import Q
+from main.management.commands.filter import WebsiteFilterCommand
 
 from websites.models import WebsiteContent
 
 
-class Command(BaseCommand):
-    def add_arguments(self, parser):
+class Command(WebsiteFilterCommand):
+    """ Update departments metadata for website(s)"""
 
+    help = __doc__
+
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
         parser.add_argument(
             "-d",
             "--departments",
@@ -20,18 +25,19 @@ class Command(BaseCommand):
         )
 
         parser.add_argument(
-            "-n",
-            "--name",
-            dest="name",
+            "-s",
+            "--startswith",
+            dest="startswith",
             nargs="*",
             help="Identifiers to filter websites based on istartswith lookup",
             required=True,
         )
 
     def handle(self, *args, **options):
-        filter_set = options["name"]
+        super().handle(*args, **options)
+        startswith = options["startswith"]
         departments = options["departments"]
-        filter_query_set = [
+        startswith_query_set = [
             "website__name__istartswith",
             "website__short_id__istartswith",
         ]
@@ -39,9 +45,17 @@ class Command(BaseCommand):
         query_set = WebsiteContent.objects.filter(
             reduce(
                 lambda x, y: x | y,
-                [Q(**{key: value}) for key, value in zip(filter_query_set, filter_set)],
+                [
+                    Q(**{key: value})
+                    for key, value in zip(startswith_query_set, startswith)
+                ],
             ),
         )
+        if self.filter_list:
+            query_set = query_set.filter(
+                Q(website__name__in=self.filter_list)
+                | Q(website__short_id__in=self.filter_list)
+            )
 
         query_set = query_set.filter(type="sitemetadata")
         self.stdout.write(

--- a/websites/management/commands/update_departments.py
+++ b/websites/management/commands/update_departments.py
@@ -3,8 +3,8 @@ from functools import reduce
 
 from django.db import transaction
 from django.db.models import Q
-from main.management.commands.filter import WebsiteFilterCommand
 
+from main.management.commands.filter import WebsiteFilterCommand
 from websites.models import WebsiteContent
 
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #1388 
Closes #1135

#### What's this PR do?
Adds a base `WebsiteFilterCommand` class that provides `--filter` and `--filter-json` options.  Modifies numerous existing commands to inherit from this wherever it seems useful.

#### How should this be manually tested?
You can try some or all the modified commands that now inherit from `WesbsiteFilterCommand` to make sure they work correctly with and without the `--filter` option.


