### PR TITLE
Pt/draft content warnings

### DIFF
--- a/websites/api.py
+++ b/websites/api.py
@@ -270,9 +270,7 @@ def videos_missing_captions(website: Website) -> List[WebsiteContent]:
 
 
 def draft_content(website: Website) -> List[WebsiteContent]:
-    """Return a list of WebsiteContent objects that are"""
-    if not is_ocw_site(website):
-        return []
+    """Return a list of WebsiteContent objects that are set to Draft"""
     query_draft_field = get_dict_query_field("metadata", "draft")
     return WebsiteContent.objects.filter(
         Q(website=website) & Q(**{query_draft_field: True})

--- a/websites/api.py
+++ b/websites/api.py
@@ -192,7 +192,7 @@ def is_ocw_site(website: Website) -> bool:
 
 
 def update_youtube_thumbnail(website_id: str, metadata: Dict, overwrite=False):
-    """ Assign a youtube thumbnail url if appropriate to a website's metadata"""
+    """Assign a youtube thumbnail url if appropriate to a website's metadata"""
     website = Website.objects.get(uuid=website_id)
     if is_ocw_site(website):
         youtube_id = get_dict_field(metadata, settings.YT_FIELD_ID)
@@ -266,6 +266,16 @@ def videos_missing_captions(website: Website) -> List[WebsiteContent]:
         Q(website=website)
         & Q(**{query_resource_type_field: RESOURCE_TYPE_VIDEO})
         & (Q(**{query_caption_field: None}) | Q(**{query_caption_field: ""}))
+    )
+
+
+def draft_content(website: Website) -> List[WebsiteContent]:
+    """Return a list of WebsiteContent objects that are"""
+    if not is_ocw_site(website):
+        return []
+    query_draft_field = get_dict_query_field("metadata", "draft")
+    return WebsiteContent.objects.filter(
+        Q(website=website) & Q(**{query_draft_field: True})
     )
 
 
@@ -364,10 +374,10 @@ def update_website_status(
         )
 
 
-def incomplete_content_warnings(website):
+def get_content_warnings(website):
     """
     Return array with error/warning messages for any website content missing expected data
-    (currently: video youtube ids and captions).
+    (currently: video youtube ids and captions) or any draft content.
     """
     missing_youtube_ids = videos_with_unassigned_youtube_ids(website)
 
@@ -380,6 +390,8 @@ def incomplete_content_warnings(website):
     truncatable_video_titles = [
         video.title for video in videos_with_truncatable_text(website)
     ]
+
+    draft_content_titles = [content.title for content in draft_content(website)]
 
     messages = []
 
@@ -394,6 +406,11 @@ def incomplete_content_warnings(website):
     if len(truncatable_video_titles) > 0:
         messages.append(
             f"The following videos have titles or descriptions that will be truncated on YouTube: {', '.join(truncatable_video_titles)}"
+        )
+
+    if len(draft_content_titles) > 0:
+        messages.append(
+            f"The following content is still set to Draft: {', '.join(draft_content_titles)}"
         )
 
     return messages

--- a/websites/api_test.py
+++ b/websites/api_test.py
@@ -11,9 +11,9 @@ from videos.constants import YT_THUMBNAIL_IMG
 from websites.api import (
     detect_mime_type,
     fetch_website,
+    get_content_warnings,
     get_valid_new_filename,
     get_valid_new_slug,
-    get_content_warnings,
     is_ocw_site,
     mail_on_publish,
     update_website_status,

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -130,9 +130,7 @@ def test_website_serializer(has_starter):
 @pytest.mark.parametrize("drive_folder", [None, "abc123"])
 def test_website_status_serializer(mocker, settings, drive_folder, warnings):
     """WebsiteStatusSerializer should serialize a Website object with the correct status fields"""
-    mocker.patch(
-        "websites.serializers.incomplete_content_warnings", return_value=warnings
-    )
+    mocker.patch("websites.serializers.get_content_warnings", return_value=warnings)
     settings.DRIVE_UPLOADS_PARENT_FOLDER_ID = "dfg789"
     settings.DRIVE_SERVICE_ACCOUNT_CREDS = {"key": "value"}
     settings.DRIVE_SHARED_ID = "abc123"
@@ -222,7 +220,7 @@ def test_website_detail_serializer_is_admin(mocker, user_is_admin, has_user):
 
 
 def test_website_detail_serializer_with_url_format(mocker, ocw_site):
-    """ The url suggestion should be equal to the starter config site-url-format"""
+    """The url suggestion should be equal to the starter config site-url-format"""
     user = UserFactory.create(is_superuser=True)
     serialized = WebsiteDetailSerializer(
         instance=ocw_site,
@@ -236,7 +234,7 @@ def test_website_detail_serializer_with_url_format(mocker, ocw_site):
 
 
 def test_website_detail_serializer_with_url_format_partial(mocker, ocw_site):
-    """ The url suggestion should have relevant metadata fields filled in"""
+    """The url suggestion should have relevant metadata fields filled in"""
     user = UserFactory.create(is_superuser=True)
     term = "Fall"
     year = "2028"
@@ -258,7 +256,7 @@ def test_website_detail_serializer_with_url_format_partial(mocker, ocw_site):
 
 
 def test_website_collaborator_serializer():
-    """ WebsiteCollaboratorSerializer should serialize a User object with correct fields """
+    """WebsiteCollaboratorSerializer should serialize a User object with correct fields"""
     collaborator = (
         User.objects.filter(id=UserFactory.create().id)
         .annotate(role=Value(ROLE_EDITOR, CharField()))
@@ -641,7 +639,7 @@ def test_website_content_create_serializer(
 
 @pytest.mark.parametrize("is_root_site", [True, False])
 def test_website_publish_serializer_base_url(settings, is_root_site):
-    """ The WebsitePublishSerializer should return the correct base_url value """
+    """The WebsitePublishSerializer should return the correct base_url value"""
     site = WebsiteFactory.create(url_path="courses/my-site")
     settings.ROOT_WEBSITE_NAME = site.name if is_root_site else "some_other_root_name"
     serializer = WebsiteMassBuildSerializer(site)
@@ -651,7 +649,7 @@ def test_website_publish_serializer_base_url(settings, is_root_site):
 @pytest.mark.parametrize("has_metadata", [True, False])
 @pytest.mark.parametrize("has_legacy_uid", [True, False])
 def test_website_unpublish_serializer(has_legacy_uid, has_metadata):
-    """ The WebsiteUnublishSerializer should return the correct value for site_uid"""
+    """The WebsiteUnublishSerializer should return the correct value for site_uid"""
     site = WebsiteFactory.create(unpublished=True)
     legacy_uid = "e6748-d7d8-76a46-5cbc-5a42-12d3619e09"
     if has_metadata:


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1438.

#### What's this PR do?
Adds a warning to the Publish Drawer listing the title of any content that has been set to Draft.

#### How should this be manually tested?
Change some content (such as Resources, Pages, etc.) to `Draft` by selecting `True` in the Edit drawer. Then, click the `Publish` button to open the Publish Drawer. There should now be a warning listing the title of the content. Change `Draft` back to `False`, and the warning should disappear.

#### Screenshots (if appropriate)

![DraftContentWarning](https://user-images.githubusercontent.com/1553279/187207489-24925a8c-d985-411d-9428-c60285400ebe.png)

