### PR TITLE
Added check to filter undefined tabs

### DIFF
--- a/static/js/components/widgets/ResourcePickerDialog.tsx
+++ b/static/js/components/widgets/ResourcePickerDialog.tsx
@@ -145,7 +145,7 @@ export default function ResourcePickerDialog(props: Props): JSX.Element {
     () =>
       contentNames
         .flatMap(name => TABS[name])
-        .filter(tab => mode !== RESOURCE_EMBED || tab.embeddable),
+        .filter(tab => tab && (mode !== RESOURCE_EMBED || tab.embeddable)),
     [mode, contentNames]
   )
   const [activeTabId, setActiveTabId] = useState(tabs[0].id)


### PR DESCRIPTION
#### What are the relevant tickets?
No ticket

#### What's this PR do?
This PR does the following
- Adds a check to fix build failure if tab exists in ocw-course config and not in tab settings

#### How should this be manually tested?
- Use resource bundle configuration for ocw-studio
- Verify you are able to add and update pages
