### PR TITLE
Removed Underline formatting from toolbar

### DIFF
--- a/static/js/lib/ckeditor/CKEditor.ts
+++ b/static/js/lib/ckeditor/CKEditor.ts
@@ -2,7 +2,6 @@ import EssentialsPlugin from "@ckeditor/ckeditor5-essentials/src/essentials"
 import AutoformatPlugin from "@ckeditor/ckeditor5-autoformat/src/autoformat"
 import BoldPlugin from "@ckeditor/ckeditor5-basic-styles/src/bold"
 import ItalicPlugin from "@ckeditor/ckeditor5-basic-styles/src/italic"
-import UnderlinePlugin from "@ckeditor/ckeditor5-basic-styles/src/underline"
 import BlockQuotePlugin from "@ckeditor/ckeditor5-block-quote/src/blockquote"
 import HeadingPlugin from "@ckeditor/ckeditor5-heading/src/heading"
 import ImagePlugin from "@ckeditor/ckeditor5-image/src/image"
@@ -69,7 +68,6 @@ export const FullEditorConfig = {
     ItalicPlugin,
     // note that this is just for inline (not block-level) code
     CodePlugin,
-    UnderlinePlugin,
     BlockQuotePlugin,
     HeadingPlugin,
     ImagePlugin,
@@ -98,7 +96,6 @@ export const FullEditorConfig = {
       "|",
       "bold",
       "italic",
-      "underline",
       "link",
       "bulletedList",
       "numberedList",
@@ -132,7 +129,6 @@ export const MinimalEditorConfig = {
     BoldPlugin,
     ItalicPlugin,
     CodePlugin,
-    UnderlinePlugin,
     BlockQuotePlugin,
     LinkPlugin,
     ListPlugin,
@@ -149,7 +145,6 @@ export const MinimalEditorConfig = {
     items: [
       "bold",
       "italic",
-      "underline",
       "code",
       "link",
       "bulletedList",


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1470 

#### What's this PR do?
Removed Underline plugin for CKEditor

#### How should this be manually tested?
- Start ocw-studio
- Add a page 
- Verify underline option does not show in toolbar

#### Any background context you want to provide?
As per issue https://github.com/mitodl/ocw-studio/issues/1084 Underline functionality was not working so removing this PR removed underline formatting options.

#### Screenshots (if appropriate)
(Optional)
<img width="1211" alt="Screenshot 2022-09-09 at 4 13 13 PM" src="https://user-images.githubusercontent.com/87968618/189344424-b27685d3-4038-46c2-ab5a-d1e57efb2f6b.png">
