### PR TITLE
Bring back synced_checksum reset for nonpublished sites after a url change

### DIFF
--- a/content_sync/factories.py
+++ b/content_sync/factories.py
@@ -1,12 +1,12 @@
 """ Content sync factories """
-from factory import SubFactory
+import factory
 from factory.django import DjangoModelFactory
 
 
 class ContentSyncStateFactory(DjangoModelFactory):
     """ Factory for ContentSyncState """
 
-    content = SubFactory("websites.factories.WebsiteContentFactory")
+    content = factory.SubFactory("websites.factories.WebsiteContentFactory")
 
     class Meta:
         model = "content_sync.ContentSyncState"


### PR DESCRIPTION
#### Pre-Flight checklist
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Closes #1497

#### What's this PR do?
Resets content sync state of all a site's resources when the site's url path is changed during draft publishing.   This should ensure that the `file` value for the resources in git are updated to use the new url path.  

#### How should this be manually tested?
- Create a site
- Add a file resource
- Fill out required metadata, add a menu link to the resource
- Publish to draft, choosing a url path
- Make an edit to a page or resource
- Publish to draft again, but choose a different url path
- Verify that the resource download url on the published sites uses the new url path and that it works
