### PR TITLE
feat: site dependencies shown while course unpublishing

### DIFF
--- a/websites/constants.py
+++ b/websites/constants.py
@@ -5,9 +5,13 @@ from model_utils import Choices
 CONTENT_TYPE_PAGE = "page"
 CONTENT_TYPE_VIDEO_GALLERY = "video_gallery"
 CONTENT_TYPE_RESOURCE = "resource"
+CONTENT_TYPE_RESOURCE_COLLECTION = "resource_collections"
+CONTENT_TYPE_RESOURCE_LIST = "resource-list"
 CONTENT_TYPE_INSTRUCTOR = "instructor"
 CONTENT_TYPE_METADATA = "sitemetadata"
 CONTENT_TYPE_NAVMENU = "navmenu"
+CONTENT_TYPE_COURSE_LIST = "course-lists"
+
 
 COURSE_PAGE_LAYOUTS = ["instructor_insights"]
 COURSE_RESOURCE_LAYOUTS = ["pdf", "video"]

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -111,6 +111,7 @@ class WebsiteBasicSerializer(serializers.ModelSerializer):
         model = Website
         fields = ["uuid", "name", "title"]
 
+
 class WebsiteUrlSerializer(serializers.ModelSerializer):
     """Serializer for assigning website urls"""
 
@@ -452,7 +453,8 @@ class WebsiteCollaboratorSerializer(serializers.Serializer):
 
 class WebsiteContentSerializer(serializers.ModelSerializer):
     """Serializes WebsiteContent for the list view"""
-    website_name = serializers.CharField(source='website.name')
+
+    website_name = serializers.CharField(source="website.name")
 
     class Meta:
         model = WebsiteContent

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -445,10 +445,11 @@ class WebsiteCollaboratorSerializer(serializers.Serializer):
 
 class WebsiteContentSerializer(serializers.ModelSerializer):
     """Serializes WebsiteContent for the list view"""
+    website_name = serializers.CharField(source='website.name')
 
     class Meta:
         model = WebsiteContent
-        read_only_fields = ["text_id", "title", "type", "updated_on"]
+        read_only_fields = ["text_id", "website_name", "title", "type", "updated_on"]
         # See WebsiteContentCreateSerializer below for creating new WebsiteContent objects
         fields = read_only_fields
 

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -104,6 +104,13 @@ class WebsiteSerializer(serializers.ModelSerializer):
         extra_kwargs = {"owner": {"write_only": True}}
 
 
+class WebsiteBasicSerializer(serializers.ModelSerializer):
+    """Serializer for websites with only basic fields"""
+
+    class Meta:
+        model = Website
+        fields = ["uuid", "name", "title"]
+
 class WebsiteUrlSerializer(serializers.ModelSerializer):
     """Serializer for assigning website urls"""
 

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -73,15 +73,16 @@ def test_serialize_website_course():
         == WebsiteStarterSerializer(instance=site.starter).data
     )
 
+
 def test_serialize_basic_website_course():
     """
     Verify that a serialized basic website contains expected fields
     """
     site = WebsiteFactory.create()
     serialized_data = WebsiteSerializer(instance=site).data
-    assert serialized_data["uuid"] == site.uuid
     assert serialized_data["name"] == site.name
     assert serialized_data["title"] == site.title
+
 
 def test_website_starter_serializer():
     """WebsiteStarterSerializer should serialize a WebsiteStarter object with the correct fields"""

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -274,6 +274,7 @@ def test_website_content_serializer():
     content = WebsiteContentFactory.create()
     serialized_data = WebsiteContentSerializer(instance=content).data
     assert serialized_data["text_id"] == str(content.text_id)
+    assert serialized_data["website_name"] == content.website.name
     assert serialized_data["title"] == content.title
     assert serialized_data["type"] == content.type
     assert serialized_data["updated_on"] == content.updated_on.isoformat()[:-6] + "Z"

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -73,6 +73,15 @@ def test_serialize_website_course():
         == WebsiteStarterSerializer(instance=site.starter).data
     )
 
+def test_serialize_basic_website_course():
+    """
+    Verify that a serialized basic website contains expected fields
+    """
+    site = WebsiteFactory.create()
+    serialized_data = WebsiteSerializer(instance=site).data
+    assert serialized_data["uuid"] == site.uuid
+    assert serialized_data["name"] == site.name
+    assert serialized_data["title"] == site.title
 
 def test_website_starter_serializer():
     """WebsiteStarterSerializer should serialize a WebsiteStarter object with the correct fields"""

