### PR TITLE
Update eslint-config-mitodl

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,5 @@ module.exports = {
   extends: ["eslint-config-mitodl", "eslint-config-mitodl/jest"],
   rules:   {
     "@typescript-eslint/no-explicit-any": "off",
-    "jest/no-conditional-expect":         "off"
   },
 }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,32 +1,7 @@
 module.exports = {
-  parser: "@typescript-eslint/parser",
-  plugins: ["@typescript-eslint"],
-  extends: ["eslint-config-mitodl", "plugin:@typescript-eslint/recommended"],
-  settings: {
-    react: {
-      version: "16.14.0"
-    }
-  },
-  env: {
-    browser: true,
-    jquery: true,
-    jest: true
-  },
-  rules: {
+  extends: ["eslint-config-mitodl", "eslint-config-mitodl/jest"],
+  rules:   {
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-non-null-assertion": "off",
-    "@typescript-eslint/no-unused-vars": [
-      "error",
-      { argsIgnorePattern: "_", varsIgnorePattern: "_" },
-    ],
-    "mocha/no-top-level-hooks": "off",
-    "mocha/no-sibling-hooks": "off",
-    "mocha/no-global-tests": "off",
-    "camelcase": [
-      "error",
-      {
-        "properties": "never"
-      }
-    ]
-  }
+    "jest/no-conditional-expect":         "off"
+  },
 }

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.6",
     "eslint": "^7.32.0",
-    "eslint-config-mitodl": "git+ssh://git@github.com:mitodl/eslint-config.git#ts",
+    "eslint-config-mitodl": "git+https://github.com/mitodl/eslint-config.git#ts",
     "eslint-plugin-jest": "^27.1.1",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-react-hooks": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.6",
     "eslint": "^7.32.0",
-    "eslint-config-mitodl": "^0.2.1",
+    "eslint-config-mitodl": "git+ssh://git@github.com:mitodl/eslint-config.git#ts",
     "eslint-plugin-jest": "^27.1.1",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-react-hooks": "^4.2.0",
@@ -168,8 +168,7 @@
     "> 1%"
   ],
   "resolutions": {
-    "turndown": "7.0.0",
-    "eslint-config-mitodl": "portal:/Users/cchudzicki/dev/eslint-config"
+    "turndown": "7.0.0"
   },
   "packageManager": "yarn@3.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.6",
     "eslint": "^7.32.0",
-    "eslint-config-mitodl": "git+https://github.com/mitodl/eslint-config.git#ts",
+    "eslint-config-mitodl": "1.0.0",
     "eslint-plugin-jest": "^27.1.1",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-react-hooks": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "@types/turndown": "^5.0.1",
     "@types/url-assembler": "^2.1.1",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
-    "@typescript-eslint/parser": "^5.4.0",
     "@use-it/interval": "^1.0.0",
     "autoprefixer": "9",
     "bootstrap": "4",
@@ -81,9 +80,8 @@
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.6",
     "eslint": "^7.32.0",
-    "eslint-config-google": "^0.14.0",
     "eslint-config-mitodl": "^0.2.1",
-    "eslint-plugin-mocha": "^9.0.0",
+    "eslint-plugin-jest": "^27.1.1",
     "eslint-plugin-react": "^7.24.0",
     "eslint-plugin-react-hooks": "^4.2.0",
     "expect-type": "^0.13.0",
@@ -170,7 +168,8 @@
     "> 1%"
   ],
   "resolutions": {
-    "turndown": "7.0.0"
+    "turndown": "7.0.0",
+    "eslint-config-mitodl": "portal:/Users/cchudzicki/dev/eslint-config"
   },
   "packageManager": "yarn@3.1.0"
 }

