### PR TITLE
Pt/resource picker tabs

### DIFF
--- a/static/js/components/widgets/ResourcePickerDialog.test.tsx
+++ b/static/js/components/widgets/ResourcePickerDialog.test.tsx
@@ -72,7 +72,7 @@ describe("ResourcePickerDialog", () => {
       ),
       {
         mode:         RESOURCE_EMBED,
-        contentNames: ["resource", "page"],
+        contentNames: ["resource", "pages"],
         isOpen:       true,
         closeDialog:  closeDialogStub,
         insertEmbed:  insertEmbedStub
@@ -102,29 +102,18 @@ describe("ResourcePickerDialog", () => {
     },
     {
       mode:         RESOURCE_LINK,
-      contentNames: ["page"],
+      contentNames: ["pages"],
       expectedTabs: [TabIds.Pages]
     },
     {
       mode:         RESOURCE_LINK,
-      contentNames: ["course_collections"],
-      expectedTabs: [TabIds.CourseCollections]
-    },
-    {
-      mode:         RESOURCE_LINK,
-      contentNames: ["resource_collections"],
-      expectedTabs: [TabIds.ResourceCollections]
-    },
-    {
-      mode:         RESOURCE_LINK,
-      contentNames: ["resource", "page", "course_collections"],
+      contentNames: ["resource", "pages"],
       expectedTabs: [
         TabIds.Documents,
         TabIds.Videos,
         TabIds.Images,
         TabIds.Other,
-        TabIds.Pages,
-        TabIds.CourseCollections
+        TabIds.Pages
       ]
     }
   ])(
@@ -226,7 +215,7 @@ describe("ResourcePickerDialog", () => {
       contentType:  "resource",
       singleColumn: true
     },
-    { index: 4, resourcetype: null, contentType: "page", singleColumn: true }
+    { index: 4, resourcetype: null, contentType: "pages", singleColumn: true }
   ])(
     "passes the correct props to ResourcePickerListing when main tab $index is clicked",
     async ({ resourcetype, contentType, singleColumn, index }) => {

--- a/static/js/components/widgets/ResourcePickerDialog.test.tsx
+++ b/static/js/components/widgets/ResourcePickerDialog.test.tsx
@@ -9,7 +9,10 @@ import IntegrationTestHelper, {
 } from "../../util/integration_test_helper_old"
 import { useDebouncedState } from "../../hooks/state"
 import { useState } from "react"
-import { makeWebsiteContentDetail } from "../../util/factories/websites"
+import {
+  makeWebsiteContentDetail,
+  makeWebsiteDetail
+} from "../../util/factories/websites"
 import { WebsiteContent } from "../../types/websites"
 import {
   RESOURCE_EMBED,
@@ -17,6 +20,8 @@ import {
 } from "../../lib/ckeditor/plugins/constants"
 import { ResourceType } from "../../constants"
 import Dialog from "../Dialog"
+import WebsiteContext from "../../context/Website"
+import { Website } from "../../types/websites"
 
 jest.mock("../../hooks/state")
 
@@ -44,10 +49,12 @@ describe("ResourcePickerDialog", () => {
     insertEmbedStub: sinon.SinonStub,
     closeDialogStub: sinon.SinonStub,
     setStub: sinon.SinonStub,
-    resource: WebsiteContent
+    resource: WebsiteContent,
+    website: Website
 
   beforeEach(() => {
     helper = new IntegrationTestHelper()
+    website = makeWebsiteDetail()
 
     insertEmbedStub = helper.sandbox.stub()
     closeDialogStub = helper.sandbox.stub()
@@ -57,13 +64,20 @@ describe("ResourcePickerDialog", () => {
     // @ts-ignore
     useDebouncedState.mockReturnValue(["", setStub])
 
-    render = helper.configureRenderer(ResourcePickerDialog, {
-      mode:         RESOURCE_EMBED,
-      contentNames: ["resource", "page"],
-      isOpen:       true,
-      closeDialog:  closeDialogStub,
-      insertEmbed:  insertEmbedStub
-    })
+    render = helper.configureRenderer(
+      props => (
+        <WebsiteContext.Provider value={website}>
+          <ResourcePickerDialog {...props} />
+        </WebsiteContext.Provider>
+      ),
+      {
+        mode:         RESOURCE_EMBED,
+        contentNames: ["resource", "page"],
+        isOpen:       true,
+        closeDialog:  closeDialogStub,
+        insertEmbed:  insertEmbedStub
+      }
+    )
   })
 
   afterEach(() => {

--- a/static/js/components/widgets/ResourcePickerDialog.test.tsx
+++ b/static/js/components/widgets/ResourcePickerDialog.test.tsx
@@ -72,7 +72,7 @@ describe("ResourcePickerDialog", () => {
       ),
       {
         mode:         RESOURCE_EMBED,
-        contentNames: ["resource", "pages"],
+        contentNames: ["resource", "page"],
         isOpen:       true,
         closeDialog:  closeDialogStub,
         insertEmbed:  insertEmbedStub
@@ -102,18 +102,18 @@ describe("ResourcePickerDialog", () => {
     },
     {
       mode:         RESOURCE_LINK,
-      contentNames: ["pages"],
-      expectedTabs: [TabIds.Pages]
+      contentNames: ["page"],
+      expectedTabs: ["page"]
     },
     {
       mode:         RESOURCE_LINK,
-      contentNames: ["resource", "pages"],
+      contentNames: ["resource", "page"],
       expectedTabs: [
         TabIds.Documents,
         TabIds.Videos,
         TabIds.Images,
         TabIds.Other,
-        TabIds.Pages
+        "page"
       ]
     }
   ])(
@@ -215,7 +215,7 @@ describe("ResourcePickerDialog", () => {
       contentType:  "resource",
       singleColumn: true
     },
-    { index: 4, resourcetype: null, contentType: "pages", singleColumn: true }
+    { index: 4, resourcetype: null, contentType: "page", singleColumn: true }
   ])(
     "passes the correct props to ResourcePickerListing when main tab $index is clicked",
     async ({ resourcetype, contentType, singleColumn, index }) => {

--- a/static/js/components/widgets/ResourcePickerDialog.tsx
+++ b/static/js/components/widgets/ResourcePickerDialog.tsx
@@ -38,10 +38,7 @@ interface TabSettings {
   singleColumn: boolean
 }
 
-export function toTabSettings(
-  contentType: string,
-  contentTitle: string
-): TabSettings {
+const toTabSettings = (contentType: string, contentTitle: string) => {
   const newTabSettings: TabSettings = {
     title:        contentTitle,
     id:           contentType,
@@ -125,7 +122,7 @@ export default function ResourcePickerDialog(props: Props): JSX.Element {
         .flatMap(name => {
           if (name && name === "resource") {
             return [documentTab, videoTab, imageTab, otherFilesTab]
-          } else if (definedCategories && _.has(definedCategories, name)) {
+          } else if (_.has(definedCategories, name)) {
             return [
               toTabSettings(
                 definedCategories[name]["name"],

--- a/static/js/components/widgets/ResourcePickerDialog.tsx
+++ b/static/js/components/widgets/ResourcePickerDialog.tsx
@@ -108,13 +108,11 @@ const modeText = {
 export default function ResourcePickerDialog(props: Props): JSX.Element {
   const { mode, isOpen, closeDialog, insertEmbed, contentNames } = props
   const website = useWebsite()
-  const definedCategories = useMemo(
-    () => {
-      return website.starter?.config?.collections
-        .filter(entry => entry.category === "Content")
-        .flatMap(elt => [elt.name, elt.label])
-    },
-    [website.starter?.config?.collections])
+  const definedCategories = useMemo(() => {
+    return website.starter?.config?.collections
+      .filter(entry => entry.category === "Content")
+      .flatMap(elt => [elt.name, elt.label])
+  }, [website.starter?.config?.collections])
   const tabs = useMemo(
     () =>
       contentNames


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1419.

#### What's this PR do?
Instead of being hardcoded in the frontend, OCW Studio now lets users define which new Content Types should appear in the Resource Picker. Any Content Type that is defined in the config file (website starter) can now be added to the `link` menu in the Resource Picker by adding it in the config file. Previously, if the new Content Type was not of the types hardcoded in the frontend, this would be ignored and it would not be possible to add a tab for it. 

See https://github.com/mitodl/ocw-studio/issues/1419#issuecomment-1206813572 and https://github.com/mitodl/ocw-studio/issues/1419#issuecomment-1209309554 for additional context.

#### How should this be manually tested?
To test this locally, open Django admin within a locally-running instance of OCW Studio. If a content type is listed under `link` or `embed` in the config file but is not defined in the config as a Content Type, it should be ignored and not show up as a tab in the Resource Picker. If a content type is added to the config file and is also listed under `link` in the config file, a new tab in the Resource Picker should appear for that Content Type.