--- a/websites/views.py
+++ b/websites/views.py
@@ -271,14 +271,14 @@ class WebsiteViewSet(
                 return Response(
                     status=200,
                     data={
-                        "Site dependencies": {
-                            "ocw www": WebsiteContentSerializer(
+                        "site_dependencies": {
+                            "ocw_www": WebsiteContentSerializer(
                                 instance=ocw_www_dependencies, many=True
                             ).data,
                             "course": WebsiteBasicSerializer(
                                 instance=course_dependencies, many=True
                             ).data,
-                            "course content": WebsiteContentSerializer(
+                            "course_content": WebsiteContentSerializer(
                                 instance=course_content_dependencies, many=True
                             ).data,
                         }

--- a/websites/views.py
+++ b/websites/views.py
@@ -58,6 +58,7 @@ from websites.permissions import (
     is_global_admin,
 )
 from websites.serializers import (
+    WebsiteBasicSerializer,
     WebsiteCollaboratorSerializer,
     WebsiteContentCreateSerializer,
     WebsiteContentDetailSerializer,
@@ -65,7 +66,6 @@ from websites.serializers import (
     WebsiteDetailSerializer,
     WebsiteMassBuildSerializer,
     WebsiteSerializer,
-    WebsiteBasicSerializer,
     WebsiteStarterDetailSerializer,
     WebsiteStarterSerializer,
     WebsiteStatusSerializer,
@@ -265,8 +265,7 @@ class WebsiteViewSet(
                     markdown__contains=website.name,
                 )
                 course_dependencies = Website.objects.filter(
-                    ~Q(name=website.name),
-                    metadata__icontains=website.name
+                    ~Q(name=website.name), metadata__icontains=website.name
                 )
                 return Response(
                     status=200,

--- a/websites/views.py
+++ b/websites/views.py
@@ -37,6 +37,7 @@ from websites.api import get_valid_new_filename, update_website_status
 from websites.constants import (
     CONTENT_TYPE_COURSE_LIST,
     CONTENT_TYPE_METADATA,
+    CONTENT_TYPE_PAGE,
     CONTENT_TYPE_RESOURCE_COLLECTION,
     PUBLISH_STATUS_NOT_STARTED,
     PUBLISH_STATUS_SUCCEEDED,
@@ -247,7 +248,7 @@ class WebsiteViewSet(
         try:
             website = self.get_object()
             if request.method == "GET":
-                site_dependencies = WebsiteContent.objects.filter(
+                ocw_www_dependencies = WebsiteContent.objects.filter(
                     (
                         Q(type=CONTENT_TYPE_COURSE_LIST)
                         | Q(type=CONTENT_TYPE_RESOURCE_COLLECTION)
@@ -258,12 +259,21 @@ class WebsiteViewSet(
                     ),
                     website__name=settings.ROOT_WEBSITE_NAME,
                 )
+                course_dependencies = WebsiteContent.objects.filter(
+                    type=CONTENT_TYPE_PAGE,
+                    markdown__contains=website.name,
+                )
                 return Response(
                     status=200,
                     data={
-                        "Site dependencies": WebsiteContentSerializer(
-                            instance=site_dependencies, many=True
-                        ).data
+                        "Site dependencies": {
+                            "ocw www": WebsiteContentSerializer(
+                                instance=ocw_www_dependencies, many=True
+                            ).data,
+                            "course": WebsiteContentSerializer(
+                                instance=course_dependencies, many=True
+                            ).data,
+                        }
                     },
                 )
             else:

--- a/websites/views.py
+++ b/websites/views.py
@@ -35,7 +35,9 @@ from users.models import User
 from websites import constants
 from websites.api import get_valid_new_filename, update_website_status
 from websites.constants import (
+    CONTENT_TYPE_COURSE_LIST,
     CONTENT_TYPE_METADATA,
+    CONTENT_TYPE_RESOURCE_COLLECTION,
     PUBLISH_STATUS_NOT_STARTED,
     PUBLISH_STATUS_SUCCEEDED,
     RESOURCE_TYPE_DOCUMENT,
@@ -236,19 +238,44 @@ class WebsiteViewSet(
         return self.publish_version(name, VERSION_LIVE, request)
 
     @action(
-        detail=True, methods=["post"], permission_classes=[HasWebsitePublishPermission]
+        detail=True,
+        methods=["post", "get"],
+        permission_classes=[HasWebsitePublishPermission],
     )
     def unpublish(self, request, name=None):
         """Unpublish the site and trigger the remove-unpublished-sites pipeline"""
         try:
             website = self.get_object()
-
-            Website.objects.filter(pk=website.pk).update(
-                unpublish_status=PUBLISH_STATUS_NOT_STARTED,
-                last_unpublished_by=request.user,
-            )
-            trigger_unpublished_removal(website)
-            return Response(status=200)
+            if request.method == "GET":
+                site_dependencies = WebsiteContent.objects.filter(
+                    (
+                        Q(type=CONTENT_TYPE_COURSE_LIST)
+                        | Q(type=CONTENT_TYPE_RESOURCE_COLLECTION)
+                    ),
+                    (
+                        Q(metadata__courses__icontains=website.name)
+                        | Q(metadata__resources__content__icontains=website.name)
+                    ),
+                    website__name=settings.ROOT_WEBSITE_NAME,
+                )
+                return Response(
+                    status=200,
+                    data={
+                        "Site dependencies": WebsiteContentSerializer(
+                            instance=site_dependencies, many=True
+                        ).data
+                    },
+                )
+            else:
+                Website.objects.filter(pk=website.pk).update(
+                    unpublish_status=PUBLISH_STATUS_NOT_STARTED,
+                    last_unpublished_by=request.user,
+                )
+                trigger_unpublished_removal(website)
+                return Response(
+                    status=200,
+                    data="Site has been unpublished and 'remove-unpublished-sites' pipeline has been triggered.",
+                )
         except Exception as exc:  # pylint: disable=broad-except
             log.exception("Error unpublishing %s", name)
             return Response(status=500, data={"details": str(exc)})

--- a/websites/views.py
+++ b/websites/views.py
@@ -65,6 +65,7 @@ from websites.serializers import (
     WebsiteDetailSerializer,
     WebsiteMassBuildSerializer,
     WebsiteSerializer,
+    WebsiteBasicSerializer,
     WebsiteStarterDetailSerializer,
     WebsiteStarterSerializer,
     WebsiteStatusSerializer,
@@ -259,9 +260,13 @@ class WebsiteViewSet(
                     ),
                     website__name=settings.ROOT_WEBSITE_NAME,
                 )
-                course_dependencies = WebsiteContent.objects.filter(
+                course_content_dependencies = WebsiteContent.objects.filter(
                     type=CONTENT_TYPE_PAGE,
                     markdown__contains=website.name,
+                )
+                course_dependencies = Website.objects.filter(
+                    ~Q(name=website.name),
+                    metadata__icontains=website.name
                 )
                 return Response(
                     status=200,
@@ -270,8 +275,11 @@ class WebsiteViewSet(
                             "ocw www": WebsiteContentSerializer(
                                 instance=ocw_www_dependencies, many=True
                             ).data,
-                            "course": WebsiteContentSerializer(
+                            "course": WebsiteBasicSerializer(
                                 instance=course_dependencies, many=True
+                            ).data,
+                            "course content": WebsiteContentSerializer(
+                                instance=course_content_dependencies, many=True
                             ).data,
                         }
                     },

--- a/websites/views.py
+++ b/websites/views.py
@@ -261,8 +261,9 @@ class WebsiteViewSet(
                     website__name=settings.ROOT_WEBSITE_NAME,
                 )
                 course_content_dependencies = WebsiteContent.objects.filter(
+                    ~Q(website__name=website.name),
                     type=CONTENT_TYPE_PAGE,
-                    markdown__contains=website.name,
+                    markdown__icontains=website.name,
                 )
                 course_dependencies = Website.objects.filter(
                     ~Q(name=website.name), metadata__icontains=website.name


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1457

#### What's this PR do?
- While unpublishing a course, returns: (in response of `GET` request)
    - course lists in ocw-www that reference the unpublished course
    - resource lists in ocw-www that reference resources in the unpublished course
    - courses that have links to the unpublished course in content

#### How should this be manually tested?
- Go to `/api/websites/<Website.name>/unpublish/`
- Use any course which has dependencies in ocw-www `course lists` and `resource collections` or in any course
- Verify that they (all the dependencies) are sent in response when you visit the above URL.
- Unpublish the course
- Verify the course is unpublished successfully.

#### Screenshots (if appropriate)
<img width="795" alt="image" src="https://user-images.githubusercontent.com/93309234/188857756-24646f54-d4d2-4a83-8c7b-f6258832debe.png">

<img width="534" alt="image" src="https://user-images.githubusercontent.com/93309234/188615011-d40d64a5-ef52-4ab9-a09e-83735e11aa90.png">


