### PR TITLE
Pt/read title from pdf metadata

### DIFF
--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -342,12 +342,12 @@ def walk_gdrive_folder(folder_id: str, fields: str) -> Iterable[Dict]:
 
 def get_pdf_title(drive_file: DriveFile) -> str:
     """Get the title of a PDF from its metadata, if available"""
-    pdf_file = io.BytesIO(GDriveStreamReader(drive_file).read())
-    pdf_reader = PyPDF2.PdfReader(pdf_file)
-    pdf_metadata = pdf_reader.metadata
-    if "/Title" in pdf_metadata and pdf_metadata["/Title"] != "":
-        return pdf_metadata["/Title"]
-    return drive_file.name
+    with io.BytesIO(GDriveStreamReader(drive_file).read()) as pdf_file:
+        pdf_reader = PyPDF2.PdfReader(pdf_file)
+        pdf_metadata = pdf_reader.metadata
+        if "/Title" in pdf_metadata and pdf_metadata["/Title"] != "":
+            return pdf_metadata["/Title"]
+        return drive_file.name
 
 
 @transaction.atomic

--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -221,7 +221,7 @@ def stream_to_s3(drive_file: DriveFile):
         drive_file.update_status(DriveFileStatus.UPLOAD_COMPLETE)
     except:  # pylint:disable=bare-except
         drive_file.sync_error = (
-            f"An error occurred uploading google drive file {drive_file.name} to S3"
+            f"An error occurred uploading Google Drive file {drive_file.name} to S3"
         )
         drive_file.update_status(DriveFileStatus.UPLOAD_FAILED)
         raise
@@ -350,7 +350,7 @@ def get_pdf_title(drive_file: DriveFile) -> str:
             return pdf_metadata["/Title"]
     except PyPDF2.errors.PdfReadError:
         log.exception("The file %s is not a valid PDF", drive_file.name)
-        drive_file.sync_error = f"Could not create a resource from Google Drive file {drive_file.name} because it not a valid PDF"
+        drive_file.sync_error = f"Could not create a resource from Google Drive file {drive_file.name} because it is not a valid PDF"
         raise
     return drive_file.name
 
@@ -417,7 +417,7 @@ def create_gdrive_resource_content(drive_file: DriveFile):
     except:  # pylint:disable=bare-except
         log.exception("Error creating resource for drive file %s", drive_file.file_id)
         drive_file.sync_error = (
-            f"Could not create a resource from google drive file {drive_file.name}"
+            f"Could not create a resource from Google Drive file {drive_file.name}"
         )
         drive_file.update_status(DriveFileStatus.FAILED)
 

--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -342,8 +342,8 @@ def walk_gdrive_folder(folder_id: str, fields: str) -> Iterable[Dict]:
 
 def get_pdf_title(drive_file: DriveFile) -> str:
     """Get the title of a PDF from its metadata, if available"""
-    pdf_file = io.BytesIO(GDriveStreamReader(drive_file).read())
     try:
+        pdf_file = io.BytesIO(GDriveStreamReader(drive_file).read())
         pdf_reader = PyPDF2.PdfReader(pdf_file)
         pdf_metadata = pdf_reader.metadata
         if "/Title" in pdf_metadata and pdf_metadata["/Title"] != "":

--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -365,11 +365,14 @@ def create_gdrive_resource_content(drive_file: DriveFile):
             }
             resource_title = drive_file.name
             if extension.lower() == ".pdf":
