### PR TITLE
fix mass-build-sites offline HTML file detection

### DIFF
--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -185,7 +185,10 @@ jobs:
                 return 1
               fi
               mkdir -p ./static/static_resources
-              [[ -f ./content/static_resources/*.html ]] && mv ./content/static_resources/*.html ./static/static_resources
+              if compgen -G "./content/static_resources/*.html" > /dev/null
+              then
+                mv ./content/static_resources/*.html ./static/static_resources
+              fi
               touch ./content/static_resources/_index.md
               # END OFFLINE-ONLY
               echo "RUNNING HUGO BUILD FOR $NAME" > /dev/tty


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1504

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/1477, in addition to adding the ZIP functionality to the offline `mass-build-sites` pipeline, we added a check to the code that runs `mv` before the Hugo build to move HTML files out of the `content` folder from `static_resources` to prevent build errors. This check isn't doing what it's supposed to do and basically always returns false. This PR uses a different method of checking if the HTML files exist

#### How should this be manually tested?
 - First of all, make sure you've taken care of the following prerequisites:
   - `ocw-studio` up and running
   - Minio support configured
   - Concourse support configured
   - Some test courses in your database using the `ocw-course` starter
 - Make a temporary edit to `websites/views.py` to limit the sites seen by `mass-build-sites`:
```
        ...
        sites = Website.objects.filter(name="2-20-marine-hydrodynamics-13-021-spring-2005")
        serializer = WebsiteMassBuildSerializer(instance=sites, many=True)
        return Response({"sites": serializer.data})
```
 - Upsert the offline `mass-build-sites` pipeline with `docker-compose exec web ./manage.py upsert_mass_build_pipeline --offline --prefix /offline --starter ocw-course --projects-branch cg/course-v2-testing`
 - Browse to http://localhost:9001 and login with your Minio credentials
 - Upload the static resources into your Minio instance under `ol-ocw-studio-app` in the courses folder, in a folder with the name being the course id (`2-20-marine-hydrodynamics-13-021-spring-2005`)
 - Browse to http://concourse:8080 and login with test/test
 - Find the offline `mass-bulid-sites` pipeline we just uploaded and trigger a build
 - Ensure the build completes without error
 - In the `views.py` file, change `sites = Website.objects.filter(name="2-20-marine-hydrodynamics-13-021-spring-2005")` to `sites = sites.prefetch_related("starter").order_by("name")[:10]`
 - Run through the above again from the step where you push up the pipeline, skipping the step where you upload the static resources manually, and ensure that the build completes without error.
