### PR TITLE
Clean up noisy detect-secrets errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
           NODE_ENV: 'production'
           OCW_STUDIO_BASE_URL: 'http://localhost:8043/'
           SOCIAL_AUTH_SAML_LOGIN_URL: 'fake.example.com/login/saml/'
-          SECRET_KEY: "secret"
+          SECRET_KEY: "secret"  # pragma: allowlist secret
           CONTENT_SYNC_BACKEND:
 
       - name: Upload coverage to CodeCov

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,8 +2,14 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: git@github.com:Yelp/detect-secrets
-    rev: v0.14.2
+    rev: v1.3.0
     hooks:
     -   id: detect-secrets
-        args: ['--baseline', '.secrets.baseline']
+        args:
+          - --baseline
+          - .secrets.baseline
+          - --exclude-files
+          - README.md
+          - --exclude-files
+          - .yarn/releases/yarn-3.1.0.cjs
         exclude: .*_test.*|yarn\.lock

--- a/content_sync/conftest.py
+++ b/content_sync/conftest.py
@@ -39,7 +39,7 @@ def required_concourse_settings(settings):
     """ Other required settings for concourse pipelines """
     settings.CONCOURSE_URL = "http://localconcourse.edu"
     settings.CONCOURSE_USERNAME = "test"
-    settings.CONCOURSE_PASSWORD = "pass"
+    settings.CONCOURSE_PASSWORD = "pass"  # pragma: allowlist secret
     settings.CONCOURSE_TEAM = "ocwtest"
     settings.AWS_PREVIEW_BUCKET_NAME = "preview_bucket"
     settings.AWS_PUBLISH_BUCKET_NAME = "publish_bucket"
@@ -50,6 +50,6 @@ def required_concourse_settings(settings):
     settings.GIT_ORGANIZATION = "test_org"
     settings.GITHUB_WEBHOOK_BRANCH = "release"
     settings.SITE_BASE_URL = "http://test.edu"
-    settings.API_BEARER_TOKEN = "abc123"
+    settings.API_BEARER_TOKEN = "abc123"  # pragma: allowlist secret
     settings.SEARCH_API_URL = "http://test.edu/api/v0/search"
     settings.OCW_GTM_ACCOUNT_ID = "abc123"

--- a/docker-compose-notebook.yml
+++ b/docker-compose-notebook.yml
@@ -5,8 +5,8 @@ x-environment:
   DEBUG: 'False'
   NODE_ENV: 'production'
   DEV_ENV: 'True'  # necessary to have nginx connect to web container
-  SECRET_KEY: local_unsafe_key
-  DATABASE_URL: postgres://postgres@db:5432/postgres
+  SECRET_KEY: local_unsafe_key  # pragma: allowlist secret
+  DATABASE_URL: postgres://postgres@db:5432/postgres  # pragma: allowlist secret
   OCW_STUDIO_SECURE_SSL_REDIRECT: 'False'
   OCW_STUDIO_DB_DISABLE_SSL: 'True'
   CELERY_TASK_ALWAYS_EAGER: 'False'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ x-environment:
   DEBUG: 'False'
   NODE_ENV: 'production'
   DEV_ENV: 'True'  # necessary to have nginx connect to web container
-  SECRET_KEY: local_unsafe_key
-  DATABASE_URL: postgres://postgres:postgres@db:5432/postgres
+  SECRET_KEY: local_unsafe_key  # pragma: allowlist secret
+  DATABASE_URL: postgres://postgres:postgres@db:5432/postgres  # pragma: allowlist secret
   OCW_STUDIO_SECURE_SSL_REDIRECT: 'False'
   OCW_STUDIO_DB_DISABLE_SSL: 'True'
   CELERY_TASK_ALWAYS_EAGER: 'False'
@@ -23,7 +23,7 @@ services:
     ports:
       - "5431:5432"
     environment:
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_PASSWORD: postgres  # pragma: allowlist secret
 
   redis:
     image: redis:6.0.10

--- a/videos/conftest.py
+++ b/videos/conftest.py
@@ -30,7 +30,7 @@ def valid_settings(settings):
 def youtube_settings(settings, mocker):
     """Populate required youtube settings with dummy values"""
     settings.YT_CLIENT_ID = "testvalue"
-    settings.YT_CLIENT_SECRET = "testvalue"
+    settings.YT_CLIENT_SECRET = "testvalue"  # pragma: allowlist secret
     settings.YT_PROJECT_ID = "testvalue"
     settings.YT_ACCESS_TOKEN = "testvalue"
     settings.YT_REFRESH_TOKEN = "testvalue"


### PR DESCRIPTION
Having a linting tool that just generates noise is not helpful and leads developers to
ignore legitimate warnings. This cleans up noisy alerts from detect-secrets so that we
can pay attention to the ones that are worth noticing.

#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
N/A

#### What's this PR do?
Updates the pre-commit config to avoid alert fatigue and notify on legitimate secrets being committed

#### How should this be manually tested?
Run `pre-commit run --all-files` and verify that there are no secrets being reported. Add a new secret and run again to ensure it gets detected.

#### Where should the reviewer start?
`.pre-commit-config.yaml`

#### Any background context you want to provide?
We recently had an incident with legitimate credentials being accidentally pushed to GitHub. This aims to prevent that from happening in the future.

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
