### PR TITLE
Remove oauth2client

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -24,7 +24,6 @@ mitol-django-mail==2.2.0
 drf-extensions
 ipython
 newrelic
-oauth2client
 psycopg2
 pygithub==1.55
 python-magic

--- a/requirements.txt
+++ b/requirements.txt
@@ -161,7 +161,6 @@ httplib2==0.19.1
     # via
     #   google-api-python-client
     #   google-auth-httplib2
-    #   oauth2client
 idna==2.10
     # via requests
 iniconfig==1.1.1
@@ -202,8 +201,6 @@ mitol-django-mail==2.2.0
     #   mitol-django-authentication
 newrelic==5.16.1.146
     # via -r requirements.in
-oauth2client==4.1.3
-    # via -r requirements.in
 oauthlib==3.1.1
     # via
     #   requests-oauthlib
@@ -238,13 +235,10 @@ py==1.10.0
     # via pytest
 pyasn1==0.4.8
     # via
-    #   oauth2client
     #   pyasn1-modules
     #   rsa
 pyasn1-modules==0.2.8
-    # via
-    #   google-auth
-    #   oauth2client
+    # via google-auth
 pycparser==2.20
     # via cffi
 pygithub==1.55
@@ -305,9 +299,7 @@ requests-oauthlib==1.3.0
     #   google-auth-oauthlib
     #   social-auth-core
 rsa==4.7.2
-    # via
-    #   google-auth
-    #   oauth2client
+    # via google-auth
 s3transfer==0.5.0
     # via boto3
 sentry-sdk==1.4.3
@@ -322,7 +314,6 @@ six==1.15.0
     #   google-auth-httplib2
     #   html5lib
     #   isodate
-    #   oauth2client
     #   protobuf
     #   pynacl
     #   pyopenssl

--- a/videos/conftest.py
+++ b/videos/conftest.py
@@ -34,7 +34,7 @@ def youtube_settings(settings, mocker):
     settings.YT_PROJECT_ID = "testvalue"
     settings.YT_ACCESS_TOKEN = "testvalue"
     settings.YT_REFRESH_TOKEN = "testvalue"
-    mocker.patch("videos.youtube.oauth2client")
+    mocker.patch("videos.youtube.Credentials")
 
 
 @pytest.fixture(autouse=True)

--- a/videos/youtube.py
+++ b/videos/youtube.py
@@ -6,10 +6,9 @@ import time
 from io import BytesIO
 from urllib.parse import urljoin
 
-import httplib2
-import oauth2client
 from django.conf import settings
 from django.db.models import Q
+from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from googleapiclient.http import MediaIoBaseUpload
@@ -169,17 +168,13 @@ class YouTubeApi:
         """
         Generate an authorized YouTube API client and S3 client
         """
-        credentials = oauth2client.client.GoogleCredentials(
+        credentials = Credentials(
             settings.YT_ACCESS_TOKEN,
-            settings.YT_CLIENT_ID,
-            settings.YT_CLIENT_SECRET,
-            settings.YT_REFRESH_TOKEN,
-            None,
-            "https://accounts.google.com/o/oauth2/token",
-            None,
+            token_uri="https://accounts.google.com/o/oauth2/token",
+            client_id=settings.YT_CLIENT_ID,
+            client_secret=settings.YT_CLIENT_SECRET,
+            refresh_token=settings.YT_REFRESH_TOKEN,
         )
-        authorization = credentials.authorize(httplib2.Http())
-        credentials.refresh(authorization)
         self.client = build("youtube", "v3", credentials=credentials)
         self.s3 = get_boto3_client("s3")
 

--- a/videos/youtube_test.py
+++ b/videos/youtube_test.py
@@ -98,16 +98,14 @@ def test_youtube_settings(mocker, settings):
     settings.YT_CLIENT_ID = "yt_client_id"
     settings.YT_CLIENT_SECRET = "yt_secret"
     settings.YT_REFRESH_TOKEN = "yt_refresh"
-    mock_oauth = mocker.patch("videos.youtube.oauth2client.client.GoogleCredentials")
+    mock_oauth = mocker.patch("videos.youtube.Credentials")
     YouTubeApi()
     mock_oauth.assert_called_with(
         settings.YT_ACCESS_TOKEN,
-        settings.YT_CLIENT_ID,
-        settings.YT_CLIENT_SECRET,
-        settings.YT_REFRESH_TOKEN,
-        None,
-        "https://accounts.google.com/o/oauth2/token",
-        None,
+        client_id=settings.YT_CLIENT_ID,
+        client_secret=settings.YT_CLIENT_SECRET,
+        refresh_token=settings.YT_REFRESH_TOKEN,
+        token_uri="https://accounts.google.com/o/oauth2/token",
     )
 
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #1465 

#### What's this PR do?
Removes oauth2client (deprecated) and uses google-oauth2 instead for the YouTube API.

#### How should this be manually tested?
- Set `OCW_STUDIO_ENVIRONMENT=devdev` to bypass use of fake minio s3 buckets.  Set `AWS_`, `YT_`, and `VIDEO_S3_TRANSCODE_ENDPOINT` .env values to the same as on RC.  
- Upload a small video to a site's videos_final folder, then sync.
- Check that there is a new `Video` object via django admin.
- Using postman or curl, send the following request to http://localhost:8043/api/transcode-jobs/:

```
{
  "version": "0",
  "id": "c120fe11-87db-c292-b3e5-1cc90740f6e1",
  "detail-type": "MediaConvert Job State Change",
  "source": "aws.mediaconvert",
  "account": "<AWS_ACCOUNT_ID>",
  "time": "2021-08-05T16:52:33Z",
  "region": "us-east-1",
  "resources": [
    "arn:aws:mediaconvert:us-east-1:11111111:jobs/111111111-abplcg"
  ],
  "detail": {
    "timestamp": 1628172900136,
    "accountId": "<AWS_ACCOUNT_ID>",
    "queue": "arn:aws:mediaconvert:us-east-1:<AWS_ACCOUNT_ID>:queues/Default",
    "jobId": "<VIDEOJOB_ID>",
    "status": "COMPLETE",
    "userMetadata": {},
    "outputGroupDetails": [
      {
        "outputDetails": [
          {
            "outputFilePaths": [
              "s3://ol-ocw-studio-app-qa/aws_mediaconvert_transcodes/<VIDEO_BASE_NAME>_youtube.mp4"
            ],
            "durationInMs": 132033,
            "videoDetails": {
              "widthInPx": 1280,
              "heightInPx": 720
            }
          }
        ],
        "type": "FILE_GROUP"
      }
    ]
  }
}
```

where `VIDEO_BASE_NAME` is derived from the `Video.source_key` value, for example:
`gdrive_uploads/course1/14EvKgqg1eQqzxoo6YxvmxOxgf-HPn0mM/medium.mp4`. -> `course1/14EvKgqg1eQqzxoo6YxvmxOxgf-HPn0mM/medium`
- Wait a few minutes and verify that the video is uploaded to Youtube, processed, and is playable (refresh the Django admin page for the video every few minutes).

