### PR TITLE
use slug and not name when filtering publishable sites by starter

### DIFF
--- a/websites/views.py
+++ b/websites/views.py
@@ -337,7 +337,7 @@ class WebsiteMassBuildViewSet(viewsets.ViewSet):
             sites = sites.exclude(unpublish_status__isnull=False)
         # If a starter has been specified by the query, only return sites made with that starter
         if starter:
-            sites = sites.filter(starter=WebsiteStarter.objects.get(name=starter))
+            sites = sites.filter(starter=WebsiteStarter.objects.get(slug=starter))
         sites = sites.prefetch_related("starter").order_by("name")
         serializer = WebsiteMassBuildSerializer(instance=sites, many=True)
         return Response({"sites": serializer.data})


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1581

#### What's this PR do?
Recently, an update was released to the `ocw-course` theme called `ocw-course-v2`. A new starter configuration was created in `ocw-hugo-projects` for the theme update so it could be tested alongside the original course theme. Once `ocw-course-v2` was released, course authors were confused as to whether they should use `ocw-course` or `ocw-course-v2`. As a solution to this, the original `ocw-course` starter was removed and the `ocw-course-v2` starter had its `name` property changed to `ocw-course`, leaving the slug as `ocw-course-v2` so the proper configuration is pulled in at build time.

In https://github.com/mitodl/ocw-studio/pull/1467, we added the `--starter` argument to the `upsert_mass_build_pipeline` management command. This flag sets the argument to be used when querying for publishable sites in `ocw-studio` before running `mass-build-sites`. This is meant to be used alongside the `--offline` flag. This way, when the offline mass build is triggered, it will only generate offline sites for courses using the specified starter configuration and not `ocw-www`.

The main issue here is that in the above PR, this filter was set up to use `WebsiteStarter.name` and not `WebsiteStarter.slug`. This PR changes the filter to use `WebsiteStarter.slug` so that changes to the name do not affect the filtering functionality.

#### How should this be manually tested?
 - This PR is most simply tested using a program like [Postman](https://www.postman.com/)
 - Check out the `master` branch
 - Spin up `ocw-studio` locally, making sure that `API_BEARER_TOKEN` is set to something
 - Make sure you have an `ocw-course-v2` starter in your database and `ocw-course` is not present (a recent database restore should reflect this)
 - Open Postman and form a new request to http://localhost:8043/api/publish/?version=live&starter=ocw-course-v2, putting your `API_BEARER_TOKEN` in the Bearer Token field under Authorization
 - Verify that the request comes back with a 500 error
 - Switch to this PR branch and restart `ocw-studio`
 - Repeat the above steps and verify that the request returns results now
