### PR TITLE
mass build starter filter

### DIFF
--- a/content_sync/api.py
+++ b/content_sync/api.py
@@ -66,6 +66,7 @@ def get_mass_build_sites_pipeline(  # pylint:disable=too-many-arguments
     prefix: Optional[str] = None,
     themes_branch: Optional[str] = None,
     projects_branch: Optional[str] = None,
+    starter: Optional[str] = None,
     offline: Optional[bool] = None,
 ) -> object:
     """Get the mass build sites pipeline if the backend has one"""
@@ -77,6 +78,7 @@ def get_mass_build_sites_pipeline(  # pylint:disable=too-many-arguments
         prefix=prefix,
         themes_branch=themes_branch,
         projects_branch=projects_branch,
+        starter=starter,
         offline=offline,
     )
 

--- a/content_sync/management/commands/upsert_mass_build_pipeline.py
+++ b/content_sync/management/commands/upsert_mass_build_pipeline.py
@@ -50,6 +50,13 @@ class Command(BaseCommand):
             help="An optional override for the branch of ocw-hugo-projects to use in the builds",
         )
         parser.add_argument(
+            "-s",
+            "--starter",
+            dest="starter",
+            default="",
+            help="",
+        )
+        parser.add_argument(
             "-o",
             "--offline",
             dest="offline",
@@ -70,6 +77,7 @@ class Command(BaseCommand):
         prefix = options["prefix"]
         themes_branch = options["themes-branch"]
         projects_branch = options["projects-branch"]
+        starter = options["starter"]
         offline = options["offline"]
         start = now_in_utc()
 
@@ -88,6 +96,7 @@ class Command(BaseCommand):
                 prefix=prefix,
                 themes_branch=themes_branch,
                 projects_branch=projects_branch,
+                starter=starter,
                 offline=offline,
             )
             pipeline.upsert_pipeline()

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -533,6 +533,7 @@ class MassBuildSitesPipeline(BaseMassBuildSitesPipeline, GeneralPipeline):
         prefix: Optional[str] = None,
         themes_branch: Optional[str] = None,
         projects_branch: Optional[str] = None,
+        starter: Optional[str] = None,
         offline: Optional[bool] = None,
     ):
         """Initialize the pipeline instance"""
@@ -559,6 +560,7 @@ class MassBuildSitesPipeline(BaseMassBuildSitesPipeline, GeneralPipeline):
         self.PROJECTS_BRANCH = (
             projects_branch if projects_branch else self.THEMES_BRANCH
         )
+        self.STARTER = starter
         self.OFFLINE = offline
         self.set_instance_vars(
             {
@@ -566,6 +568,7 @@ class MassBuildSitesPipeline(BaseMassBuildSitesPipeline, GeneralPipeline):
                 "themes_branch": self.THEMES_BRANCH,
                 "projects_branch": self.PROJECTS_BRANCH,
                 "prefix": self.PREFIX,
+                "starter": self.STARTER,
                 "offline": self.OFFLINE,
             }
         )
@@ -656,6 +659,7 @@ class MassBuildSitesPipeline(BaseMassBuildSitesPipeline, GeneralPipeline):
             .replace("((resource-base-url))", template_vars["resource_base_url"])
             .replace("((prefix))", self.PREFIX)
             .replace("((search-api-url))", settings.SEARCH_API_URL)
