### PR TITLE
change slack-webhook to slack-url var

### DIFF
--- a/content_sync/pipelines/definitions/concourse/theme-assets-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/theme-assets-pipeline.yml
@@ -13,7 +13,7 @@ resources:
   type: slack-alert
   check_every: never
   source:
-    url: ((slack-webhook))
+    url: ((slack-url))
     disabled: false
   # END NON-DEV
 - name: ocw-hugo-themes


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
#1558 

#### What's this PR do?
This PR is a followup to #1576. In that PR, I made a mistake naming the variable. Now the variable is `slack-url`, just like in the site pipelines.

#### How should this be manually tested?
It should be tested on RC: All other testing of this functionality was done with #1576. This just changes how concourse gets the var from vault.
