### PR TITLE
Adding management command to unpublish list of course sites

### DIFF
--- a/websites/management/commands/unpublish_sites.py
+++ b/websites/management/commands/unpublish_sites.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.db.models import Q
 
 from content_sync import api
+from content_sync.constants import VERSION_LIVE
 from main.management.commands.filter import WebsiteFilterCommand
 from users.models import User
 from websites.constants import (
@@ -35,95 +36,92 @@ class Command(WebsiteFilterCommand):
     def handle(self, *args, **options):
         super().handle(*args, **options)
         if not self.filter_list:
-            self.stdout.write("Please provide a list of course ids to unpublish.")
-        else:
-            user_id = User.objects.filter(email__exact=options["user"]).first()
-            if not user_id:
-                self.stderr.write(
-                    "Please provide a valid email address for an existing user to unpublish courses."
-                )
-                return
-            websites = Website.objects.filter(
-                Q(name__in=self.filter_list) | Q(short_id__in=self.filter_list)
+            self.stderr.write("Please provide a list of course ids to unpublish.")
+            return
+        user_id = User.objects.filter(email__exact=options["user"]).first()
+        if not user_id:
+            self.stderr.write(
+                "Please provide a valid email address for an existing user to unpublish courses."
             )
-            unpublished_count = 0
-            unpublished_names = []
-            for website in websites:
-                ocw_www_dependencies = WebsiteContent.objects.filter(
-                    (
-                        Q(type=CONTENT_TYPE_COURSE_LIST)
-                        | Q(type=CONTENT_TYPE_RESOURCE_COLLECTION)
-                    ),
-                    (
-                        Q(metadata__courses__icontains=website.name)
-                        | Q(metadata__resources__content__icontains=website.name)
-                    ),
-                    website__name=settings.ROOT_WEBSITE_NAME,
-                )
-                course_content_dependencies = WebsiteContent.objects.filter(
-                    ~Q(website__name=website.name),
-                    type=CONTENT_TYPE_PAGE,
-                    markdown__icontains=website.name,
-                )
-                course_dependencies = Website.objects.filter(
-                    ~Q(name=website.name), metadata__icontains=website.name
-                )
-                # if there are dependencies, don't unpublish and list dependencies
-                if (
-                    ocw_www_dependencies
-                    or course_dependencies
-                    or course_content_dependencies
-                ):
-                    self.stdout.write(
-                        "Not unpublishing " + website.name + " due to dependencies:"
-                    )
-                    if ocw_www_dependencies:
-                        self.stdout.write(
-                            json.dumps(
-                                {
-                                    "ocw_www": WebsiteContentSerializer(
-                                        instance=ocw_www_dependencies, many=True
-                                    ).data
-                                }
-                            )
-                        )
-                    if course_dependencies:
-                        self.stdout.write(
-                            json.dumps(
-                                {
-                                    "course": WebsiteBasicSerializer(
-                                        instance=course_dependencies, many=True
-                                    ).data
-                                }
-                            )
-                        )
-                    if course_content_dependencies:
-                        self.stdout.write(
-                            json.dumps(
-                                {
-                                    "course_content": WebsiteContentSerializer(
-                                        instance=course_content_dependencies, many=True
-                                    ).data
-                                }
-                            )
-                        )
-                else:  # unpublish
-                    unpublished_count += 1
-                    unpublished_names.append(website.name)
-                    Website.objects.filter(pk=website.pk).update(
-                        unpublish_status=PUBLISH_STATUS_NOT_STARTED,
-                        last_unpublished_by=user_id,
-                    )
-                    site_pipeline = api.get_site_pipeline(website)
-                    site_pipeline.pause_pipeline(VERSION_LIVE)
-            removal_pipeline = api.get_unpublished_removal_pipeline()
-            removal_pipeline.unpause()
-            removal_pipeline.trigger()
-            self.stdout.write(
-                str(unpublished_count) + " course sites were unpublished."
+            return
+        websites = Website.objects.filter(
+            Q(name__in=self.filter_list) | Q(short_id__in=self.filter_list)
+        )
+        unpublished_count = 0
+        unpublished_names = []
+        for website in websites:
+            ocw_www_dependencies = WebsiteContent.objects.filter(
+                (
+                    Q(type=CONTENT_TYPE_COURSE_LIST)
+                    | Q(type=CONTENT_TYPE_RESOURCE_COLLECTION)
+                ),
+                (
+                    Q(metadata__courses__icontains=website.name)
+                    | Q(metadata__resources__content__icontains=website.name)
+                ),
+                website__name=settings.ROOT_WEBSITE_NAME,
             )
-            if unpublished_count > 0:
+            course_content_dependencies = WebsiteContent.objects.filter(
+                ~Q(website__name=website.name),
+                type=CONTENT_TYPE_PAGE,
+                markdown__icontains=website.name,
+            )
+            course_dependencies = Website.objects.filter(
+                ~Q(name=website.name), metadata__icontains=website.name
+            )
+            # if there are dependencies, don't unpublish and list dependencies
+            if (
+                ocw_www_dependencies
+                or course_dependencies
+                or course_content_dependencies
+            ):
                 self.stdout.write(
-                    "The following course sites were unpublished: "
-                    + str(unpublished_names)
+                    "Not unpublishing " + website.name + " due to dependencies:"
                 )
+                if ocw_www_dependencies:
+                    self.stdout.write(
+                        json.dumps(
+                            {
+                                "ocw_www": WebsiteContentSerializer(
+                                    instance=ocw_www_dependencies, many=True
+                                ).data
+                            }
+                        )
+                    )
+                if course_dependencies:
+                    self.stdout.write(
+                        json.dumps(
+                            {
+                                "course": WebsiteBasicSerializer(
+                                    instance=course_dependencies, many=True
+                                ).data
+                            }
+                        )
+                    )
+                if course_content_dependencies:
+                    self.stdout.write(
+                        json.dumps(
+                            {
+                                "course_content": WebsiteContentSerializer(
+                                    instance=course_content_dependencies, many=True
+                                ).data
+                            }
+                        )
+                    )
+            else:  # unpublish
+                unpublished_count += 1
+                unpublished_names.append(website.name)
+                Website.objects.filter(pk=website.pk).update(
+                    unpublish_status=PUBLISH_STATUS_NOT_STARTED,
+                    last_unpublished_by=user_id,
+                )
+                site_pipeline = api.get_site_pipeline(website)
+                site_pipeline.pause_pipeline(VERSION_LIVE)
+        removal_pipeline = api.get_unpublished_removal_pipeline()
+        removal_pipeline.unpause()
+        removal_pipeline.trigger()
+        self.stdout.write(str(unpublished_count) + " course sites were unpublished.")
+        if unpublished_count > 0:
+            self.stdout.write(
+                "The following course sites were unpublished: " + str(unpublished_names)
+            )

--- a/websites/management/commands/unpublish_sites.py
+++ b/websites/management/commands/unpublish_sites.py
@@ -116,7 +116,12 @@ class Command(WebsiteFilterCommand):
                     )
                     site_pipeline = api.get_site_pipeline(website)
                     site_pipeline.pause_pipeline(VERSION_LIVE)
-            self.stdout.write(str(unpublished_count) + " course sites were unpublished")
+            removal_pipeline = api.get_unpublished_removal_pipeline()
+            removal_pipeline.unpause()
+            removal_pipeline.trigger()
+            self.stdout.write(
+                str(unpublished_count) + " course sites were unpublished."
+            )
             if unpublished_count > 0:
                 self.stdout.write(
                     "The following course sites were unpublished: "

--- a/websites/management/commands/unpublish_sites.py
+++ b/websites/management/commands/unpublish_sites.py
@@ -1,0 +1,125 @@
+"""Unpublish course webpages provided to the command that have no dependencies. If there are dependencies, print the dependencies."""
+import json
+
+from django.conf import settings
+from django.db.models import Q
+
+from content_sync.api import trigger_unpublished_removal
+from main.management.commands.filter import WebsiteFilterCommand
+from users.models import User
+from websites.constants import (
+    CONTENT_TYPE_COURSE_LIST,
+    CONTENT_TYPE_PAGE,
+    CONTENT_TYPE_RESOURCE_COLLECTION,
+    PUBLISH_STATUS_NOT_STARTED,
+)
+from websites.models import Website, WebsiteContent
+from websites.serializers import WebsiteBasicSerializer, WebsiteContentSerializer
+
+
+class Command(WebsiteFilterCommand):
+    """Unpublish course webpages provided to the command that have no dependencies. If there are dependencies, print the dependencies."""
+
+    help = __doc__
+
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+        parser.add_argument(
+            "--course-ids",
+            nargs="+",
+            dest="course_ids",
+            help="List of course webpages to be unpublished",
+        )
+
+        parser.add_argument(
+            "--user",
+            dest="user",
+            help="Username (email address) for unpublishing courses",
+        )
+
+    def check_email(self, email_id):
+        try:
+            user = User.objects.get(email__exact=email_id)
+            return user
+        except User.DoesNotExist:
+            return None
+
+    def handle(self, *args, **options):
+        super().handle(*args, **options)
+        if not options["course_ids"]:
+            self.stdout.write("Please provide a list of course ids to unpublish.")
+        elif not options["user"]:
+            self.stdout.write("Please provide a username to unpublish courses.")
+        elif not self.check_email(options["user"]):
+            self.stdout.write(
+                "Please provide a valid username (email address) to unpublish courses."
+            )
+        else:
+            user_id = self.check_email(options["user"])
+            websites = Website.objects.filter(name__in=options["course_ids"])
+            for website in websites:
+                ocw_www_dependencies = WebsiteContent.objects.filter(
+                    (
+                        Q(type=CONTENT_TYPE_COURSE_LIST)
+                        | Q(type=CONTENT_TYPE_RESOURCE_COLLECTION)
+                    ),
+                    (
+                        Q(metadata__courses__icontains=website.name)
+                        | Q(metadata__resources__content__icontains=website.name)
+                    ),
+                    website__name=settings.ROOT_WEBSITE_NAME,
+                )
+                course_content_dependencies = WebsiteContent.objects.filter(
+                    ~Q(website__name=website.name),
+                    type=CONTENT_TYPE_PAGE,
+                    markdown__icontains=website.name,
+                )
+                course_dependencies = Website.objects.filter(
+                    ~Q(name=website.name), metadata__icontains=website.name
+                )
+                # if there are dependencies, don't unpublish and list dependencies
+                if (
+                    ocw_www_dependencies
+                    or course_dependencies
+                    or course_content_dependencies
+                ):
+                    self.stdout.write(
+                        "Not unpublishing " + website.name + " due to dependencies:"
+                    )
+                    if ocw_www_dependencies:
+                        self.stdout.write(
+                            json.dumps(
+                                {
+                                    "ocw_www": WebsiteContentSerializer(
+                                        instance=ocw_www_dependencies, many=True
+                                    ).data
+                                }
+                            )
+                        )
+                    if course_dependencies:
+                        self.stdout.write(
+                            json.dumps(
+                                {
+                                    "course": WebsiteBasicSerializer(
+                                        instance=course_dependencies, many=True
+                                    ).data
+                                }
+                            )
+                        )
+                    if course_content_dependencies:
+                        self.stdout.write(
+                            json.dumps(
+                                {
+                                    "course_content": WebsiteContentSerializer(
+                                        instance=course_content_dependencies, many=True
+                                    ).data
+                                }
+                            )
+                        )
+                else:  # unpublish
+                    self.stdout.write("Unpublishing " + website.name)
+                    Website.objects.filter(pk=website.pk).update(
+                        unpublish_status=PUBLISH_STATUS_NOT_STARTED,
+                        last_unpublished_by=user_id,
+                    )
+                    trigger_unpublished_removal(website)


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
Once this command is run on the list of relevant courses, this PR closes https://github.com/mitodl/ocw-studio/issues/1517.

#### What's this PR do?
Adds a management command to unpublish a list of courses. This should be run (locally) as follows:

`
docker-compose run --rm web ./manage.py unpublish_sites --filter 8-06-quantum-physics-iii-spring-2005,6-0001-introduction-to-computer-science-and-programming-in-python-fall-2016 --user example@example.com
`

This requires that the user with the email address provided to the command exists in the Django database. 

If a course that is provided to the command does not exist, it will be ignored. If the course does exist but has dependencies, those dependencies will be printed and the course will not be unpublished. Otherwise, the course will be unpublished.

#### How should this be manually tested?

Run this command for courses that have dependencies (such as `6-0001-introduction-to-computer-science-and-programming-in-python-fall-2016`) and those that do not (such as `21l-011-the-film-experience-fall-2013`) and verify that the latter triggers the unpublishing pipeline.