### PR TITLE
ocw hugo themes sentry dsn added 

### DIFF
--- a/app.json
+++ b/app.json
@@ -612,6 +612,10 @@
     "YT_UPLOAD_LIMIT": {
       "description": "Max Youtube uploads allowed per day",
       "required": false
+    },
+    "OCW_HUGO_THEMES_SENTRY_DSN": {
+      "description": "The sentry DSN that will be used in ocw-hugo-themes",
+      "required": false
     }
   },
   "keywords": [

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -467,7 +467,10 @@ class SitePipeline(BaseSitePipeline, GeneralPipeline):
                     f" --endpoint-url {DEV_ENDPOINT_URL}" if is_dev() else "",
                 )
                 .replace("((resource-base-url))", resource_base_url or "")
-                .replace("((ocw-hugo-themes-sentry-dsn))", settings.OCW_HUGO_THEMES_SENTRY_DSN)
+                .replace(
+                    "((ocw-hugo-themes-sentry-dsn))",
+                    settings.OCW_HUGO_THEMES_SENTRY_DSN,
+                )
             )
             self.upsert_config(config_str, pipeline_name)
 
@@ -670,7 +673,9 @@ class MassBuildSitesPipeline(
                     and self.PROJECTS_BRANCH == settings.GITHUB_WEBHOOK_BRANCH
                 ),
             )
-            .replace("((ocw-hugo-themes-sentry-dsn))", settings.OCW_HUGO_THEMES_SENTRY_DSN)
+            .replace(
+                "((ocw-hugo-themes-sentry-dsn))", settings.OCW_HUGO_THEMES_SENTRY_DSN
+            )
         )
         self.upsert_config(config_str, self.PIPELINE_NAME)
 

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -467,6 +467,7 @@ class SitePipeline(BaseSitePipeline, GeneralPipeline):
                     f" --endpoint-url {DEV_ENDPOINT_URL}" if is_dev() else "",
                 )
                 .replace("((resource-base-url))", resource_base_url or "")
+                .replace("((ocw-hugo-themes-sentry-dsn))", settings.OCW_HUGO_THEMES_SENTRY_DSN)
             )
             self.upsert_config(config_str, pipeline_name)
 
@@ -669,6 +670,7 @@ class MassBuildSitesPipeline(
                     and self.PROJECTS_BRANCH == settings.GITHUB_WEBHOOK_BRANCH
                 ),
             )
+            .replace("((ocw-hugo-themes-sentry-dsn))", settings.OCW_HUGO_THEMES_SENTRY_DSN)
         )
         self.upsert_config(config_str, self.PIPELINE_NAME)
 

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -674,7 +674,8 @@ class MassBuildSitesPipeline(
                 ),
             )
             .replace(
-                "((ocw-hugo-themes-sentry-dsn))", settings.OCW_HUGO_THEMES_SENTRY_DSN or ""
+                "((ocw-hugo-themes-sentry-dsn))",
+                settings.OCW_HUGO_THEMES_SENTRY_DSN or "",
             )
         )
         self.upsert_config(config_str, self.PIPELINE_NAME)

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -469,7 +469,7 @@ class SitePipeline(BaseSitePipeline, GeneralPipeline):
                 .replace("((resource-base-url))", resource_base_url or "")
                 .replace(
                     "((ocw-hugo-themes-sentry-dsn))",
-                    settings.OCW_HUGO_THEMES_SENTRY_DSN,
+                    settings.OCW_HUGO_THEMES_SENTRY_DSN or "",
                 )
             )
             self.upsert_config(config_str, pipeline_name)
@@ -674,7 +674,7 @@ class MassBuildSitesPipeline(
                 ),
             )
             .replace(
-                "((ocw-hugo-themes-sentry-dsn))", settings.OCW_HUGO_THEMES_SENTRY_DSN
+                "((ocw-hugo-themes-sentry-dsn))", settings.OCW_HUGO_THEMES_SENTRY_DSN or ""
             )
         )
         self.upsert_config(config_str, self.PIPELINE_NAME)

--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -113,7 +113,7 @@ jobs:
       GIT_KEY: ((git-private-key-var))
       SITEMAP_DOMAIN: ((sitemap-domain))
       PREFIX: ((prefix))
-      OCW_HUGO_THEMES_SENTRY_DSN: ((ocw-hugo-themes-sentry-dsn))
+      SENTRY_DSN: ((ocw-hugo-themes-sentry-dsn))
       # START DEV-ONLY
       AWS_ACCESS_KEY_ID: ((minio-root-user))
       AWS_SECRET_ACCESS_KEY: ((minio-root-password))

--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -113,6 +113,7 @@ jobs:
       GIT_KEY: ((git-private-key-var))
       SITEMAP_DOMAIN: ((sitemap-domain))
       PREFIX: ((prefix))
+      OCW_HUGO_THEMES_SENTRY_DSN: ((ocw-hugo-themes-sentry-dsn))
       # START DEV-ONLY
       AWS_ACCESS_KEY_ID: ((minio-root-user))
       AWS_SECRET_ACCESS_KEY: ((minio-root-password))

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -327,7 +327,7 @@ jobs:
           STATIC_API_BASE_URL: ((static-api-base-url))
           OCW_IMPORT_STARTER_SLUG: ((ocw-import-starter-slug))
           SITEMAP_DOMAIN: ((sitemap-domain))
-          OCW_HUGO_THEMES_SENTRY_DSN: ((ocw-hugo-themes-sentry-dsn))
+          SENTRY_DSN: ((ocw-hugo-themes-sentry-dsn))
           # START DEV-ONLY
           RESOURCE_BASE_URL: ((resource-base-url))
           # END DEV-ONLY

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -327,6 +327,7 @@ jobs:
           STATIC_API_BASE_URL: ((static-api-base-url))
           OCW_IMPORT_STARTER_SLUG: ((ocw-import-starter-slug))
           SITEMAP_DOMAIN: ((sitemap-domain))
+          OCW_HUGO_THEMES_SENTRY_DSN: ((ocw-hugo-themes-sentry-dsn))
           # START DEV-ONLY
           RESOURCE_BASE_URL: ((resource-base-url))
           # END DEV-ONLY

--- a/main/settings.py
+++ b/main/settings.py
@@ -1132,3 +1132,8 @@ SITEMAP_DOMAIN = get_string(
     default="ocw.mit.edu",
     description="The domain to be used in Hugo builds for fully qualified URLs in the sitemap",
 )
+OCW_HUGO_THEMES_SENTRY_DSN = get_string(
+    name="OCW_HUGO_THEMES_SENTRY_DSN",
+    required=False,
+    description="The sentry DSN that will be used in ocw-hugo-themes",
+)


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
- None

#### What's this PR do?
- Sets `OCW_HUGO_THEMES_SENTRY_DSN` env so it can be templated into the pipelines

#### How should this be manually tested?
- Checkout this branch
- Set any value for `OCW_HUGO_THEMES_SENTRY_DSN` in your `.env` file.
- Run `backpopulate_pipelines` or `upsert_mass_build_pipeline` and verify that the env value is propagated into your local pipelines.

#### Any background context you want to provide?
- This PR has a dependency on https://github.com/mitodl/ocw-hugo-themes/pull/903

