### PR TITLE
give db service static ip on concourse network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ x-environment:
 networks:
   default-network:
     driver: bridge
-  minio-network:
+  concourse-network:
     driver: bridge
     ipam:
       driver: default
@@ -34,7 +34,9 @@ services:
     environment:
       POSTGRES_PASSWORD: postgres  # pragma: allowlist secret
     networks:
-     - default-network
+      default-network:
+      concourse-network:
+        ipv4_address: 10.1.0.103
 
   redis:
     image: redis:6.0.10
@@ -42,7 +44,7 @@ services:
       - "6379"
     networks:
      - default-network
-     - minio-network
+     - concourse-network
 
   nginx:
     image: nginx:1.22.0
@@ -58,7 +60,7 @@ services:
       - s3
     networks:
       default-network:
-      minio-network:
+      concourse-network:
         ipv4_address: 10.1.0.102
 
   web:
@@ -84,7 +86,7 @@ services:
       - redis
     networks:
       - default-network
-      - minio-network
+      - concourse-network
 
   watch:
     image: node:16.15.0
@@ -116,7 +118,7 @@ services:
       - redis
     networks:
       - default-network
-      - minio-network
+      - concourse-network
 
   concourse-db:
     image: postgres:11.6
@@ -160,7 +162,7 @@ services:
       - s3
     networks:
       default-network:
-      minio-network:
+      concourse-network:
         ipv4_address: 10.1.0.101
 
   s3:
@@ -181,7 +183,7 @@ services:
       retries: 3
     networks:
       default-network:
-      minio-network:
+      concourse-network:
         ipv4_address: 10.1.0.100
   create-buckets:
     image: minio/mc
@@ -210,4 +212,4 @@ services:
       /usr/bin/mc version enable minio/$AWS_ARTIFACTS_BUCKET_NAME;
       "
     networks:
-      - minio-network
+      - concourse-network


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1539

#### What's this PR do?
This PR sets a static IP for the `db` service on the internal Concourse Docker network. This allows the pipeline defined by https://github.com/mitodl/ol-infrastructure/pull/1151 to be used locally with `ocw-studio` to restore your dev database from production or RC.

#### How should this be manually tested?
 - Back up your local database if you wish to save it first. Since port 5432 of the Postgres container is forwarded to 5431 on the host, we can accomplish this with something like `pg_dump postgres://postgres:postgres@localhost:5431/postgres > local.sql` and then save the `local.sql` file somewhere.
 - Before spinning up `ocw-studio` you'll need to run `docker network rm ocw-studio_minio-network` as the Concourse Docker network was renamed from `minio-network` to `concourse-network`
 - Clone the `cg/ocw-database-replication` branch of `ol-infrastructure` from [this](https://github.com/mitodl/ol-infrastructure/pull/1151) PR
 - If you don't have an environment set up for `ol-infrastructure`, you're going to want to do that first. Make sure you have [Poetry](https://python-poetry.org/) installed in your local python and run `poetry install`, and then `poetry shell`.
 - Make sure you have the Concourse `fly` CLI installed locally and that the version matches the version running locally in Docker through the `ocw-studio` Docker configuration.
 - Add your local Concourse server as a target in `fly` by using [`fly login`](https://concourse-ci.org/fly.html#fly-login) against your local concourse URL. If you added a hosts file entry for Concourse, use that. I named my target `local` so that's how I'll be referring to it.
 - Run `cd src/concourse/pipelines/infrastructure/ocw_studio_db_replication`
 - Create a `vars.yaml` file with the following values:
```
source:
  username: <prod / qa username>
  password: <prod / qa password>
  host: <prod / qa host>
  port: 5432
  database: ocw_studio
destination:
  username: postgres
  password: postgres
  host: 10.1.0.103
  port: 5432
  database: postgres

```
 - Run `python pipeline.py`
 - You should get some output and a `fly set-pipeline` command at the end. Change the `-t` argument to match the target we created above and run the command and add `--load-vars-from vars.yaml` at the end. You should get a confirmation to upsert the pipeline into your local Concourse instance. If everything looks right, confirm and upsert.
 - Browse to http://concourse:8080 and find the pipeline we pushed up. Trigger a run of the pipeline. CAUTION: This will replace your local database with the database found at the `source` connection parameters that you filled out above. Now's your last chance to back up your local DB if you want it.
 - Verify that the restore completes successfully and your local `ocw-studio` database has been replaced.
