### PR TITLE
Add management command to assist in populating default license values

### DIFF
--- a/main/management/commands/filter.py
+++ b/main/management/commands/filter.py
@@ -2,6 +2,9 @@
 import json
 
 from django.core.management import BaseCommand
+from django.db.models import Q
+
+from websites.models import WebsiteContentQuerySet
 
 
 class WebsiteFilterCommand(BaseCommand):
@@ -36,3 +39,14 @@ class WebsiteFilterCommand(BaseCommand):
             ]
         if self.filter_list and options["verbosity"] > 1:
             self.stdout.write(f"Filtering by website: {self.filter_list}")
+
+    def filter_website_contents(
+        self, website_contents: WebsiteContentQuerySet
+    ) -> WebsiteContentQuerySet:
+        """Filter website_contents based on CLI arguments."""
+        if not self.filter_list:
+            return website_contents
+        return website_contents.filter(
+            Q(website__name__in=self.filter_list)
+            | Q(website__short_id__in=self.filter_list)
+        )

--- a/websites/management/commands/set_content_metadata_to_default.py
+++ b/websites/management/commands/set_content_metadata_to_default.py
@@ -1,0 +1,79 @@
+""" Update content metadata for websites based on a specific starter """
+from django.db import transaction
+
+from main.management.commands.filter import WebsiteFilterCommand
+from websites.models import WebsiteContent, WebsiteStarter
+from websites.site_config_api import SiteConfig
+from websites.utils import get_dict_field, set_dict_field
+
+
+class Command(WebsiteFilterCommand):
+    """Update content metadata to the default value spcecified in starter. Only
+    affects content whose value for that metadata entry are null or empty.
+    """
+
+    help = __doc__
+
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+        parser.add_argument(
+            "--starter", help="The WebsiteStarter slug to process", required=True
+        )
+        parser.add_argument(
+            "--field",
+            help="The metadata field's name path to update, in dot notation. Example: image_metadata.caption",
+            required=True,
+        )
+        parser.add_argument(
+            "-t",
+            "--type",
+            dest="type",
+            help="Only update metadata for content with this type.",
+            required=True,
+        )
+
+    def handle(self, *args, **options):
+        super().handle(*args, **options)
+        starter_str = options["starter"]
+        field_path = options["field"]
+        type_str = options["type"]
+
+        content_qset = WebsiteContent.objects.filter(
+            website__starter__slug=starter_str, type=type_str
+        )
+        content_qset = self.filter_website_contents(content_qset)
+
+        base_metadata = SiteConfig(
+            WebsiteStarter.objects.get(slug=starter_str).config
+        ).generate_item_metadata(type_str, cls=WebsiteContent, use_defaults=True)
+        default_value = get_dict_field(base_metadata, field_path)
+        if default_value is None:
+            raise Exception(f"Metadata field {field_path} has no default")
+
+        def should_update(website_content):
+            current_value = get_dict_field(website_content.metadata, field_path)
+            return current_value is None or current_value == ""
+
+        expected_updated = sum(1 for wc in content_qset.iterator() if should_update(wc))
+
+        confirmation = input(
+            f"""You are about to change {expected_updated} records metadata value:
+    field:     {field_path}
+    new value: {default_value}
+    old value: '' or null
+
+Would you like to proceed? (y/n):"""
+        )
+        if confirmation != "y":
+            self.stdout.write("Aborting...")
+            return
+
+        updated = 0
+        with transaction.atomic():
+            for content in content_qset.iterator():
+                if should_update(content):
+                    set_dict_field(content.metadata, field_path, default_value)
+                    content.save()
+                    updated += 1
+
+        self.stdout.write(f"Finished updating {updated} records.")


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1343 

#### What's this PR do?
This PR adds a management command `set_content_metadata_to_default` that updates content metadata to the default value specified in the config, only affecting content that has null or empty value for that metadata field. 

The present use-case is to set resources to have the default license (CC-BY-SA). Currently on prod:
```
license                                            ,count  ,text_id

NULL                                               ,110660 ,70518f87-dfd5-c723-ee3c-d5d912001b51
""                                                 ,   296 ,8f80e269-30e5-4db7-86d9-bd10e17b2136
https://creativecommons.org/licenses/by-nc-sa/4.0/ ,   270 ,ac106d0a-b0e2-6e50-51d6-b47de9445f3d
https://creativecommons.org/licenses/by-nc/4.0/    ,    20 ,43dd1e03-1b2e-4122-67e4-4b5e6d9d7a1f
https://creativecommons.org/licenses/by/4.0/       ,    11 ,bca02d3a-7d36-b448-fcde-27950d22f93b
https://creativecommons.org/publicdomain/zero/1.0/ ,     8 ,b18f7e34-a663-4eb4-b228-0d433102f5ad
```

#### How should this be manually tested?
1. Make sure your local `ocw-course` starter has a default value for resource licenses. (It should)
2. Find example resources with
    - A) null license
    - B) empty string license
    - C) license set to some value besides the default (cc-by-sa)

    *Create the data in django admin, or if you have a local copy of prod data, the table above can help you find examples.*
4. Run `docker compose run --rm web ./manage.py set_content_metadata_to_default --start ocw-course --type resource --field license`. *Optionally filter by websites, if you like.*
5. Check that the license field was updated for (A) and (B), but not (C).
