### PR TITLE
Add Filename to Edit Resource Menu When GDrive Sync Enabled

### DIFF
--- a/static/js/components/forms/SiteContentForm.test.tsx
+++ b/static/js/components/forms/SiteContentForm.test.tsx
@@ -244,6 +244,31 @@ test.each`
   }
 )
 
+test.each`
+  isGdriveEnabled | isResource | willRender
+  ${true}         | ${true}    | ${true}
+  ${false}        | ${true}    | ${false}
+  ${true}         | ${false}   | ${false}
+  ${false}        | ${false}   | ${false}
+`(
+  "filename label field render:$willRender when gdrive:$isGdriveEnabled and resource:$isResource",
+  ({ isGdriveEnabled, isResource, willRender }) => {
+    const data = setupData()
+    SETTINGS.gdrive_enabled = isGdriveEnabled
+    data.content.type = isResource ? "resource" : "page"
+    const configItem = makeEditableConfigItem(data.content.type)
+    const field = makeWebsiteConfigField({ widget: WidgetVariant.File })
+    configItem.fields = [field]
+    const values = { file: "courses/file.pdf" }
+    const { form } = setupInnerForm({
+      ...data,
+      configItem,
+      values
+    })
+    expect(form.find("Label").exists()).toBe(willRender)
+  }
+)
+
 test("SiteContentField creates new values", () => {
   const data = setupData()
   data.configItem.fields = [

--- a/static/js/components/forms/SiteContentForm.test.tsx
+++ b/static/js/components/forms/SiteContentForm.test.tsx
@@ -22,6 +22,7 @@ import * as domUtil from "../../util/dom"
 import ObjectField from "../widgets/ObjectField"
 
 import * as Website from "../../context/Website"
+import Label from "../widgets/Label"
 const { useWebsite: mockUseWebsite } = Website as jest.Mocked<typeof Website>
 
 // ckeditor is not working properly in tests, but we don't need to test it here so just mock it away
@@ -91,7 +92,7 @@ function setupInnerForm(props: Partial<InnerFormProps> = {}) {
     <Formik
       onSubmit={data.onSubmit}
       validate={validate}
-      initialValues={{}}
+      initialValues={props.values ?? {}}
       enableReinitialize={true}
     >
       {formikProps => (
@@ -245,27 +246,30 @@ test.each`
 )
 
 test.each`
-  isGdriveEnabled | isResource | willRender
-  ${true}         | ${true}    | ${true}
-  ${false}        | ${true}    | ${false}
-  ${true}         | ${false}   | ${false}
-  ${false}        | ${false}   | ${false}
+  isGdriveEnabled | isResource | willRender | filename
+  ${true}         | ${true}    | ${true}    | ${"courses/file.pdf"}
+  ${false}        | ${true}    | ${false}   | ${null}
+  ${true}         | ${false}   | ${false}   | ${null}
+  ${false}        | ${false}   | ${false}   | ${null}
 `(
-  "filename label field render:$willRender when gdrive:$isGdriveEnabled and resource:$isResource",
-  ({ isGdriveEnabled, isResource, willRender }) => {
+  "filename label field render:$willRender with filename:$filename when gdrive:$isGdriveEnabled and resource:$isResource",
+  ({ isGdriveEnabled, isResource, willRender, filename }) => {
     const data = setupData()
     SETTINGS.gdrive_enabled = isGdriveEnabled
     data.content.type = isResource ? "resource" : "page"
     const configItem = makeEditableConfigItem(data.content.type)
     const field = makeWebsiteConfigField({ widget: WidgetVariant.File })
     configItem.fields = [field]
-    const values = { file: "courses/file.pdf" }
+    const values = { [field.name]: "courses/file.pdf" }
     const { form } = setupInnerForm({
       ...data,
       configItem,
       values
     })
-    expect(form.find("Label").exists()).toBe(willRender)
+    expect(form.find(Label).exists()).toBe(willRender)
+    if (willRender) {
+      expect(form.find(Label).prop("value")).toBe(filename)
+    }
   }
 )
 

--- a/static/js/components/forms/SiteContentForm.test.tsx
+++ b/static/js/components/forms/SiteContentForm.test.tsx
@@ -235,7 +235,7 @@ test.each`
     const configItem = makeEditableConfigItem(data.content.type)
     const field = makeWebsiteConfigField({ widget: WidgetVariant.File })
     configItem.fields = [field]
-    const values = { file: "courses/file.pdf" }
+    const values = { [field.name]: "courses/file.pdf" }
     const { form } = setupInnerForm({
       ...data,
       configItem,

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -144,14 +144,14 @@ export function FormFields(props: InnerFormProps): JSX.Element {
             ) : SETTINGS.gdrive_enabled &&
               content?.type === "resource" &&
               field.widget === WidgetVariant.File ? (
-                
+
                 <Field
-                   as={Label}
-                   name={field.name}
-                   className="form-control"
-                   onChange={handleChange}
-              />
-                  
+                  as={Label}
+                  name={field.name}
+                  className="form-control"
+                  onChange={handleChange}
+                />
+
               ) : (
                 <SiteContentField
                   field={field}

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -144,14 +144,12 @@ export function FormFields(props: InnerFormProps): JSX.Element {
             ) : SETTINGS.gdrive_enabled &&
               content?.type === "resource" &&
               field.widget === WidgetVariant.File ? (
-
                 <Field
                   as={Label}
                   name={field.name}
                   className="form-control"
                   onChange={handleChange}
                 />
-
               ) : (
                 <SiteContentField
                   field={field}

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -144,7 +144,7 @@ export function FormFields(props: InnerFormProps): JSX.Element {
             ) : SETTINGS.gdrive_enabled &&
               content?.type === "resource" &&
               field.widget === WidgetVariant.File ? (
-                <div className="form-group">
+                <div>
                   <label htmlFor={field.name}>{field.label}</label>
                   <Field
                     as={Label}

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo } from "react"
 import {
+  Field,
   Form,
   Formik,
   FormikHelpers,
@@ -12,6 +13,7 @@ import {
 
 import SiteContentField from "./SiteContentField"
 import ObjectField from "../widgets/ObjectField"
+import Label from "../widgets/Label"
 
 import {
   contentInitialValues,
@@ -141,7 +143,16 @@ export function FormFields(props: InnerFormProps): JSX.Element {
               />
             ) : SETTINGS.gdrive_enabled &&
               content?.type === "resource" &&
-              field.widget === WidgetVariant.File ? null : (
+              field.widget === WidgetVariant.File ? (
+                
+                <Field
+                   as={Label}
+                   name={field.name}
+                   className="form-control"
+                   onChange={handleChange}
+              />
+                  
+              ) : (
                 <SiteContentField
                   field={field}
                   key={field.name}

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -144,12 +144,15 @@ export function FormFields(props: InnerFormProps): JSX.Element {
             ) : SETTINGS.gdrive_enabled &&
               content?.type === "resource" &&
               field.widget === WidgetVariant.File ? (
-                <Field
-                  as={Label}
-                  name={field.name}
-                  className="form-control"
-                  onChange={handleChange}
-                />
+                <div className="form-group">
+                  <label htmlFor={field.name}>{field.label}</label>
+                  <Field
+                    as={Label}
+                    name={field.name}
+                    className="form-control"
+                    onChange={handleChange}
+                  />
+                </div>
               ) : (
                 <SiteContentField
                   field={field}

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -144,7 +144,7 @@ export function FormFields(props: InnerFormProps): JSX.Element {
             ) : SETTINGS.gdrive_enabled &&
               content?.type === "resource" &&
               field.widget === WidgetVariant.File ? (
-                <div>
+                <div key={field.name}>
                   <label htmlFor={field.name}>{field.label}</label>
                   <Field
                     as={Label}

--- a/static/js/components/widgets/FileUploadField.test.tsx
+++ b/static/js/components/widgets/FileUploadField.test.tsx
@@ -63,7 +63,7 @@ describe("FileUploadField", () => {
         <FileUploadField
           name={fileFieldName}
           onChange={jest.fn()}
-          value={`https://aws.com/uuid_${currentFile}`}
+          value={`https://aws.com/32629a023dc541288e430392b51e7b61_${currentFile}`}
         />
       )
       expect(

--- a/static/js/components/widgets/Label.tsx
+++ b/static/js/components/widgets/Label.tsx
@@ -10,7 +10,7 @@ export interface Props {
  * A component for showing a read-only label
  */
 const Label: React.FC<Props> = props => {
-  const { name, value } = props
+  const { value } = props
   return (
     <div className="py-2">
       {value && !(value instanceof File) ? (

--- a/static/js/components/widgets/Label.tsx
+++ b/static/js/components/widgets/Label.tsx
@@ -7,14 +7,20 @@ export interface Props {
 }
 
 /**
- * A component for showing a read-only label; handleChange is not defined so this is readOnly
+ * A component for showing a read-only label
  */
 const Label: React.FC<Props> = props => {
   const { value } = props
   return (
     <div className="form-group">
       {value && !(value instanceof File) ? (
-        <div className="form-control">{filenameFromPath(value)}</div>
+        <input
+          className="form-control"
+          placeholder={filenameFromPath(value)}
+          type="text"
+          readOnly
+          style={{ cursor: "not-allowed" }}
+        ></input>
       ) : null}
     </div>
   )

--- a/static/js/components/widgets/Label.tsx
+++ b/static/js/components/widgets/Label.tsx
@@ -9,17 +9,17 @@ export interface Props {
 /**
  * A component for showing a read-only label
  */
-const Label: React.FC<Props> = (props) => {
+const Label: React.FC<Props> = props => {
   const { name, value } = props
-  const fileInputName = name || "file"
   return (
     <div className="py-2">
-    {value && !(value instanceof File) ? (
-      <div className="current-file">
+      {value && !(value instanceof File) ? (
+        <div className="current-file">
         Current file: {filenameFromPath(value)}
-      </div>
-    ) : null}
+        </div>
+      ) : null}
     </div>
-    )}
+  )
+}
 
 export default Label

--- a/static/js/components/widgets/Label.tsx
+++ b/static/js/components/widgets/Label.tsx
@@ -16,7 +16,7 @@ const Label: React.FC<Props> = props => {
       {value && !(value instanceof File) ? (
         <input
           className="form-control"
-          placeholder={filenameFromPath(value)}
+          value={filenameFromPath(value)}
           type="text"
           readOnly
           style={{ cursor: "not-allowed" }}

--- a/static/js/components/widgets/Label.tsx
+++ b/static/js/components/widgets/Label.tsx
@@ -1,0 +1,25 @@
+import React from "react"
+import { filenameFromPath } from "../../lib/util"
+
+export interface Props {
+  name?: string
+  value?: string | File | null
+}
+
+/**
+ * A component for showing a read-only label
+ */
+const Label: React.FC<Props> = (props) => {
+  const { name, value } = props
+  const fileInputName = name || "file"
+  return (
+    <div className="py-2">
+    {value && !(value instanceof File) ? (
+      <div className="current-file">
+        Current file: {filenameFromPath(value)}
+      </div>
+    ) : null}
+    </div>
+    )}
+
+export default Label

--- a/static/js/components/widgets/Label.tsx
+++ b/static/js/components/widgets/Label.tsx
@@ -14,9 +14,9 @@ const Label: React.FC<Props> = props => {
   return (
     <div className="py-2">
       {value && !(value instanceof File) ? (
-        <div className="current-file">
-          Current file: {filenameFromPath(value)}
-        </div>
+        <form className="current-file">
+          <input value={filenameFromPath(value)} readOnly></input>
+        </form>
       ) : null}
     </div>
   )

--- a/static/js/components/widgets/Label.tsx
+++ b/static/js/components/widgets/Label.tsx
@@ -3,7 +3,7 @@ import { filenameFromPath } from "../../lib/util"
 
 export interface Props {
   name?: string
-  value?: string | File | null
+  value?: string | File
 }
 
 /**

--- a/static/js/components/widgets/Label.tsx
+++ b/static/js/components/widgets/Label.tsx
@@ -15,7 +15,7 @@ const Label: React.FC<Props> = props => {
     <div className="py-2">
       {value && !(value instanceof File) ? (
         <div className="current-file">
-        Current file: {filenameFromPath(value)}
+          Current file: {filenameFromPath(value)}
         </div>
       ) : null}
     </div>

--- a/static/js/components/widgets/Label.tsx
+++ b/static/js/components/widgets/Label.tsx
@@ -7,16 +7,14 @@ export interface Props {
 }
 
 /**
- * A component for showing a read-only label
+ * A component for showing a read-only label; handleChange is not defined so this is readOnly
  */
 const Label: React.FC<Props> = props => {
   const { value } = props
   return (
-    <div className="py-2">
+    <div className="form-group">
       {value && !(value instanceof File) ? (
-        <form className="current-file">
-          <input value={filenameFromPath(value)} readOnly></input>
-        </form>
+        <div className="form-control">{filenameFromPath(value)}</div>
       ) : null}
     </div>
   )

--- a/static/js/lib/util.test.ts
+++ b/static/js/lib/util.test.ts
@@ -64,12 +64,19 @@ describe("util", () => {
     expect(result).toBeNull()
   })
   ;[
-    ["http://aws.amazon.com/bucket/uuid/uuid_filename.jpg", "filename.jpg"],
     [
-      "http://aws.amazon.com/bucket/uuid/uuid_longer_filename.jpg",
+      "http://aws.amazon.com/bucket/32629a023dc541288e430392b51e7b61/32629a023dc541288e430392b51e7b61_filename.jpg",
+      "filename.jpg"
+    ],
+    [
+      "http://aws.amazon.com/bucket/32629a02-3dc5-4128-8e43-0392b51e7b61/32629a02-3dc5-4128-8e43-0392b51e7b61_longer_filename.jpg",
       "longer_filename.jpg"
     ],
-    ["/media/text_id/uuid_filename.jpg", "filename.jpg"],
+    ["http://aws.amazon.com/bucket/longer_filename.jpg", "longer_filename.jpg"],
+    [
+      "/media/text_id/32629a02-3dc5-4128-8e43-0392b51e7b61_filename.jpg",
+      "filename.jpg"
+    ],
     ["/media/text_id/filename.jpg", "filename.jpg"]
   ].forEach(([filepath, expected]) => {
     it("filenameFromPath should return expected values", () => {

--- a/static/js/lib/util.ts
+++ b/static/js/lib/util.ts
@@ -48,11 +48,17 @@ export const objectToFormData = (
 
 export const filenameFromPath = (filepath: string): string => {
   const basename = filepath.split("/").pop() || ""
-  if (basename.includes("_")) {
-    return basename
-      .split("_")
-      .slice(1)
-      .join("_")
+  const UUID = new RegExp(
+    "^[0-9A-F]{8}-?[0-9A-F]{4}-?[4][0-9A-F]{3}-?[89AB][0-9A-F]{3}-?[0-9A-F]{12}",
+    "i"
+  )
+  if (UUID.test(basename)) {
+    if (basename.includes("_")) {
+      return basename
+        .split("_")
+        .slice(1)
+        .join("_")
+    }
   }
   return basename
 }


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-studio/issues/878

#### What's this PR do?
When Google Drive syncing is enabled, the filename of the uploaded file will be rendered as a read-only input field in the `Edit Resource` menu.

Completed items:
- [x] Updating filename display format to a [read-only input field](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly) to be consistent with UI pattern for other fields.
- [x] Updating the current test for SiteContentForm to check that the filename is properly displayed whether Google Drive syncing is on or off: https://github.com/mitodl/ocw-studio/blob/e7721c7882ac43c5c3317c40ee4e59b2c30037d2/static/js/components/forms/SiteContentForm.test.tsx#L222-L245
- [x] Checking for UUID in filename (for legacy uploads) and removing it from rendered filename.
- [x] Testing UUID removal and correct filename rendering.

#### How should this be manually tested?

- On a locally-running version of OCW studio, upload a file and check that its name is rendered correctly in the `Edit Resource` drawer.
- Test uploading a file where the filename has the format `<uuid>_my_file.png` where `<uuid>` is a 32-character hexadecimal string (with or without dashes, e.g., `32629a02-3dc5-4128-8e43-0392b51e7b61`). The UUID should not be rendered as part of the filename.