### PR TITLE
don't retry the mass build automatically

### DIFF
--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -71,7 +71,7 @@ jobs:
         - |
           wget -O publishable_sites/sites.json --header="Authorization: Bearer ((api-token))" "((ocw-studio-url))/api/publish/?version=((version))"
   - task: get-repo-build-course-publish-course
-    attempts: 3
+    attempts: 1
     timeout: 300m
     params:
       API_BEARER_TOKEN: ((api-token))


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Follow up for https://github.com/mitodl/ocw-studio/pull/1442

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/1442, we made some changes to the mass build pipeline that cleans up the logging and also will set the build as failed if any errors are detected during the build. With `attempts: 3` set on the job, the pipeline will retry the ~2 hour mass build step 3 times if any of the sites fail.  This is obviously not great and should only be done manually after the issues with the first run are addressed.  This sets it to `attempts: 1`

#### How should this be manually tested?
Follow the same instructions as https://github.com/mitodl/ocw-studio/pull/1442, except skip straight to the failure mode. Ensure that when the pipeline fails, it isn't retried.
