### PR TITLE
handle HTML files in static resources in mass-build-sites offline mode

### DIFF
--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -184,6 +184,8 @@ jobs:
                 echo "SYNCING s3://((ocw-studio-bucket))/$S3_PATH to ./content/static_resources FAILED FOR $NAME" > /dev/tty
                 return 1
               fi
+              mkdir -p ./static/static_resources
+              mv ./content/static_resources/*.html ./static/static_resources
               touch ./content/static_resources/_index.md
               # END OFFLINE-ONLY
               echo "RUNNING HUGO BUILD FOR $NAME" > /dev/tty


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1463

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/1453, we added an `--offline` flag to the `upsert_mass_build_pipeline` management command to upsert an alternate version of the mass build pipeline made for rendering sites for offline use. Part of that PR set up the offline build to first copy in the static resources of a course site (images, PDF's, etc.) and include them in a page bundle before executing the Hugo build. Hugo does not like HTML files being in a page bundle, and at least one legacy course has an HTML file as a static resource. This PR addresses that issue by first moving any HTML files from `content/static_resources` to `static/static_resources` within the course Hugo data. This way, the files will end up with the rest of the static resources after the build is complete (so links will still work) but the Hugo build will not error due to the presence of an HTML file in the `content` directory.

#### How should this be manually tested?
 - First of all, make sure you've taken care of the following prerequisites:
   - `ocw-studio` up and running
   - Minio support configured
   - Concourse support configured
   - Some test courses in your database using the `ocw-course` starter (I used the course causing the error in RC, `2-20-marine-hydrodynamics-13-021-spring-2005`, but it doesn't matter what you use locally)
   - If you've pulled in a full backup of the prod database into your local instance and have a ton of courses, you may want to 
 - Pull in the static resources for `2-20-marine-hydrodynamics-13-021-spring-2005` from RC to your local machine by first getting the AWS credentials from Heroku RC and then running `aws s3 sync s3://ol-ocw-studio-app-qa/courses/2-20-marine-hydrodynamics-13-021-spring-2005 ./` in a directory you've created to store them
 - Visit http://localhost:9001 and log into the Minio console
 - Browse to `ol-ocw-studio-app/courses/2-20-marine-hydrodynamics-13-021-spring-2005` (or whatever your course id is)
 - Drop the static resources you synced down from RC into your local Minio bucket
 - Make a temporary edit to `websites/views.py` to limit the sites seen by `mass-build-sites`:
```
...
        if version == VERSION_LIVE:
            sites = sites.exclude(unpublish_status__isnull=False)
        sites = Website.objects.filter(Q(name="ocw-www") | Q(name="2-20-marine-hydrodynamics-13-021-spring-2005"))
...
```
 - Upsert the mass build pipeline to your local Concourse with `docker-compose exec web ./manage.py upsert_mass_build_pipeline --offline --prefix /offline --starter ocw-course --projects-branch cg/course-v2-testing`
 - Browse to http://concourse:8080 and find the pipeline we just upserted and trigger a build
 - Verify that the pipeline completes without error and that you see this in the `get-repo-build-course-publish-course` step:
```
STARTING PUBLISH OF 2-20-marine-hydrodynamics-13-021-spring-2005
PULLING IN STATIC RESOURCES FOR 2-20-marine-hydrodynamics-13-021-spring-2005
RUNNING HUGO BUILD FOR 2-20-marine-hydrodynamics-13-021-spring-2005
STARTING S3 SYNC FOR 2-20-marine-hydrodynamics-13-021-spring-2005
PUBLISH OF 2-20-marine-hydrodynamics-13-021-spring-2005 COMPLETE
ALL BUILDS SUCCEEDED
```
 - Back in the Minio control panel, browse to `ocw-content-live/offline/courses/2-20-marine-hydrodynamics-13-021-spring-2005`. Go into the `static_resources` folder and confirm that `AMass3D.html` exists in the folder.

#### Where should the reviewer start?
`content_sync/pipelines/definitions/concourse/mass-build-sites.yml`
