### PR TITLE
upgrade version of ocw-course-publisher

### DIFF
--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -66,7 +66,7 @@ jobs:
       platform: linux
       image_resource:
         type: docker-image
-        source: {repository: mitodl/ocw-course-publisher, tag: 0.2}
+        source: {repository: mitodl/ocw-course-publisher, tag: 0.3}
       inputs:
       - name: ocw-hugo-themes
       outputs:
@@ -122,7 +122,7 @@ jobs:
       platform: linux
       image_resource:
         type: docker-image
-        source: {repository: mitodl/ocw-course-publisher, tag: 0.2}
+        source: {repository: mitodl/ocw-course-publisher, tag: 0.3}
       inputs:
         - name: publishable_sites
         - name: ocw-hugo-projects

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -334,7 +334,7 @@ jobs:
           platform: linux
           image_resource:
             type: docker-image
-            source: {repository: mitodl/ocw-course-publisher, tag: 0.2}
+            source: {repository: mitodl/ocw-course-publisher, tag: 0.3}
           inputs:
             - name: ocw-hugo-themes
             - name: course-markdown

--- a/content_sync/pipelines/definitions/concourse/theme-assets-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/theme-assets-pipeline.yml
@@ -18,7 +18,7 @@ jobs:
       platform: linux
       image_resource:
         type: docker-image
-        source: {repository: mitodl/ocw-course-publisher, tag: 0.2}
+        source: {repository: mitodl/ocw-course-publisher, tag: 0.3}
       inputs:
       - name: ocw-hugo-themes
       outputs:


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1525

#### What's this PR do?
This PR upgrades the version of the `ocw-course-publisher` referenced in pipeline definitions that are upserted by `ocw-studio` management commands. This will include the changes made in https://github.com/mitodl/ol-infrastructure/pull/1133 which upgrade the version of Hugo used to 104.3

#### How should this be manually tested?
 - First of all, make sure you've taken care of the following prerequisites:
   - `ocw-studio` up and running
   - Minio support configured
   - Concourse support configured
   - Some test courses in your database using the `ocw-course` starter
 - Make a temporary edit to `websites/views.py` to limit the sites seen by `mass-build-sites`:
```
        ...
        sites = sites.prefetch_related("starter").order_by("name")[:10]
        serializer = WebsiteMassBuildSerializer(instance=sites, many=True)
        return Response({"sites": serializer.data})
```
 - Upsert the theme assets pipeline to your local Concourse with `docker-compose exec web ./manage.py upsert_theme_assets_pipeline`
 - Upsert some individual course pipelines to your local Concourse by either creating new courses or using the `backpopulate_pipelines` management command with a filter for the sites you want to test
 - Upsert the mass build pipeline with `docker-compose exec web ./manage.py upsert_mass_build_pipeline`
 - Browse to http://concourse:8080 and login with test/test, then trigger the following pipelines:
   - Theme assets pipeline
   - `ocw-www` and `ocw-course` individual pipelines
   - `mass-bulid-sites` pipeline (limited by the code change we made above)
 - Make sure the builds complete without error, and browse the sites briefly to ensure they built correctly, at http://localhost:8044 for draft or port 8045 for live
