### PR TITLE
Use registry-image in concourse pipelines

### DIFF
--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -207,14 +207,14 @@ jobs:
               echo "STARTING S3 SYNC FOR $NAME" > /dev/tty
               # START OFFLINE-ONLY
               cd $CURDIR/$SHORT_ID/public
-              zip $NAME.zip -r ./
-              PUBLISH_S3_RESULT=$(aws s3((cli-endpoint-url)) sync ./ s3://((ocw-bucket))$PREFIX/$BASE_URL --exclude="*" --include="$NAME.zip" --metadata site-id=$NAME --only-show-errors) || PUBLISH_S3_RESULT=1
+              zip $SHORT_ID.zip -r ./
+              PUBLISH_S3_RESULT=$(aws s3((cli-endpoint-url)) sync ./ s3://((ocw-bucket))$PREFIX/$BASE_URL --exclude="*" --include="$SHORT_ID.zip" --metadata site-id=$NAME --only-show-errors) || PUBLISH_S3_RESULT=1
               if [[ $PUBLISH_S3_RESULT == 1 ]]
               then
-                echo "SYNCING $NAME.zip to s3://((ocw-bucket))$PREFIX/$SITE_URL failed for $NAME" > /dev/tty
+                echo "SYNCING $SHORT_ID.zip to s3://((ocw-bucket))$PREFIX/$SITE_URL failed for $NAME" > /dev/tty
                 return 1
               fi
-              rm $NAME.zip
+              rm $SHORT_ID.zip
               cd $CURDIR
               # END OFFLINE-ONLY
               # START ONLINE-ONLY

--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -1,12 +1,12 @@
 ---
 resource_types:
   - name: http-resource
-    type: docker-image
+    type: registry-image
     source:
       repository: jgriff/http-resource
       tag: latest
   - name: s3-resource-iam
-    type: docker-image
+    type: registry-image
     source:
       repository: governmentpaas/s3-resource
       tag: latest
@@ -37,7 +37,7 @@ resources:
 task-config: &webhook-config
   platform: linux
   image_resource:
-    type: docker-image
+    type: registry-image
     source: {repository: curlimages/curl}
 # END ONLINE-ONLY
 jobs:
@@ -65,7 +65,7 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source: {repository: mitodl/ocw-course-publisher, tag: 0.3}
       inputs:
       - name: ocw-hugo-themes
@@ -91,7 +91,7 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source: {repository: bash, tag: latest}
       outputs:
         - name: publishable_sites
@@ -121,7 +121,7 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source: {repository: mitodl/ocw-course-publisher, tag: 0.3}
       inputs:
         - name: publishable_sites
@@ -140,7 +140,7 @@ jobs:
             if [[ "$GIT_KEY" != "" ]]
             then
               echo $GIT_KEY > $CURDIR/git.key
-              sed -i -E "s/(-----BEGIN[^-]+-----)(.+)(-----END[^-]+-----)/-----BEGINSSHKEY-----\2\-----ENDSSHKEY-----/" git.key  
+              sed -i -E "s/(-----BEGIN[^-]+-----)(.+)(-----END[^-]+-----)/-----BEGINSSHKEY-----\2\-----ENDSSHKEY-----/" git.key
               sed -i -E "s/\s/\n/g" git.key
               sed -i -E "s/SSHKEY/ OPENSSH PRIVATE KEY/g" git.key
               chmod 400 $CURDIR/git.key
@@ -271,7 +271,7 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source: {repository: curlimages/curl}
       run:
         path: curl

--- a/content_sync/pipelines/definitions/concourse/remove-unpublished-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/remove-unpublished-sites.yml
@@ -1,19 +1,19 @@
 ---
 resource_types:
   - name: http-resource
-    type: docker-image
+    type: registry-image
     source:
       repository: jgriff/http-resource
       tag: latest
   - name: s3-resource-iam
-    type: docker-image
+    type: registry-image
     source:
       repository: governmentpaas/s3-resource
       tag: latest
 task-config: &webhook-config
   platform: linux
   image_resource:
-    type: docker-image
+    type: registry-image
     source: {repository: curlimages/curl}
 jobs:
 - name: remove-unpublished-sites
@@ -25,7 +25,7 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source: {repository: bash, tag: latest}
       outputs:
         - name: unpublishable_sites
@@ -51,7 +51,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source: {repository: curlimages/curl}
         run:
           path: curl
@@ -96,7 +96,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source: {repository: amazon/aws-cli, tag: latest}
         run:
           path: sh
@@ -131,7 +131,7 @@ jobs:
       config:
         platform: linux
         image_resource:
-          type: docker-image
+          type: registry-image
           source: {repository: curlimages/curl}
         run:
           path: curl

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -1,18 +1,18 @@
 ---
 resource_types:
   - name: http-resource
-    type: docker-image
+    type: registry-image
     source:
       repository: jgriff/http-resource
       tag: latest
   - name: s3-resource-iam
-    type: docker-image
+    type: registry-image
     source:
       repository: governmentpaas/s3-resource
       tag: latest
   # START NON-DEV
   - name: slack-alert
-    type: docker-image
+    type: registry-image
     source:
       repository: arbourd/concourse-slack-alert-resource
       tag: v0.15.0
@@ -101,7 +101,7 @@ jobs:
                       "version": "((pipeline_name))",
                       "status": "errored"
                     }
-            # START NON-DEV  
+            # START NON-DEV
             - put: slack-webhook
               timeout: 1m
               params:
@@ -119,7 +119,7 @@ jobs:
                       "version": "((pipeline_name))",
                       "status": "errored"
                     }
