### PR TITLE
Raising an error when 3Play transcript submission fails

### DIFF
--- a/videos/threeplay_api.py
+++ b/videos/threeplay_api.py
@@ -105,7 +105,7 @@ def threeplay_order_transcript_request(video_id: int, threeplay_video_id: int) -
     if response:
         return response.json()
     else:
-        return {}
+        raise Exception("3Play transcript request failed for video_id " + str(video_id))
 
 
 def threeplay_remove_tags(threeplay_video_id: int):


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1450.

#### What's this PR do?
Instead of silently failing when a transcript request to 3Play does not go through, this PR adds functionality to raise an exception.

#### How should this be manually tested?

To test this locally, start a local Django shell with `docker-compose run --rm web ./manage.py shell` and then run `from videos import threeplay_api`. Test giving invalid input to `threeplay_api.threeplay_order_transcript_request` and check that an exception is raised.