### PR TITLE
Issue slack alert when theme assets pipeline fails

### DIFF
--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -528,6 +528,7 @@ class ThemeAssetsPipeline(GeneralPipeline, BaseThemeAssetsPipeline):
                 "((ocw-hugo-themes-sentry-dsn))",
                 settings.OCW_HUGO_THEMES_SENTRY_DSN or "",
             )
+            .replace("((atc-search-params))", self.instance_vars)
         )
         self.upsert_config(config_str, self.PIPELINE_NAME)
 

--- a/content_sync/pipelines/definitions/concourse/theme-assets-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/theme-assets-pipeline.yml
@@ -1,21 +1,21 @@
 ---
 resource_types:
- #
+ # START NON-DEV
   - name: slack-alert
     type: registry-image
     source:
       repository: arbourd/concourse-slack-alert-resource
       tag: v0.15.0
-  #
+  # END NON-DEV
 resources:
-#
+  # START NON-DEV
 - name: slack-webhook
   type: slack-alert
   check_every: never
   source:
     url: ((slack-webhook))
     disabled: false
-#
+  # END NON-DEV
 - name: ocw-hugo-themes
   type: git
   source:
@@ -110,7 +110,7 @@ jobs:
           - 'Fastly-Key: ((fastly_live.api_token))'((purge_header))
           - https://api.fastly.com/service/((fastly_live.service_id))/purge/ocw-hugo-themes
   # END NON-DEV
-  #
+  # START NON-DEV
   on_failure:
     try:
       do:
@@ -133,4 +133,4 @@ jobs:
             User aborted while building theme assets.
             
             Append `((atc-search-params))` to the url below for more details.
-#
+   # END NON-DEV

--- a/content_sync/pipelines/definitions/concourse/theme-assets-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/theme-assets-pipeline.yml
@@ -1,5 +1,21 @@
 ---
+resource_types:
+ #
+  - name: slack-alert
+    type: registry-image
+    source:
+      repository: arbourd/concourse-slack-alert-resource
+      tag: v0.15.0
+  #
 resources:
+#
+- name: slack-webhook
+  type: slack-alert
+  check_every: never
+  source:
+    url: ((slack-webhook))
+    disabled: false
+#
 - name: ocw-hugo-themes
   type: git
   source:
@@ -94,3 +110,27 @@ jobs:
           - 'Fastly-Key: ((fastly_live.api_token))'((purge_header))
           - https://api.fastly.com/service/((fastly_live.service_id))/purge/ocw-hugo-themes
   # END NON-DEV
+  #
+  on_failure:
+    try:
+      do:
+      - put: slack-webhook
+        timeout: 1m
+        params:
+          alert_type: failed
+          text: |
+            Failed to build theme assets.
+            
+            Append `((atc-search-params))` to the url below for more details.
+  on_abort:
+    try:
+      do:
+      - put: slack-webhook
+        timeout: 1m
+        params:
+          alert_type: aborted
+          text: |
+            User aborted while building theme assets.
+            
+            Append `((atc-search-params))` to the url below for more details.
+#


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1558 

#### What's this PR do?
This PR uses concourse's [job hooks](https://concourse-ci.org/hooks-example.html#hooks-example) to issue a slack alert when a job is aborted or fails. 

#### How should this be manually tested?
Two options: either don't test it locally—we can test it on rc using our actual slack channel—or test on your own slack organization.

If you would like to test locally:
1. [Create a slack workspace](https://slack.com/help/articles/206845317-Create-a-Slack-workspace) _or use a workspace you already own_
2. In the workspace you own, [create a slack app and enable incoming webhooks](https://api.slack.com/messaging/webhooks#getting_started__1.-create-a-slack-app-if-you-dont-have-one-already). Use whatever channel you want.
3. Copy the webhook URL
4. Checkout this branch, and modify `theme-assets-pipeline.yml`:
    - replace `((slack-webhook))` with your webhook url
    - remove the `START NON-DEV` and `END NON-DEV` comments surrounding the webhook stuff. (Or checkout  https://github.com/mitodl/ocw-studio/commit/a1f061567d2a75b7341ee9c2a36176c32570d393, the first commit in this two-commit PR, which does not have those comments.)
5. `docker compose run --rm web ./manage.py upsert_theme_assets_pipeline` 
6. In your local concourse ui http://concourse:8080/:
    - trigger a theme assets build
    - abort it
    - check your slack channel for notification
7. Insert some artificial error into the pipeline definition, re-upsert the pipeline, and start it. The pipeline should fail, and you should get a slack notification.