### PR TITLE
Replace `@ts-ignore` with `@ts-expect-error`, and remove most of them

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,6 @@ module.exports = {
     jest: true
   },
   rules: {
-    "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-unused-vars": [

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Setup NodeJS
         uses: actions/setup-node@v2-beta
         with:
-          node-version: "15.14.0"
+          node-version: "16.15.0"
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/static/js/components/DriveSyncStatusIndicator.test.tsx
+++ b/static/js/components/DriveSyncStatusIndicator.test.tsx
@@ -18,73 +18,86 @@ describe("DriveSyncStatusIndicator", () => {
   afterEach(() => {
     helper.cleanup()
   })
-  //
-  ;[
-    [GoogleDriveSyncStatuses.SYNC_STATUS_PROCESSING, []],
-    [GoogleDriveSyncStatuses.SYNC_STATUS_PENDING, []],
-    [GoogleDriveSyncStatuses.SYNC_STATUS_COMPLETE, []],
-    [GoogleDriveSyncStatuses.SYNC_STATUS_ERRORS, ["error1", "error2"]],
-    [GoogleDriveSyncStatuses.SYNC_STATUS_FAILED, ["total failure"]]
-  ].forEach(([status, syncErrors]) => {
-    describe("sync status drawer", () => {
-      beforeEach(() => {
-        website = {
-          ...makeWebsiteDetail(),
-          sync_status: status as GoogleDriveSyncStatuses,
-          sync_errors: syncErrors as Array<string>,
-          synced_on:   "2021-01-01"
-        }
-        render = helper.configureRenderer(DriveSyncStatusIndicator, {
-          website
-        })
-      })
 
-      afterEach(() => {
-        helper.cleanup()
+  describe.each([
+    {
+      status:     GoogleDriveSyncStatuses.SYNC_STATUS_PROCESSING,
+      syncErrors: []
+    },
+    {
+      status:     GoogleDriveSyncStatuses.SYNC_STATUS_PENDING,
+      syncErrors: []
+    },
+    {
+      status:     GoogleDriveSyncStatuses.SYNC_STATUS_COMPLETE,
+      syncErrors: []
+    },
+    {
+      status:     GoogleDriveSyncStatuses.SYNC_STATUS_ERRORS,
+      syncErrors: ["error1", "error2"]
+    },
+    {
+      status:     GoogleDriveSyncStatuses.SYNC_STATUS_FAILED,
+      syncErrors: ["total failure"]
+    }
+  ])("sync status drawer", ({ status, syncErrors }) => {
+    beforeEach(() => {
+      website = {
+        ...makeWebsiteDetail(),
+        sync_status: status,
+        sync_errors: syncErrors,
+        synced_on:   "2021-01-01"
+      }
+      render = helper.configureRenderer(DriveSyncStatusIndicator, {
+        website
       })
+    })
 
-      it(`renders for status=${status}`, async () => {
-        const { wrapper } = await render()
-        expect(wrapper.text()).toContain(status)
-        expect(wrapper.find(".status-indicator").prop("className")).toContain(
-          status.toString().toLowerCase()
-        )
+    afterEach(() => {
+      helper.cleanup()
+    })
+
+    it(`renders for status=${status}`, async () => {
+      const { wrapper } = await render()
+      expect(wrapper.text()).toContain(status)
+      expect(wrapper.find(".status-indicator").prop("className")).toContain(
+        status.toString().toLowerCase()
+      )
+    })
+
+    it(`shows details with sync date and ${syncErrors.length} errors in side drawer`, async () => {
+      const { wrapper } = await render()
+      expect(wrapper.find("BasicModal").prop("isVisible")).toBe(false)
+
+      const statusDiv = wrapper.find(".sync-status")
+      act(() => {
+        // @ts-expect-error Not mocking the whole event
+        statusDiv.prop("onClick")({ preventDefault: helper.sandbox.stub() })
       })
+      wrapper.update()
+      const drawer = wrapper.find("BasicModal").at(0)
+      expect(drawer.prop("isVisible")).toBe(true)
 
-      it(`shows details with sync date and ${syncErrors.length} errors in side drawer`, async () => {
-        const { wrapper } = await render()
-        expect(wrapper.find("BasicModal").prop("isVisible")).toBe(false)
-
-        const statusDiv = wrapper.find(".sync-status")
-        act(() => {
-          // @ts-ignore
-          statusDiv.prop("onClick")({ preventDefault: helper.sandbox.stub() })
-        })
-        wrapper.update()
-        const drawer = wrapper.find("BasicModal").at(0)
-        expect(drawer.prop("isVisible")).toBe(true)
-        //@ts-ignore
-        syncErrors.forEach((error: string, idx: number) => {
-          expect(
-            drawer
-              .find("li")
-              .at(idx)
-              .text()
-          ).toBe(error)
-        })
-        expect(drawer.find("li").length).toBe(syncErrors.length)
-        if (syncErrors.length === 0) {
-          expect(
-            drawer
-              .find(".sync-success")
-              .at(0)
-              .text()
-          ).toContain("The latest Google Drive sync was successful.")
-        }
-        expect(drawer.find(".sync-time").text()).toContain(
-          moment(website.synced_on).format("dddd, MMMM D h:mma ZZ")
-        )
+      syncErrors.forEach((error: string, idx: number) => {
+        expect(
+          drawer
+            .find("li")
+            .at(idx)
+            .text()
+        ).toBe(error)
       })
+      expect(drawer.find("li").length).toBe(syncErrors.length)
+      if (syncErrors.length === 0) {
+        expect(
+          drawer
+            .find(".sync-success")
+            .at(0)
+            .text()
+        ).toContain("The latest Google Drive sync was successful.")
+      }
+      expect(drawer.find(".sync-time").text()).toContain(
+        moment(website.synced_on).format("dddd, MMMM D h:mma ZZ")
+      )
     })
   })
 })

--- a/static/js/components/SingletonsContentListing.test.tsx
+++ b/static/js/components/SingletonsContentListing.test.tsx
@@ -119,7 +119,7 @@ describe("SingletonsContentListing", () => {
     const { wrapper } = await render()
     const tabLinks = wrapper.find("NavLink")
     act(() => {
-      // @ts-ignore
+      // @ts-expect-error Not mocking whole event
       tabLinks.at(tabIndexToSelect).prop("onClick")({
         preventDefault: helper.sandbox.stub()
       })
@@ -171,7 +171,7 @@ describe("SingletonsContentListing", () => {
       sinon.assert.notCalled(contentDetailStub)
       const tabLink = wrapper.find("NavLink").at(tabIndexToSelect)
       act(() => {
-        // @ts-ignore
+        // @ts-expect-error Not mocking whole event
         tabLink.prop("onClick")({ preventDefault: helper.sandbox.stub() })
       })
       wrapper.update()

--- a/static/js/components/SiteCollaboratorDrawer.test.tsx
+++ b/static/js/components/SiteCollaboratorDrawer.test.tsx
@@ -1,4 +1,5 @@
 import sinon, { SinonStub } from "sinon"
+import { ReactWrapper } from "enzyme"
 import { act } from "react-dom/test-utils"
 
 import SiteCollaboratorDrawer from "./SiteCollaboratorDrawer"
@@ -15,13 +16,33 @@ import {
   siteApiCollaboratorsUrl
 } from "../lib/urls"
 
-import { Website, WebsiteCollaborator } from "../types/websites"
+import {
+  Website,
+  WebsiteCollaborator,
+  WebsiteCollaboratorFormData
+} from "../types/websites"
+
+const simulateClickSubmit = (
+  wrapper: ReactWrapper,
+  stubs: FormikStubs,
+  data: WebsiteCollaboratorFormData
+) => {
+  const onSubmit = wrapper.prop("onSubmit")
+  if (typeof onSubmit !== "function") {
+    throw new Error("onSubmit should be a function")
+  }
+  return act(async () => {
+    onSubmit(data, stubs)
+  })
+}
+
+type FormikStubs = Record<string, SinonStub>
 
 describe("SiteCollaboratorDrawerTest", () => {
   let helper: IntegrationTestHelper,
     render: TestRenderer,
     website: Website,
-    formikStubs: { [key: string]: SinonStub },
+    formikStubs: FormikStubs,
     editCollaboratorStub: SinonStub,
     addCollaboratorStub: SinonStub,
     toggleVisibilityStub: SinonStub,
@@ -40,7 +61,6 @@ describe("SiteCollaboratorDrawerTest", () => {
       setStatus:     sinon.stub()
     }
     render = helper.configureRenderer(
-      // @ts-ignore
       SiteCollaboratorDrawer,
       {
         collaborator:     null,
@@ -91,17 +111,9 @@ describe("SiteCollaboratorDrawerTest", () => {
       )
       const { wrapper } = await render({ collaborator })
       const form = wrapper.find("SiteCollaboratorForm")
-      const onSubmit = form.prop("onSubmit")
-      await act(async () => {
-        // @ts-ignore
-        onSubmit(
-          {
-            role: ROLE_EDITOR
-          },
-          // @ts-ignore
-          formikStubs
-        )
-      })
+
+      await simulateClickSubmit(form, formikStubs, { role: ROLE_EDITOR })
+
       sinon.assert.calledOnce(editCollaboratorStub)
       sinon.assert.calledOnceWithExactly(formikStubs.setSubmitting, false)
       sinon.assert.calledOnce(toggleVisibilityStub)
@@ -125,17 +137,9 @@ describe("SiteCollaboratorDrawerTest", () => {
       )
       const { wrapper } = await render({ collaborator })
       const form = wrapper.find("SiteCollaboratorForm")
-      const onSubmit = form.prop("onSubmit")
-      await act(async () => {
-        // @ts-ignore
-        onSubmit(
-          {
-            role: ROLE_EDITOR
-          },
-          // @ts-ignore
-          formikStubs
-        )
-      })
+
+      await simulateClickSubmit(form, formikStubs, { role: ROLE_EDITOR })
+
       sinon.assert.calledOnce(editCollaboratorStub)
       sinon.assert.calledOnceWithExactly(formikStubs.setErrors, {
         ...errorResp.errors
@@ -159,17 +163,7 @@ describe("SiteCollaboratorDrawerTest", () => {
       )
       const { wrapper } = await render({ collaborator })
       const form = wrapper.find("SiteCollaboratorForm")
-      const onSubmit = form.prop("onSubmit")
-      await act(async () => {
-        // @ts-ignore
-        onSubmit(
-          {
-            role: ROLE_EDITOR
-          },
-          // @ts-ignore
-          formikStubs
-        )
-      })
+      await simulateClickSubmit(form, formikStubs, { role: ROLE_EDITOR })
       sinon.assert.calledOnce(editCollaboratorStub)
       sinon.assert.calledOnceWithExactly(formikStubs.setStatus, errorMsg)
       sinon.assert.notCalled(toggleVisibilityStub)
@@ -190,17 +184,9 @@ describe("SiteCollaboratorDrawerTest", () => {
       )
       const { wrapper } = await render()
       const form = wrapper.find("SiteCollaboratorForm")
-      const onSubmit = form.prop("onSubmit")
-      await act(async () => {
-        // @ts-ignore
-        onSubmit(
-          {
-            email: "test@mit.edu",
-            role:  ROLE_EDITOR
-          },
-          // @ts-ignore
-          formikStubs
-        )
+      await simulateClickSubmit(form, formikStubs, {
+        role:  ROLE_EDITOR,
+        email: "test@mit.edu"
       })
       sinon.assert.calledOnce(addCollaboratorStub)
       sinon.assert.calledOnceWithExactly(formikStubs.setSubmitting, false)
@@ -221,17 +207,9 @@ describe("SiteCollaboratorDrawerTest", () => {
       )
       const { wrapper } = await render()
       const form = wrapper.find("SiteCollaboratorForm")
-      const onSubmit = form.prop("onSubmit")
-      await act(async () => {
-        // @ts-ignore
-        onSubmit(
-          {
-            email: "oops@mit.edu",
-            role:  ROLE_EDITOR
-          },
-          // @ts-ignore
-          formikStubs
-        )
+      await simulateClickSubmit(form, formikStubs, {
+        role:  ROLE_EDITOR,
+        email: "oops@mit.edu"
       })
       sinon.assert.calledOnce(addCollaboratorStub)
       sinon.assert.calledOnceWithExactly(formikStubs.setErrors, {
@@ -251,17 +229,9 @@ describe("SiteCollaboratorDrawerTest", () => {
       )
       const { wrapper } = await render()
       const form = wrapper.find("SiteCollaboratorForm")
-      const onSubmit = form.prop("onSubmit")
-      await act(async () => {
-        // @ts-ignore
-        onSubmit(
-          {
-            email: "oops@mit.edu",
-            role:  ROLE_EDITOR
-          },
-          // @ts-ignore
-          formikStubs
-        )
+      await simulateClickSubmit(form, formikStubs, {
+        role:  ROLE_EDITOR,
+        email: "oops@mit.edu"
       })
       sinon.assert.calledOnce(addCollaboratorStub)
       sinon.assert.calledOnceWithExactly(formikStubs.setStatus, errorMsg)

--- a/static/js/components/SiteCollaboratorList.test.tsx
+++ b/static/js/components/SiteCollaboratorList.test.tsx
@@ -19,6 +19,7 @@ import IntegrationTestHelper, {
 import WebsiteContext from "../context/Website"
 
 import { Website, WebsiteCollaborator } from "../types/websites"
+import SiteCollaboratorDrawer from "./SiteCollaboratorDrawer"
 
 describe("SiteCollaboratorList", () => {
   let helper: IntegrationTestHelper,
@@ -90,25 +91,21 @@ describe("SiteCollaboratorList", () => {
       .simulate("click")
 
     act(() => {
-      // @ts-ignore
       wrapper
         .find("button.dropdown-item")
         .at(0)
         .simulate("click")
     })
     wrapper.update()
-    const component = wrapper.find("SiteCollaboratorDrawer")
+    const component = wrapper.find(SiteCollaboratorDrawer)
     expect(component.prop("collaborator")).toBe(collaborators[0])
     expect(component.prop("visibility")).toBe(true)
 
     act(() => {
-      // @ts-ignore
       component.prop("toggleVisibility")()
     })
     wrapper.update()
-    expect(wrapper.find("SiteCollaboratorDrawer").prop("visibility")).toBe(
-      false
-    )
+    expect(wrapper.find(SiteCollaboratorDrawer).prop("visibility")).toBe(false)
   })
 
   it("the delete collaborator dialog works as expected", async () => {
@@ -155,21 +152,18 @@ describe("SiteCollaboratorList", () => {
     const { wrapper } = await render()
     const addLink = wrapper.find("button").at(0)
     act(() => {
-      // @ts-ignore
+      // @ts-expect-error Not simulating whole event
       addLink.prop("onClick")({ preventDefault: helper.sandbox.stub() })
     })
     wrapper.update()
-    const component = wrapper.find("SiteCollaboratorDrawer")
+    const component = wrapper.find(SiteCollaboratorDrawer)
     expect(component.prop("collaborator")).toBe(null)
     expect(component.prop("visibility")).toBe(true)
 
     act(() => {
-      // @ts-ignore
       component.prop("toggleVisibility")()
     })
     wrapper.update()
-    expect(wrapper.find("SiteCollaboratorDrawer").prop("visibility")).toBe(
-      false
-    )
+    expect(wrapper.find(SiteCollaboratorDrawer).prop("visibility")).toBe(false)
   })
 })

--- a/static/js/components/SortableItem.tsx
+++ b/static/js/components/SortableItem.tsx
@@ -35,7 +35,7 @@ export default function SortableItem<T>(props: Props<T>): JSX.Element {
     <div
       className="d-flex my-3"
       ref={setNodeRef}
-      // @ts-ignore unfortunately unavoidable because of library types :/
+      // @ts-expect-error unfortunately unavoidable because of library types :/
       style={style}
       {...attributes}
       {...listeners}

--- a/static/js/components/forms/MenuItemForm.test.tsx
+++ b/static/js/components/forms/MenuItemForm.test.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import { shallow } from "enzyme"
+import { Formik, FormikProps } from "formik"
 
 import MenuItemForm from "./MenuItemForm"
 import { defaultFormikChildProps } from "../../test_util"
@@ -27,18 +28,13 @@ describe("MenuItemForm", () => {
 
   const renderInnerForm = (
     formProps: { [key: string]: any },
-    formikChildProps: { [key: string]: any } = {}
+    formikChildProps: Partial<FormikProps<any>>
   ) => {
     const wrapper = renderForm(formProps || {})
-    return (
-      wrapper
-        .find("Formik")
-        // @ts-ignore
-        .renderProp("children")({
-          ...defaultFormikChildProps,
-          ...formikChildProps
-        })
-    )
+    return wrapper.find(Formik).renderProp("children")({
+      ...defaultFormikChildProps,
+      ...formikChildProps
+    })
   }
 
   it("calls the onSubmit method", () => {
@@ -106,10 +102,10 @@ describe("MenuItemForm", () => {
     expect(internalBtn.prop("value")).toEqual(LinkType.Internal)
     expect(externalBtn.prop("checked")).toBe(false)
     expect(externalBtn.prop("value")).toEqual(LinkType.External)
-    // @ts-ignore
+    // @ts-expect-error Not going to simulate the event
     externalBtn.prop("onChange")()
     expect(setFieldValueStub).toBeCalledWith("menuItemType", LinkType.External)
-    // @ts-ignore
+    // @ts-expect-error Not going to simulate the event
     internalBtn.prop("onChange")()
     expect(setFieldValueStub).toBeCalledWith("menuItemType", LinkType.Internal)
   })
@@ -179,7 +175,7 @@ describe("MenuItemForm", () => {
     const fakeEvent = {
       target: { value: { content: "abc", website: "ignored" } }
     }
-    // @ts-ignore
+    // @ts-expect-error Not using a full event
     relationField.prop("onChange")(fakeEvent)
     expect(setFieldValueStub).toBeCalledWith("internalLink", "abc")
   })

--- a/static/js/components/forms/PublishForm.test.tsx
+++ b/static/js/components/forms/PublishForm.test.tsx
@@ -7,6 +7,7 @@ import PublishForm, { websiteUrlValidation } from "./PublishForm"
 import { PublishingEnv } from "../../constants"
 import { assertInstanceOf, defaultFormikChildProps } from "../../test_util"
 import { makeWebsiteDetail } from "../../util/factories/websites"
+import { Formik, FormikProps } from "formik"
 
 describe("PublishForm", () => {
   let sandbox, onSubmitStub: SinonStub
@@ -24,19 +25,14 @@ describe("PublishForm", () => {
     )
 
   const renderInnerForm = (
-    formikChildProps: { [key: string]: any },
+    formikChildProps: Partial<FormikProps<any>>,
     wrapperProps: { [key: string]: any }
   ) => {
     const wrapper = renderForm(wrapperProps)
-    return (
-      wrapper
-        .find("Formik")
-        // @ts-ignore
-        .renderProp("children")({
-          ...defaultFormikChildProps,
-          ...formikChildProps
-        })
-    )
+    return wrapper.find(Formik).renderProp("children")({
+      ...defaultFormikChildProps,
+      ...formikChildProps
+    })
   }
 
   beforeEach(() => {

--- a/static/js/components/forms/PublishForm.tsx
+++ b/static/js/components/forms/PublishForm.tsx
@@ -1,4 +1,5 @@
 import React from "react"
+import { last } from "lodash"
 import { Formik, Form, ErrorMessage, Field, FormikHelpers } from "formik"
 import * as yup from "yup"
 
@@ -42,10 +43,7 @@ const PublishForm: React.FC<Props> = ({
   option
 }) => {
   const initialValues: SiteFormValues = {
-    // @ts-expect-error
-    url_path: website.url_path ?
-      website.url_path.split("/").pop() :
-      website.url_suggestion
+    url_path: last(website.url_path?.split("/")) ?? website.url_suggestion
   }
 
   const fullUrl =

--- a/static/js/components/forms/SiteCollaboratorForm.test.tsx
+++ b/static/js/components/forms/SiteCollaboratorForm.test.tsx
@@ -8,11 +8,12 @@ import SiteCollaboratorForm, {
   roleValidation
 } from "./SiteCollaboratorForm"
 import { EDITABLE_ROLES } from "../../constants"
-import { defaultFormikChildProps } from "../../test_util"
+import { assertInstanceOf, defaultFormikChildProps } from "../../test_util"
 import { makeWebsiteCollaborator } from "../../util/factories/websites"
 
 import { WebsiteCollaborator } from "../../types/websites"
 import { Option } from "../widgets/SelectField"
+import { Formik, FormikProps } from "formik"
 
 describe("SiteCollaboratorForm", () => {
   let sandbox,
@@ -30,19 +31,14 @@ describe("SiteCollaboratorForm", () => {
     )
 
   const renderInnerForm = (
-    formikChildProps: { [key: string]: any },
+    formikChildProps: Partial<FormikProps<any>>,
     collaborator: WebsiteCollaborator | null
   ) => {
     const wrapper = renderForm(collaborator)
-    return (
-      wrapper
-        .find("Formik")
-        // @ts-ignore
-        .renderProp("children")({
-          ...defaultFormikChildProps,
-          ...formikChildProps
-        })
-    )
+    return wrapper.find(Formik).renderProp("children")({
+      ...defaultFormikChildProps,
+      ...formikChildProps
+    })
   }
 
   beforeEach(() => {
@@ -55,11 +51,9 @@ describe("SiteCollaboratorForm", () => {
     it("passes onSubmit to Formik", () => {
       const wrapper = renderForm(null)
       expect(wrapper.props().onSubmit).toBe(onSubmitStub)
-      const props = wrapper.find("Formik").props()
+      const props = wrapper.find(Formik).props()
       expect(props.onSubmit).toBe(onSubmitStub)
-      // @ts-ignore
       expect(props.validationSchema.fields.role).toBeDefined()
-      // @ts-ignore
       expect(props.validationSchema.fields.email).toBeDefined()
     })
 
@@ -109,18 +103,15 @@ describe("SiteCollaboratorForm", () => {
 
     it("passes onSubmit to Formik", () => {
       const wrapper = renderForm(collaborator)
-      const props = wrapper.find("Formik").props()
+      const props = wrapper.find(Formik).props()
       expect(props.onSubmit).toBe(onSubmitStub)
-      // @ts-ignore
       expect(props.validationSchema.fields.role).toBeDefined()
-      // @ts-ignore
       expect(props.validationSchema.fields.email).toBeUndefined()
     })
 
     it("has current role selected", () => {
       const wrapper = renderForm(collaborator)
-      const props = wrapper.find("Formik").props()
-      //@ts-ignore
+      const props = wrapper.find(Formik).props()
       expect(props.initialValues.role).toBe(collaborator.role)
     })
 
@@ -151,8 +142,7 @@ describe("SiteCollaboratorForm", () => {
           await collaboratorValidation.validateAt("role", "")
         ).rejects.toThrow()
       } catch (error) {
-        expect(error).toBeInstanceOf(yup.ValidationError)
-        // @ts-ignore
+        assertInstanceOf(error, yup.ValidationError)
         expect(error.errors).toStrictEqual(["Role is a required field"])
       }
     })
@@ -163,8 +153,7 @@ describe("SiteCollaboratorForm", () => {
           await collaboratorValidation.validateAt("email", { email: "" })
         ).rejects.toThrow()
       } catch (error) {
-        expect(error).toBeInstanceOf(yup.ValidationError)
-        // @ts-ignore
+        assertInstanceOf(error, yup.ValidationError)
         expect(error.errors).toStrictEqual(["Email is a required field"])
       }
     })
@@ -177,8 +166,7 @@ describe("SiteCollaboratorForm", () => {
           })
         ).rejects.toThrow()
       } catch (error) {
-        expect(error).toBeInstanceOf(yup.ValidationError)
-        // @ts-ignore
+        assertInstanceOf(error, yup.ValidationError)
         expect(error.errors).toStrictEqual(["Email must be a valid email"])
       }
     })
@@ -189,8 +177,7 @@ describe("SiteCollaboratorForm", () => {
           await collaboratorValidation.validateAt("role", "admin")
         ).rejects.toThrow()
       } catch (error) {
-        expect(error).toBeInstanceOf(yup.ValidationError)
-        // @ts-ignore
+        assertInstanceOf(error, yup.ValidationError)
         expect(error.errors).toStrictEqual(["Role is a required field"])
       }
     })

--- a/static/js/components/forms/SiteForm.test.tsx
+++ b/static/js/components/forms/SiteForm.test.tsx
@@ -5,10 +5,11 @@ import { ValidationError } from "yup"
 
 import { SiteForm, websiteValidation } from "./SiteForm"
 import { makeWebsiteStarter } from "../../util/factories/websites"
-import { defaultFormikChildProps } from "../../test_util"
+import { assertInstanceOf, defaultFormikChildProps } from "../../test_util"
 
 import { WebsiteStarter } from "../../types/websites"
 import { Option } from "../widgets/SelectField"
+import { Formik } from "formik"
 
 describe("SiteForm", () => {
   let sandbox, onSubmitStub: SinonStub, websiteStarters: Array<WebsiteStarter>
@@ -20,15 +21,10 @@ describe("SiteForm", () => {
 
   const renderInnerForm = (formikChildProps: { [key: string]: any }) => {
     const wrapper = renderForm()
-    return (
-      wrapper
-        .find("Formik")
-        // @ts-ignore
-        .renderProp("children")({
-          ...defaultFormikChildProps,
-          ...formikChildProps
-        })
-    )
+    return wrapper.find(Formik).renderProp("children")({
+      ...defaultFormikChildProps,
+      ...formikChildProps
+    })
   }
 
   beforeEach(() => {
@@ -40,9 +36,8 @@ describe("SiteForm", () => {
   it("passes onSubmit to Formik", () => {
     const wrapper = renderForm()
 
-    const props = wrapper.find("Formik").props()
+    const props = wrapper.find(Formik).props()
     expect(props.onSubmit).toBe(onSubmitStub)
-    // @ts-ignore
     expect(props.validationSchema).toBe(websiteValidation)
   })
 
@@ -65,8 +60,7 @@ describe("SiteForm", () => {
           await websiteValidation.validateAt("title", { title: "" })
         ).rejects.toThrow()
       } catch (error) {
-        expect(error).toBeInstanceOf(ValidationError)
-        // @ts-ignore
+        assertInstanceOf(error, ValidationError)
         expect(error.errors).toStrictEqual(["Title is a required field"])
       }
     })
@@ -78,8 +72,8 @@ describe("SiteForm", () => {
           })
         ).rejects.toThrow()
       } catch (error) {
+        assertInstanceOf(error, ValidationError)
         expect(error).toBeInstanceOf(ValidationError)
-        // @ts-ignore
         expect(error.errors).toStrictEqual([
           "Only alphanumeric characters, periods, dashes, or underscores allowed"
         ])

--- a/static/js/components/forms/SiteForm.tsx
+++ b/static/js/components/forms/SiteForm.tsx
@@ -15,7 +15,7 @@ export interface SiteFormValues {
   starter: number | null
 }
 
-type Props = {
+type SiteFormProps = {
   onSubmit: (
     values: any,
     formikHelpers: FormikHelpers<any>
@@ -46,7 +46,7 @@ export const websiteValidation = yup.object().shape({
 export const SiteForm = ({
   onSubmit,
   websiteStarters
-}: Props): JSX.Element | null => {
+}: SiteFormProps): JSX.Element | null => {
   const defaultWebsiteStarter =
     websiteStarters.find(obj => obj.status === WebsiteStarterStatus.Default) ||
     (websiteStarters.length > 0 ? websiteStarters[0] : null)
@@ -113,3 +113,5 @@ export const SiteForm = ({
     </Formik>
   )
 }
+
+export { SiteFormProps }

--- a/static/js/components/forms/validation.test.ts
+++ b/static/js/components/forms/validation.test.ts
@@ -8,7 +8,6 @@ import {
   makeSingletonConfigItem,
   makeWebsiteConfigField
 } from "../../util/factories/websites"
-import { isIf } from "../../test_util"
 
 import {
   ConfigItem,
@@ -48,20 +47,31 @@ describe("form validation utils", () => {
         widget:   WidgetVariant.String
       }
 
-      //
-      ;[
-        [null, true, false, true],
-        [titleField, true, true, true],
-        [null, false, false, false]
-      ].forEach(([field, isRepeatable, fieldIncluded, expAddedTitleField]) => {
-        it(`validates correctly if 'title' field ${isIf(
-          fieldIncluded
-        )} included, config item ${isIf(
-          isRepeatable
-        )} repeatable`, async () => {
+      it.each([
+        {
+          field:              null,
+          isRepeatable:       true,
+          expAddedTitleField: true,
+          desc:               "'title' is NOT included, config IS repeatable"
+        },
+        {
+          field:              titleField,
+          isRepeatable:       true,
+          expAddedTitleField: true,
+          desc:               "'title' IS included, config IS repeatable"
+        },
+        {
+          field:              null,
+          isRepeatable:       false,
+          expAddedTitleField: false,
+          desc:               "'title' is NOT included, config is NOT repeatable"
+        }
+      ])(
+        `validates correctly if $desc`,
+        async ({ field, isRepeatable, expAddedTitleField }) => {
+          // @ts-expect-error Unsure the ts error here; possibly types on getContentSchema are wrong
           configItem = {
             ...(isRepeatable ? repeatableConfigItem : singletonConfigItem),
-            // @ts-ignore
             fields: field ? [field] : []
           }
           const schema = getContentSchema(configItem, {})
@@ -77,8 +87,8 @@ describe("form validation utils", () => {
               new yup.ValidationError("Title is a required field")
             )
           }
-        })
-      })
+        }
+      )
     })
 
     it("should skip validation for fields which aren't visible", () => {

--- a/static/js/components/widgets/EmbeddedResource.test.tsx
+++ b/static/js/components/widgets/EmbeddedResource.test.tsx
@@ -2,7 +2,7 @@ import EmbeddedResource from "./EmbeddedResource"
 import IntegrationTestHelper, {
   TestRenderer
 } from "../../util/integration_test_helper_old"
-import { useWebsite } from "../../context/Website"
+import * as contextWebsite from "../../context/Website"
 import {
   makeWebsiteContentDetail,
   makeWebsiteDetail
@@ -13,6 +13,7 @@ import { ResourceType } from "../../constants"
 
 jest.mock("../../context/Website")
 jest.mock("../../hooks/state")
+const useWebsite = jest.mocked(contextWebsite.useWebsite)
 
 describe("EmbeddedResource", () => {
   let helper: IntegrationTestHelper,
@@ -25,7 +26,7 @@ describe("EmbeddedResource", () => {
     helper = new IntegrationTestHelper()
     website = makeWebsiteDetail()
     content = makeWebsiteContentDetail()
-    // @ts-ignore
+
     useWebsite.mockReturnValue(website)
 
     helper.mockGetRequest(

--- a/static/js/components/widgets/HierarchicalSelectField.test.tsx
+++ b/static/js/components/widgets/HierarchicalSelectField.test.tsx
@@ -8,7 +8,23 @@ import HierarchicalSelectField, {
   calcOptions,
   Level
 } from "./HierarchicalSelectField"
-import { Option } from "./SelectField"
+import SelectField, { Option } from "./SelectField"
+
+const simulateSelectValue = (
+  wrapper: ShallowWrapper,
+  value: string,
+  idx: number
+) => {
+  return act(() => {
+    wrapper
+      .find(SelectField)
+      .at(idx)
+      .prop("onChange")({
+      // @ts-expect-error not simulating whole event
+        target: { value }
+      })
+  })
+}
 
 describe("HierarchicalSelectField", () => {
   let render: (props?: any) => ShallowWrapper,
@@ -91,14 +107,7 @@ describe("HierarchicalSelectField", () => {
     const wrapper = render()
 
     for (let idx = 0; idx < levels.length; ++idx) {
-      act(() => {
-        // @ts-ignore
-        wrapper
-          .find("SelectField")
-          .at(idx)
-          // @ts-ignore
-          .prop("onChange")({ target: { value: selectPath[idx].value } })
-      })
+      simulateSelectValue(wrapper, selectPath[idx].value, idx)
       expect(
         wrapper
           .find("SelectField")
@@ -111,23 +120,9 @@ describe("HierarchicalSelectField", () => {
   it("resets values on deeper levels when a value is set", () => {
     const wrapper = render()
     for (let idx = 0; idx < levels.length; ++idx) {
-      act(() => {
-        // @ts-ignore
-        wrapper
-          .find("SelectField")
-          .at(idx)
-          // @ts-ignore
-          .prop("onChange")({ target: { value: selectPath[idx].value } })
-      })
+      simulateSelectValue(wrapper, selectPath[idx].value, idx)
     }
-    act(() => {
-      // @ts-ignore
-      wrapper
-        .find("SelectField")
-        .at(0)
-        // @ts-ignore
-        .prop("onChange")({ target: { value: "Topic2" } })
-    })
+    simulateSelectValue(wrapper, "Topic2", 0)
     expect(
       wrapper
         .find("SelectField")
@@ -147,24 +142,10 @@ describe("HierarchicalSelectField", () => {
   it("keeps selection on higher levels when a value is set at a deeper one", () => {
     const wrapper = render()
     for (let idx = 0; idx < levels.length; ++idx) {
-      act(() => {
-        // @ts-ignore
-        wrapper
-          .find("SelectField")
-          .at(idx)
-          // @ts-ignore
-          .prop("onChange")({ target: { value: selectPath[idx].value } })
-      })
+      simulateSelectValue(wrapper, selectPath[idx].value, idx)
     }
     const lastIdx = levels.length - 1
-    act(() => {
-      // @ts-ignore
-      wrapper
-        .find("SelectField")
-        .at(lastIdx)
-        // @ts-ignore
-        .prop("onChange")({ target: { value: "potato" } })
-    })
+    simulateSelectValue(wrapper, "potato", lastIdx)
     expect(
       wrapper
         .find("SelectField")
@@ -201,7 +182,7 @@ describe("HierarchicalSelectField", () => {
       const button = wrapper.find(".values div button").at(valueIndex)
       expect(button.text()).toBe("delete")
       const event = { preventDefault: jest.fn() }
-      // @ts-ignore
+      // @ts-expect-error Not simulating the whole event
       button.prop("onClick")(event)
       expect(event.preventDefault).toBeCalled()
       expect(onChangeStub).toBeCalledWith({
@@ -222,17 +203,10 @@ describe("HierarchicalSelectField", () => {
       const wrapper = render({
         value
       })
-      act(() => {
-        // @ts-ignore
-        wrapper
-          .find("SelectField")
-          .at(0)
-          // @ts-ignore
-          .prop("onChange")({ target: { value: "Topic2" } })
-      })
+      simulateSelectValue(wrapper, "Topic2", 0)
 
       const event = { preventDefault: jest.fn() }
-      // @ts-ignore
+      // @ts-expect-error Not simulating the whole event
       wrapper.find(".add").prop("onClick")(event)
 
       expect(event.preventDefault).toBeCalled()
@@ -252,7 +226,7 @@ describe("HierarchicalSelectField", () => {
     })
 
     const event = { preventDefault: jest.fn() }
-    // @ts-ignore
+    // @ts-expect-error Not simulating the whole event
     wrapper.find(".add").prop("onClick")(event)
 
     expect(event.preventDefault).toBeCalled()

--- a/static/js/components/widgets/MarkdownEditor.test.tsx
+++ b/static/js/components/widgets/MarkdownEditor.test.tsx
@@ -113,7 +113,7 @@ describe("MarkdownEditor", () => {
     const wrapper = render()
     const editor = wrapper.find("CKEditor").prop("config")
     const el = document.createElement("div")
-    // @ts-ignore
+    // @ts-expect-error CKEditor types are a work in progress
     editor[CKEDITOR_RESOURCE_UTILS].renderResource("resource-uuid", el)
     wrapper.update()
     expect(
@@ -132,7 +132,7 @@ describe("MarkdownEditor", () => {
     ({ embed, hasTool }) => {
       const wrapper = render({ embed })
       const editorConfig = wrapper.find("CKEditor").prop("config")
-      // @ts-ignore
+      // @ts-expect-error CKEditor types are a work in progress
       expect(editorConfig.toolbar.items.includes(ADD_RESOURCE_EMBED)).toBe(
         hasTool
       )
@@ -147,7 +147,7 @@ describe("MarkdownEditor", () => {
     ({ link, hasTool }) => {
       const wrapper = render({ link })
       const editorConfig = wrapper.find("CKEditor").prop("config")
-      // @ts-ignore
+      // @ts-expect-error CKEditor types are a work in progress
       expect(editorConfig.toolbar.items.includes(ADD_RESOURCE_LINK)).toBe(
         hasTool
       )
@@ -162,7 +162,7 @@ describe("MarkdownEditor", () => {
         link:  ["resource", "page"]
       })
       const editor = wrapper.find("CKEditor").prop("config")
-      // @ts-ignore
+      // @ts-expect-error CKEditor types are a work in progress
       editor[CKEDITOR_RESOURCE_UTILS].openResourcePicker(resourceNodeType)
       wrapper.update()
       expect(
@@ -192,7 +192,7 @@ describe("MarkdownEditor", () => {
 
         const data = "some data"
         const editor = { getData: sandbox.stub().returns(data) }
-        // @ts-ignore
+        // @ts-expect-error CKEditor types are a work in progress
         ckWrapper.prop("onChange")(null, editor)
         if (hasOnChange) {
           sinon.assert.calledOnceWithExactly(onChangeStub, {

--- a/static/js/components/widgets/MarkdownEditor.tsx
+++ b/static/js/components/widgets/MarkdownEditor.tsx
@@ -69,7 +69,6 @@ export default function MarkdownEditor(props: Props): JSX.Element {
           editor.current.execute(ResourceCommandMap[variant], uuid)
         }
 
-        // @ts-ignore
         editor.current.editing.view.focus()
       }
     },

--- a/static/js/components/widgets/MenuField.test.tsx
+++ b/static/js/components/widgets/MenuField.test.tsx
@@ -32,7 +32,7 @@ const dummyHugoItems: HugoItem[] = [
   }
 ]
 
-const dummyInternalMenuItems: InternalSortableMenuItem[] = [
+const dummyInternalMenuItems: Required<InternalSortableMenuItem>[] = [
   {
     id:       "32629a02-3dc5-4128-8e43-0392b51e7b61",
     text:     "Unit 1",
@@ -154,7 +154,7 @@ describe("MenuField", () => {
     expect(deleteBtn.prop("className")).toContain("material-icons")
     expect(deleteBtn.text()).toEqual("delete")
     const preventDefaultStub = jest.fn()
-    // @ts-ignore
+    // @ts-expect-error Not simulating the whole event
     deleteBtn.prop("onClick")({ preventDefault: preventDefaultStub })
     wrapper.update()
     expect(preventDefaultStub).toBeCalledTimes(1)
@@ -219,7 +219,7 @@ describe("MenuField", () => {
       const title = "My Title"
       const internalLinkUuid = "12629a02-3dc5-4128-8e43-0392b51e7b61"
       const externalLinkUrl = "http://example.com"
-      const menuItem = useExistingItem ? // @ts-ignored
+      const menuItem = useExistingItem ?
         dummyInternalMenuItems[0].children[0] :
         null
       const menuItemForm = renderMenuItemForm(menuItem)

--- a/static/js/components/widgets/MenuField.tsx
+++ b/static/js/components/widgets/MenuField.tsx
@@ -300,7 +300,7 @@ export default function MenuField(props: MenuFieldProps): JSX.Element {
       internalItems: menuItems,
       hugoItems:     hugoItems
     })
-    // @ts-ignore
+    // @ts-expect-error the type of onChange is not quite right
     onChange({ target: { value: hugoItems, name } })
   }
 
@@ -353,7 +353,6 @@ export default function MenuField(props: MenuFieldProps): JSX.Element {
     </div>
   )
 
-  // @ts-ignore
   const onSubmitMenuItem = ({
     values,
     hideModal

--- a/static/js/components/widgets/ObjectField.test.tsx
+++ b/static/js/components/widgets/ObjectField.test.tsx
@@ -16,6 +16,7 @@ import {
 import { SiteFormValues } from "../../types/forms"
 
 jest.mock("../../lib/site_content")
+const mockSiteContent = siteContent as jest.Mocked<typeof siteContent>
 
 describe("ObjectField", () => {
   let render: any,
@@ -29,8 +30,7 @@ describe("ObjectField", () => {
       widget: WidgetVariant.Object
     }) as ObjectConfigField
 
-    // @ts-ignore
-    siteContent.fieldIsVisible.mockReturnValue(true)
+    mockSiteContent.fieldIsVisible.mockReturnValue(true)
 
     const otherContent = makeWebsiteContentDetail()
     contentContext = [otherContent]
@@ -78,14 +78,16 @@ describe("ObjectField", () => {
   //
   ;[true, false].forEach(isVisible => {
     it(`should hide fields which are ${isVisible ? "" : "not "}visible`, () => {
-      // @ts-ignore
-      siteContent.fieldIsVisible.mockReturnValue(isVisible)
+      mockSiteContent.fieldIsVisible.mockReturnValue(isVisible)
       const wrapper = render()
       expect(wrapper.find("SiteContentField")).toHaveLength(
         isVisible ? field.fields.length : 0
       )
       for (const innerField of field.fields) {
-        expect(siteContent.fieldIsVisible).toBeCalledWith(innerField, values)
+        expect(mockSiteContent.fieldIsVisible).toBeCalledWith(
+          innerField,
+          values
+        )
       }
     })
   })

--- a/static/js/components/widgets/ResourcePickerListing.test.tsx
+++ b/static/js/components/widgets/ResourcePickerListing.test.tsx
@@ -12,11 +12,13 @@ import {
 import IntegrationTestHelper, {
   TestRenderer
 } from "../../util/integration_test_helper_old"
-import { useWebsite } from "../../context/Website"
+import * as websiteContext from "../../context/Website"
 import ResourcePickerListing from "./ResourcePickerListing"
 import { ResourceType } from "../../constants"
+import { assertNotNil } from "../../test_util"
 
 jest.mock("../../context/Website")
+const useWebsite = jest.mocked(websiteContext.useWebsite)
 
 const apiResponse = (results: WebsiteContentListItem[]) => ({
   results,
@@ -53,7 +55,7 @@ describe("ResourcePickerListing", () => {
     })
 
     website = makeWebsiteDetail()
-    // @ts-ignore
+
     useWebsite.mockReturnValue(website)
 
     contentListingItems = {
@@ -163,9 +165,8 @@ describe("ResourcePickerListing", () => {
   })
 
   it("should display an image for images", async () => {
-    // @ts-ignore
+    assertNotNil(contentListingItems.videos[0].metadata)
     contentListingItems.videos[0].metadata.resourcetype = ResourceType.Image
-    // @ts-ignore
     contentListingItems.videos[0].file = "/path/to/image.jpg"
     const { wrapper } = await render()
     expect(
@@ -178,9 +179,8 @@ describe("ResourcePickerListing", () => {
   })
 
   it("should display a thumbnail for videos", async () => {
-    // @ts-ignore
+    assertNotNil(contentListingItems.videos[0].metadata)
     contentListingItems.videos[0].metadata.resourcetype = ResourceType.Video
-    // @ts-ignore
     contentListingItems.videos[0].metadata.video_files = {
       video_thumbnail_file: "/path/to/image.jpg"
     }

--- a/static/js/components/widgets/WebsiteCollectionField.test.tsx
+++ b/static/js/components/widgets/WebsiteCollectionField.test.tsx
@@ -3,10 +3,7 @@ import IntegrationTestHelper, {
 } from "../../util/integration_test_helper_old"
 import WebsiteCollectionField from "./WebsiteCollectionField"
 
-import {
-  formatWebsiteOptions,
-  useWebsiteSelectOptions
-} from "../../hooks/websites"
+import * as websiteHooks from "../../hooks/websites"
 import { Website } from "../../types/websites"
 import { makeWebsites } from "../../util/factories/websites"
 import { triggerSortableSelect } from "./test_util"
@@ -17,6 +14,9 @@ jest.mock("../../hooks/websites", () => ({
   ...jest.requireActual("../../hooks/websites"),
   useWebsiteSelectOptions: jest.fn()
 }))
+const useWebsiteSelectOptions = jest.mocked(
+  websiteHooks.useWebsiteSelectOptions
+)
 
 describe("WebsiteCollectionField", () => {
   let helper: IntegrationTestHelper,
@@ -34,8 +34,7 @@ describe("WebsiteCollectionField", () => {
       value: []
     })
     websites = makeWebsites()
-    websiteOptions = formatWebsiteOptions(websites, "name")
-    // @ts-ignore
+    websiteOptions = websiteHooks.formatWebsiteOptions(websites, "name")
     useWebsiteSelectOptions.mockReturnValue({
       options:     websiteOptions,
       loadOptions: jest.fn()

--- a/static/js/components/widgets/test_util.ts
+++ b/static/js/components/widgets/test_util.ts
@@ -1,5 +1,6 @@
 import { ReactWrapper } from "enzyme"
 import { act } from "react-dom/test-utils"
+import { assertNotNil } from "../../test_util"
 
 /**
  * A little helper function to find the SelectField
@@ -10,9 +11,10 @@ import { act } from "react-dom/test-utils"
  */
 export async function triggerSortableSelect(wrapper: ReactWrapper, value: any) {
   await act(async () => {
-    // @ts-ignore
-    wrapper.find("SelectField").prop("onChange")({
-      // @ts-ignore
+    const onChange = wrapper.find("SelectField").prop("onChange")
+    assertNotNil(onChange)
+    onChange({
+      // @ts-expect-error Not simnulating the whole event
       target: { value }
     })
   })

--- a/static/js/hooks/websites.test.ts
+++ b/static/js/hooks/websites.test.ts
@@ -3,13 +3,14 @@ import { act, renderHook } from "@testing-library/react-hooks"
 import { Website } from "../types/websites"
 import { makeWebsites } from "../util/factories/websites"
 import { formatWebsiteOptions, useWebsiteSelectOptions } from "./websites"
-import { debouncedFetch } from "../lib/api/util"
+import * as apiUtils from "../lib/api/util"
 import { siteApiListingUrl } from "../lib/urls"
 
 jest.mock("../lib/api/util", () => ({
   ...jest.requireActual("../lib/api/util"),
   debouncedFetch: jest.fn()
 }))
+const debouncedFetch = jest.mocked(apiUtils.debouncedFetch)
 
 describe("website hooks", () => {
   describe("useWebsiteSelectOptions", () => {
@@ -17,9 +18,10 @@ describe("website hooks", () => {
 
     beforeEach(() => {
       websites = makeWebsites()
-      // @ts-ignore
-      debouncedFetch.mockReturnValue({
-        json: () => ({ results: websites })
+
+      // @ts-expect-error Not mocking all the properties on Response
+      debouncedFetch.mockResolvedValue({
+        json: async () => ({ results: websites })
       })
       global.mockFetch.mockReturnValue({
         json: () => ({ results: websites })
@@ -27,7 +29,6 @@ describe("website hooks", () => {
     })
 
     afterEach(() => {
-      // @ts-ignore
       debouncedFetch.mockReset()
     })
 

--- a/static/js/lib/api/util.ts
+++ b/static/js/lib/api/util.ts
@@ -43,13 +43,14 @@ export const sharedWait = async (
     return
   }
 
-  let resolve
+  let resolve = (): void => {
+    throw new Error("Not assigned yet")
+  }
   sharedWaitPromises[key] = new Promise(_resolve => {
     resolve = _resolve
   })
   await wait(delayMillis)
   delete sharedWaitPromises[key]
-  // @ts-ignore
   resolve()
 }
 

--- a/static/js/lib/ckeditor/plugins/DisallowNestedTables.ts
+++ b/static/js/lib/ckeditor/plugins/DisallowNestedTables.ts
@@ -7,7 +7,7 @@ import {
 // based on https://ckeditor.com/docs/ckeditor5/latest/features/table.html#disallow-nesting-tables
 export default function DisallowNestedTables(editor: editor.Editor): void {
   editor.model.schema.addChildCheck(
-    // @ts-ignore
+    // @ts-expect-error The CKEditor docs return undefined in the check, maybe their types are wrong?
     (
       context: SchemaContext,
       childDefinition: SchemaCompiledItemDefinition

--- a/static/js/lib/ckeditor/plugins/LegacyShortcodes.test.ts
+++ b/static/js/lib/ckeditor/plugins/LegacyShortcodes.test.ts
@@ -21,7 +21,6 @@ describe("ResourceEmbed plugin", () => {
     async shortcode => {
       const md = `{{< ${shortcode} >}}`
       const editor = await getEditor(md)
-      // @ts-ignore
       expect(editor.getData()).toBe(md)
     }
   )
@@ -31,7 +30,6 @@ describe("ResourceEmbed plugin", () => {
     async shortcode => {
       const md1 = `{{< /${shortcode} >}}`
       const editor1 = await getEditor(md1)
-      // @ts-ignore
       expect(editor1.getData()).toBe(md1)
 
       /**
@@ -41,7 +39,6 @@ describe("ResourceEmbed plugin", () => {
        */
       const md2 = `{{</ ${shortcode} >}}`
       const editor2 = await getEditor(md2)
-      // @ts-ignore
       expect(editor2.getData()).toBe(md1)
     }
   )
@@ -52,7 +49,6 @@ describe("ResourceEmbed plugin", () => {
       const md = `{{< ${shortcode} arguments "and chemistry H{{< sub 2 >}}0" >}}`
       const expected = `{{< ${shortcode} "arguments" "and chemistry H{{< sub 2 >}}0" >}}`
       const editor = await getEditor(md)
-      // @ts-ignore
       expect(editor.getData()).toBe(expected)
     }
   )
@@ -63,14 +59,12 @@ describe("ResourceEmbed plugin", () => {
       const md = `{{< ${shortcode} foo=123 html="<for some reason/>" >}}`
       const expected = `{{< ${shortcode} foo="123" html="<for some reason/>" >}}`
       const editor = await getEditor(md)
-      // @ts-ignore
       expect(editor.getData()).toBe(expected)
     }
   )
 
   test("should support a quiz example", async () => {
     const editor = await getEditor(quizTestMD)
-    // @ts-ignore
     expect(editor.getData()).toBe(quizTestMD)
   })
 })

--- a/static/js/lib/ckeditor/plugins/LegacyShortcodes.ts
+++ b/static/js/lib/ckeditor/plugins/LegacyShortcodes.ts
@@ -1,5 +1,5 @@
 import { ShowdownExtension } from "showdown"
-import Plugin from "@ckeditor/ckeditor5-core/src/plugin"
+import CKPlugin from "@ckeditor/ckeditor5-core/src/plugin"
 import { editor } from "@ckeditor/ckeditor5-core"
 
 import MarkdownSyntaxPlugin from "./MarkdownSyntaxPlugin"
@@ -79,7 +79,7 @@ class LegacyShortcodeSyntax extends MarkdownSyntaxPlugin {
 const shortcodeModelName = (shortcode: string) =>
   `legacy-shortcode-${shortcode}`
 
-class LegacyShortcodeEditing extends Plugin {
+class LegacyShortcodeEditing extends CKPlugin {
   static get pluginName(): string {
     return "LegacyShortcodeEditing"
   }
@@ -185,13 +185,8 @@ class LegacyShortcodeEditing extends Plugin {
   }
 }
 
-export default class LegacyShortcodes extends Plugin {
-  static get requires(): Plugin[] {
-    return [
-      // @ts-ignore
-      LegacyShortcodeEditing,
-      // @ts-ignore
-      LegacyShortcodeSyntax
-    ]
+export default class LegacyShortcodes extends CKPlugin {
+  static get requires(): typeof CKPlugin[] {
+    return [LegacyShortcodeEditing, LegacyShortcodeSyntax]
   }
 }

--- a/static/js/lib/ckeditor/plugins/ResourceEmbed.test.tsx
+++ b/static/js/lib/ckeditor/plugins/ResourceEmbed.test.tsx
@@ -14,7 +14,6 @@ describe("ResourceEmbed plugin", () => {
 
   it("should take in and return 'resource' shortcode", async () => {
     const editor = await getEditor("{{< resource 1234567890 >}}")
-    // @ts-ignore
     expect(editor.getData()).toBe('{{< resource uuid="1234567890" >}}')
   })
 

--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
@@ -33,7 +33,6 @@ describe("ResourceLink plugin", () => {
     const md = '{{% resource_link "1234567890" "link text" %}}'
     const editor = await getEditor(md)
 
-    // @ts-ignore
     expect(editor.getData()).toBe(md)
   })
 
@@ -41,7 +40,6 @@ describe("ResourceLink plugin", () => {
     const md =
       '{{% resource_link "1234-5678" "link text" "some-header-id" %}}{{% resource_link "link-this-here-uuid" "Title of the Link" "some-heading-id" %}}'
     const editor = await getEditor(md)
-    // @ts-ignore
     expect(editor.getData()).toBe(md)
 
     markdownTest(

--- a/static/js/lib/ckeditor/plugins/ResourcePicker.ts
+++ b/static/js/lib/ckeditor/plugins/ResourcePicker.ts
@@ -20,7 +20,6 @@ export default class ResourcePicker extends Plugin {
   init(): void {
     const editor = this.editor
 
-    // @ts-ignore
     const { openResourcePicker } =
       this.editor.config.get(CKEDITOR_RESOURCE_UTILS) ?? {}
 

--- a/static/js/lib/ckeditor/plugins/TableMarkdownSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/TableMarkdownSyntax.ts
@@ -46,11 +46,10 @@ export default class TableMarkdownSyntax extends MarkdownSyntaxPlugin {
           filter:      TABLE_ELS,
           replacement: (content: string, node: Turndown.Node): string => {
             const name = node.nodeName.toLowerCase()
-            const attributes = (node as HTMLElement).hasAttributes() ?
+            const el = node as HTMLElement
+            const attributes = el.hasAttributes() ?
               buildAttrsString(
-                //@ts-ignore
-                Array.from(node.attributes).map(
-                  //@ts-ignore
+                Array.from(el.attributes).map(
                   attr => `${attr.name}="${attr.value}"`
                 )
               ) :

--- a/static/js/lib/ckeditor/plugins/test_util.ts
+++ b/static/js/lib/ckeditor/plugins/test_util.ts
@@ -7,7 +7,7 @@ class ClassicTestEditor extends ClassicEditorBase {}
 
 export const createTestEditor = (plugins: any[]) => async (
   initialData = ""
-): Promise<editor.Editor> => {
+): Promise<editor.Editor & { getData(): string }> => {
   const editor = await ClassicTestEditor.create(initialData, {
     plugins
   })

--- a/static/js/lib/ckeditor/turndown.ts
+++ b/static/js/lib/ckeditor/turndown.ts
@@ -60,7 +60,7 @@ turndownService.options.emDelimiter = "*"
 // see here for details:
 // https://github.com/domchristie/turndown/issues/293
 //
-// @ts-ignore also typing for `rules.blankRule` is incorrect
+// @ts-expect-error also typing for `rules.blankRule` is incorrect
 turndownService.rules.blankRule.replacement = (
   content: string,
   node: Turndown.Node,
@@ -97,10 +97,9 @@ turndownService.rules.array.find(rule => rule.filter === "li")!.replacement = (
     .replace(/\n/gm, "\n    ") // indent
 
   let prefix = `${options.bulletListMarker} `
-  const parent = node.parentNode
+  const parent = node.parentElement
   if (parent && parent.nodeName === "OL") {
-    // @ts-ignore
-    const start: string = parent.getAttribute("start")
+    const start = parent.getAttribute("start")
     const index = Array.prototype.indexOf.call(parent.children, node)
     prefix = `${start ? Number(start) + index : index + 1}. `
   }

--- a/static/js/lib/site_content.test.ts
+++ b/static/js/lib/site_content.test.ts
@@ -31,7 +31,7 @@ import {
   DEFAULT_TITLE_FIELD
 } from "./site_content"
 import { exampleSiteConfigFields, MAIN_PAGE_CONTENT_FIELD } from "../constants"
-import { isIf, shouldIf } from "../test_util"
+import { shouldIf } from "../test_util"
 
 import {
   ConfigField,
@@ -117,7 +117,7 @@ describe("site_content", () => {
           widget: "text"
         }
       ]
-      // @ts-ignore
+      // @ts-expect-error TODO-EXPECT-ERROR
       const payload = contentFormValuesToPayload(values, fields)
       expect(payload).toStrictEqual({
         title:    "a title",
@@ -144,7 +144,7 @@ describe("site_content", () => {
         },
         ...makeFileConfigItem().fields
       ]
-      // @ts-ignore
+      // @ts-expect-error TODO-EXPECT-ERROR
       const payload = contentFormValuesToPayload(values, fields)
       expect(payload instanceof FormData).toBe(true)
     })
@@ -164,7 +164,6 @@ describe("site_content", () => {
         {
           tags: []
         },
-        // @ts-ignore
         [descriptionField],
         makeWebsiteDetail()
       )
@@ -189,7 +188,7 @@ describe("site_content", () => {
         }
         const payload = contentFormValuesToPayload(
           {
-            // @ts-ignore
+            // @ts-expect-error TODO-EXPECT-ERROR
             description: value
           },
           [field],
@@ -239,7 +238,6 @@ describe("site_content", () => {
             [field.fields[1].name]: true
           }
         },
-        // @ts-ignore
         [field],
         makeWebsiteDetail()
       )
@@ -274,7 +272,6 @@ describe("site_content", () => {
       }
       const payload = contentFormValuesToPayload(
         values,
-        // @ts-ignore
         [field],
         makeWebsiteDetail()
       )
@@ -294,7 +291,7 @@ describe("site_content", () => {
       const content = makeWebsiteContentDetail()
       // combine all possible fields so we can test all code paths
       const fields = cloneDeep(exampleSiteConfigFields)
-      // @ts-ignore
+      // @ts-expect-error TODO-EXPECT-ERROR
       const payload = contentInitialValues(content, fields)
       expect(payload).toStrictEqual({
         tags:                      [],
@@ -318,11 +315,11 @@ describe("site_content", () => {
         (field: ConfigField) => !field.default
       )
       const fields = [fieldWithDefault, fieldWithoutDefault]
-      // @ts-ignore
+      // @ts-expect-error TODO-EXPECT-ERROR
       const values = newInitialValues(fields)
-      // @ts-ignore
+      // @ts-expect-error TODO-EXPECT-ERROR
       expect(values[fieldWithDefault.name]).toBe(fieldWithDefault.default)
-      // @ts-ignore
+      // @ts-expect-error TODO-EXPECT-ERROR
       expect(values[fieldWithoutDefault.name]).toBe("")
     })
 
@@ -546,38 +543,43 @@ describe("site_content", () => {
   })
 
   describe("fieldIsVisible and fieldHasData", () => {
-    [
-      [true, "input", { conditionField: "matching value" }, true, true],
-      [true, "input", { conditionField: "non-matching value" }, false, false],
-      [false, "input", { conditionField: "matching value" }, true, true],
-      [false, "input", { conditionField: "non-matching value" }, true, true],
-      [true, "hidden", { conditionField: "matching value" }, false, true],
-      [true, "hidden", { conditionField: "non-matching value" }, false, false],
-      [false, "hidden", { conditionField: "matching value" }, false, true],
-      [false, "hidden", { conditionField: "non-matching value" }, false, true]
-    ].forEach(
-      ([hasCondition, widget, values, expectedVisible, expectedHasData]) => {
-        // @ts-ignore
-        it(`${isIf(expectedVisible)} visible if the condition ${isIf(
-          // @ts-ignore
-          hasCondition
-          // @ts-ignore
-        )} existing and value is a ${values.conditionField}`, () => {
-          const condition: FieldValueCondition = {
-            field:  "conditionField",
-            equals: "matching value"
-          }
-          const field = makeWebsiteConfigField()
-          // @ts-ignore
-          field.widget = widget
-          if (hasCondition) {
-            field.condition = condition
-          }
-          // @ts-ignore
-          expect(fieldIsVisible(field, values)).toBe(expectedVisible)
-          // @ts-ignore
-          expect(fieldHasData(field, values)).toBe(expectedHasData)
-        })
+    const condition: FieldValueCondition = {
+      field:  "conditionField",
+      equals: "matching value"
+    }
+    const conditionCases = [
+      [true, { conditionField: "matching value" }, true],
+      [true, { conditionField: "non-matching value" }, false],
+      [false, { conditionField: "matching value" }, true],
+      [false, { conditionField: "non-matching value" }, true]
+    ] as const
+    test.each(conditionCases)(
+      "When field has condition, is visible iff condition is met",
+      (hasCondition, values, isMet) => {
+        const field = makeWebsiteConfigField()
+        field.widget = WidgetVariant.Text
+        if (hasCondition) {
+          field.condition = condition
+        }
+        // Only visible if condition is met
+        expect(fieldIsVisible(field, values)).toBe(isMet)
+        // Only has data if condition is met
+        expect(fieldHasData(field, values)).toBe(isMet)
+      }
+    )
+
+    test.each(conditionCases)(
+      "Hidden field is never visible, but has data iff condition is met",
+      (hasCondition, values, isMet) => {
+        const field = makeWebsiteConfigField()
+        field.widget = WidgetVariant.Hidden
+        if (hasCondition) {
+          field.condition = condition
+        }
+        // Only visible if condition is met
+        expect(fieldIsVisible(field, values)).toBe(false)
+        // Only has data if condition is met
+        expect(fieldHasData(field, values)).toBe(isMet)
       }
     )
   })
@@ -661,7 +663,7 @@ describe("site_content", () => {
         const expectedResult = expAddField ?
           [DEFAULT_TITLE_FIELD, randomField] :
           fields
-        // @ts-ignore
+        // @ts-expect-error TODO-EXPECT-ERROR
         expect(addDefaultFields(configItem).fields).toEqual(expectedResult)
       })
     })

--- a/static/js/lib/util.ts
+++ b/static/js/lib/util.ts
@@ -13,7 +13,7 @@ export const isErrorResponse = (response: ActionPromiseValue<any>): boolean =>
  * If an HTTP response contains errors in the body, return either a string representing
  */
 export const getResponseBodyError = (
-  response: ActionPromiseValue<any>
+  response: ActionPromiseValue<any> | null
 ): string | { [key: string]: string } | null => {
   if (!response || !response.body) {
     return null
@@ -39,8 +39,7 @@ export const objectToFormData = (
     if (key === "metadata") {
       formData.append(key, JSON.stringify(value))
     } else if (!isNil(value)) {
-      // @ts-ignore
-      formData.append(key, value)
+      formData.append(key, String(value))
     }
   })
   return formData

--- a/static/js/pages/SiteCreationPage.test.tsx
+++ b/static/js/pages/SiteCreationPage.test.tsx
@@ -12,6 +12,23 @@ import {
 import { siteDetailUrl, siteApi, startersApi } from "../lib/urls"
 
 import { Website, WebsiteStarter } from "../types/websites"
+import { assertNotNil } from "../test_util"
+import { ReactWrapper } from "enzyme"
+import { SiteForm, SiteFormProps } from "../components/forms/SiteForm"
+import { FormikHelpers } from "formik"
+
+const simulateSubmit = (
+  wrapper: ReactWrapper<SiteFormProps>,
+  formikStubs: Partial<Record<keyof FormikHelpers<any>, jest.Mock>>,
+  data: any
+) => {
+  const onSubmit = wrapper.prop("onSubmit")
+  assertNotNil(onSubmit)
+  return act(async () => {
+    // @ts-expect-error using Partial on FormikHelpers... we don't need all of them
+    onSubmit(data, formikStubs)
+  })
+}
 
 describe("SiteCreationPage", () => {
   let helper: IntegrationTestHelper,
@@ -25,17 +42,13 @@ describe("SiteCreationPage", () => {
     starters = [makeWebsiteStarter(), makeWebsiteStarter()]
     website = makeWebsiteDetail()
     historyPushStub = jest.fn()
-    render = helper.configureRenderer(
-      // @ts-ignore
-      SiteCreationPage,
-      {
-        history:  { push: historyPushStub },
-        entities: {
-          starters: []
-        },
-        queries: {}
-      }
-    )
+    render = helper.configureRenderer(SiteCreationPage, {
+      history:  { push: historyPushStub },
+      entities: {
+        starters: []
+      },
+      queries: {}
+    })
 
     helper.mockGetRequest(startersApi.toString(), starters)
   })
@@ -73,19 +86,11 @@ describe("SiteCreationPage", () => {
     it("that creates a new site and redirect on success", async () => {
       createWebsiteStub = helper.mockPostRequest(siteApi.toString(), website)
       const { wrapper } = await render()
-      const form = wrapper.find("SiteForm")
-      const onSubmit = form.prop("onSubmit")
-      await act(async () => {
-        // @ts-ignore
-        onSubmit(
-          {
-            title:    "My Title",
-            short_id: "My-Title",
-            starter:  1
-          },
-          // @ts-ignore
-          formikStubs
-        )
+      const form = wrapper.find(SiteForm)
+      await simulateSubmit(form, formikStubs, {
+        title:    "My Title",
+        short_id: "My-Title",
+        starter:  1
       })
       sinon.assert.calledOnce(createWebsiteStub)
       expect(formikStubs.setSubmitting).toHaveBeenCalledTimes(1)
@@ -108,19 +113,11 @@ describe("SiteCreationPage", () => {
         400
       )
       const { wrapper } = await render()
-      const form = wrapper.find("SiteForm")
-      const onSubmit = form.prop("onSubmit")
-      await act(async () => {
-        // @ts-ignore
-        onSubmit(
-          {
-            title:    errorMsg,
-            short_id: "my-site",
-            starter:  1
-          },
-          // @ts-ignore
-          formikStubs
-        )
+      const form = wrapper.find(SiteForm)
+      await simulateSubmit(form, formikStubs, {
+        title:    errorMsg,
+        short_id: "my-site",
+        starter:  1
       })
       sinon.assert.calledOnce(createWebsiteStub)
       expect(formikStubs.setErrors).toHaveBeenCalledTimes(1)
@@ -142,19 +139,11 @@ describe("SiteCreationPage", () => {
         400
       )
       const { wrapper } = await render()
-      const form = wrapper.find("SiteForm")
-      const onSubmit = form.prop("onSubmit")
-      await act(async () => {
-        // @ts-ignore
-        onSubmit(
-          {
-            title:    "My Title",
-            short_id: "My-Title",
-            starter:  1
-          },
-          // @ts-ignore
-          formikStubs
-        )
+      const form = wrapper.find(SiteForm)
+      await simulateSubmit(form, formikStubs, {
+        title:    "My Title",
+        short_id: "My-Title",
+        starter:  1
       })
       sinon.assert.calledOnce(createWebsiteStub)
       expect(formikStubs.setStatus).toHaveBeenCalledTimes(1)

--- a/static/js/selectors/websites.ts
+++ b/static/js/selectors/websites.ts
@@ -35,7 +35,6 @@ export const getWebsiteListingCursor = createSelector(
       (offset: number): WebsiteListingResponse => {
         const response = listing[offset] ?? {}
         const names = response?.results ?? []
-        // @ts-ignore
         const sites = names.map(websiteDetailCursor)
 
         return {

--- a/static/js/store/configureStore.ts
+++ b/static/js/store/configureStore.ts
@@ -24,7 +24,7 @@ export default function configureStore(initialState?: ReduxState) {
       window.__REDUX_DEVTOOLS_EXTENSION__ ?
         window.__REDUX_DEVTOOLS_EXTENSION__() :
         (f: any) => f
-      // @ts-ignore
+      // @ts-expect-error Unsure why this is an error
     )(createStore)
   } else {
     createStoreWithMiddleware = compose(applyMiddleware(...COMMON_MIDDLEWARE))(

--- a/static/js/test_setup.ts
+++ b/static/js/test_setup.ts
@@ -65,6 +65,4 @@ afterEach(function() {
   }
   document.body.innerHTML = ""
   global.SETTINGS = _createSettings()
-  // @ts-ignore
-  window.location = "http://fake/"
 })

--- a/static/js/test_util.ts
+++ b/static/js/test_util.ts
@@ -1,15 +1,29 @@
-import { FormikState } from "formik"
+import { FormikProps } from "formik"
 import * as R from "ramda"
 
-export const defaultFormikChildProps: FormikState<any> = {
-  values:       {},
-  errors:       {},
-  touched:      {},
-  isSubmitting: false,
-  isValidating: false,
-  status:       null,
-  submitCount:  0
+const throwProxyHandler: ProxyHandler<Record<string | symbol, unknown>> = {
+  get(target, prop) {
+    if (Object.prototype.hasOwnProperty.call(target, prop)) {
+      return target[prop]
+    }
+    throw new Error(
+      `${prop.toString()} not implemented; add it if you need it. `
+    )
+  }
 }
+// @ts-expect-error This does not current supply all the formik child props
+export const defaultFormikChildProps: FormikProps<any> = new Proxy(
+  {
+    values:       {},
+    errors:       {},
+    touched:      {},
+    isSubmitting: false,
+    isValidating: false,
+    status:       null,
+    submitCount:  0
+  },
+  throwProxyHandler
+)
 
 export const isIf = (
   tf: any // eslint-disable-line


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Toward https://github.com/mitodl/eslint-config/issues/14, updating our eslint config for typescript

#### What's this PR do?
This PR:
1. Replaces all `@ts-ignore` with `@ts-expect-error`. The latter has the advantage that if it is used unnecessarily, TS will yell at you.
2. Additionally, I made some fairly minor code changes to reduce the number of `@ts-expect-error`s needed. For the most part, these were in test files, things like
    - using `const thing = jest.mocked(originalThing)` which does nothing but change the object's type to a jest mock (with signature matching `originalThing`).
    - changed a bunch of enzyme calls like `wrapper.find("StringComponentName")` to `wrapper.find(ComponentClass)`. That way TS knows the types of props, etc
    - Adding `as const` to our test case arrays (or rearranging them to objects)
3. I updated our CI's node version to 16.15, to match docker. My motivation was that CI said [Array.prototype.at](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at) was not a function, though I ended up switching to `lodash.last` since `at` only has 90% browser support.

    But, still seems good for CI to match docker.

**All in all:** We had 176 ignore/expect-errors. Now we have 44 expect-errors.

#### How should this be manually tested?
There should be no behavior change, but if you want, check ... that Studio still works.

#### Where should the reviewer start?

⚠️ ⚠️ ⚠️ Strongly suggest reviewing this commit-by-commit. https://github.com/mitodl/ocw-studio/pull/1520/commits/d79aa320418286a1a581d4ec08eb7fbde76afa4d is the only commit that could affect app behavior; the other commits are all about linting or tests.
