### PR TITLE
add site_short_id to JSON file serializer

### DIFF
--- a/content_sync/serializers.py
+++ b/content_sync/serializers.py
@@ -143,6 +143,7 @@ class JsonFileSerializer(BaseContentFileSerializer):
         metadata = website_content.metadata
         if website_content.type == CONTENT_TYPE_METADATA:
             metadata["site_uid"] = str(website_content.website.uuid)
+            metadata["site_short_id"] = str(website_content.website.short_id)
 
         return json.dumps(
             self.serialize_contents(metadata, website_content.title),


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Prerequisite for https://github.com/mitodl/ocw-hugo-themes/issues/937

#### What's this PR do?
This PR adds `Website.short_id` to JSON files serialized through `content_sync.serializers.JsonFileSerializer` as `site_short_id`. When sites are being rendered in Hugo, it will be useful to have the `short_id` property to check if a ZIP download of a given site exists. In https://github.com/mitodl/ocw-studio/pull/1546 we set the offline mass site build to name the ZIP files using a site's `short_id`. The content Github repos are also named with the same ID and it will be useful in the future to have a unique way to refer to a given site being rendered.

#### How should this be manually tested?
 - First of all, make sure you've taken care of the following prerequisites:
   - `ocw-studio` up and running
   - Custom Github test organization configured
   - Minio support configured
   - Concourse support configured
 - Reset the sync states for a site in your local `ocw-studio` using the `reset_sync_states` and push to the backend with `sync_website_to_backend`, then publish the site live through the studio UI
 - Browse to your private Github org and find the repo matching your site
 - Browse to the `data/course.json` file and verify that the `site_short_id` property contains the site's `short_id`
