### PR TITLE
Provide a more helpful error log message when something goes wrong w/git authentication

### DIFF
--- a/content_sync/apis/github.py
+++ b/content_sync/apis/github.py
@@ -152,9 +152,9 @@ def get_token():
                 ),
             )
             return app.get_access_token(get_app_installation_id(app)).token
-        except Exception as exc:
+        except (requests.HTTPError, ValueError, TypeError) as exc:
             raise ImproperlyConfigured(
-                "Could not initialize github app, check credentials"
+                "Could not initialize github app, check the relevant settings"
             ) from exc
     elif settings.GIT_TOKEN:
         return settings.GIT_TOKEN

--- a/content_sync/apis/github_test.py
+++ b/content_sync/apis/github_test.py
@@ -601,7 +601,10 @@ def test_get_token_bad_private_key(settings):
     settings.GITHUB_APP_PRIVATE_KEY = "not_a_valid_key"
     with pytest.raises(ImproperlyConfigured) as exc:
         get_token()
-    assert exc.value.args[0] == "Could not initialize github app, check credentials"
+    assert (
+        exc.value.args[0]
+        == "Could not initialize github app, check the relevant settings"
+    )
 
 
 def test_get_token_401(settings, mocker, mock_rsa_key):
@@ -620,7 +623,10 @@ def test_get_token_401(settings, mocker, mock_rsa_key):
     )
     with pytest.raises(ImproperlyConfigured) as exc:
         get_token()
-    assert exc.value.args[0] == "Could not initialize github app, check credentials"
+    assert (
+        exc.value.args[0]
+        == "Could not initialize github app, check the relevant settings"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1493 

#### What's this PR do?
If anything goes wrong authenticating with github, raise an `ImproperlyConfigured` exception with the message "Could not initialize github app, check credentials"

#### How should this be manually tested?
- Assuming you already have  valid `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY` .env values for your own github organization or the same as RC, edit and save any page/resource.  There should be no console errors and the changes should be saved to the git repo.
- Set `GITHUB_APP_PRIVATE_KEY` to "bad_key", restart containers.
- Edit any page/resource and save, there should be an `ImproperlyConfigured` exception with the message "Could not initialize github app, check credentials" in the console.
- Set `GITHUB_APP_PRIVATE_KEY` to your original valid value, but set  `GITHUB_APP_ID` to a different integer, then restart containers.
- Edit any page/resource and save, there should be an `ImproperlyConfigured` exception with the message "Could not initialize github app, check credentials" in the console.
