### PR TITLE
clean up mass build sites logging

### DIFF
--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -625,7 +625,7 @@ def test_upsert_mass_build_pipeline(
     config_str = json.dumps(kwargs)
     assert settings.OCW_GTM_ACCOUNT_ID in config_str
     assert (
-        f"s3://{settings.AWS_STORAGE_BUCKET_NAME}/$S3_PATH s3://{bucket}/$PREFIX/$SITE_URL"
+        f"s3://{settings.AWS_STORAGE_BUCKET_NAME}/$S3_PATH s3://{bucket}$PREFIX/$SITE_URL"
         in config_str
     )
     assert bucket in config_str

--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -100,8 +100,9 @@ jobs:
       run:
         path: bash
         args:
-          - -exc
+          - -ec
           - |
+            ANY_FAILED=0
             CURDIR=$(pwd)
             if [[ "$GIT_KEY" != "" ]]
             then
@@ -123,40 +124,70 @@ jobs:
               S3_PATH=$(echo $1 | jq -c '.s3_path' | tr -d '"')
               SITE_URL=$(echo $1 | jq -c '.site_url' | tr -d '"')
               BASE_URL=$(echo $1 | jq -c '.base_url' | tr -d '"')
+              echo "STARTING PUBLISH OF $NAME" > /dev/tty
               if [[ "$SITE_URL" == null || "$S3_PATH" == null ]]
               then
                 return 1
               fi
               if [[ "$GITKEYSSH" != "" ]]
               then
-                git -c core.sshCommand="ssh $GITKEYSSH -o StrictHostKeyChecking=no" clone -b ((ocw-site-repo-branch)) ((markdown-uri))/$SHORT_ID.git || return 1
+                git -c core.sshCommand="ssh $GITKEYSSH -o StrictHostKeyChecking=no" clone -b ((ocw-site-repo-branch)) ((markdown-uri))/$SHORT_ID.git --quiet || return 1
               else
-                git clone -b ((ocw-site-repo-branch)) ((markdown-uri))/$SHORT_ID.git || return 1
+                git clone -b ((ocw-site-repo-branch)) ((markdown-uri))/$SHORT_ID.git --quiet || return 1
               fi
               cd $CURDIR/$SHORT_ID
               cp ../webpack-json/webpack.json ../ocw-hugo-themes/base-theme/data
-              hugo --config ../ocw-hugo-projects/$STARTER_SLUG/config.yaml --baseUrl /$PREFIX/$BASE_URL --themesDir ../ocw-hugo-themes/ ((build-drafts))  || return 1
+              echo "RUNNING HUGO BUILD FOR $NAME" > /dev/tty
+              HUGO_RESULT=$(hugo --config ../ocw-hugo-projects/$STARTER_SLUG/config.yaml --baseUrl /$PREFIX/$BASE_URL --themesDir ../ocw-hugo-themes/ ((build-drafts)) --quiet) || HUGO_RESULT=1
+              if [[ $HUGO_RESULT == 1 ]]
+              then
+                echo "HUGO BUILD FAILED FOR $NAME" > /dev/tty
+                return 1
+              fi
               cd $CURDIR
-              aws s3((cli-endpoint-url)) sync s3://((ocw-studio-bucket))/$S3_PATH s3://((ocw-bucket))/$PREFIX/$SITE_URL --metadata site-id=$NAME || return 1            
-              aws s3((cli-endpoint-url)) sync $SHORT_ID/public s3://((ocw-bucket))/$PREFIX/$BASE_URL --metadata site-id=$NAME || return 1
-              curl -X POST -H 'Content-Type: application/json' --data '{"webhook_key":"((open-webhook-key))","prefix":"'"$SITE_URL"/'","version":"((version))"}' ((open-discussions-url))/api/v0/ocw_next_webhook/
-              curl -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer ((api-token))' --data '{"version":"((version))","status":"succeeded"}' ((ocw-studio-url))/api/websites/$NAME/pipeline_status/
+              echo "STARTING S3 SYNC FOR $NAME" > /dev/tty
+              STUDIO_S3_RESULT=$(aws s3((cli-endpoint-url)) sync s3://((ocw-studio-bucket))/$S3_PATH s3://((ocw-bucket))/$PREFIX/$SITE_URL --metadata site-id=$NAME --only-show-errors) || STUDIO_S3_RESULT=1
+              if [[ $STUDIO_S3_RESULT == 1 ]]
+              then
+                echo "SYNCING s3://((ocw-studio-bucket))/$S3_PATH to s3://((ocw-bucket))/$PREFIX/$SITE_URL FAILED FOR $NAME" > /dev/tty
+                return 1
+              fi
+              PUBLISH_S3_RESULT=$(aws s3((cli-endpoint-url)) sync $SHORT_ID/public s3://((ocw-bucket))/$PREFIX/$BASE_URL --metadata site-id=$NAME --only-show-errors) || PUBLISH_S3_RESULT=1
+              if [[ $PUBLISH_S3_RESULT == 1 ]]
+              then
+                echo "SYNCING $SHORT_ID/public to s3://((ocw-bucket))/$PREFIX/$SITE_URL failed for $NAME" > /dev/tty
+                return 1
+              fi
+              # START NON-DEV
+              curl -s -X POST -H 'Content-Type: application/json' --data '{"webhook_key":"((open-webhook-key))","prefix":"'"$SITE_URL"/'","version":"((version))"}' ((open-discussions-url))/api/v0/ocw_next_webhook/
+              # END NON-DEV
+              curl -s -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer ((api-token))' --data '{"version":"((version))","status":"succeeded"}' ((ocw-studio-url))/api/websites/$NAME/pipeline_status/
               rm -rf $SHORT_ID
+              echo "PUBLISH OF $NAME COMPLETE" > /dev/tty
               return 0
             }
             fail_site()
             {
               NAME=$(echo $1 | jq -c '.name' | tr -d '"')
-              curl -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer ((api-token))' --data '{"version":"((version))","status":"errored"}' ((ocw-studio-url))/api/websites/$NAME/pipeline_status/
+              echo "PUBLISH OF $NAME FAILED" > /dev/tty
+              curl -s -X POST -H 'Content-Type: application/json' -H 'Authorization: Bearer ((api-token))' --data '{"version":"((version))","status":"errored"}' ((ocw-studio-url))/api/websites/$NAME/pipeline_status/
             }
-            jq -c '.sites[]' publishable_sites/sites.json | while read i; do
-              result=$(process_site $i) || result=1
-              echo "RESULT IS $result"
-              if [[ $result == 1 ]]
+            while read SITE; do
+              RESULT=$(process_site $SITE) || RESULT=1
+              if [[ $RESULT == 1 ]]
               then
-                fail_site $i
+                ANY_FAILED=1
+                fail_site $SITE
               fi
-            done
+            done <<< $(jq -c '.sites[]' publishable_sites/sites.json)
+            if [[ $ANY_FAILED == 1 ]]
+            then
+              echo "FAILED BUILDS HAPPENED" > /dev/tty
+              exit 1
+            else
+              echo "ALL BUILDS SUCCEEDED" > /dev/tty
+              exit 0
+            fi
   # START NON-DEV
   - task: clear-cdn-cache
     timeout: 1m

--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -124,6 +124,10 @@ jobs:
               S3_PATH=$(echo $1 | jq -c '.s3_path' | tr -d '"')
               SITE_URL=$(echo $1 | jq -c '.site_url' | tr -d '"')
               BASE_URL=$(echo $1 | jq -c '.base_url' | tr -d '"')
+              if [[ "$PREFIX" != "" ]]
+              then
+                PREFIX="/$PREFIX"
+              fi
               echo "STARTING PUBLISH OF $NAME" > /dev/tty
               if [[ "$SITE_URL" == null || "$S3_PATH" == null ]]
               then
@@ -138,7 +142,7 @@ jobs:
               cd $CURDIR/$SHORT_ID
               cp ../webpack-json/webpack.json ../ocw-hugo-themes/base-theme/data
               echo "RUNNING HUGO BUILD FOR $NAME" > /dev/tty
-              HUGO_RESULT=$(hugo --config ../ocw-hugo-projects/$STARTER_SLUG/config.yaml --baseUrl /$PREFIX/$BASE_URL --themesDir ../ocw-hugo-themes/ ((build-drafts)) --quiet) || HUGO_RESULT=1
+              HUGO_RESULT=$(hugo --config ../ocw-hugo-projects/$STARTER_SLUG/config.yaml --baseUrl $PREFIX/$BASE_URL --themesDir ../ocw-hugo-themes/ ((build-drafts)) --quiet) || HUGO_RESULT=1
               if [[ $HUGO_RESULT == 1 ]]
               then
                 echo "HUGO BUILD FAILED FOR $NAME" > /dev/tty
@@ -146,16 +150,16 @@ jobs:
               fi
               cd $CURDIR
               echo "STARTING S3 SYNC FOR $NAME" > /dev/tty
-              STUDIO_S3_RESULT=$(aws s3((cli-endpoint-url)) sync s3://((ocw-studio-bucket))/$S3_PATH s3://((ocw-bucket))/$PREFIX/$SITE_URL --metadata site-id=$NAME --only-show-errors) || STUDIO_S3_RESULT=1
+              STUDIO_S3_RESULT=$(aws s3((cli-endpoint-url)) sync s3://((ocw-studio-bucket))/$S3_PATH s3://((ocw-bucket))$PREFIX/$SITE_URL --metadata site-id=$NAME --only-show-errors) || STUDIO_S3_RESULT=1
               if [[ $STUDIO_S3_RESULT == 1 ]]
               then
-                echo "SYNCING s3://((ocw-studio-bucket))/$S3_PATH to s3://((ocw-bucket))/$PREFIX/$SITE_URL FAILED FOR $NAME" > /dev/tty
+                echo "SYNCING s3://((ocw-studio-bucket))/$S3_PATH to s3://((ocw-bucket))$PREFIX/$SITE_URL FAILED FOR $NAME" > /dev/tty
                 return 1
               fi
-              PUBLISH_S3_RESULT=$(aws s3((cli-endpoint-url)) sync $SHORT_ID/public s3://((ocw-bucket))/$PREFIX/$BASE_URL --metadata site-id=$NAME --only-show-errors) || PUBLISH_S3_RESULT=1
+              PUBLISH_S3_RESULT=$(aws s3((cli-endpoint-url)) sync $SHORT_ID/public s3://((ocw-bucket))$PREFIX/$BASE_URL --metadata site-id=$NAME --only-show-errors) || PUBLISH_S3_RESULT=1
               if [[ $PUBLISH_S3_RESULT == 1 ]]
               then
-                echo "SYNCING $SHORT_ID/public to s3://((ocw-bucket))/$PREFIX/$SITE_URL failed for $NAME" > /dev/tty
+                echo "SYNCING $SHORT_ID/public to s3://((ocw-bucket))$PREFIX/$SITE_URL failed for $NAME" > /dev/tty
                 return 1
               fi
               # START NON-DEV


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1440

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/950, we added the `mass-build-sites` pipeline and the associated management command for pushing it up to Concourse. This pipeline runs a bash script that queries the `ocw-studio` API for a list of publishable courses, iterating them and building them one by one. One major issue with this has been that it produces so much log output that the resulting pipeline output is unreadable.  There is so much in it that it will eventually crash the Concourse web UI when trying to view the pipeline run. This PR sets a "quiet" option for `curl`,`hugo` and `aws` commands and produces intentional logging where applicable. Errors will still be logged, so looking back at the log it should be easy to tell where and why a given error occurred. The volume of logging will be significantly reduced, so the log should actually load in the Concourse UI without crashing the browser.

#### How should this be manually tested?
 - Spin up `ocw-studio` locally with Concourse and Minio enabled; see the readme for more details on this if you are unsure how to do so
 - Restore a production backup to your local `ocw-studio` database or make sure you have `ocw-www` as well as some test course sites in your database
 - If you have many sites in your local database, you may want to edit `websites/views.py` and on line 292 change it to be: `sites = sites.prefetch_related("starter").order_by("name")[:10]` to limit to 10 sites
 - Upsert the mass build pipeline to your local Concourse instance with `docker-compose exec web ./manage.py upsert_mass_build_pipeline`
 - Browse to http://concourse:8080, login and find the mass build pipeline then trigger a build
 - View the log output of the `get-repo-build-course-publish-course` step and make sure you see only 4 lines of logging per course and the build should succeed:
```
STARTING PUBLISH OF 10-01-ethics-for-engineers-artificial-intelligence-spring-2020
RUNNING HUGO BUILD FOR 10-01-ethics-for-engineers-artificial-intelligence-spring-2020
STARTING S3 SYNC FOR 10-01-ethics-for-engineers-artificial-intelligence-spring-2020
PUBLISH OF 10-01-ethics-for-engineers-artificial-intelligence-spring-2020 COMPLETE
```
 - Make a temporary edit on `mass-build-sites.yml` at line 149 changing `s3://((ocw-studio-bucket))/$S3_PATH` to `s3://((ocw-studio-bucket))1/$S3_PATH`
 - Upsert the mass build pipeline again and run it. You should see errors in the log and when the build finishes it should show as failed in Concourse with a red background on the build tab