-                pdf_file = io.BytesIO(GDriveStreamReader(drive_file).read())
-                pdf_reader = PyPDF2.PdfReader(pdf_file)
-                pdf_metadata = pdf_reader.metadata
-                if "/Title" in pdf_metadata and pdf_metadata["/Title"] != "":
-                    resource_title = pdf_metadata["/Title"]
+                try:
+                    pdf_file = io.BytesIO(GDriveStreamReader(drive_file).read())
+                    pdf_reader = PyPDF2.PdfReader(pdf_file)
+                    pdf_metadata = pdf_reader.metadata
+                    if "/Title" in pdf_metadata and pdf_metadata["/Title"] != "":
+                        resource_title = pdf_metadata["/Title"]
+                except:  # if no access to Google Drive stream, silently continue
+                    pass
 
             resource = WebsiteContent.objects.create(
                 website=drive_file.website,
@@ -393,11 +396,14 @@ def create_gdrive_resource_content(drive_file: DriveFile):
         else:
             resource.file = drive_file.s3_key
             if extension.lower() == ".pdf":
-                pdf_file = io.BytesIO(GDriveStreamReader(drive_file).read())
-                pdf_reader = PyPDF2.PdfReader(pdf_file)
-                pdf_metadata = pdf_reader.metadata
-                if "/Title" in pdf_metadata and pdf_metadata["/Title"] != "":
-                    resource.title = pdf_metadata["/Title"]
+                try:
+                    pdf_file = io.BytesIO(GDriveStreamReader(drive_file).read())
+                    pdf_reader = PyPDF2.PdfReader(pdf_file)
+                    pdf_metadata = pdf_reader.metadata
+                    if "/Title" in pdf_metadata and pdf_metadata["/Title"] != "":
+                        resource.title = pdf_metadata["/Title"]
+                except:  # if no access to Google Drive stream, silently continue
+                    pass
             resource.save()
         drive_file.resource = resource
         drive_file.update_status(DriveFileStatus.COMPLETE)

--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -365,14 +365,11 @@ def create_gdrive_resource_content(drive_file: DriveFile):
             }
             resource_title = drive_file.name
             if extension.lower() == ".pdf":
