### PR TITLE
filter out mp4 files in the offline mass-build-sites

### DIFF
--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -180,7 +180,7 @@ jobs:
               # END ONLINE-ONLY
               # START OFFLINE-ONLY
               echo "PULLING IN STATIC RESOURCES FOR $NAME" > /dev/tty
-              STUDIO_S3_RESULT=$(aws s3((cli-endpoint-url)) sync s3://((ocw-studio-bucket))/$S3_PATH ./content/static_resources --only-show-errors) || STUDIO_S3_RESULT=1
+              STUDIO_S3_RESULT=$(aws s3((cli-endpoint-url)) sync s3://((ocw-studio-bucket))/$S3_PATH ./content/static_resources --exclude "*.mp4" --only-show-errors) || STUDIO_S3_RESULT=1
               if [[ $STUDIO_S3_RESULT == 1 ]]
               then
                 echo "SYNCING s3://((ocw-studio-bucket))/$S3_PATH to ./content/static_resources FAILED FOR $NAME" > /dev/tty


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1578

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/1453 and some subsequent PR's, we added the ability to upsert an alternate version of the `mass-build-sites` pipeline that builds sites using the offline configuration for a given site in `ocw-hugo-themes` / `ocw-hugo-projects`. The output of these offline sites are zipped up and pushed up to S3 along with the live version of the site for download. For legacy OCW courses, which are the majority of courses on the platform at this point, there is no issue. For newer course created exclusively through studio with their videos uploaded through there, a 360p version of the video is included alongside the other resources in the `ol-ocw-studio-app-qa/production` buckets. This is being pulled in with the other static resources during the ZIP build and bloats the size of the archive. This PR simply sets the `aws s3 sync` command that pulls in the static resources to filter out mp4 files.

#### How should this be manually tested?
 - You should have `ocw-studio` up and running with Minio and Concourse configured. Go ahead and also set the following env variables in your `.env` before we get started:
```
OCW_HUGO_THEMES_BRANCH=main
OCW_HUGO_PROJECTS_BRANCH=main
OCW_COURSE_STARTER_SLUG=ocw-course-v2
```
 - Since we are testing a change to the mass build, we'll want to artificially limit the amount of sites it processes. Make the following edit to line 341 of `websites/views.py`, swapping out the course id for any course you want to test: `sites = sites.prefetch_related("starter").order_by("name").filter(name="18-102-introduction-to-functional-analysis-spring-2021")`
 - Navigate to the Minio dashboard at http://localhost:9001 and log in
 - Browse to `ol-ocw-studio-app/courses/18-102-introduction-to-functional-analysis-spring-2021`, replacing the course id with whatever course you are using to test. If the folder doesn't exist, you will need to create it. Drop any `.mp4` file inside this directory.
 - Upsert the offline mass build pipeline with `docker-compose exec web ./manage.py upsert_mass_build_pipeline --offline --starter ocw-course-v2`
 - Browse to your local Concourse instance at http://localhost:8080/ and log in
 - Browse to the `mass-build-sites` pipelines folder and select the live version of the pipeline we just upserted with `offline: true` and trigger a build
 - Wait for the build to complete, then go back to our folder in Minio. There should be a ZIP file there in the folder. Download the ZIP file and extract it. Verify that your mp4 file *does not* exist in the `static_resources` folder.
