### PR TITLE
ZIP up offline sites in mass-build-sites

### DIFF
--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -185,7 +185,7 @@ jobs:
                 return 1
               fi
               mkdir -p ./static/static_resources
-              mv ./content/static_resources/*.html ./static/static_resources
+              [[ -f ./content/static_resources/*.html ]] && mv ./content/static_resources/*.html ./static/static_resources
               touch ./content/static_resources/_index.md
               # END OFFLINE-ONLY
               echo "RUNNING HUGO BUILD FOR $NAME" > /dev/tty

--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -202,6 +202,16 @@ jobs:
               fi
               cd $CURDIR
               echo "STARTING S3 SYNC FOR $NAME" > /dev/tty
+              # START OFFLINE-ONLY
+              zip $NAME.zip -r $SHORT_ID/public
+              PUBLISH_S3_RESULT=$(aws s3((cli-endpoint-url)) sync ./ s3://((ocw-bucket))$PREFIX/$BASE_URL --exclude="*" --include="$NAME.zip" --metadata site-id=$NAME --only-show-errors) || PUBLISH_S3_RESULT=1
+              if [[ $PUBLISH_S3_RESULT == 1 ]]
+              then
+                echo "SYNCING $NAME.zip to s3://((ocw-bucket))$PREFIX/$SITE_URL failed for $NAME" > /dev/tty
+                return 1
+              fi
+              rm $NAME.zip
+              # END OFFLINE-ONLY
               # START ONLINE-ONLY
               STUDIO_S3_RESULT=$(aws s3((cli-endpoint-url)) sync s3://((ocw-studio-bucket))/$S3_PATH s3://((ocw-bucket))$PREFIX/$SITE_URL --metadata site-id=$NAME --only-show-errors) || STUDIO_S3_RESULT=1
               if [[ $STUDIO_S3_RESULT == 1 ]]
@@ -209,14 +219,12 @@ jobs:
                 echo "SYNCING s3://((ocw-studio-bucket))/$S3_PATH to s3://((ocw-bucket))$PREFIX/$SITE_URL FAILED FOR $NAME" > /dev/tty
                 return 1
               fi
-              # END ONLINE-ONLY
               PUBLISH_S3_RESULT=$(aws s3((cli-endpoint-url)) sync $SHORT_ID/public s3://((ocw-bucket))$PREFIX/$BASE_URL --metadata site-id=$NAME --only-show-errors) || PUBLISH_S3_RESULT=1
               if [[ $PUBLISH_S3_RESULT == 1 ]]
               then
                 echo "SYNCING $SHORT_ID/public to s3://((ocw-bucket))$PREFIX/$SITE_URL failed for $NAME" > /dev/tty
                 return 1
               fi
-              # START ONLINE-ONLY
               # START NON-DEV
               curl -s -X POST -H 'Content-Type: application/json' --data '{"webhook_key":"((open-webhook-key))","prefix":"'"$SITE_URL"/'","version":"((version))"}' ((open-discussions-url))/api/v0/ocw_next_webhook/
               # END NON-DEV


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1476

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/1453, we added the `--offline` flag to the `upsert_mass_build_pipeline` management command, which will upsert an alternate version of the `mass-build-sites` pipeline that uses the `course-offline` theme for generating OCW sites that can be browsed locally on any device. This PR alters the final step of that process, which is syncing the output to S3. The online pipeline will remain the same, but the offline pipeline will now create a ZIP archive of the build output and instead push that up to S3. 

#### How should this be manually tested?
 - First of all, make sure you've taken care of the following prerequisites:
   - `ocw-studio` up and running
   - Minio support configured
   - Concourse support configured
   - Some test courses in your database using the `ocw-course` starter
 - Make a temporary edit to `websites/views.py` to limit the sites seen by `mass-build-sites`:
```
        ...
        sites = sites.prefetch_related("starter").order_by("name")[:10]
        serializer = WebsiteMassBuildSerializer(instance=sites, many=True)
        return Response({"sites": serializer.data})
```
 - Upsert the offline `mass-build-sites` pipeline with `docker-compose exec web ./manage.py upsert_mass_build_pipeline --offline --prefix /offline --starter ocw-course --projects-branch cg/course-v2-testing`
 - Browse to http://concourse:8080 and login with test/test
 - Find the offline `mass-bulid-sites` pipeline we just uploaded and trigger a build
 - After the build completes, browse to http://localhost:9001 and login with your Minio credentials
 - Browse to `ocw-content-live/offline/courses` and look in the various course folders. In there, you should find a ZIP file for each course. Extract one or two of them and double click the `index.html` file to open the course site. Note that these will not include the static resources for each site unless you first upload them to Minio in the appropraite folder in the `ol-ocw-studio-app` bucket before running the pipeline, or if you created the site locally and used Google drive to upload the resources.