### PR TITLE
update yarn install

### DIFF
--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -79,7 +79,7 @@ jobs:
         - -exc
         - |
           cd ocw-hugo-themes
-          yarn install --pure-lockfile
+          yarn install --immutable
           npm run build:webpack
           npm run build:githash
           mkdir -p ./base-theme/static/static/

--- a/content_sync/pipelines/definitions/concourse/theme-assets-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/theme-assets-pipeline.yml
@@ -31,7 +31,7 @@ jobs:
         - -exc
         - |
           cd ocw-hugo-themes
-          yarn install --pure-lockfile
+          yarn install --immutable
           npm run build:webpack
           npm run build:githash
   - task: copy-s3-buckets


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
See https://github.com/mitodl/ocw-hugo-themes/pull/921#issuecomment-1290167978

#### What's this PR do?
We recently updated yarn from v1 to v3 in ocw-hugo-themes. Some of the CLI flags for `yarn install` had their names changed. This PR updates the pipeline definitions accordingly.

#### How should this be manually tested?
1. Set up minio so you can run pipelines locally. See https://github.com/mitodl/ocw-studio#local-s3-emulation-with-minio
2. Run:
    ```bash
    docker compose run --rm watch
    ./manage.py upsert_mass_build_pipeline --delete-all --offline
    ./manage.py upsert_theme_assets_pipeline --delete-all
    ```
3. Go to the concourse UI http://concourse:8080/
4. Navigate to the theme assets pipeline. Unpause it and run a build.
5. Navigate to the offline mass build pipeline; unpause it and trigger a new run. This will take a long time to finish. You can cancel it after a few courses build successfully.