+            .replace("((starter))", f"&starter={self.STARTER}" if self.STARTER else "")
             .replace(
                 "((trigger))",
                 str(

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -521,7 +521,9 @@ class ThemeAssetsPipeline(GeneralPipeline, BaseThemeAssetsPipeline):
         self.upsert_config(config_str, self.PIPELINE_NAME)
 
 
-class MassBuildSitesPipeline(BaseMassBuildSitesPipeline, GeneralPipeline):  # pylint: disable=too-many-instance-attributes
+class MassBuildSitesPipeline(
+    BaseMassBuildSitesPipeline, GeneralPipeline
+):  # pylint: disable=too-many-instance-attributes
     """Specialized concourse pipeline for mass building multiple sites"""
 
     PIPELINE_NAME = BaseMassBuildSitesPipeline.PIPELINE_NAME

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -521,7 +521,7 @@ class ThemeAssetsPipeline(GeneralPipeline, BaseThemeAssetsPipeline):
         self.upsert_config(config_str, self.PIPELINE_NAME)
 
 
-class MassBuildSitesPipeline(BaseMassBuildSitesPipeline, GeneralPipeline):
+class MassBuildSitesPipeline(BaseMassBuildSitesPipeline, GeneralPipeline):  # pylint: disable=too-many-instance-attributes
     """Specialized concourse pipeline for mass building multiple sites"""
 
     PIPELINE_NAME = BaseMassBuildSitesPipeline.PIPELINE_NAME

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -554,6 +554,7 @@ def test_upsert_pipeline(
 @pytest.mark.parametrize("themes_branch", ["", "main", "test_themes_branch"])
 @pytest.mark.parametrize("projects_branch", ["", "main", "test_projects_branch"])
 @pytest.mark.parametrize("prefix", ["", "/test_prefix", "test_prefix"])
+@pytest.mark.parametrize("starter", ["", "ocw-course"])
 @pytest.mark.parametrize("offline", [True, False])
 def test_upsert_mass_build_pipeline(
     settings,
@@ -565,6 +566,7 @@ def test_upsert_mass_build_pipeline(
     themes_branch,
     projects_branch,
     prefix,
+    starter,
     offline,
 ):  # pylint:disable=too-many-locals,too-many-arguments,too-many-statements
     """The mass build pipeline should have expected configuration"""
@@ -599,6 +601,7 @@ def test_upsert_mass_build_pipeline(
         "themes_branch": themes_branch,
         "projects_branch": projects_branch,
         "prefix": stripped_prefix,
+        "starter": starter,
         "offline": offline,
     }
     instance_vars_str = f"?vars={quote(json.dumps(instance_vars))}"
@@ -637,6 +640,8 @@ def test_upsert_mass_build_pipeline(
     assert settings.OCW_GTM_ACCOUNT_ID in config_str
     assert bucket in config_str
     assert version in config_str
+    if starter:
+        assert f"&starter={starter}" in config_str
     if stripped_prefix:
         assert f'\\"PREFIX\\": \\"{stripped_prefix}\\"' in config_str
     assert f'\\"branch\\": \\"{themes_branch}\\"' in config_str

--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -100,7 +100,7 @@ jobs:
         args:
         - -exc
         - |
-          wget -O publishable_sites/sites.json --header="Authorization: Bearer ((api-token))" "((ocw-studio-url))/api/publish/?version=((version))"
+          wget -O publishable_sites/sites.json --header="Authorization: Bearer ((api-token))" "((ocw-studio-url))/api/publish/?version=((version))((starter))"
   - task: get-repo-build-course-publish-course
     attempts: 1
     timeout: 300m

--- a/websites/views.py
+++ b/websites/views.py
@@ -276,6 +276,7 @@ class WebsiteMassBuildViewSet(viewsets.ViewSet):
     def list(self, request):
         """Return a list of websites that have been previously published, per version"""
         version = self.request.query_params.get("version")
+        starter = self.request.query_params.get("starter")
         if version not in (VERSION_LIVE, VERSION_DRAFT):
             raise ValidationError("Invalid version")
         publish_date_field = (
@@ -289,6 +290,9 @@ class WebsiteMassBuildViewSet(viewsets.ViewSet):
         # For live builds, exclude previously published sites that have been unpublished
         if version == VERSION_LIVE:
             sites = sites.exclude(unpublish_status__isnull=False)
+        # If a starter has been specified by the query, only return sites made with that starter
+        if starter:
+            sites = sites.filter(starter=WebsiteStarter.objects.get(name=starter))
         sites = sites.prefetch_related("starter").order_by("name")
         serializer = WebsiteMassBuildSerializer(instance=sites, many=True)
         return Response({"sites": serializer.data})


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1462

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/1453, we added the `--offline` flag to the `upsert_mass_build_pipeline` management command, which pushes up an alternate version of `mass-build-sites` designed to build sites meant for offline viewing. This PR does two things:

 - Checking of the `starter` query parameter was added to `WebsiteMassBuildViewSet`, and if it is set the queryset of `Website` objects returned is filtered on the starter matching the name specified
 - A `--starter` argument was added to `upsert_mass_build_pipeline` which sets the query string param noted above to what was passed in on the `get-sites` step of the `mass-build-sites` pipeline, ensuring that the mass build only processes sites matching this starter

#### How should this be manually tested?
 - First of all, make sure you've taken care of the following prerequisites:
   - `ocw-studio` up and running
   - Minio support configured
   - Concourse support configured
   - An `ocw-www` site in your database using the `ocw-www` starter
   - Some test courses in your database using the `ocw-course` starter
   - If you've pulled in a full backup of the prod database into your local instance and have a ton of courses, you may want to make a temporary edit to `websites/views.py` and set `sites = sites.prefetch_related("starter").order_by("name")[:10]`, noting the `[:10]` at the end to limit to 10 sites
 - Using a utility like Postman, form a GET with the URL http://localhost:8043/api/publish/?version=live, setting the authorization bearer token to the value you have in `API_BEARER_TOKEN`
 - Verify that you see `ocw-www` in the response:
```
        {
            "name": "ocw-www",
            "short_id": "ocw-www",
            "starter_slug": "ocw-www",
            "site_url": "ocw-www",
            "base_url": "",
            "s3_path": "ocw-www"
        },
```
 - Modify the URL in Postman to be http://localhost:8043/api/publish/?version=live&starter=ocw-course
 - Verify that the `ocw-www` listing is gone
 - Make some temporary edits to `websites/views.py` for our testing to ensure that our `ocw-www` site and a course site are picked up before the new filter is applied and the full mass build doesn't have to run:
   - Add an import to the top of the file: `from django.db.models import Q`
   - At line 294: `sites = Website.objects.filter(Q(name="ocw-www") | Q(name="1-00-introduction-to-computers-and-engineering-problem-solving-spring-2012")))` (the name of the second site should be an `ocw-course` site in your database, if 1-00 isn't in yours then use another)
 - In your terminal, run `docker-compose exec web ./manage.py upsert_mass_build_pipeline --offline --prefix /offline --starter ocw-course --projects-branch cg/course-v2-testing`
 - Visit http://concourse:8080 and log in with test/test, then find the pipeline we just upserted and trigger a build. Once it gets to the `get-repo-build-course-publish-course` step, you should only see the one course you specified in `views.py` build, not `ocw-www`
