### PR TITLE
proper pathing for the zip command

### DIFF
--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -203,7 +203,8 @@ jobs:
               cd $CURDIR
               echo "STARTING S3 SYNC FOR $NAME" > /dev/tty
               # START OFFLINE-ONLY
-              zip $NAME.zip -r $SHORT_ID/public
+              cd $CURDIR/$SHORT_ID/public
+              zip $NAME.zip -r ./
               PUBLISH_S3_RESULT=$(aws s3((cli-endpoint-url)) sync ./ s3://((ocw-bucket))$PREFIX/$BASE_URL --exclude="*" --include="$NAME.zip" --metadata site-id=$NAME --only-show-errors) || PUBLISH_S3_RESULT=1
               if [[ $PUBLISH_S3_RESULT == 1 ]]
               then
@@ -211,6 +212,7 @@ jobs:
                 return 1
               fi
               rm $NAME.zip
+              cd $CURDIR
               # END OFFLINE-ONLY
               # START ONLINE-ONLY
               STUDIO_S3_RESULT=$(aws s3((cli-endpoint-url)) sync s3://((ocw-studio-bucket))/$S3_PATH s3://((ocw-bucket))$PREFIX/$SITE_URL --metadata site-id=$NAME --only-show-errors) || STUDIO_S3_RESULT=1


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1506

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/1477, we added functionality that zips up the output of Hugo builds in `mass-build-sites` when run with the `--offline` flag. Something off with those zip files is that the root of the archive is the `$SHORT_ID/public` path that the site builds at in the Concourse container. This PR corrects that so that the root of the ZIP archive matches the root of the built site.

#### How should this be manually tested?
 - First of all, make sure you've taken care of the following prerequisites:
   - `ocw-studio` up and running
   - Minio support configured
   - Concourse support configured
   - Some test courses in your database using the `ocw-course` starter
 - Make a temporary edit to `websites/views.py` to limit the sites seen by `mass-build-sites`:
```
        ...
        sites = sites.prefetch_related("starter").order_by("name")[:10]
        serializer = WebsiteMassBuildSerializer(instance=sites, many=True)
        return Response({"sites": serializer.data})
```
 - Upsert the offline `mass-build-sites` pipeline with `docker-compose exec web ./manage.py upsert_mass_build_pipeline --offline --prefix /offline --starter ocw-course --projects-branch cg/course-v2-testing`
 - Browse to http://concourse:8080 and login with test/test
 - Find the offline `mass-bulid-sites` pipeline we just uploaded and trigger a build
 - Ensure the build completes without error
 - Browse to http://localhost:9001 and login with your Minio credentials
 - Browse to the `ocw-content-live` bucket, go the `offline/courses` folder, pick a course and download the ZIP file
 - Verify that the root of the ZIP folder matches the root of the course site