-            # START NON-DEV  
+            # START NON-DEV
             - put: slack-webhook
               timeout: 1m
               params:
@@ -137,7 +137,7 @@ jobs:
                       "version": "((pipeline_name))",
                       "status": "aborted"
                     }
-            # START NON-DEV  
+            # START NON-DEV
             - put: slack-webhook
               timeout: 1m
               params:
@@ -333,7 +333,7 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source: {repository: mitodl/ocw-course-publisher, tag: 0.3}
           inputs:
             - name: ocw-hugo-themes
@@ -419,14 +419,14 @@ jobs:
             - name: course-markdown
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source: {repository: amazon/aws-cli, tag: latest}
           run:
             path: sh
             args:
             - -exc
             - |
-              aws s3((cli-endpoint-url)) sync s3://((ocw-studio-bucket))/((s3-path)) s3://((ocw-bucket))/((site-url)) --metadata site-id=((site-name))              
+              aws s3((cli-endpoint-url)) sync s3://((ocw-studio-bucket))/((s3-path)) s3://((ocw-bucket))/((site-url)) --metadata site-id=((site-name))
               aws s3((cli-endpoint-url)) sync course-markdown/public s3://((ocw-bucket))/((base-url)) --metadata site-id=((site-name))
         # START DEV-ONLY
         on_success:
@@ -506,7 +506,7 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source: {repository: curlimages/curl}
           run:
             path: curl

--- a/content_sync/pipelines/definitions/concourse/theme-assets-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/theme-assets-pipeline.yml
@@ -17,7 +17,7 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source: {repository: mitodl/ocw-course-publisher, tag: 0.3}
       inputs:
       - name: ocw-hugo-themes
@@ -47,7 +47,7 @@ jobs:
         AWS_SECRET_ACCESS_KEY: ((minio-root-password))
       # END DEV-ONLY
       image_resource:
-        type: docker-image
+        type: registry-image
         source: {repository: amazon/aws-cli, tag: latest}
       run:
         path: sh
@@ -64,7 +64,7 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source: {repository: curlimages/curl}
       run:
         path: curl
@@ -81,7 +81,7 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source: {repository: curlimages/curl}
       run:
         path: curl


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1550.

#### What's this PR do?
Updates the concourse pipeline definitions to use `registry-image` instead of `docker-image`. For additional background, please see https://github.com/concourse/registry-image-resource#comparison-to-docker-image-resource.

#### How should this be manually tested?

All of the relevant pipelines should be tested, ideally on both Apple Silicon and Intel processors, to make sure that no compatibility issues arise. Note that for Apple Silicon, we are using the `rdclda/concourse:7.7.1` Docker image for concourse.

For example, to upsert the theme assets, execute `docker-compose exec web ./manage.py upsert_theme_assets_pipeline --delete-all`.
