### PR TITLE
increase timeout on mass-build-sites

### DIFF
--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -103,7 +103,7 @@ jobs:
           wget -O publishable_sites/sites.json --header="Authorization: Bearer ((api-token))" "((ocw-studio-url))/api/publish/?version=((version))((starter))"
   - task: get-repo-build-course-publish-course
     attempts: 1
-    timeout: 300m
+    timeout: 1200m
     params:
       API_BEARER_TOKEN: ((api-token))
       GTM_ACCOUNT_ID: ((gtm-account-id))


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1499

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/1477 we set up the offline flag in `mass-build-sites` to ZIP up the build output before syncing to S3. In local testing, this didn't seem to increase build time much. In previous testing on RC before introducing the ZIP feature, the offline build seemed to take about double the time, around 4 hours. In reality, the ZIP feature has been timing out builds at 5 hours. This PR increases the timeout to 20 hours, which may seem overkill. I want to see how long exactly the build will take, and if necessary we can adjust the timeout again in the future.

#### How should this be manually tested?
There isn't really a great way to test this locally, it will have to be tested in RC
