### PR TITLE
alternate theme rendering - mass build pipeline

### DIFF
--- a/content_sync/api.py
+++ b/content_sync/api.py
@@ -60,11 +60,23 @@ def get_theme_assets_pipeline(api: Optional[object] = None) -> BasePipeline:
 
 
 @is_publish_pipeline_enabled
-def get_mass_build_sites_pipeline(version: str, api: Optional[object] = None) -> object:
+def get_mass_build_sites_pipeline(
+    version: str,
+    api: Optional[object] = None,
+    prefix: Optional[str] = None,
+    themes_branch: Optional[str] = None,
+    projects_branch: Optional[str] = None,
+) -> object:
     """Get the mass build sites pipeline if the backend has one"""
     return import_string(
         f"content_sync.pipelines.{settings.CONTENT_SYNC_PIPELINE_BACKEND}.MassBuildSitesPipeline"
-    )(version, api=api)
+    )(
+        version,
+        api=api,
+        prefix=prefix,
+        themes_branch=themes_branch,
+        projects_branch=projects_branch,
+    )
 
 
 @is_publish_pipeline_enabled

--- a/content_sync/management/commands/upsert_mass_build_pipeline.py
+++ b/content_sync/management/commands/upsert_mass_build_pipeline.py
@@ -28,6 +28,27 @@ class Command(BaseCommand):
             action="store_true",
             help="Delete existing mass publish pipelines first",
         )
+        parser.add_argument(
+            "-p",
+            "--prefix",
+            dest="prefix",
+            default="",
+            help="An optional prefix to prepend to the deploy path",
+        )
+        parser.add_argument(
+            "-t",
+            "--themes-branch",
+            dest="themes-branch",
+            default="",
+            help="An optional override for the branch of ocw-hugo-themes to use in the builds",
+        )
+        parser.add_argument(
+            "-r",
+            "--projects-branch",
+            dest="projects-branch",
+            default="",
+            help="An optional override for the branch of ocw-hugo-projects to use in the builds",
+        )
 
     def handle(self, *args, **options):
 
@@ -39,6 +60,9 @@ class Command(BaseCommand):
 
         unpause = options["unpause"]
         delete_all = options["delete_all"]
+        prefix = options["prefix"]
+        themes_branch = options["themes-branch"]
+        projects_branch = options["projects-branch"]
         start = now_in_utc()
 
         if delete_all:
@@ -51,7 +75,12 @@ class Command(BaseCommand):
                 self.stdout.error("No pipeline api configured")
 
         for version in (VERSION_DRAFT, VERSION_LIVE):
-            pipeline = get_mass_build_sites_pipeline(version)
+            pipeline = get_mass_build_sites_pipeline(
+                version,
+                prefix=prefix,
+                themes_branch=themes_branch,
+                projects_branch=projects_branch,
+            )
             pipeline.upsert_pipeline()
             self.stdout.write(f"Created {version} mass build pipeline")
             if unpause:
@@ -59,6 +88,4 @@ class Command(BaseCommand):
                 self.stdout.write(f"Unpaused {version} mass build pipeline")
 
         total_seconds = (now_in_utc() - start).total_seconds()
-        self.stdout.write(
-            "Pipeline upsert finished, took {} seconds".format(total_seconds)
-        )
+        self.stdout.write(f"Pipeline upsert finished, took {total_seconds} seconds")

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -513,7 +513,7 @@ class MassBuildSitesPipeline(BaseMassBuildSitesPipeline, GeneralPipeline):
 
     PIPELINE_NAME = BaseMassBuildSitesPipeline.PIPELINE_NAME
 
