### PR TITLE
Setting default language for code blocks to plain text

### DIFF
--- a/static/js/lib/ckeditor/CKEditor.ts
+++ b/static/js/lib/ckeditor/CKEditor.ts
@@ -44,8 +44,6 @@ import LegacyShortcodes from "./plugins/LegacyShortcodes"
  */
 const SUPPORTED_PROGRAMMING_LANGUAGES = [
   { language: "plaintext", label: "Plain text" },
-  { language: "matlab", label: "Matlab" },
-  { language: "julia", label: "Julia" },
   { language: "c", label: "C" },
   { language: "cs", label: "C#" },
   { language: "cpp", label: "C++" },
@@ -54,23 +52,14 @@ const SUPPORTED_PROGRAMMING_LANGUAGES = [
   { language: "html", label: "HTML" },
   { language: "java", label: "Java" },
   { language: "javascript", label: "JavaScript" },
+  { language: "julia", label: "Julia" },
+  { language: "matlab", label: "Matlab" },
   { language: "php", label: "PHP" },
   { language: "python", label: "Python" },
   { language: "ruby", label: "Ruby" },
   { language: "typescript", label: "TypeScript" },
   { language: "xml", label: "XML" }
-].sort((first, second) => {
-  const labelOne = first.label.toUpperCase()
-  const labelTwo = second.label.toUpperCase()
-
-  if (labelOne < labelTwo) {
-    return -1
-  }
-  if (labelOne > labelTwo) {
-    return 1
-  }
-  return 0
-})
+]
 
 export const FullEditorConfig = {
   plugins: [


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1434.

#### What's this PR do?
The default language for code blocks in OCW Studio is now "plain text"; users can still select a different language as before from the dropdown menu next to the code block icon.

#### How should this be manually tested?
Create a code block within a page in OCW Studio, and verify that `plain text` is the default.

#### Any background context you want to provide?
The code previously sorted all of the languages available for code blocks alphabetically, resulting in C appearing first. Since CKEditor sets the first language listed as the default, the previous default was C.