--- a/static/js/components/RepeatableContentListing.test.tsx
+++ b/static/js/components/RepeatableContentListing.test.tsx
@@ -211,7 +211,7 @@ describe("RepeatableContentListing", () => {
     filterInput.simulate("change", event)
     jest.runAllTimers()
     wrapper.update()
-    expect(spy).toBeCalledWith("?q=my-search-string")
+    expect(spy).toHaveBeenCalledWith("?q=my-search-string")
   })
 
   it("should show each content item with edit links", async () => {
@@ -448,7 +448,7 @@ describe("RepeatableContentListing", () => {
         apiResponse
       )
       await render({ website })
-      expect(spyUseInterval).toBeCalledTimes(2)
+      expect(spyUseInterval).toHaveBeenCalledTimes(2)
       await spyUseInterval.mock.calls[0][0]()
 
       if (shouldUpdate) {
@@ -461,7 +461,7 @@ describe("RepeatableContentListing", () => {
     })
   })
 
-  test("should have a route for the EditorDrawer component ", async () => {
+  test("should have a route for the EditorDrawer component", async () => {
     const { wrapper } = await render()
     const listing = wrapper.find(RepeatableContentListing)
     const route = listing.find(Route)

--- a/static/js/components/SortableItem.test.tsx
+++ b/static/js/components/SortableItem.test.tsx
@@ -36,6 +36,6 @@ describe("SortableItem", () => {
     const deleteButton = wrapper.find(".material-icons").at(1)
     expect(deleteButton.text()).toBe("remove_circle_outline")
     deleteButton.simulate("click")
-    expect(deleteStub).toBeCalledWith("item-id")
+    expect(deleteStub).toHaveBeenCalledWith("item-id")
   })
 })

--- a/static/js/components/forms/MenuItemForm.test.tsx
+++ b/static/js/components/forms/MenuItemForm.test.tsx
@@ -41,7 +41,7 @@ describe("MenuItemForm", () => {
     const wrapper = renderForm()
 
     wrapper.prop("onSubmit")()
-    expect(onSubmitStub).toBeCalledTimes(1)
+    expect(onSubmitStub).toHaveBeenCalledTimes(1)
     const innerWrapper = renderInnerForm({}, {})
     const submitBtn = innerWrapper.find("button.cyan-button")
     expect(submitBtn.prop("type")).toEqual("submit")
@@ -104,10 +104,16 @@ describe("MenuItemForm", () => {
     expect(externalBtn.prop("value")).toEqual(LinkType.External)
     // @ts-expect-error Not going to simulate the event
     externalBtn.prop("onChange")()
-    expect(setFieldValueStub).toBeCalledWith("menuItemType", LinkType.External)
+    expect(setFieldValueStub).toHaveBeenCalledWith(
+      "menuItemType",
+      LinkType.External
+    )
     // @ts-expect-error Not going to simulate the event
     internalBtn.prop("onChange")()
-    expect(setFieldValueStub).toBeCalledWith("menuItemType", LinkType.Internal)
+    expect(setFieldValueStub).toHaveBeenCalledWith(
+      "menuItemType",
+      LinkType.Internal
+    )
   })
 
   it("renders an internal link dropdown if the 'internal' radio is selected", () => {
@@ -177,6 +183,6 @@ describe("MenuItemForm", () => {
     }
     // @ts-expect-error Not using a full event
     relationField.prop("onChange")(fakeEvent)
-    expect(setFieldValueStub).toBeCalledWith("internalLink", "abc")
+    expect(setFieldValueStub).toHaveBeenCalledWith("internalLink", "abc")
   })
 })

--- a/static/js/components/widgets/FileUploadField.test.tsx
+++ b/static/js/components/widgets/FileUploadField.test.tsx
@@ -46,7 +46,7 @@ describe("FileUploadField", () => {
         .simulate("change", {
           target: { name: fileFieldName, files: [mockFile] }
         })
-      expect(onChangeStub).toBeCalledWith({
+      expect(onChangeStub).toHaveBeenCalledWith({
         target: {
           name:  fileFieldName,
           value: mockFile

--- a/static/js/components/widgets/HierarchicalSelectField.test.tsx
+++ b/static/js/components/widgets/HierarchicalSelectField.test.tsx
@@ -184,8 +184,8 @@ describe("HierarchicalSelectField", () => {
       const event = { preventDefault: jest.fn() }
       // @ts-expect-error Not simulating the whole event
       button.prop("onClick")(event)
-      expect(event.preventDefault).toBeCalled()
-      expect(onChangeStub).toBeCalledWith({
+      expect(event.preventDefault).toHaveBeenCalled()
+      expect(onChangeStub).toHaveBeenCalledWith({
         target: {
           name,
           value: [value[valueIndex === 0 ? 1 : 0]]
@@ -209,8 +209,8 @@ describe("HierarchicalSelectField", () => {
       // @ts-expect-error Not simulating the whole event
       wrapper.find(".add").prop("onClick")(event)
 
-      expect(event.preventDefault).toBeCalled()
-      expect(onChangeStub).toBeCalledWith({
+      expect(event.preventDefault).toHaveBeenCalled()
+      expect(onChangeStub).toHaveBeenCalledWith({
         target: {
           value: sortBy(duplicate ? value : [...value, ["Topic2"]]),
           name
@@ -229,8 +229,8 @@ describe("HierarchicalSelectField", () => {
     // @ts-expect-error Not simulating the whole event
     wrapper.find(".add").prop("onClick")(event)
 
-    expect(event.preventDefault).toBeCalled()
-    expect(onChangeStub).not.toBeCalled()
+    expect(event.preventDefault).toHaveBeenCalled()
+    expect(onChangeStub).not.toHaveBeenCalled()
   })
 
   describe("calcOptions", () => {

--- a/static/js/components/widgets/MenuField.test.tsx
+++ b/static/js/components/widgets/MenuField.test.tsx
@@ -102,7 +102,7 @@ describe("MenuField", () => {
     formShowBtn.prop("onClick")({ preventDefault: preventDefaultStub })
     wrapper.update()
     if (menuItem) {
-      expect(preventDefaultStub).toBeCalledTimes(1)
+      expect(preventDefaultStub).toHaveBeenCalledTimes(1)
     }
     const itemFormPanel = wrapper.find("BasicModal")
     expect(itemFormPanel.prop("isVisible")).toBe(true)
@@ -157,7 +157,7 @@ describe("MenuField", () => {
     // @ts-expect-error Not simulating the whole event
     deleteBtn.prop("onClick")({ preventDefault: preventDefaultStub })
     wrapper.update()
-    expect(preventDefaultStub).toBeCalledTimes(1)
+    expect(preventDefaultStub).toHaveBeenCalledTimes(1)
     const removeDialog = wrapper.find("Dialog")
     expect(removeDialog.prop("open")).toBe(true)
     removeDialog.prop("onAccept")()

--- a/static/js/components/widgets/ObjectField.test.tsx
+++ b/static/js/components/widgets/ObjectField.test.tsx
@@ -84,7 +84,7 @@ describe("ObjectField", () => {
         isVisible ? field.fields.length : 0
       )
       for (const innerField of field.fields) {
-        expect(mockSiteContent.fieldIsVisible).toBeCalledWith(
+        expect(mockSiteContent.fieldIsVisible).toHaveBeenCalledWith(
           innerField,
           values
         )

--- a/static/js/components/widgets/RelationField.test.tsx
+++ b/static/js/components/widgets/RelationField.test.tsx
@@ -329,7 +329,7 @@ describe("RelationField", () => {
         // @ts-expect-error Not fully simulating the event
         select.prop("onChange")(fakeEvent)
       })
-      expect(onChangeStub).toBeCalledWith({
+      expect(onChangeStub).toHaveBeenCalledWith({
         target: {
           name:  expectedName,
           value: {
@@ -381,14 +381,14 @@ describe("RelationField", () => {
           })
           .param({ name: website.name })
           .toString()
-      expect(debouncedFetch).toBeCalledTimes(2)
-      expect(debouncedFetch).toBeCalledWith(
+      expect(debouncedFetch).toHaveBeenCalledTimes(2)
+      expect(debouncedFetch).toHaveBeenCalledWith(
         "relationfield",
         300,
         urlForSearch(searchString1),
         { credentials: "include" }
       )
-      expect(debouncedFetch).toBeCalledWith(
+      expect(debouncedFetch).toHaveBeenCalledWith(
         "relationfield",
         300,
         urlForSearch(searchString2),
@@ -435,7 +435,7 @@ describe("RelationField", () => {
     })
   })
 
-  it("should display an error message ", async () => {
+  it("should display an error message", async () => {
     global.mockFetch.mockClear()
     const fakeResponse = {
       results:  undefined,

--- a/static/js/components/widgets/SortableSelect.test.tsx
+++ b/static/js/components/widgets/SortableSelect.test.tsx
@@ -82,7 +82,7 @@ describe("SortableSelect", () => {
   it("should allow adding another element", async () => {
     const { wrapper } = await render()
     await triggerSortableSelect(wrapper, newOptions[0].label)
-    expect(onChange).toBeCalledWith([newOptions[0].label])
+    expect(onChange).toHaveBeenCalledWith([newOptions[0].label])
     expect(wrapper.find("SelectField").prop("value")).toBeUndefined()
   })
 
@@ -102,6 +102,10 @@ describe("SortableSelect", () => {
         over:   { id: value[0].id }
       } as any)
     })
-    expect(onChange).toBeCalledWith([value[2].id, value[0].id, value[1].id])
+    expect(onChange).toHaveBeenCalledWith([
+      value[2].id,
+      value[0].id,
+      value[1].id
+    ])
   })
 })

--- a/static/js/components/widgets/WebsiteCollectionField.test.tsx
+++ b/static/js/components/widgets/WebsiteCollectionField.test.tsx
@@ -47,7 +47,7 @@ describe("WebsiteCollectionField", () => {
 
   it("should pass published=true to the useWebsiteSelectOptions", async () => {
     await render()
-    expect(useWebsiteSelectOptions).toBeCalledWith("url_path", true)
+    expect(useWebsiteSelectOptions).toHaveBeenCalledWith("url_path", true)
   })
 
   it("should pass things down to SortableSelect", async () => {
@@ -69,7 +69,7 @@ describe("WebsiteCollectionField", () => {
     const { wrapper } = await render()
     wrapper.update()
     await triggerSortableSelect(wrapper, websites[0].name)
-    expect(onChange).toBeCalledWith({
+    expect(onChange).toHaveBeenCalledWith({
       target: {
         name:  "test-site-collection",
         value: [

--- a/static/js/hooks/websites.test.ts
+++ b/static/js/hooks/websites.test.ts
@@ -37,7 +37,7 @@ describe("website hooks", () => {
       await act(async () => {
         await waitForNextUpdate()
       })
-      expect(global.fetch).toBeCalledWith(
+      expect(global.fetch).toHaveBeenCalledWith(
         siteApiListingUrl
           .query({ offset: 0 })
           .param({ search: "" })
@@ -60,7 +60,7 @@ describe("website hooks", () => {
         await act(async () => {
           await waitForNextUpdate()
         })
-        expect(global.fetch).toBeCalledWith(
+        expect(global.fetch).toHaveBeenCalledWith(
           siteApiListingUrl
             .query({ offset: 0 })
             .param({ search: "" })
@@ -78,7 +78,7 @@ describe("website hooks", () => {
         await waitForNextUpdate()
         await result.current.loadOptions("search string", cb)
       })
-      expect(debouncedFetch).toBeCalledWith(
+      expect(debouncedFetch).toHaveBeenCalledWith(
         "website-collection",
         300,
         siteApiListingUrl
@@ -87,7 +87,7 @@ describe("website hooks", () => {
           .toString(),
         { credentials: "include" }
       )
-      expect(cb).toBeCalledWith(formatWebsiteOptions(websites, "uuid"))
+      expect(cb).toHaveBeenCalledWith(formatWebsiteOptions(websites, "uuid"))
     })
   })
 })

--- a/static/js/lib/api/util.test.ts
+++ b/static/js/lib/api/util.test.ts
@@ -18,7 +18,7 @@ describe("api utility functions", () => {
     // - the fourth has a different key so it should get its own wait
     // - and the fifth is executed after the other sharedWait calls have resolved,
     // so it should start with a clean slate
-    expect(wait).toBeCalledTimes(3)
+    expect(wait).toHaveBeenCalledTimes(3)
   })
 
   it("debounces and fetches", async () => {
@@ -31,7 +31,7 @@ describe("api utility functions", () => {
       debouncedFetch("key", 30, "url3", { credentials: "omit" })
     ])
 
-    expect(global.fetch).toBeCalledTimes(1)
+    expect(global.fetch).toHaveBeenCalledTimes(1)
     // only the last set of arguments should be passed to fetch
     expect(global.fetch).toHaveBeenCalledWith("url3", {
       credentials: "omit"

--- a/static/js/lib/ckeditor/plugins/util.ts
+++ b/static/js/lib/ckeditor/plugins/util.ts
@@ -166,8 +166,8 @@ export class Shortcode {
     const interior = s.slice(3, -3)
     const isClosingMatch = interior.match(Shortcode.IS_CLOSING_REGEXP)
     // IS_CLOSING_REGEXP will always match, hence the non-null assertion !
-    const isClosing = isClosingMatch!.groups!.isClosing === "/"
-    const nameAndArgs = interior.slice(isClosingMatch![0].length)
+    const isClosing = isClosingMatch?.groups?.isClosing === "/"
+    const nameAndArgs = interior.slice(isClosingMatch?.[0].length ?? 0)
 
     const [nameMatch, ...argMatches] = nameAndArgs.matchAll(
       Shortcode.ARG_REGEXP

--- a/static/js/lib/ckeditor/plugins/validateMdConversion.test.ts
+++ b/static/js/lib/ckeditor/plugins/validateMdConversion.test.ts
@@ -30,17 +30,17 @@ const md = {
 }
 
 describe("validateHtml2md", () => {
-  it("Does nothing when ", async () => {
+  it("Does nothing when", async () => {
     const { md2html } = getConverters(await getEditor())
     const shouldNotError = () =>
       validateHtml2md(md.oneTable, html.oneTable, md2html)
-    expect(shouldNotError).not.toThrowError()
+    expect(shouldNotError).not.toThrow()
   })
 
   it("Errors when", async () => {
     const { md2html } = getConverters(await getEditor())
     const shouldError = () =>
       validateHtml2md(md.oneTable, html.twoTable, md2html)
-    expect(shouldError).toThrowError(/Markdown conversion error/)
+    expect(shouldError).toThrow(/Markdown conversion error/)
   })
 })

--- a/static/js/lib/ckeditor/turndown.ts
+++ b/static/js/lib/ckeditor/turndown.ts
@@ -76,7 +76,7 @@ turndownService.rules.blankRule.replacement = (
 
   if (matchingRules.length === 1) {
     const [rule] = matchingRules
-    return rule.replacement!(content, node, options)
+    return rule.replacement?.(content, node, options)
   } else {
     return "\n\n"
   }
@@ -86,7 +86,11 @@ turndownService.rules.blankRule.replacement = (
 // extra spaces to the beginning of a list item. So it maps
 // "<ul><li>item</li></ul>" -> "-   item" instead of "- item"
 // see https://github.com/domchristie/turndown/issues/291
-turndownService.rules.array.find(rule => rule.filter === "li")!.replacement = (
+const itemRule = turndownService.rules.array.find(rule => rule.filter === "li")
+if (!itemRule) {
+  throw new Error("Expected rule to exist.")
+}
+itemRule.replacement = (
   content: string,
   node: Turndown.Node,
   options: Turndown.Options

--- a/static/js/pages/SiteCreationPage.test.tsx
+++ b/static/js/pages/SiteCreationPage.test.tsx
@@ -95,8 +95,8 @@ describe("SiteCreationPage", () => {
       sinon.assert.calledOnce(createWebsiteStub)
       expect(formikStubs.setSubmitting).toHaveBeenCalledTimes(1)
       expect(formikStubs.setSubmitting).toHaveBeenCalledWith(false)
-      expect(historyPushStub).toBeCalledTimes(1)
-      expect(historyPushStub).toBeCalledWith(
+      expect(historyPushStub).toHaveBeenCalledTimes(1)
+      expect(historyPushStub).toHaveBeenCalledWith(
         siteDetailUrl.param({ name: website.name }).toString()
       )
     })
@@ -126,7 +126,7 @@ describe("SiteCreationPage", () => {
         short_id: undefined,
         starter:  undefined
       })
-      expect(historyPushStub).not.toBeCalled()
+      expect(historyPushStub).not.toHaveBeenCalled()
     })
 
     it("that sets a status if the API request fails with a string error message", async () => {

--- a/static/js/test_setup.ts
+++ b/static/js/test_setup.ts
@@ -50,7 +50,6 @@ declare global {
 }
 
 // cleanup after each test run
-// eslint-disable-next-line mocha/no-top-level-hooks
 afterEach(function() {
   /**
    * Clear all mock call counts between tests.

--- a/static/js/util/dom.test.tsx
+++ b/static/js/util/dom.test.tsx
@@ -61,7 +61,7 @@ describe("scrollToError", () => {
     }
   }
 
-  it("it scrolls to and focuses the first matching div in container", () => {
+  it("scrolls to and focuses the first matching div in container", () => {
     mockMatchMedia()
     const { containers, spies } = getTestPage()
 
@@ -78,7 +78,7 @@ describe("scrollToError", () => {
     expect(spies.div1c.focus).toHaveBeenCalledTimes(1)
   })
 
-  it("it smoothly scrolls to center by default", () => {
+  it("smoothly scrolls to center by default", () => {
     mockMatchMedia()
     const { containers, spies } = getTestPage()
 
@@ -90,7 +90,7 @@ describe("scrollToError", () => {
     expect(spies.div1b.focus).toHaveBeenCalledWith({ preventScroll: true })
   })
 
-  it("it respects (prefers-reduced-motion: reduce)", () => {
+  it("respects (prefers-reduced-motion: reduce)", () => {
     const matchMedia = mockMatchMedia()
     const { containers, spies } = getTestPage()
 
@@ -105,7 +105,7 @@ describe("scrollToError", () => {
     expect(spies.div1b.focus).toHaveBeenCalledWith({ preventScroll: true })
   })
 
-  it("it does not error when no element is found", () => {
+  it("does not error when no element is found", () => {
     const matchMedia = mockMatchMedia()
     const { containers } = getTestPage()
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6216,9 +6216,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-mitodl@git+https://github.com/mitodl/eslint-config.git#ts":
-  version: 0.2.1
-  resolution: "eslint-config-mitodl@https://github.com/mitodl/eslint-config.git#commit=e9f51554d306eca3ea239ce8cdd0e2c143c3db86"
+"eslint-config-mitodl@npm:1.0.0":
+  version: 1.0.0
+  resolution: "eslint-config-mitodl@npm:1.0.0"
   dependencies:
     "@typescript-eslint/parser": ^5.39.0
     babel-eslint: ^10.1.0
@@ -6237,7 +6237,7 @@ __metadata:
       optional: true
     eslint-plugin-mocha:
       optional: true
-  checksum: 9e6d46d78eaf1908902d80fe708a6ef2f8bfae656165c91385b7ab6de802da51cafbfc07881fe025442f525c1569fdf48d8b9319e41491dd61cde5cea6e1116f
+  checksum: 26dd6ed29794872fdb587d474f095dcb491d51c762ec45ced6fc117a372f1406b66549341639cc76b882c51d4c85423de44492af0f6343a0ea69abb36caa4412
   languageName: node
   linkType: hard
 
@@ -10650,7 +10650,7 @@ __metadata:
     enzyme: ^3.11.0
     enzyme-adapter-react-16: ^1.15.6
     eslint: ^7.32.0
-    eslint-config-mitodl: "git+https://github.com/mitodl/eslint-config.git#ts"
+    eslint-config-mitodl: 1.0.0
     eslint-plugin-jest: ^27.1.1
     eslint-plugin-react: ^7.24.0
     eslint-plugin-react-hooks: ^4.2.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,6 +32,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/code-frame@npm:7.18.6"
+  dependencies:
+    "@babel/highlight": ^7.18.6
+  checksum: 195e2be3172d7684bf95cff69ae3b7a15a9841ea9d27d3c843662d50cdd7d6470fd9c8e64be84d031117e4a4083486effba39f9aef6bbb2c89f7f21bcfba33ba
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.17.7":
   version: 7.17.7
   resolution: "@babel/compat-data@npm:7.17.7"
@@ -73,6 +82,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:^7.19.3":
+  version: 7.19.3
+  resolution: "@babel/generator@npm:7.19.3"
+  dependencies:
+    "@babel/types": ^7.19.3
+    "@jridgewell/gen-mapping": ^0.3.2
+    jsesc: ^2.5.1
+  checksum: b1585e398f6c37f442a2fdac964a326b348fbc8fb99a6aaf4f72bbe993adb0ca792bc0a9c65e59930b2a2e55eb5aa3aab360ceb678d3d40692eb0cda2b7b6aa6
+  languageName: node
+  linkType: hard
+
 "@babel/helper-compilation-targets@npm:^7.17.7":
   version: 7.17.7
   resolution: "@babel/helper-compilation-targets@npm:7.17.7"
@@ -96,6 +116,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-environment-visitor@npm:^7.18.9":
+  version: 7.18.9
+  resolution: "@babel/helper-environment-visitor@npm:7.18.9"
+  checksum: b25101f6162ddca2d12da73942c08ad203d7668e06663df685634a8fde54a98bc015f6f62938e8554457a592a024108d45b8f3e651fd6dcdb877275b73cc4420
+  languageName: node
+  linkType: hard
+
 "@babel/helper-function-name@npm:^7.16.7":
   version: 7.16.7
   resolution: "@babel/helper-function-name@npm:7.16.7"
@@ -104,6 +131,16 @@ __metadata:
     "@babel/template": ^7.16.7
     "@babel/types": ^7.16.7
   checksum: fc77cbe7b10cfa2a262d7a37dca575c037f20419dfe0c5d9317f589599ca24beb5f5c1057748011159149eaec47fe32338c6c6412376fcded68200df470161e1
+  languageName: node
+  linkType: hard
+
+"@babel/helper-function-name@npm:^7.19.0":
+  version: 7.19.0
+  resolution: "@babel/helper-function-name@npm:7.19.0"
+  dependencies:
+    "@babel/template": ^7.18.10
+    "@babel/types": ^7.19.0
+  checksum: eac1f5db428ba546270c2b8d750c24eb528b8fcfe50c81de2e0bdebf0e20f24bec688d4331533b782e4a907fad435244621ca2193cfcf80a86731299840e0f6e
   languageName: node
   linkType: hard
 
@@ -122,6 +159,15 @@ __metadata:
   dependencies:
     "@babel/types": ^7.16.7
   checksum: 6ae1641f4a751cd9045346e3f61c3d9ec1312fd779ab6d6fecfe2a96e59a481ad5d7e40d2a840894c13b3fd6114345b157f9e3062fc5f1580f284636e722de60
+  languageName: node
+  linkType: hard
+
+"@babel/helper-hoist-variables@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/helper-hoist-variables@npm:7.18.6"
+  dependencies:
+    "@babel/types": ^7.18.6
+  checksum: fd9c35bb435fda802bf9ff7b6f2df06308a21277c6dec2120a35b09f9de68f68a33972e2c15505c1a1a04b36ec64c9ace97d4a9e26d6097b76b4396b7c5fa20f
   languageName: node
   linkType: hard
 
@@ -175,10 +221,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-split-export-declaration@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/helper-split-export-declaration@npm:7.18.6"
+  dependencies:
+    "@babel/types": ^7.18.6
+  checksum: c6d3dede53878f6be1d869e03e9ffbbb36f4897c7cc1527dc96c56d127d834ffe4520a6f7e467f5b6f3c2843ea0e81a7819d66ae02f707f6ac057f3d57943a2b
+  languageName: node
+  linkType: hard
+
+"@babel/helper-string-parser@npm:^7.18.10":
+  version: 7.18.10
+  resolution: "@babel/helper-string-parser@npm:7.18.10"
+  checksum: d554a4393365b624916b5c00a4cc21c990c6617e7f3fe30be7d9731f107f12c33229a7a3db9d829bfa110d2eb9f04790745d421640e3bd245bb412dc0ea123c1
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.16.7":
   version: 7.16.7
   resolution: "@babel/helper-validator-identifier@npm:7.16.7"
   checksum: dbb3db9d184343152520a209b5684f5e0ed416109cde82b428ca9c759c29b10c7450657785a8b5c5256aa74acc6da491c1f0cf6b784939f7931ef82982051b69
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.18.6, @babel/helper-validator-identifier@npm:^7.19.1":
+  version: 7.19.1
+  resolution: "@babel/helper-validator-identifier@npm:7.19.1"
+  checksum: 0eca5e86a729162af569b46c6c41a63e18b43dbe09fda1d2a3c8924f7d617116af39cac5e4cd5d431bb760b4dca3c0970e0c444789b1db42bcf1fa41fbad0a3a
   languageName: node
   linkType: hard
 
@@ -211,12 +280,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/highlight@npm:^7.18.6":
+  version: 7.18.6
+  resolution: "@babel/highlight@npm:7.18.6"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.18.6
+    chalk: ^2.0.0
+    js-tokens: ^4.0.0
+  checksum: 92d8ee61549de5ff5120e945e774728e5ccd57fd3b2ed6eace020ec744823d4a98e242be1453d21764a30a14769ecd62170fba28539b211799bbaf232bbb2789
+  languageName: node
+  linkType: hard
+
 "@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.16.7, @babel/parser@npm:^7.17.3, @babel/parser@npm:^7.17.8":
   version: 7.17.8
   resolution: "@babel/parser@npm:7.17.8"
   bin:
     parser: ./bin/babel-parser.js
   checksum: 1771808491982cc47baa888a997aef6b58308e3844c8c00f730f8fd97defe57d32cdbf46075cd49aaee310fa31f3d2c80a0d41b41a4ee0ff336ee09e2ff6c222
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.18.10, @babel/parser@npm:^7.19.3, @babel/parser@npm:^7.7.0":
+  version: 7.19.3
+  resolution: "@babel/parser@npm:7.19.3"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 854f1390328a8cea5d95ed2a8655a8976cdb41e72393845df0f86088dc777817a5e015a1a61739d312accccf1a22358fb70707a013d25596251cceba2c8985ee
   languageName: node
   linkType: hard
 
@@ -394,6 +483,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/template@npm:^7.18.10":
+  version: 7.18.10
+  resolution: "@babel/template@npm:7.18.10"
+  dependencies:
+    "@babel/code-frame": ^7.18.6
+    "@babel/parser": ^7.18.10
+    "@babel/types": ^7.18.10
+  checksum: 93a6aa094af5f355a72bd55f67fa1828a046c70e46f01b1606e6118fa1802b6df535ca06be83cc5a5e834022be95c7b714f0a268b5f20af984465a71e28f1473
+  languageName: node
+  linkType: hard
+
 "@babel/traverse@npm:^7.17.3, @babel/traverse@npm:^7.7.2":
   version: 7.17.3
   resolution: "@babel/traverse@npm:7.17.3"
@@ -412,6 +512,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.7.0":
+  version: 7.19.3
+  resolution: "@babel/traverse@npm:7.19.3"
+  dependencies:
+    "@babel/code-frame": ^7.18.6
+    "@babel/generator": ^7.19.3
+    "@babel/helper-environment-visitor": ^7.18.9
+    "@babel/helper-function-name": ^7.19.0
+    "@babel/helper-hoist-variables": ^7.18.6
+    "@babel/helper-split-export-declaration": ^7.18.6
+    "@babel/parser": ^7.19.3
+    "@babel/types": ^7.19.3
+    debug: ^4.1.0
+    globals: ^11.1.0
+  checksum: ef16c98fca7f2c347febd06737c13230ea103d619a0d6c142445bc8eff6359d2fce026f27dece02b4838f614cda8a9330bc4a576ccc6cd0ce21844d1d0205769
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.0.0, @babel/types@npm:^7.16.7, @babel/types@npm:^7.17.0, @babel/types@npm:^7.3.0, @babel/types@npm:^7.3.3, @babel/types@npm:^7.8.3":
   version: 7.17.0
   resolution: "@babel/types@npm:7.17.0"
@@ -419,6 +537,17 @@ __metadata:
     "@babel/helper-validator-identifier": ^7.16.7
     to-fast-properties: ^2.0.0
   checksum: 12e5a287986fe557188e87b2c5202223f1dc83d9239a196ab936fdb9f8c1eb0be717ff19f934b5fad4e29a75586d5798f74bed209bccea1c20376b9952056f0e
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.18.10, @babel/types@npm:^7.18.6, @babel/types@npm:^7.19.0, @babel/types@npm:^7.19.3, @babel/types@npm:^7.7.0":
+  version: 7.19.3
+  resolution: "@babel/types@npm:7.19.3"
+  dependencies:
+    "@babel/helper-string-parser": ^7.18.10
+    "@babel/helper-validator-identifier": ^7.19.1
+    to-fast-properties: ^2.0.0
+  checksum: 34a5b3db3b99a1a80ec2a784c2bb0e48769a38f1526dc377a5753a3ac5e5704663c405a393117ecc7a9df9da07b01625be7c4c3fee43ae46aba23b0c40928d77
   languageName: node
   linkType: hard
 
@@ -1291,7 +1420,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/gen-mapping@npm:^0.3.0":
+"@jridgewell/gen-mapping@npm:^0.3.0, @jridgewell/gen-mapping@npm:^0.3.2":
   version: 0.3.2
   resolution: "@jridgewell/gen-mapping@npm:0.3.2"
   dependencies:
@@ -1299,13 +1428,6 @@ __metadata:
     "@jridgewell/sourcemap-codec": ^1.4.10
     "@jridgewell/trace-mapping": ^0.3.9
   checksum: 1832707a1c476afebe4d0fbbd4b9434fdb51a4c3e009ab1e9938648e21b7a97049fa6009393bdf05cab7504108413441df26d8a3c12193996e65493a4efb6882
-  languageName: node
-  linkType: hard
-
-"@jridgewell/resolve-uri@npm:3.1.0":
-  version: 3.1.0
-  resolution: "@jridgewell/resolve-uri@npm:3.1.0"
-  checksum: b5ceaaf9a110fcb2780d1d8f8d4a0bfd216702f31c988d8042e5f8fbe353c55d9b0f55a1733afdc64806f8e79c485d2464680ac48a0d9fcadb9548ee6b81d267
   languageName: node
   linkType: hard
 
@@ -1333,13 +1455,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:1.4.14":
-  version: 1.4.14
-  resolution: "@jridgewell/sourcemap-codec@npm:1.4.14"
-  checksum: 61100637b6d173d3ba786a5dff019e1a74b1f394f323c1fee337ff390239f053b87266c7a948777f4b1ee68c01a8ad0ab61e5ff4abb5a012a0b091bec391ab97
-  languageName: node
-  linkType: hard
-
 "@jridgewell/sourcemap-codec@npm:^1.4.10":
   version: 1.4.11
   resolution: "@jridgewell/sourcemap-codec@npm:1.4.11"
@@ -1358,12 +1473,12 @@ __metadata:
   linkType: hard
 
 "@jridgewell/trace-mapping@npm:^0.3.9":
-  version: 0.3.17
-  resolution: "@jridgewell/trace-mapping@npm:0.3.17"
+  version: 0.3.15
+  resolution: "@jridgewell/trace-mapping@npm:0.3.15"
   dependencies:
-    "@jridgewell/resolve-uri": 3.1.0
-    "@jridgewell/sourcemap-codec": 1.4.14
-  checksum: 9d703b859cff5cd83b7308fd457a431387db5db96bd781a63bf48e183418dd9d3d44e76b9e4ae13237f6abeeb25d739ec9215c1d5bfdd08f66f750a50074a339
+    "@jridgewell/resolve-uri": ^3.0.3
+    "@jridgewell/sourcemap-codec": ^1.4.10
+  checksum: 38917e9c2b014d469a9f51c016ed506acbe44dd16ec2f6f99b553ebf3764d22abadbf992f2367b6d2b3511f3eae8ed3a8963f6c1030093fda23efd35ecab2bae
   languageName: node
   linkType: hard
 
@@ -2831,20 +2946,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@typescript-eslint/parser@npm:^5.4.0":
-  version: 5.17.0
-  resolution: "@typescript-eslint/parser@npm:5.17.0"
+"@typescript-eslint/parser@npm:^5.39.0":
+  version: 5.39.0
+  resolution: "@typescript-eslint/parser@npm:5.39.0"
   dependencies:
-    "@typescript-eslint/scope-manager": 5.17.0
-    "@typescript-eslint/types": 5.17.0
-    "@typescript-eslint/typescript-estree": 5.17.0
-    debug: ^4.3.2
+    "@typescript-eslint/scope-manager": 5.39.0
+    "@typescript-eslint/types": 5.39.0
+    "@typescript-eslint/typescript-estree": 5.39.0
+    debug: ^4.3.4
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 15b855ea84e44371366d44b5add87ed0dc34b856ca8a6949ecc4066faaf3ea3d7e016ea92db06ab97a637530148c472c38c19cc5eff68b691701ff89dc5c1abc
+  checksum: f55a1ef540e5c70d063e0112c0c4c950504d263ce180480973ca72c015a3e826942ebe8aa0a6bbd557def987b07d9d410784b6c96aa000679dfa3f4cb00e063c
   languageName: node
   linkType: hard
 
@@ -2855,6 +2970,16 @@ __metadata:
     "@typescript-eslint/types": 5.17.0
     "@typescript-eslint/visitor-keys": 5.17.0
   checksum: 8fc28d5742f36994ce05f09b0000f696a600d6f757f39ccae7875c08398b266f21d48ed1dfb027549d9c6692255a1fb3e8482ef94d765bb134371824da7d5ba7
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/scope-manager@npm:5.39.0":
+  version: 5.39.0
+  resolution: "@typescript-eslint/scope-manager@npm:5.39.0"
+  dependencies:
+    "@typescript-eslint/types": 5.39.0
+    "@typescript-eslint/visitor-keys": 5.39.0
+  checksum: 8d8b55eb219a23b3de64602ea23269fb1e16120ff03c58ebb7ed571372cbc591c5f4641b91ba1cf7fd02cf13f7bb906a7bd6e3db6da3543c97fcea8c61c15c07
   languageName: node
   linkType: hard
 
@@ -2878,6 +3003,13 @@ __metadata:
   version: 5.17.0
   resolution: "@typescript-eslint/types@npm:5.17.0"
   checksum: 06ed4c3c3f0a05bee9c23b6cb5eb679336c0f4769beb28848e8ce674f726fec88adba059f20e0b0f7271685d7f5480931b3bcafcf6b60044b93da162e29f3f68
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:5.39.0":
+  version: 5.39.0
+  resolution: "@typescript-eslint/types@npm:5.39.0"
+  checksum: 5f67fe02adc87d594b6cc8ec5387d64419d4bbff701f4da51bf9929cdc50bc613df865e5a2457f13e4a637e8dfdb1fdf15fe8138f8968462de9e54ea056cc1a7
   languageName: node
   linkType: hard
 
@@ -2909,6 +3041,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/typescript-estree@npm:5.39.0":
+  version: 5.39.0
+  resolution: "@typescript-eslint/typescript-estree@npm:5.39.0"
+  dependencies:
+    "@typescript-eslint/types": 5.39.0
+    "@typescript-eslint/visitor-keys": 5.39.0
+    debug: ^4.3.4
+    globby: ^11.1.0
+    is-glob: ^4.0.3
+    semver: ^7.3.7
+    tsutils: ^3.21.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 86143dd9dd33ce65a20badbce5509ae4e77e9dfe202a6966dd416a8ce8147e5b05d12ce0b8f593ed7924797f6420d0bcd558c773042466e24386cdda24f24eb8
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/utils@npm:5.17.0":
   version: 5.17.0
   resolution: "@typescript-eslint/utils@npm:5.17.0"
@@ -2925,6 +3075,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript-eslint/utils@npm:^5.10.0":
+  version: 5.39.0
+  resolution: "@typescript-eslint/utils@npm:5.39.0"
+  dependencies:
+    "@types/json-schema": ^7.0.9
+    "@typescript-eslint/scope-manager": 5.39.0
+    "@typescript-eslint/types": 5.39.0
+    "@typescript-eslint/typescript-estree": 5.39.0
+    eslint-scope: ^5.1.1
+    eslint-utils: ^3.0.0
+  peerDependencies:
+    eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+  checksum: 460a883775c24ed1a328db15101d58e1207797c97d2347a6e1adb2e26ef56ac0b525a326d2dd74333daf00e2b2e3dd28d51e0d4c4c38cdade2d132d8b08917cb
+  languageName: node
+  linkType: hard
+
 "@typescript-eslint/visitor-keys@npm:5.17.0":
   version: 5.17.0
   resolution: "@typescript-eslint/visitor-keys@npm:5.17.0"
@@ -2932,6 +3098,16 @@ __metadata:
     "@typescript-eslint/types": 5.17.0
     eslint-visitor-keys: ^3.0.0
   checksum: 333468277b50e2fc381ba1b99ccb410046c422e0329c791c51bea62e705edd16ba97f75b668c6945a3ea3dc43b89a1739693ea60bfa241c67ce42e8b474e5048
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:5.39.0":
+  version: 5.39.0
+  resolution: "@typescript-eslint/visitor-keys@npm:5.39.0"
+  dependencies:
+    "@typescript-eslint/types": 5.39.0
+    eslint-visitor-keys: ^3.3.0
+  checksum: 941e49fd1f4d2e42cd15a52a50f6f1102e2a83b173d182b5dd43ba3d7b7f0f1457d74fcaac710da4a19c28f804c78bc265d900802f4e2c7c46a608fff3204e7c
   languageName: node
   linkType: hard
 
@@ -3751,6 +3927,22 @@ __metadata:
   bin:
     autoprefixer: bin/autoprefixer
   checksum: 8f017672fbac248db0cf4e86aa707d8b148d9abadb842b5cf4c6be306d80fa6a654fadefd17e46213234c1f0947612acce2864f93e903f3e736b183fc1aedc45
+  languageName: node
+  linkType: hard
+
+"babel-eslint@npm:^10.1.0":
+  version: 10.1.0
+  resolution: "babel-eslint@npm:10.1.0"
+  dependencies:
+    "@babel/code-frame": ^7.0.0
+    "@babel/parser": ^7.7.0
+    "@babel/traverse": ^7.7.0
+    "@babel/types": ^7.7.0
+    eslint-visitor-keys: ^1.0.0
+    resolve: ^1.12.0
+  peerDependencies:
+    eslint: ">= 4.12.1"
+  checksum: bdc1f62b6b0f9c4d5108c96d835dad0c0066bc45b7c020fcb2d6a08107cf69c9217a99d3438dbd701b2816896190c4283ba04270ed9a8349ee07bd8dafcdc050
   languageName: node
   linkType: hard
 
@@ -5115,7 +5307,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2":
+"debug@npm:4, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4":
   version: 4.3.4
   resolution: "debug@npm:4.3.4"
   dependencies:
@@ -5965,29 +6157,44 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-mitodl@npm:^0.2.1":
-  version: 0.2.1
-  resolution: "eslint-config-mitodl@npm:0.2.1"
-  peerDependencies:
-    eslint: 7.x
-    eslint-config-google: 0.x
-    eslint-plugin-mocha: 6.x
-    eslint-plugin-react: 7.x
-    eslint-plugin-react-hooks: 4.x
-    prettier-eslint-cli: 5.x
-  checksum: 9bcf826a794a6d0f91b34c449bb265edf0570af415328dd694cf8fc333a83b6cff0ed4216d3521e4de7ff6d224cd7c01749eff40cbe9bd04918f5881c13579d7
-  languageName: node
-  linkType: hard
-
-"eslint-plugin-mocha@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "eslint-plugin-mocha@npm:9.0.0"
+"eslint-config-mitodl@portal:/Users/cchudzicki/dev/eslint-config::locator=ocw_studio%40workspace%3A.":
+  version: 0.0.0-use.local
+  resolution: "eslint-config-mitodl@portal:/Users/cchudzicki/dev/eslint-config::locator=ocw_studio%40workspace%3A."
   dependencies:
-    eslint-utils: ^3.0.0
-    ramda: ^0.27.1
+    "@typescript-eslint/parser": ^5.39.0
+    babel-eslint: ^10.1.0
+    eslint-config-google: ^0.14.0
   peerDependencies:
-    eslint: ">=7.0.0"
-  checksum: f33143815a998ed5057ca9b2e8f0dd2ca062dc311a046490a832ab84f9de0ecf1b933276bd9db3c84b34b315ba07ac68d586f468f98d424bbeb44e1505ba94e8
+    "@typescript-eslint/eslint-plugin": ^5.39.0
+    eslint: ^7.32.0
+    eslint-plugin-jest: ^27.1.1
+    eslint-plugin-mocha: 6.x
+    eslint-plugin-react: ^7.31.8
+    eslint-plugin-react-hooks: ^4.6
+  peerDependenciesMeta:
+    eslint-plugin-flowtype:
+      optional: true
+    eslint-plugin-jest:
+      optional: true
+    eslint-plugin-mocha:
+      optional: true
+  languageName: node
+  linkType: soft
+
+"eslint-plugin-jest@npm:^27.1.1":
+  version: 27.1.1
+  resolution: "eslint-plugin-jest@npm:27.1.1"
+  dependencies:
+    "@typescript-eslint/utils": ^5.10.0
+  peerDependencies:
+    "@typescript-eslint/eslint-plugin": ^5.0.0
+    eslint: ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    "@typescript-eslint/eslint-plugin":
+      optional: true
+    jest:
+      optional: true
+  checksum: 215a60d0c9ca641f3c1c7c5e4ff78093ad80c5f0ee22f44c50b9c8625ec0624ec4f47bf281684157f6231a4c480a4ca40bafad4ac6438a2105bb8527920e341f
   languageName: node
   linkType: hard
 
@@ -6097,7 +6304,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-visitor-keys@npm:^3.0.0":
+"eslint-visitor-keys@npm:^3.0.0, eslint-visitor-keys@npm:^3.3.0":
   version: 3.3.0
   resolution: "eslint-visitor-keys@npm:3.3.0"
   checksum: d59e68a7c5a6d0146526b0eec16ce87fbf97fe46b8281e0d41384224375c4e52f5ffb9e16d48f4ea50785cde93f766b0c898e31ab89978d88b0e1720fbfb7808
@@ -7176,7 +7383,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"globby@npm:^11.0.4":
+"globby@npm:^11.0.4, globby@npm:^11.1.0":
   version: 11.1.0
   resolution: "globby@npm:11.1.0"
   dependencies:
@@ -10372,7 +10579,6 @@ __metadata:
     "@types/turndown": ^5.0.1
     "@types/url-assembler": ^2.1.1
     "@typescript-eslint/eslint-plugin": ^5.4.0
-    "@typescript-eslint/parser": ^5.4.0
     "@use-it/interval": ^1.0.0
     autoprefixer: 9
     bootstrap: 4
@@ -10384,9 +10590,8 @@ __metadata:
     enzyme: ^3.11.0
     enzyme-adapter-react-16: ^1.15.6
     eslint: ^7.32.0
-    eslint-config-google: ^0.14.0
     eslint-config-mitodl: ^0.2.1
-    eslint-plugin-mocha: ^9.0.0
+    eslint-plugin-jest: ^27.1.1
     eslint-plugin-react: ^7.24.0
     eslint-plugin-react-hooks: ^4.2.0
     expect-type: ^0.13.0
@@ -12763,6 +12968,17 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 5eafe6102bea2a7439897c1856362e31cc348ccf96efd455c8b5bc2c61e6f7e7b8250dc26b8828c1d76a56f818a7ee907a36ae9fb37a599d3d24609207001d60
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.3.7":
+  version: 7.3.8
+  resolution: "semver@npm:7.3.8"
+  dependencies:
+    lru-cache: ^6.0.0
+  bin:
+    semver: bin/semver.js
+  checksum: ba9c7cbbf2b7884696523450a61fee1a09930d888b7a8d7579025ad93d459b2d1949ee5bbfeb188b2be5f4ac163544c5e98491ad6152df34154feebc2cc337c1
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6216,9 +6216,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-mitodl@git+ssh://git@github.com:mitodl/eslint-config.git#ts":
+"eslint-config-mitodl@git+https://github.com/mitodl/eslint-config.git#ts":
   version: 0.2.1
-  resolution: "eslint-config-mitodl@git+ssh://git@github.com:mitodl/eslint-config.git#commit=e9f51554d306eca3ea239ce8cdd0e2c143c3db86"
+  resolution: "eslint-config-mitodl@https://github.com/mitodl/eslint-config.git#commit=e9f51554d306eca3ea239ce8cdd0e2c143c3db86"
   dependencies:
     "@typescript-eslint/parser": ^5.39.0
     babel-eslint: ^10.1.0
@@ -10650,7 +10650,7 @@ __metadata:
     enzyme: ^3.11.0
     enzyme-adapter-react-16: ^1.15.6
     eslint: ^7.32.0
-    eslint-config-mitodl: "git+ssh://git@github.com:mitodl/eslint-config.git#ts"
+    eslint-config-mitodl: "git+https://github.com/mitodl/eslint-config.git#ts"
     eslint-plugin-jest: ^27.1.1
     eslint-plugin-react: ^7.24.0
     eslint-plugin-react-hooks: ^4.2.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -82,14 +82,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.19.3":
-  version: 7.19.3
-  resolution: "@babel/generator@npm:7.19.3"
+"@babel/generator@npm:^7.19.4":
+  version: 7.19.5
+  resolution: "@babel/generator@npm:7.19.5"
   dependencies:
-    "@babel/types": ^7.19.3
+    "@babel/types": ^7.19.4
     "@jridgewell/gen-mapping": ^0.3.2
     jsesc: ^2.5.1
-  checksum: b1585e398f6c37f442a2fdac964a326b348fbc8fb99a6aaf4f72bbe993adb0ca792bc0a9c65e59930b2a2e55eb5aa3aab360ceb678d3d40692eb0cda2b7b6aa6
+  checksum: a66eafc540f80fc36c1b009b28bde1d12aff85e7916e7f5adf49c5a8866fecee4906b3c3c6db315d2723ea54e4e5ddfb2913fe6ab424f51dbccf753000930eaf
   languageName: node
   linkType: hard
 
@@ -230,10 +230,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-string-parser@npm:^7.18.10":
-  version: 7.18.10
-  resolution: "@babel/helper-string-parser@npm:7.18.10"
-  checksum: d554a4393365b624916b5c00a4cc21c990c6617e7f3fe30be7d9731f107f12c33229a7a3db9d829bfa110d2eb9f04790745d421640e3bd245bb412dc0ea123c1
+"@babel/helper-string-parser@npm:^7.19.4":
+  version: 7.19.4
+  resolution: "@babel/helper-string-parser@npm:7.19.4"
+  checksum: b2f8a3920b30dfac81ec282ac4ad9598ea170648f8254b10f475abe6d944808fb006aab325d3eb5a8ad3bea8dfa888cfa6ef471050dae5748497c110ec060943
   languageName: node
   linkType: hard
 
@@ -300,12 +300,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.18.10, @babel/parser@npm:^7.19.3, @babel/parser@npm:^7.7.0":
-  version: 7.19.3
-  resolution: "@babel/parser@npm:7.19.3"
+"@babel/parser@npm:^7.18.10, @babel/parser@npm:^7.19.4, @babel/parser@npm:^7.7.0":
+  version: 7.19.4
+  resolution: "@babel/parser@npm:7.19.4"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: 854f1390328a8cea5d95ed2a8655a8976cdb41e72393845df0f86088dc777817a5e015a1a61739d312accccf1a22358fb70707a013d25596251cceba2c8985ee
+  checksum: 5ef97da97915085ff3b9c562b04fb6316074ece52d20de95f44c47b46abf87fd754cbcae769a69570a84652b736afe5bb2cb7dc117aa7ad6d81ab40eed0c613b
   languageName: node
   linkType: hard
 
@@ -513,20 +513,20 @@ __metadata:
   linkType: hard
 
 "@babel/traverse@npm:^7.7.0":
-  version: 7.19.3
-  resolution: "@babel/traverse@npm:7.19.3"
+  version: 7.19.4
+  resolution: "@babel/traverse@npm:7.19.4"
   dependencies:
     "@babel/code-frame": ^7.18.6
-    "@babel/generator": ^7.19.3
+    "@babel/generator": ^7.19.4
     "@babel/helper-environment-visitor": ^7.18.9
     "@babel/helper-function-name": ^7.19.0
     "@babel/helper-hoist-variables": ^7.18.6
     "@babel/helper-split-export-declaration": ^7.18.6
-    "@babel/parser": ^7.19.3
-    "@babel/types": ^7.19.3
+    "@babel/parser": ^7.19.4
+    "@babel/types": ^7.19.4
     debug: ^4.1.0
     globals: ^11.1.0
-  checksum: ef16c98fca7f2c347febd06737c13230ea103d619a0d6c142445bc8eff6359d2fce026f27dece02b4838f614cda8a9330bc4a576ccc6cd0ce21844d1d0205769
+  checksum: 8ae1ac3dace181620cd0e3078aec99604a48302fb873193a171e37a7cc4f8909ed496f286bf08c6473f9692db36423e2601eb9c771493d19f6a5fd1a56745af5
   languageName: node
   linkType: hard
 
@@ -540,14 +540,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.18.10, @babel/types@npm:^7.18.6, @babel/types@npm:^7.19.0, @babel/types@npm:^7.19.3, @babel/types@npm:^7.7.0":
-  version: 7.19.3
-  resolution: "@babel/types@npm:7.19.3"
+"@babel/types@npm:^7.18.10, @babel/types@npm:^7.18.6, @babel/types@npm:^7.19.0, @babel/types@npm:^7.19.4, @babel/types@npm:^7.7.0":
+  version: 7.19.4
+  resolution: "@babel/types@npm:7.19.4"
   dependencies:
-    "@babel/helper-string-parser": ^7.18.10
+    "@babel/helper-string-parser": ^7.19.4
     "@babel/helper-validator-identifier": ^7.19.1
     to-fast-properties: ^2.0.0
-  checksum: 34a5b3db3b99a1a80ec2a784c2bb0e48769a38f1526dc377a5753a3ac5e5704663c405a393117ecc7a9df9da07b01625be7c4c3fee43ae46aba23b0c40928d77
+  checksum: 4032f6407093f80dd4f4764be676f7527d2a5c0381586967cd79683cf8af01cdc16745a381b9cef045f702f0c9b0dffd880d84ee55dad59ba01bd23d5d52a8e0
   languageName: node
   linkType: hard
 
@@ -1431,6 +1431,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/resolve-uri@npm:3.1.0":
+  version: 3.1.0
+  resolution: "@jridgewell/resolve-uri@npm:3.1.0"
+  checksum: b5ceaaf9a110fcb2780d1d8f8d4a0bfd216702f31c988d8042e5f8fbe353c55d9b0f55a1733afdc64806f8e79c485d2464680ac48a0d9fcadb9548ee6b81d267
+  languageName: node
+  linkType: hard
+
 "@jridgewell/resolve-uri@npm:^3.0.3":
   version: 3.0.5
   resolution: "@jridgewell/resolve-uri@npm:3.0.5"
@@ -1455,6 +1462,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@jridgewell/sourcemap-codec@npm:1.4.14":
+  version: 1.4.14
+  resolution: "@jridgewell/sourcemap-codec@npm:1.4.14"
+  checksum: 61100637b6d173d3ba786a5dff019e1a74b1f394f323c1fee337ff390239f053b87266c7a948777f4b1ee68c01a8ad0ab61e5ff4abb5a012a0b091bec391ab97
+  languageName: node
+  linkType: hard
+
 "@jridgewell/sourcemap-codec@npm:^1.4.10":
   version: 1.4.11
   resolution: "@jridgewell/sourcemap-codec@npm:1.4.11"
@@ -1473,12 +1487,12 @@ __metadata:
   linkType: hard
 
 "@jridgewell/trace-mapping@npm:^0.3.9":
-  version: 0.3.15
-  resolution: "@jridgewell/trace-mapping@npm:0.3.15"
+  version: 0.3.17
+  resolution: "@jridgewell/trace-mapping@npm:0.3.17"
   dependencies:
-    "@jridgewell/resolve-uri": ^3.0.3
-    "@jridgewell/sourcemap-codec": ^1.4.10
-  checksum: 38917e9c2b014d469a9f51c016ed506acbe44dd16ec2f6f99b553ebf3764d22abadbf992f2367b6d2b3511f3eae8ed3a8963f6c1030093fda23efd35ecab2bae
+    "@jridgewell/resolve-uri": 3.1.0
+    "@jridgewell/sourcemap-codec": 1.4.14
+  checksum: 9d703b859cff5cd83b7308fd457a431387db5db96bd781a63bf48e183418dd9d3d44e76b9e4ae13237f6abeeb25d739ec9215c1d5bfdd08f66f750a50074a339
   languageName: node
   linkType: hard
 
@@ -2947,19 +2961,19 @@ __metadata:
   linkType: hard
 
 "@typescript-eslint/parser@npm:^5.39.0":
-  version: 5.39.0
-  resolution: "@typescript-eslint/parser@npm:5.39.0"
+  version: 5.40.1
+  resolution: "@typescript-eslint/parser@npm:5.40.1"
   dependencies:
-    "@typescript-eslint/scope-manager": 5.39.0
-    "@typescript-eslint/types": 5.39.0
-    "@typescript-eslint/typescript-estree": 5.39.0
+    "@typescript-eslint/scope-manager": 5.40.1
+    "@typescript-eslint/types": 5.40.1
+    "@typescript-eslint/typescript-estree": 5.40.1
     debug: ^4.3.4
   peerDependencies:
     eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: f55a1ef540e5c70d063e0112c0c4c950504d263ce180480973ca72c015a3e826942ebe8aa0a6bbd557def987b07d9d410784b6c96aa000679dfa3f4cb00e063c
+  checksum: 9fe410c1b14934803bb7c26de9b8de5d46ef9b6fe5dcbee1d7e111f0259659c214549b60dacdc729a3e23da835e6a44f08a9aa6bcb73ffff3c4fd5b9142358ed
   languageName: node
   linkType: hard
 
@@ -2980,6 +2994,16 @@ __metadata:
     "@typescript-eslint/types": 5.39.0
     "@typescript-eslint/visitor-keys": 5.39.0
   checksum: 8d8b55eb219a23b3de64602ea23269fb1e16120ff03c58ebb7ed571372cbc591c5f4641b91ba1cf7fd02cf13f7bb906a7bd6e3db6da3543c97fcea8c61c15c07
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/scope-manager@npm:5.40.1":
+  version: 5.40.1
+  resolution: "@typescript-eslint/scope-manager@npm:5.40.1"
+  dependencies:
+    "@typescript-eslint/types": 5.40.1
+    "@typescript-eslint/visitor-keys": 5.40.1
+  checksum: 5f25b86bfd09fbf8cdfdf932eaf0b41a7594c9b4539d3c8321f882bf7b4bf486454256fdb9a5a8c4eae305419d377fa93d382f80004711d759ff77b3d565c1dc
   languageName: node
   linkType: hard
 
@@ -3010,6 +3034,13 @@ __metadata:
   version: 5.39.0
   resolution: "@typescript-eslint/types@npm:5.39.0"
   checksum: 5f67fe02adc87d594b6cc8ec5387d64419d4bbff701f4da51bf9929cdc50bc613df865e5a2457f13e4a637e8dfdb1fdf15fe8138f8968462de9e54ea056cc1a7
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/types@npm:5.40.1":
+  version: 5.40.1
+  resolution: "@typescript-eslint/types@npm:5.40.1"
+  checksum: 2430c799667c820903df7ef39bc4c2762cb7654dbb8525d56f37e73f8cefb82186b80654dbbe0294c5b55affe929c641cdb90232e2749dcd7838f9e500a41549
   languageName: node
   linkType: hard
 
@@ -3056,6 +3087,24 @@ __metadata:
     typescript:
       optional: true
   checksum: 86143dd9dd33ce65a20badbce5509ae4e77e9dfe202a6966dd416a8ce8147e5b05d12ce0b8f593ed7924797f6420d0bcd558c773042466e24386cdda24f24eb8
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/typescript-estree@npm:5.40.1":
+  version: 5.40.1
+  resolution: "@typescript-eslint/typescript-estree@npm:5.40.1"
+  dependencies:
+    "@typescript-eslint/types": 5.40.1
+    "@typescript-eslint/visitor-keys": 5.40.1
+    debug: ^4.3.4
+    globby: ^11.1.0
+    is-glob: ^4.0.3
+    semver: ^7.3.7
+    tsutils: ^3.21.0
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: d0426a55d24b76a3f042816dd8baaaa7a8da0158870bb08fff5a5524821c13ca196117dc269f098b8887ef75e01da1a498637153ab3c29c370ca356bfe4a1716
   languageName: node
   linkType: hard
 
@@ -3108,6 +3157,16 @@ __metadata:
     "@typescript-eslint/types": 5.39.0
     eslint-visitor-keys: ^3.3.0
   checksum: 941e49fd1f4d2e42cd15a52a50f6f1102e2a83b173d182b5dd43ba3d7b7f0f1457d74fcaac710da4a19c28f804c78bc265d900802f4e2c7c46a608fff3204e7c
+  languageName: node
+  linkType: hard
+
+"@typescript-eslint/visitor-keys@npm:5.40.1":
+  version: 5.40.1
+  resolution: "@typescript-eslint/visitor-keys@npm:5.40.1"
+  dependencies:
+    "@typescript-eslint/types": 5.40.1
+    eslint-visitor-keys: ^3.3.0
+  checksum: b5dbf1e484ba2832ca1883ee9cf7da5967f70aa5624f3fb67f13c3be90a3770b0bb96e64ccfb0c31b5d8f80794b5727e14b6c0d8c5184634a686f0ea6e798772
   languageName: node
   linkType: hard
 
@@ -6157,9 +6216,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-mitodl@portal:/Users/cchudzicki/dev/eslint-config::locator=ocw_studio%40workspace%3A.":
-  version: 0.0.0-use.local
-  resolution: "eslint-config-mitodl@portal:/Users/cchudzicki/dev/eslint-config::locator=ocw_studio%40workspace%3A."
+"eslint-config-mitodl@git+ssh://git@github.com:mitodl/eslint-config.git#ts":
+  version: 0.2.1
+  resolution: "eslint-config-mitodl@git+ssh://git@github.com:mitodl/eslint-config.git#commit=e9f51554d306eca3ea239ce8cdd0e2c143c3db86"
   dependencies:
     "@typescript-eslint/parser": ^5.39.0
     babel-eslint: ^10.1.0
@@ -6178,8 +6237,9 @@ __metadata:
       optional: true
     eslint-plugin-mocha:
       optional: true
+  checksum: 9e6d46d78eaf1908902d80fe708a6ef2f8bfae656165c91385b7ab6de802da51cafbfc07881fe025442f525c1569fdf48d8b9319e41491dd61cde5cea6e1116f
   languageName: node
-  linkType: soft
+  linkType: hard
 
 "eslint-plugin-jest@npm:^27.1.1":
   version: 27.1.1
@@ -10590,7 +10650,7 @@ __metadata:
     enzyme: ^3.11.0
     enzyme-adapter-react-16: ^1.15.6
     eslint: ^7.32.0
-    eslint-config-mitodl: ^0.2.1
+    eslint-config-mitodl: "git+ssh://git@github.com:mitodl/eslint-config.git#ts"
     eslint-plugin-jest: ^27.1.1
     eslint-plugin-react: ^7.24.0
     eslint-plugin-react-hooks: ^4.2.0


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
https://github.com/mitodl/eslint-config/pull/16, https://github.com/mitodl/eslint-config/pull/15

#### What's this PR do?
Updates to a new version of `eslint-config-mitodl`: https://github.com/mitodl/eslint-config/pull/16

The new config:
- supports Typescript, so Studio doesn't need to do that itself (hence smaller studio config)
- allows using Jest instead of Mocha... *Previously we were using Mocha linting rules in OCW Studio. But Studio doesn't use Mocha. Mocha and Jest are similar enough this didn't cause very many problems, but it does cause a few. E.g, with top-level hooks.*

#### How should this be manually tested?
1. Check that linting / formatting pass. (Or don't, since CI does.)
2. Introduce a linting error and check that linting fails.