-    def __init__(
+    def __init__(  # pylint: disable=too-many-arguments
         self,
         version,
         api: Optional[PipelineApi] = None,

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -513,7 +513,14 @@ class MassBuildSitesPipeline(BaseMassBuildSitesPipeline, GeneralPipeline):
 
     PIPELINE_NAME = BaseMassBuildSitesPipeline.PIPELINE_NAME
 
-    def __init__(self, version, api: Optional[PipelineApi] = None):
+    def __init__(
+        self,
+        version,
+        api: Optional[PipelineApi] = None,
+        prefix: Optional[str] = None,
+        themes_branch: Optional[str] = None,
+        projects_branch: Optional[str] = None,
+    ):
         """Initialize the pipeline instance"""
         self.MANDATORY_SETTINGS = MANDATORY_CONCOURSE_SETTINGS + [
             "AWS_PREVIEW_BUCKET_NAME",
@@ -528,9 +535,23 @@ class MassBuildSitesPipeline(BaseMassBuildSitesPipeline, GeneralPipeline):
         ]
         super().__init__(api=api)
         self.pipeline_name = "mass_build_sites"
-        self.BRANCH = get_theme_branch()
         self.VERSION = version
-        self.set_instance_vars({"version": version})
+        if prefix:
+            self.PREFIX = prefix[1:] if prefix.startswith("/") else prefix
+        else:
+            self.PREFIX = ""
+        self.THEMES_BRANCH = themes_branch if themes_branch else get_theme_branch()
+        self.PROJECTS_BRANCH = (
+            projects_branch if projects_branch else self.THEMES_BRANCH
+        )
+        self.set_instance_vars(
+            {
+                "version": version,
+                "themes_branch": self.THEMES_BRANCH,
+                "projects_branch": self.PROJECTS_BRANCH,
+                "prefix": self.PREFIX,
+            }
+        )
 
     def upsert_pipeline(self):  # pylint:disable=too-many-locals
         """
@@ -586,13 +607,13 @@ class MassBuildSitesPipeline(BaseMassBuildSitesPipeline, GeneralPipeline):
                 "((artifacts-bucket))", template_vars["artifacts_bucket_name"] or ""
             )
             .replace("((ocw-bucket))", template_vars["destination_bucket"] or "")
-            .replace("((ocw-hugo-themes-branch))", self.BRANCH)
+            .replace("((ocw-hugo-themes-branch))", self.THEMES_BRANCH)
             .replace("((ocw-hugo-themes-uri))", OCW_HUGO_THEMES_GIT)
             .replace(
                 "((ocw-hugo-projects-branch))",
-                (settings.OCW_HUGO_PROJECTS_BRANCH or self.BRANCH)
+                (settings.OCW_HUGO_PROJECTS_BRANCH or self.PROJECTS_BRANCH)
                 if is_dev()
-                else self.BRANCH,
+                else self.PROJECTS_BRANCH,
             )
             .replace("((ocw-hugo-projects-uri))", hugo_projects_url)
             .replace("((ocw-import-starter-slug))", settings.OCW_IMPORT_STARTER_SLUG)
@@ -614,6 +635,14 @@ class MassBuildSitesPipeline(BaseMassBuildSitesPipeline, GeneralPipeline):
             .replace("((minio-root-user))", settings.AWS_ACCESS_KEY_ID or "")
             .replace("((minio-root-password))", settings.AWS_SECRET_ACCESS_KEY or "")
             .replace("((resource-base-url))", template_vars["resource_base_url"])
+            .replace("((prefix))", self.PREFIX)
+            .replace(
+                "((trigger))",
+                str(
+                    self.THEMES_BRANCH == settings.GITHUB_WEBHOOK_BRANCH
+                    and self.PROJECTS_BRANCH == settings.GITHUB_WEBHOOK_BRANCH
+                ),
+            )
         )
         self.upsert_config(config_str, self.PIPELINE_NAME)
 

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -625,7 +625,7 @@ def test_upsert_mass_build_pipeline(
     config_str = json.dumps(kwargs)
     assert settings.OCW_GTM_ACCOUNT_ID in config_str
     assert (
-        f"s3://{settings.AWS_STORAGE_BUCKET_NAME}/$S3_PATH s3://{bucket}$PREFIX/$SITE_URL"
+        f"s3://{settings.AWS_STORAGE_BUCKET_NAME}/$S3_PATH s3://{bucket}/$PREFIX/$SITE_URL"
         in config_str
     )
     assert bucket in config_str

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -2,7 +2,6 @@
 import json
 from html import unescape
 from urllib.parse import quote, urljoin
-from main.utils import is_dev
 
 import pytest
 from django.core.exceptions import ImproperlyConfigured
@@ -21,6 +20,7 @@ from content_sync.pipelines.concourse import (
     UnpublishedSiteRemovalPipeline,
 )
 from content_sync.utils import get_template_vars, get_theme_branch
+from main.utils import is_dev
 from websites.constants import STARTER_SOURCE_GITHUB, STARTER_SOURCE_LOCAL
 from websites.factories import WebsiteFactory, WebsiteStarterFactory
 

--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -149,18 +149,14 @@ jobs:
               NAME=$(echo $1 | jq -c '.name' | tr -d '"')
               curl -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer ((api-token))' --data '{"version":"((version))","status":"errored"}' ((ocw-studio-url))/api/websites/$NAME/pipeline_status/
             }
-            index=0
             jq -c '.sites[]' publishable_sites/sites.json | while read i; do
-              if [[ $index < 10 ]]
+              result=$(process_site $i) || result=1
+              echo "RESULT IS $result"
+              if [[ $result == 1 ]]
               then
-                result=$(process_site $i) || result=1
-                echo "RESULT IS $result"
-                if [[ $result == 1 ]]
-                then
-                  fail_site $i
-                fi
-                ((index=index+1))
+                fail_site $i
               fi
+            fi
             done
   # START NON-DEV
   - task: clear-cdn-cache

--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -156,7 +156,6 @@ jobs:
               then
                 fail_site $i
               fi
-            fi
             done
   # START NON-DEV
   - task: clear-cdn-cache

--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -46,13 +46,13 @@ jobs:
     trigger: false
   - get: webpack-json
     # START NON-DEV
-    trigger: true
+    trigger: ((trigger))
     # END NON-DEV
   - get: ocw-hugo-projects
     timeout: 1m
     attempts: 3
     # START NON-DEV
-    trigger: true
+    trigger: ((trigger))
     # END NON-DEV
   - task: get-sites
     timeout: 2m
@@ -81,6 +81,7 @@ jobs:
       STATIC_API_BASE_URL: ((static-api-base-url))
       GIT_KEY: ((git-private-key-var))
       SITEMAP_DOMAIN: ((sitemap-domain))
+      PREFIX: ((prefix))
       # START DEV-ONLY
       AWS_ACCESS_KEY_ID: ((minio-root-user))
       AWS_SECRET_ACCESS_KEY: ((minio-root-password))
@@ -134,10 +135,10 @@ jobs:
               fi
               cd $CURDIR/$SHORT_ID
               cp ../webpack-json/webpack.json ../ocw-hugo-themes/base-theme/data
-              hugo --config ../ocw-hugo-projects/$STARTER_SLUG/config.yaml --baseUrl /$BASE_URL --themesDir ../ocw-hugo-themes/ ((build-drafts))  || return 1
+              hugo --config ../ocw-hugo-projects/$STARTER_SLUG/config.yaml --baseUrl $PREFIX/$BASE_URL --themesDir ../ocw-hugo-themes/ ((build-drafts))  || return 1
               cd $CURDIR
-              aws s3((cli-endpoint-url)) sync s3://((ocw-studio-bucket))/$S3_PATH s3://((ocw-bucket))/$SITE_URL --metadata site-id=$NAME || return 1            
-              aws s3((cli-endpoint-url)) sync $SHORT_ID/public s3://((ocw-bucket))/$BASE_URL --metadata site-id=$NAME || return 1
+              aws s3((cli-endpoint-url)) sync s3://((ocw-studio-bucket))/$S3_PATH s3://((ocw-bucket))$PREFIX/$SITE_URL --metadata site-id=$NAME || return 1            
+              aws s3((cli-endpoint-url)) sync $SHORT_ID/public s3://((ocw-bucket))$PREFIX/$BASE_URL --metadata site-id=$NAME || return 1
               curl -X POST -H 'Content-Type: application/json' --data '{"webhook_key":"((open-webhook-key))","prefix":"'"$SITE_URL"/'","version":"((version))"}' ((open-discussions-url))/api/v0/ocw_next_webhook/
               curl -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer ((api-token))' --data '{"version":"((version))","status":"succeeded"}' ((ocw-studio-url))/api/websites/$NAME/pipeline_status/
               rm -rf $SHORT_ID
@@ -148,12 +149,17 @@ jobs:
               NAME=$(echo $1 | jq -c '.name' | tr -d '"')
               curl -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer ((api-token))' --data '{"version":"((version))","status":"errored"}' ((ocw-studio-url))/api/websites/$NAME/pipeline_status/
             }
+            index=0
             jq -c '.sites[]' publishable_sites/sites.json | while read i; do
-              result=$(process_site $i) || result=1
-              echo "RESULT IS $result"
-              if [[ $result == 1 ]]
+              if [[ $index < 10 ]]
               then
-                fail_site $i
+                result=$(process_site $i) || result=1
+                echo "RESULT IS $result"
+                if [[ $result == 1 ]]
+                then
+                  fail_site $i
+                fi
+                ((index=index+1))
               fi
             done
   # START NON-DEV

--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -135,10 +135,10 @@ jobs:
               fi
               cd $CURDIR/$SHORT_ID
               cp ../webpack-json/webpack.json ../ocw-hugo-themes/base-theme/data
-              hugo --config ../ocw-hugo-projects/$STARTER_SLUG/config.yaml --baseUrl $PREFIX/$BASE_URL --themesDir ../ocw-hugo-themes/ ((build-drafts))  || return 1
+              hugo --config ../ocw-hugo-projects/$STARTER_SLUG/config.yaml --baseUrl /$PREFIX/$BASE_URL --themesDir ../ocw-hugo-themes/ ((build-drafts))  || return 1
               cd $CURDIR
-              aws s3((cli-endpoint-url)) sync s3://((ocw-studio-bucket))/$S3_PATH s3://((ocw-bucket))$PREFIX/$SITE_URL --metadata site-id=$NAME || return 1            
-              aws s3((cli-endpoint-url)) sync $SHORT_ID/public s3://((ocw-bucket))$PREFIX/$BASE_URL --metadata site-id=$NAME || return 1
+              aws s3((cli-endpoint-url)) sync s3://((ocw-studio-bucket))/$S3_PATH s3://((ocw-bucket))/$PREFIX/$SITE_URL --metadata site-id=$NAME || return 1            
+              aws s3((cli-endpoint-url)) sync $SHORT_ID/public s3://((ocw-bucket))/$PREFIX/$BASE_URL --metadata site-id=$NAME || return 1
               curl -X POST -H 'Content-Type: application/json' --data '{"webhook_key":"((open-webhook-key))","prefix":"'"$SITE_URL"/'","version":"((version))"}' ((open-discussions-url))/api/v0/ocw_next_webhook/
               curl -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer ((api-token))' --data '{"version":"((version))","status":"succeeded"}' ((ocw-studio-url))/api/websites/$NAME/pipeline_status/
               rm -rf $SHORT_ID

--- a/main/settings.py
+++ b/main/settings.py
@@ -1113,14 +1113,12 @@ RESOURCE_BASE_URL_LIVE = get_string(
 OCW_HUGO_THEMES_BRANCH = get_string(
     name="OCW_HUGO_THEMES_BRANCH",
     description="The branch to use in development of ocw-hugo-themes",
-    default="main",
     required=False,
     dev_only=True,
 )
 OCW_HUGO_PROJECTS_BRANCH = get_string(
     name="OCW_HUGO_PROJECTS_BRANCH",
     description="The branch to use in development of ocw-hugo-projects",
-    default="main",
     required=False,
     dev_only=True,
 )


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1428

#### What's this PR do?
This PR adds 3 optional arugments to the `upsert_mass_build_pipeline` management command:

 - `--prefix` - Adds an optional prefix to the path of sites deployed by the mass build pipeline
 - `--themes-branch` - Adds an optional override for the branch of `ocw-hugo-themes` to be used when building sites in the mass build pipeline
 - `--projects-branch` - Adds an optional override for the branch of `ocw-hugo-projects` to be used when building sites in the mass build pipeline

Each unique configuration will create a new set of pipelines for `draft` and `live` in the Concourse `mass-build-sites` group.  The only set of pipelines with automatic triggering enabled, however, will be the pipeline with the default branches of `ocw-hugo-themes` and `ocw-hugo-projects` matching `settings.GITHUB_WEBHOOK_BRANCH`.  Other mass build pipelines will need to be triggered manually.

#### How should this be manually tested?
 - Testing this PR will require setting up Concourse and Minio containers locally as well as a Github test organization, which only requires that you set some environment variables before running `docker-compose up`.  Check the readme for details.  You will also want to probably have a recent backup of the production database restored to your local instance by doing the following (replace `PROD_DB_URL` with the URL of the production database, `TODAY_DATE` with today's date):
```
pg_dump PROD_DB_URL > ./dumps/prod_TODAY_DATE.sql
docker-compose rm -sv db
docker-compose up -d db
docker-compose exec -T -e PGPASSWORD=postgres db psql -h db -U postgres < ./dumps/prod_TODAY_DATE.sql
docker-compose exec web ./manage.py createsuperuser
```
 -  Once your instance of `ocw-studio` is running, run the following to push up the theme assets pipeline and `ocw-www` pipeline:
```
docker-compose exec web ./manage.py upsert_theme_assets_pipeline
docker-compose exec web ./manage.py backpopulate_pipelines --filter ocw-www
```
- Once this is complete, browse to http://concourse:8080, login with test / test and go to the theme assets pipeline and trigger a build
- Once the theme assets build is complete, go to the live `ocw-www` pipeline and trigger a build
- Once both of these are complete, verify that you see the OCW home page at http://localhost:8045
- Make a temporary edit for testing to the `mass-build-sites.yml` template file (line 152) for this testing procedure to artifically limit the mass build to 10 sites:
```
            index=0
            jq -c '.sites[]' publishable_sites/sites.json | while read i; do
              if [[ $index < 10 ]]
              then
                result=$(process_site $i) || result=1
                echo "RESULT IS $result"
                if [[ $result == 1 ]]
                then
                  fail_site $i
                fi
                ((index=index+1))
              fi
            done
```
- Upsert the default mass build pipeline by simply running: `docker-compose exec web ./manage.py upsert_mass_build_pipeline`
- Upsert a test pipeline for building `course-v2` by running: `docker-compose exec web ./manage.py upsert_mass_build_pipeline --prefix /course-v2 --themes-branch main --projects-branch cg/course-v2-testing`
- Visit http://concourse:8080/?search=team%3A%22main%22%20group%3A%22mass-build-sites%22 and verify that you see 4 pipelines like this (yours will all be paused and grey):
![image](https://user-images.githubusercontent.com/12089658/181852838-b04ac349-8e2f-4a18-ae65-64094f22e71f.png)
- Unpause the `live` versions of the pipelines and start the one on the `main` branch (or whatever you have `GITHUB_WEBHOOK_BRANCH` set to)
- Once the pipeline completes, verify that you have a site at http://localhost:8045/courses/10-01-ethics-for-engineers-artificial-intelligence-spring-2020/ that is using the current version of the `course` theme:
![image](https://user-images.githubusercontent.com/12089658/181853118-e05774a2-113e-4b9f-8db7-d1ee9edf720d.png)
- Run the mass build pipeline with `projects_branch: cg/course-v2-testing`
- Visit http://localhost:8045/course-v2/courses/10-01-ethics-for-engineers-artificial-intelligence-spring-2020/and verify that you have a site rendered with the `course-v2` theme like this:
![image](https://user-images.githubusercontent.com/12089658/181853326-7e1fab49-4a88-4730-9a25-a815d0391cc3.png)


#### Where should the reviewer start?
`upsert_mass_build_pipeline.py`, `concourse.py`, `concourse_test.py`, `mass-build-sites.yml`

#### Any background context you want to provide?
This will be used to build alternate versions of the site in RC for testing new themes
