### PR TITLE
Adding management command to delete objects with missing type

### DIFF
--- a/websites/management/commands/delete_missing_type_objects.py
+++ b/websites/management/commands/delete_missing_type_objects.py
@@ -10,7 +10,11 @@ class Command(BaseCommand):
     help = __doc__
 
     def handle(self, *args, **options):
-        for content in WebsiteContent.objects.all(force_visibility=True).filter(
+        missing_type_content = WebsiteContent.objects.all(force_visibility=True).filter(
             type=""
-        ):
+        )
+        for content in missing_type_content:
             content.delete(force_policy=HARD_DELETE)
+        self.stdout.write(
+            str(len(missing_type_content)) + " objects with missing type deleted.\n"
+        )


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1577.

#### What's this PR do?
Adds a management command for deleting objects that have been soft-deleted but still remain in the Django database.

#### How should this be manually tested?
First, make sure that you have a reasonably recent copy of the production database in your local instance of OCW Studio. Then, start a Django shell interactive session, by running `docker-compose run --rm web manage.py shell`. Run the following code to see the list of objects that have missing type:

```
from websites.models import WebsiteContent
for content in WebsiteContent.objects.all(force_visibility=True).filter(type=""):
    print(content.website.short_id, content.id)
```

Then, run 
`docker-compose run --rm web ./manage.py delete_missing_type_objects`.

Run the code block above again to verify that no objects with missing type remain in the database.