### PR TITLE
Removing UUID v1 from displayed filenames in Edit Resource drawer

### DIFF
--- a/static/js/lib/util.test.ts
+++ b/static/js/lib/util.test.ts
@@ -77,6 +77,10 @@ describe("util", () => {
       "/media/text_id/32629a02-3dc5-4128-8e43-0392b51e7b61_filename.jpg",
       "filename.jpg"
     ],
+    [
+      "/media/text_id/ab3d029952cda060f4afcd811189a591_longer_filename.jpg",
+      "longer_filename.jpg"
+    ],
     ["/media/text_id/filename.jpg", "filename.jpg"]
   ].forEach(([filepath, expected]) => {
     it("filenameFromPath should return expected values", () => {

--- a/static/js/lib/util.ts
+++ b/static/js/lib/util.ts
@@ -48,10 +48,7 @@ export const objectToFormData = (
 
 export const filenameFromPath = (filepath: string): string => {
   const basename = filepath.split("/").pop() || ""
-  const UUID = new RegExp(
-    "^[0-9A-F]{8}-?[0-9A-F]{4}-?[4][0-9A-F]{3}-?[89AB][0-9A-F]{3}-?[0-9A-F]{12}",
-    "i"
-  )
+  const UUID = /^[0-9A-F]{8}-?[0-9A-F]{4}-?[0-9A-F]{4}-?[0-9A-F]{4}-?[0-9A-F]{12}/i
   if (UUID.test(basename)) {
     if (basename.includes("_")) {
       return basename


### PR DESCRIPTION
#### Pre-Flight checklist
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/ocw-studio/issues/1414

#### What's this PR do?
If a filename starts with a UUID v1 (as opposed to UUID v4), this part of the filename will not be shown in the `Edit Resource` drawer.

#### How should this be manually tested?
Open the `Edit Resource` drawer for files in a course with filenames that begin with a UUID v1, such as `sites/17-20-introduction-to-american-politics-spring-2013`.

