### PR TITLE
name offline site zip with short_id instead of name

### DIFF
--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -207,14 +207,14 @@ jobs:
               echo "STARTING S3 SYNC FOR $NAME" > /dev/tty
               # START OFFLINE-ONLY
               cd $CURDIR/$SHORT_ID/public
-              zip $NAME.zip -r ./
-              PUBLISH_S3_RESULT=$(aws s3((cli-endpoint-url)) sync ./ s3://((ocw-bucket))$PREFIX/$BASE_URL --exclude="*" --include="$NAME.zip" --metadata site-id=$NAME --only-show-errors) || PUBLISH_S3_RESULT=1
+              zip $SHORT_ID.zip -r ./
+              PUBLISH_S3_RESULT=$(aws s3((cli-endpoint-url)) sync ./ s3://((ocw-bucket))$PREFIX/$BASE_URL --exclude="*" --include="$SHORT_ID.zip" --metadata site-id=$NAME --only-show-errors) || PUBLISH_S3_RESULT=1
               if [[ $PUBLISH_S3_RESULT == 1 ]]
               then
-                echo "SYNCING $NAME.zip to s3://((ocw-bucket))$PREFIX/$SITE_URL failed for $NAME" > /dev/tty
+                echo "SYNCING $SHORT_ID.zip to s3://((ocw-bucket))$PREFIX/$SITE_URL failed for $NAME" > /dev/tty
                 return 1
               fi
-              rm $NAME.zip
+              rm $SHORT_ID.zip
               cd $CURDIR
               # END OFFLINE-ONLY
               # START ONLINE-ONLY


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1545

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/1477 we added code to the `mass-bulid-sites` pipeline to create a ZIP archive of the built site at the end of the run when `offline` is true. Currently, the ZIP archive is named with the `Website.name` property. This property is not available in the course metadata published with course sites, however, all the components of `short_id` are. If we simply name the ZIP archives with `short_id` instead, then we can construct URLs to the ZIP archives easily within the theme.

#### How should this be manually tested?
 - First of all, make sure you've taken care of the following prerequisites:
   - `ocw-studio` up and running
   - Minio support configured
   - Concourse support configured
   - Some test courses in your database using the `ocw-course-v2` starter
 - Make a temporary edit to `websites/views.py` to limit the sites seen by `mass-build-sites`:
```
        ...
        sites = Website.objects.filter(name="9-40-introduction-to-neural-computation-spring-2018")
        serializer = WebsiteMassBuildSerializer(instance=sites, many=True)
        return Response({"sites": serializer.data})
```
 - Upsert the offline `mass-build-sites` pipeline with `docker-compose exec web ./manage.py upsert_mass_build_pipeline --offline --starter ocw-course-v2 --projects-branch main --themes-branch main`
 - Browse to http://localhost:9001 and login with your Minio credentials
 - Browse to http://concourse:8080 and login with test/test
 - Find the offline `mass-bulid-sites` pipeline we just uploaded and trigger a build
 - Ensure the build completes without error
 - In the Minio UI, browse to `ol-ocw-studio-app/courses/9-40-introduction-to-neural-computation-spring-2018/ and verify that there is a ZIP file in there with a filename matching the course's `short_id`, which should be `9.40-spring-2018.zip`
