### PR TITLE
increase timeout on copy-s3-buckets

### DIFF
--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -407,7 +407,7 @@ jobs:
                 text: "User Aborted during build-course-task : ((pipeline_name))/((site-name))"
             # END NON-DEV
       - task: copy-s3-buckets
-        timeout: 20m
+        timeout: 40m
         attempts: 3
         # START DEV-ONLY
         params:


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1514

#### What's this PR do?
Recently we added the ability in PR's related to https://github.com/mitodl/ocw-studio/pull/1429 to upsert additional `mass-build-sites` pipelines to the Concourse instance attached to `ocw-studio` with different prefixes, essentially creating an entire other copy of every site at that prefix. The purpose of this functionality is testing alternate theme rendering with all sites, like `course-v2` and `offline`. This creates a lot of extra files in the s3 bucket. When publishing `ocw-www`, the site is published to the root of the bucket. The S3 sync that pushes the files up now has to deal with scanning all of the extra files created by essentially duplicating the entire site, significantly increasing the sync time. This PR simply increases the timeout on teh `copy-s3-buckets` step from 20 minutes to 40 minutes. This is a stopgap to make sure `ocw-www` will publish in RC. In the long term we should come up with a better solution because `ocw-www` should not take as long to publish as it does. The amount of instructor static JSON combined with the fact that it's syncing to the root makes for a very long sync time in general, and an alternate strategy for `ocw-www` should likely be pursued.

#### How should this be manually tested?
This needs to be tested on RC.