-                try:
-                    pdf_file = io.BytesIO(GDriveStreamReader(drive_file).read())
-                    pdf_reader = PyPDF2.PdfReader(pdf_file)
-                    pdf_metadata = pdf_reader.metadata
-                    if "/Title" in pdf_metadata and pdf_metadata["/Title"] != "":
-                        resource_title = pdf_metadata["/Title"]
-                except:  # if no access to Google Drive stream, silently continue
-                    pass
+                pdf_file = io.BytesIO(GDriveStreamReader(drive_file).read())
+                pdf_reader = PyPDF2.PdfReader(pdf_file)
+                pdf_metadata = pdf_reader.metadata
+                if "/Title" in pdf_metadata and pdf_metadata["/Title"] != "":
+                    resource_title = pdf_metadata["/Title"]
 
             resource = WebsiteContent.objects.create(
                 website=drive_file.website,
@@ -396,14 +393,11 @@ def create_gdrive_resource_content(drive_file: DriveFile):
         else:
             resource.file = drive_file.s3_key
             if extension.lower() == ".pdf":
-                try:
-                    pdf_file = io.BytesIO(GDriveStreamReader(drive_file).read())
-                    pdf_reader = PyPDF2.PdfReader(pdf_file)
-                    pdf_metadata = pdf_reader.metadata
-                    if "/Title" in pdf_metadata and pdf_metadata["/Title"] != "":
-                        resource.title = pdf_metadata["/Title"]
-                except:  # if no access to Google Drive stream, silently continue
-                    pass
+                pdf_file = io.BytesIO(GDriveStreamReader(drive_file).read())
+                pdf_reader = PyPDF2.PdfReader(pdf_file)
+                pdf_metadata = pdf_reader.metadata
+                if "/Title" in pdf_metadata and pdf_metadata["/Title"] != "":
+                    resource.title = pdf_metadata["/Title"]
             resource.save()
         drive_file.resource = resource
         drive_file.update_status(DriveFileStatus.COMPLETE)

--- a/gdrive_sync/api_test.py
+++ b/gdrive_sync/api_test.py
@@ -5,9 +5,9 @@ from datetime import timedelta
 import pytest
 from botocore.exceptions import ClientError
 from googleapiclient.http import MediaDownloadProgress
-from PyPDF2.errors import PdfReadError
 from mitol.common.utils import now_in_utc
 from moto import mock_s3
+from PyPDF2.errors import PdfReadError
 from requests import HTTPError
 
 from gdrive_sync import api

--- a/gdrive_sync/api_test.py
+++ b/gdrive_sync/api_test.py
@@ -52,13 +52,13 @@ pytestmark = pytest.mark.django_db
 
 @pytest.fixture
 def mock_service(mocker):
-    """Mock google drive service """
+    """Mock google drive service"""
     return mocker.patch("gdrive_sync.api.get_drive_service")
 
 
 @pytest.fixture
 def mock_get_s3_content_type(mocker):
-    """Mock gdrive_sync.api.get_s3_content_type """
+    """Mock gdrive_sync.api.get_s3_content_type"""
     mocker.patch(
         "gdrive_sync.api.get_s3_content_type", return_value="application/ms-word"
     )
@@ -506,8 +506,17 @@ def test_create_gdrive_resource_content(mime_type, mock_get_s3_content_type):
         assert drive_file.resource == content
 
 
-def test_create_gdrive_resource_content_forbidden_name(mock_get_s3_content_type):
+def test_create_gdrive_resource_content_forbidden_name(
+    mock_get_s3_content_type, mocker
+):
     """content for a google drive file with a forbidden name should have its filename attribute modified"""
+    mocker.patch(
+        "gdrive_sync.api.GDriveStreamReader",
+        return_value=mocker.Mock(read=mocker.Mock(return_value=b"fake_bytes")),
+    )
+    mocker.patch(
+        "gdrive_sync.api.PyPDF2.PdfReader", return_value=mocker.Mock(metadata={})
+    )
     drive_file = DriveFileFactory.create(
         name=f"{CONTENT_FILENAMES_FORBIDDEN[0]}.pdf",
         s3_key=f"test/path/{CONTENT_FILENAMES_FORBIDDEN[0]}.pdf",
@@ -519,6 +528,27 @@ def test_create_gdrive_resource_content_forbidden_name(mock_get_s3_content_type)
         drive_file.resource.filename
         == f"{CONTENT_FILENAMES_FORBIDDEN[0]}-{CONTENT_TYPE_RESOURCE}"
     )
+
+
+@pytest.mark.parametrize("mytitle", ["", "MyTitle"])
+def test_create_gdrive_pdf(mock_get_s3_content_type, mocker, mytitle):
+    """PDFs that have a non-blank title in the metadata should use that title in the resource"""
+    mocker.patch(
+        "gdrive_sync.api.GDriveStreamReader",
+        return_value=mocker.Mock(read=mocker.Mock(return_value=b"fake_bytes")),
+    )
+    mocker.patch(
+        "gdrive_sync.api.PyPDF2.PdfReader",
+        return_value=mocker.Mock(metadata={"/Title": mytitle}),
+    )
+    drive_file = DriveFileFactory.create(
+        name="mylecturenotes123.pdf",
+        s3_key="test/path/mylecturenotes123.pdf",
+        mime_type="application/pdf",
+    )
+    create_gdrive_resource_content(drive_file)
+    drive_file.refresh_from_db()
+    assert drive_file.resource.title == mytitle if mytitle != "" else drive_file.name
 
 
 def test_create_gdrive_resource_content_update(mock_get_s3_content_type):
@@ -559,7 +589,7 @@ def test_create_gdrive_resource_content_error(mocker):
 @pytest.mark.parametrize("region", [None, "us-west-1"])
 @pytest.mark.parametrize("role_name", [None, "test-role"])
 def test_transcode_gdrive_video(settings, mocker, account_id, region, role_name):
-    """ transcode_gdrive_video should create Video object and call create_media_convert_job"""
+    """transcode_gdrive_video should create Video object and call create_media_convert_job"""
     settings.AWS_ACCOUNT_ID = account_id
     settings.AWS_REGION = region
     settings.AWS_ROLE_NAME = role_name
@@ -580,7 +610,7 @@ def test_transcode_gdrive_video(settings, mocker, account_id, region, role_name)
     [VideoJobStatus.CREATED, VideoJobStatus.CREATED, VideoJobStatus.FAILED],
 )
 def test_transcode_gdrive_video_prior_job(settings, mocker, prior_status):
-    """ create_media_convert_job should be called only if the prior job failed"""
+    """create_media_convert_job should be called only if the prior job failed"""
     settings.AWS_ACCOUNT_ID = "accountABC"
     settings.AWS_REGION = "us-east-1"
     settings.AWS_ROLE_NAME = "roleDEF"

--- a/gdrive_sync/api_test.py
+++ b/gdrive_sync/api_test.py
@@ -473,6 +473,19 @@ def test_walk_gdrive_folder(mocker):
     )  # parent, subfolder1, subfolder1_1, subfolder2
 
 
+@pytest.fixture
+def mock_gdrive_pdf(mocker):
+    """Mock reading the metadata of a PDF file with blank metadata"""
+    mocker.patch(
+        "gdrive_sync.api.GDriveStreamReader",
+        return_value=mocker.Mock(read=mocker.Mock(return_value=b"fake_bytes")),
+    )
+    mocker.patch(
+        "gdrive_sync.api.PyPDF2.PdfReader",
+        return_value=mocker.Mock(metadata={}),
+    )
+
+
 @pytest.mark.parametrize(
     "mime_type", ["application/pdf", "application/vnd.ms-powerpoint"]
 )
@@ -507,16 +520,9 @@ def test_create_gdrive_resource_content(mime_type, mock_get_s3_content_type):
 
 
 def test_create_gdrive_resource_content_forbidden_name(
-    mock_get_s3_content_type, mocker
+    mock_get_s3_content_type, mock_gdrive_pdf
 ):
     """content for a google drive file with a forbidden name should have its filename attribute modified"""
-    mocker.patch(
-        "gdrive_sync.api.GDriveStreamReader",
-        return_value=mocker.Mock(read=mocker.Mock(return_value=b"fake_bytes")),
-    )
-    mocker.patch(
-        "gdrive_sync.api.PyPDF2.PdfReader", return_value=mocker.Mock(metadata={})
-    )
     drive_file = DriveFileFactory.create(
         name=f"{CONTENT_FILENAMES_FORBIDDEN[0]}.pdf",
         s3_key=f"test/path/{CONTENT_FILENAMES_FORBIDDEN[0]}.pdf",

--- a/requirements.in
+++ b/requirements.in
@@ -26,6 +26,7 @@ ipython
 newrelic
 psycopg2
 pygithub==1.55
+PyPDF2
 python-magic
 redis
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -257,6 +257,8 @@ pyparsing==2.4.7
     # via
     #   httplib2
     #   packaging
+pypdf2==2.11.0
+    # via -r requirements.in
 pytest==6.1.2
     # via mitol-django-common
 python-dateutil==2.8.1
@@ -348,6 +350,8 @@ traitlets==4.3.3
     # via
     #   ipython
     #   matplotlib-inline
+typing-extensions==4.3.0
+    # via pypdf2
 uritemplate==3.0.1
     # via google-api-python-client
 urllib3==1.25.10


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1495.

#### What's this PR do?
If a PDF is uploaded to Google Drive and synced, and if the PDF contains `Title` in its metadata, the update in this PR populates the `Title` field in OCW Studio. If an existing resource has its title changed (and replaced in Google Drive), then its `Title` field will be updated.

#### How should this be manually tested?
Upload a test PDF via Google Drive and sync to Studio. The `Title` in metadata can be set via Adobe Acrobat or via the `exiftool` command line tool (available via most package managers depending on OS, including `apt` and `homebrew`). For example, 
```
exiftool -Title="TestTitle" mypdf.pdf
``` 
Then, change the `Title` field to something else, for example,
```
exiftool -Title="NewTestTitle" mypdf.pdf
``` 
replace the resource in Google Drive, sync again, and check that the resource's `Title` has been updated in OCW Studio.