### PR TITLE
Subscripts and superscripts

### DIFF
--- a/static/js/components/widgets/MarkdownEditor.test.tsx
+++ b/static/js/components/widgets/MarkdownEditor.test.tsx
@@ -38,7 +38,7 @@ jest.mock("@ckeditor/ckeditor5-react", () => ({
 }))
 
 const render = (props = {}) =>
-  shallow(<MarkdownEditor link={[]} embed={[]} {...props} />)
+  shallow(<MarkdownEditor allowedHtml={[]} link={[]} embed={[]} {...props} />)
 
 describe("MarkdownEditor", () => {
   let sandbox: SinonSandbox

--- a/static/js/components/widgets/MarkdownEditor.tsx
+++ b/static/js/components/widgets/MarkdownEditor.tsx
@@ -18,7 +18,8 @@ import {
   ResourceCommandMap,
   ResourceDialogMode,
   ADD_RESOURCE_EMBED,
-  RESOURCE_LINK
+  RESOURCE_LINK,
+  MARKDOWN_CONFIG_KEY
 } from "../../lib/ckeditor/plugins/constants"
 import ResourcePickerDialog from "./ResourcePickerDialog"
 import useThrowSynchronously from "../../hooks/useAsyncError"
@@ -31,6 +32,7 @@ export interface Props {
   minimal?: boolean
   embed: string[]
   link: string[]
+  allowedHtml: string[]
 }
 
 type RenderQueueEntry = [string, HTMLElement]
@@ -41,7 +43,7 @@ type RenderQueueEntry = [string, HTMLElement]
  * pass minimal: true to get a minimal version.
  */
 export default function MarkdownEditor(props: Props): JSX.Element {
-  const { link, embed, value, name, onChange, minimal } = props
+  const { link, embed, value, name, onChange, minimal, allowedHtml } = props
   const throwSynchronously = useThrowSynchronously()
 
   const editor = useRef<editor.Editor>()
@@ -100,6 +102,12 @@ export default function MarkdownEditor(props: Props): JSX.Element {
       if (item === ADD_RESOURCE_EMBED) {
         return embed.length > 0
       }
+      if (item === "superscript") {
+        return allowedHtml.includes("sup")
+      }
+      if (item === "subscript") {
+        return allowedHtml.includes("sub")
+      }
       return true
     }
 
@@ -128,10 +136,13 @@ export default function MarkdownEditor(props: Props): JSX.Element {
         toolbar: {
           ...FullEditorConfig.toolbar,
           items: FullEditorConfig.toolbar.items.filter(toolbarItemsFilter)
+        },
+        [MARKDOWN_CONFIG_KEY]: {
+          allowedHtml
         }
       }
     }
-  }, [minimal, renderResource, openResourcePicker, link, embed])
+  }, [minimal, renderResource, openResourcePicker, link, embed, allowedHtml])
 
   const onChangeCB = useCallback(
     (_event: any, editor: any) => {

--- a/static/js/lib/ckeditor/CKEditor.ts
+++ b/static/js/lib/ckeditor/CKEditor.ts
@@ -25,7 +25,11 @@ import { editor } from "@ckeditor/ckeditor5-core"
 import Markdown from "./plugins/Markdown"
 import ResourceEmbed from "./plugins/ResourceEmbed"
 import ResourcePicker from "./plugins/ResourcePicker"
-import { ADD_RESOURCE_EMBED, ADD_RESOURCE_LINK } from "./plugins/constants"
+import {
+  ADD_RESOURCE_EMBED,
+  ADD_RESOURCE_LINK,
+  MARKDOWN_CONFIG_KEY
+} from "./plugins/constants"
 import ResourceLink from "@mitodl/ckeditor5-resource-link/src/link"
 import { RESOURCE_LINK_COMMAND } from "@mitodl/ckeditor5-resource-link/src/constants"
 import ResourceLinkMarkdownSyntax, {

--- a/static/js/lib/ckeditor/CKEditor.ts
+++ b/static/js/lib/ckeditor/CKEditor.ts
@@ -1,6 +1,8 @@
 import EssentialsPlugin from "@ckeditor/ckeditor5-essentials/src/essentials"
 import AutoformatPlugin from "@ckeditor/ckeditor5-autoformat/src/autoformat"
 import BoldPlugin from "@ckeditor/ckeditor5-basic-styles/src/bold"
+import SubscriptPlugin from "@ckeditor/ckeditor5-basic-styles/src/subscript"
+import SuperscriptPlugin from "@ckeditor/ckeditor5-basic-styles/src/superscript"
 import ItalicPlugin from "@ckeditor/ckeditor5-basic-styles/src/italic"
 import BlockQuotePlugin from "@ckeditor/ckeditor5-block-quote/src/blockquote"
 import HeadingPlugin from "@ckeditor/ckeditor5-heading/src/heading"
@@ -86,6 +88,8 @@ export const FullEditorConfig = {
     ResourcePicker,
     ResourceLink,
     ResourceLinkMarkdownSyntax,
+    SubscriptPlugin,
+    SuperscriptPlugin,
     TableMarkdownSyntax,
     MathSyntax, // Needs to go before MarkdownListSyntax
     MarkdownListSyntax,
@@ -100,6 +104,8 @@ export const FullEditorConfig = {
       "|",
       "bold",
       "italic",
+      "subscript",
+      "superscript",
       "link",
       "bulletedList",
       "numberedList",

--- a/static/js/lib/ckeditor/CKEditor.ts
+++ b/static/js/lib/ckeditor/CKEditor.ts
@@ -25,11 +25,7 @@ import { editor } from "@ckeditor/ckeditor5-core"
 import Markdown from "./plugins/Markdown"
 import ResourceEmbed from "./plugins/ResourceEmbed"
 import ResourcePicker from "./plugins/ResourcePicker"
-import {
-  ADD_RESOURCE_EMBED,
-  ADD_RESOURCE_LINK,
-  MARKDOWN_CONFIG_KEY
-} from "./plugins/constants"
+import { ADD_RESOURCE_EMBED, ADD_RESOURCE_LINK } from "./plugins/constants"
 import ResourceLink from "@mitodl/ckeditor5-resource-link/src/link"
 import { RESOURCE_LINK_COMMAND } from "@mitodl/ckeditor5-resource-link/src/constants"
 import ResourceLinkMarkdownSyntax, {

--- a/static/js/lib/ckeditor/plugins/Markdown.test.ts
+++ b/static/js/lib/ckeditor/plugins/Markdown.test.ts
@@ -111,3 +111,40 @@ describe("Multiple Markdown CKEditors", () => {
     expect(sup.html2md(paragraph)).toBe("Hello world sub123 sup<sup>abc</sup>!")
   })
 })
+
+describe("Handling of raw HTML", () => {
+  const getEditor = createTestEditor([Markdown], {
+    "markdown-config": { allowedHtml: ["sup"] }
+  })
+
+  test("When raw HTML is allowed, its content is converted to markdown", async () => {
+    const editor = await getEditor()
+
+    const html =
+      '<p>Hello world <sup><a href="https://mit.edu">mit</a></sup>!</p>'
+    const markdown = "Hello world <sup>[mit](https://mit.edu)</sup>!"
+    markdownTest(editor, markdown, html)
+  })
+
+  test("Raw HTML at the beginning of a line gets an extra zwsp", async () => {
+    const editor = await getEditor()
+    const { md2html, html2md } = getConverters(editor)
+
+    const html = "<p><sup>1</sup> First <strong>important</strong> footnote</p>"
+    const md = "\u200b<sup>1</sup> First **important** footnote"
+    expect(html2md(html)).toBe(md)
+    expect(md2html(md)).toBe(
+      "<p>\u200b<sup>1</sup> First <strong>important</strong> footnote</p>"
+    )
+  })
+
+  test("Raw block HTML throws errors, for now", async () => {
+    const editor = await getEditor("", {
+      "markdown-config": { allowedHtml: ["div"] }
+    })
+    const { html2md } = getConverters(editor)
+
+    const html = "<p>Hello world!</p> <div>mit</div>"
+    expect(() => html2md(html)).toThrow()
+  })
+})

--- a/static/js/lib/ckeditor/plugins/Markdown.test.ts
+++ b/static/js/lib/ckeditor/plugins/Markdown.test.ts
@@ -147,4 +147,23 @@ describe("Handling of raw HTML", () => {
     const html = "<p>Hello world!</p> <div>mit</div>"
     expect(() => html2md(html)).toThrow()
   })
+
+  /**
+   * This is different from Turndown's default behavior.
+   */
+  test("Disallowed children of allowed tags are not included", async () => {
+    const editor = await getEditor("", {
+      "markdown-config": { allowedHtml: ["sup", "span"] }
+    })
+    const { html2md } = getConverters(editor)
+
+    const html = `
+    <p>
+    hello <sup><span>meow</span><script>alert("maliciousness")</script></sup> world
+    </p>
+    `
+    expect(html2md(html)).toBe(
+      'hello <sup><span>meow</span>alert("maliciousness")</sup> world'
+    )
+  })
 })

--- a/static/js/lib/ckeditor/plugins/Markdown.test.ts
+++ b/static/js/lib/ckeditor/plugins/Markdown.test.ts
@@ -126,17 +126,25 @@ describe("Handling of raw HTML", () => {
     markdownTest(editor, markdown, html)
   })
 
-  test("Raw HTML at the beginning of a line gets an extra zwsp", async () => {
-    const editor = await getEditor()
-    const { md2html, html2md } = getConverters(editor)
+  test.each([
+    {
+      html: "<p><sup>1</sup> First <strong>important</strong> footnote</p>",
+      md:   "\u200b<sup>1</sup> First **important** footnote"
+    },
+    {
+      html:
+        "<p>cat</p><p><sup>1</sup> First <strong>important</strong> footnote</p>",
+      md: "cat\n\n\u200b<sup>1</sup> First **important** footnote"
+    }
+  ])(
+    "Raw HTML at the beginning of a line gets an extra zwsp",
+    async ({ html, md }) => {
+      const editor = await getEditor()
+      const { html2md } = getConverters(editor)
 
-    const html = "<p><sup>1</sup> First <strong>important</strong> footnote</p>"
-    const md = "\u200b<sup>1</sup> First **important** footnote"
-    expect(html2md(html)).toBe(md)
-    expect(md2html(md)).toBe(
-      "<p>\u200b<sup>1</sup> First <strong>important</strong> footnote</p>"
-    )
-  })
+      expect(html2md(html)).toBe(md)
+    }
+  )
 
   test("Raw block HTML throws errors, for now", async () => {
     const editor = await getEditor("", {

--- a/static/js/lib/ckeditor/plugins/Markdown.test.ts
+++ b/static/js/lib/ckeditor/plugins/Markdown.test.ts
@@ -93,4 +93,21 @@ describe("Multiple Markdown CKEditors", () => {
     expect(cat.html2md(paragraph)).toBe("meowmeowmeow!")
     expect(dog.html2md(paragraph)).toBe("woofwoofwoof!")
   })
+
+  test("Separate editors can use conflicting allowedHtml lists", async () => {
+    const subEditor = await createTestEditor([Markdown], {
+      "markdown-config": { allowedHtml: ["sub"] }
+    })()
+    const supEditor = await createTestEditor([Markdown], {
+      "markdown-config": { allowedHtml: ["sup"] }
+    })()
+
+    const sub = getConverters(subEditor)
+    const sup = getConverters(supEditor)
+
+    const paragraph = "<p>Hello world sub<sub>123</sub> sup<sup>abc</sup>!</p>"
+
+    expect(sub.html2md(paragraph)).toBe("Hello world sub<sub>123</sub> supabc!")
+    expect(sup.html2md(paragraph)).toBe("Hello world sub123 sup<sup>abc</sup>!")
+  })
 })

--- a/static/js/lib/ckeditor/plugins/Markdown.ts
+++ b/static/js/lib/ckeditor/plugins/Markdown.ts
@@ -6,7 +6,11 @@ import { editor } from "@ckeditor/ckeditor5-core"
 import MarkdownConfigPlugin from "./MarkdownConfigPlugin"
 import { ATTRIBUTE_REGEX } from "./constants"
 
-import { resetTurndownService, turndownService } from "../turndown"
+import {
+  resetTurndownService,
+  turndownService,
+  turndownHtmlHelpers
+} from "../turndown"
 import Turndown from "turndown"
 import { buildAttrsString } from "./util"
 import { validateHtml2md } from "./validateMdConversion"
@@ -159,9 +163,10 @@ export default class Markdown extends MarkdownConfigPlugin {
     try {
       turndownService.rules.array = this.turndownRules
 
+      turndownService.rules.keepReplacement = turndownHtmlHelpers.keepReplacer
       turndownService.keep(this.allowedHtml)
 
-      return turndownService.turndown(html)
+      return turndownHtmlHelpers.turndown(html)
     } finally {
       resetTurndownService()
     }

--- a/static/js/lib/ckeditor/plugins/Markdown.ts
+++ b/static/js/lib/ckeditor/plugins/Markdown.ts
@@ -6,7 +6,7 @@ import { editor } from "@ckeditor/ckeditor5-core"
 import MarkdownConfigPlugin from "./MarkdownConfigPlugin"
 import { ATTRIBUTE_REGEX } from "./constants"
 
-import { turndownService } from "../turndown"
+import { resetTurndownService, turndownService } from "../turndown"
 import Turndown from "turndown"
 import { buildAttrsString } from "./util"
 import { validateHtml2md } from "./validateMdConversion"
@@ -70,28 +70,6 @@ export class MarkdownDataProcessor extends GFMDataProcessor {
 const TD_CONTENT_REGEX = /<td.*?>([\S\s]*?)<\/td>/g
 const TH_CONTENT_REGEX = /<th(?!ead).*?>([\S\s]*?)<\/th>/g
 
-const BASE_TURNDOWN_RULES = [...turndownService.rules.array]
-
-const BASE_TURNDOWN_KEEP = [
-  // @ts-expect-error `_keep` is not part of Turndown's public API, see `resetTurndownKeep` for more.
-  ...turndownService.rules._keep
-]
-/**
- * By default, Turndown does not keep any HTML tags when converting from html -> md.
- * We can tell turndown to keep some tags via a `turndown.keep(tags)`. Subsequent
- * calls to `keep` ADD more tags that turndown should keep.
- *
- * Howevver, Turndown has no public API to remove tags from the keep list after
- * they have been added.
- *
- * All of these machinations are only necessary because CKEditor's GFM plugin
- * uses a single global turndown instance.
- */
-const resetTurndownKeep = () => {
-  // @ts-expect-error `_keep` is not part of Turndown's public API, see `resetTurndownKeep` for more.
-  turndownService.rules._keep = [...BASE_TURNDOWN_KEEP]
-}
-
 /**
  * Plugin implementing Markdown for CKEditor
  *
@@ -119,7 +97,7 @@ export default class Markdown extends MarkdownConfigPlugin {
 
     converter.setFlavor("github")
 
-    turndownService.rules.array = [...BASE_TURNDOWN_RULES]
+    resetTurndownService()
     turndownRules.forEach(({ name, rule }) =>
       turndownService.addRule(name, rule)
     )
@@ -181,11 +159,11 @@ export default class Markdown extends MarkdownConfigPlugin {
     try {
       turndownService.rules.array = this.turndownRules
 
-      resetTurndownKeep()
       turndownService.keep(this.allowedHtml)
+
       return turndownService.turndown(html)
     } finally {
-      turndownService.rules.array = BASE_TURNDOWN_RULES
+      resetTurndownService()
     }
   }
 

--- a/static/js/lib/ckeditor/plugins/MarkdownConfigPlugin.ts
+++ b/static/js/lib/ckeditor/plugins/MarkdownConfigPlugin.ts
@@ -2,8 +2,7 @@ import Plugin from "@ckeditor/ckeditor5-core/src/plugin"
 import { editor } from "@ckeditor/ckeditor5-core"
 
 import { MarkdownConfig } from "../../../types/ckeditor_markdown"
-
-const MARKDOWN_CONFIG_KEY = "markdown-config"
+import { MARKDOWN_CONFIG_KEY } from "./constants"
 
 /**
  * Abstract class providing functionality to get and set the
@@ -11,6 +10,12 @@ const MARKDOWN_CONFIG_KEY = "markdown-config"
  * syntax rules need to inherit from this plugin.
  */
 export default abstract class MarkdownConfigPlugin extends Plugin {
+  static defaults = {
+    showdownExtensions: [],
+    turndownRules:      [],
+    allowedHtml:        []
+  }
+
   constructor(editor: editor.Editor) {
     super(editor)
   }
@@ -19,12 +24,9 @@ export default abstract class MarkdownConfigPlugin extends Plugin {
    * Returns the Markdown configuration set on this.editor
    */
   getMarkdownConfig(): MarkdownConfig {
-    return (
-      this.editor.config.get(MARKDOWN_CONFIG_KEY) ?? {
-        showdownExtensions: [],
-        turndownRules:      []
-      }
-    )
+    const provided = this.editor.config.get(MARKDOWN_CONFIG_KEY)
+
+    return { ...MarkdownConfigPlugin.defaults, ...provided }
   }
 
   /**

--- a/static/js/lib/ckeditor/plugins/MarkdownConfigPlugin.ts
+++ b/static/js/lib/ckeditor/plugins/MarkdownConfigPlugin.ts
@@ -12,8 +12,7 @@ import { MARKDOWN_CONFIG_KEY } from "./constants"
 export default abstract class MarkdownConfigPlugin extends Plugin {
   static defaults = {
     showdownExtensions: [],
-    turndownRules:      [],
-    allowedHtml:        []
+    turndownRules:      []
   }
 
   constructor(editor: editor.Editor) {

--- a/static/js/lib/ckeditor/plugins/MarkdownSyntaxPlugin.ts
+++ b/static/js/lib/ckeditor/plugins/MarkdownSyntaxPlugin.ts
@@ -25,6 +25,7 @@ export default abstract class MarkdownSyntaxPlugin extends MarkdownConfigPlugin 
   loadMarkdownSyntax(): void {
     const currentConfig = this.getMarkdownConfig()
     const newConfig = {
+      ...currentConfig,
       showdownExtensions: [
         ...currentConfig.showdownExtensions,
         this.showdownExtension

--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
@@ -149,4 +149,27 @@ describe("ResourceLink plugin", () => {
       )
     }
   )
+
+  /**
+   * It seems that this scenario cannot actually be constructed in CKEditor.
+   * CKEditor treats subscripts, subscripts, links, and resource links as
+   * attributes on a text node, not as some sort of tree structure (like html)
+   * with nesting. It's unclear how the conversion order from "attributes on
+   * text node" to an HTML tree is performed, but it seems that resource_link
+   * always ends up on the outside.
+   *
+   * Still, nice that this works.
+   */
+  it("Preserves resource links inside superscripts if sup enabled", async () => {
+    const editor = await getEditor("", {
+      "markdown-config": { allowedHtml: ["sup"] }
+    })
+    const md =
+      'Cool reference<sup>{{% resource_link "uuid123" "\\[1\\]" %}}</sup>'
+    const html = `<p>Cool reference<sup><a class="resource-link" data-uuid="${encode(
+      "uuid123"
+    )}">[1]</a></sup></p>`
+
+    markdownTest(editor, md, html)
+  })
 })

--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
@@ -110,4 +110,43 @@ describe("ResourceLink plugin", () => {
     )}">{{&lt; sup 2 &gt;}}</a> Woof</p>`
     markdownTest(editor, md, html)
   })
+
+  it.each([
+    {
+      allowedHtml: ["sup"],
+      sup:         (x: string) => `<sup>${x}</sup>`
+    },
+    {
+      allowedHtml: [""],
+      sup:         (x: string) => x
+    }
+  ])(
+    "Preserves superscripts in the link title iff sub tag is permitted",
+    async ({ allowedHtml, sup }) => {
+      const editor = await getEditor("", {
+        "markdown-config": { allowedHtml }
+      })
+      const { md2html, html2md } = getConverters(editor)
+
+      const html = `<p>Dogs <sup>x</sup> <a class="resource-link" data-uuid="${encode(
+        "uuid123"
+      )}">Einstein says E=mc<sup>2</sup></a> Woof</p>`
+
+      const md =
+        'Dogs <sup>x</sup> {{% resource_link "uuid123" "Einstein says E=mc<sup>2</sup>" %}} Woof'
+      /**
+       * md -> html always keeps extra tags
+       */
+      expect(md2html(md)).toBe(html)
+
+      /**
+       * html -> md only keeps extra tags if specified by allowedHtml
+       */
+      expect(html2md(html)).toBe(
+        `Dogs ${sup("x")} {{% resource_link "uuid123" "Einstein says E=mc${sup(
+          "2"
+        )}" %}} Woof`
+      )
+    }
+  )
 })

--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
@@ -10,6 +10,7 @@ import {
   RESOURCE_LINK
 } from "@mitodl/ckeditor5-resource-link/src/constants"
 import { Shortcode, escapeShortcodes } from "./util"
+import { turndownService } from "../turndown"
 
 export const encodeShortcodeArgs = (...args: (string | undefined)[]) =>
   encodeURIComponent(JSON.stringify(args))
@@ -76,15 +77,22 @@ export default class ResourceLinkMarkdownSyntax extends MarkdownSyntaxPlugin {
             )
           },
           replacement: (_content: string, node: Turndown.Node): string => {
-            const [uuid, anchor] = decodeShortcodeArgs(
-              (node as any).getAttribute("data-uuid") as string
+            const anchor = node as HTMLAnchorElement
+            const [uuid, fragment] = decodeShortcodeArgs(
+              anchor.getAttribute("data-uuid") as string
             )
 
-            const text = node.textContent
+            const text = turndownService
+              .turndown(anchor.innerHTML)
+              /**
+               * When turndown converts innerHTML to markdown, it will convert
+               * `{{&lt;` to `{{\<`. So we need to unescape that.
+               */
+              .replace(/{{\\</g, "{{<")
 
             if (text === null) return ""
 
-            return Shortcode.resourceLink(uuid, text, anchor).toHugo()
+            return Shortcode.resourceLink(uuid, text, fragment).toHugo()
           }
         }
       }

--- a/static/js/lib/ckeditor/plugins/constants.ts
+++ b/static/js/lib/ckeditor/plugins/constants.ts
@@ -10,6 +10,8 @@ export const RESOURCE_LINK = "resourceLink"
 
 export const RESOURCE_EMBED_COMMAND = "insertResourceEmbed"
 
+export const MARKDOWN_CONFIG_KEY = "markdown-config"
+
 import { RESOURCE_LINK_COMMAND } from "@mitodl/ckeditor5-resource-link/src/constants"
 import TurndownService from "turndown"
 

--- a/static/js/lib/ckeditor/plugins/test_util.ts
+++ b/static/js/lib/ckeditor/plugins/test_util.ts
@@ -5,11 +5,17 @@ import { MarkdownDataProcessor } from "./Markdown"
 
 class ClassicTestEditor extends ClassicEditorBase {}
 
-export const createTestEditor = (plugins: any[]) => async (
-  initialData = ""
+export const createTestEditor = (
+  plugins: unknown[],
+  remainingConfig: Record<string, unknown> = {}
+) => async (
+  initialData = "",
+  configOverrides: Record<string, unknown> = {}
 ): Promise<editor.Editor & { getData(): string }> => {
   const editor = await ClassicTestEditor.create(initialData, {
-    plugins
+    plugins,
+    ...remainingConfig,
+    ...configOverrides
   })
   return editor
 }

--- a/static/js/lib/ckeditor/turndown.ts
+++ b/static/js/lib/ckeditor/turndown.ts
@@ -114,7 +114,7 @@ itemRule.replacement = (
 
 const BASE_TURNDOWN_RULES = [...turndownService.rules.array]
 const BASE_TURNDOWN_KEEP = [
-  // @ts-expect-error `_keep` is not part of Turndown's public API, see `resetTurndownKeep` for more.
+  // @ts-expect-error `_keep` is not part of Turndown's public API, see `resetTurndownService` for more.
   ...turndownService.rules._keep
 ]
 const BASE_TURNDOWN_KEEP_REPLACEMENT = turndownService.rules.keepReplacement
@@ -127,17 +127,12 @@ export const resetTurndownService = () => {
   turndownService.rules.array = [...BASE_TURNDOWN_RULES]
 
   /**
-   * By default, Turndown does not keep any HTML tags when converting from html -> md.
-   * We can tell turndown to keep some tags via a `turndown.keep(tags)`. Subsequent
-   * calls to `keep` ADD more tags that turndown should keep.
-   *
-   * Howevver, Turndown has no public API to remove tags from the keep list after
-   * they have been added.
-   *
-   * All of these machinations are only necessary because CKEditor's GFM plugin
-   * uses a single global turndown instance.
+   * We need to access `_keep` in order to "reset" what HTML tags Turndown will
+   * keep when converting HTML to Markdown. Turndown has a public API for
+   * adding tags to its "keep" list, but not for removing tags or resetting its
+   * list.
    */
-  // @ts-expect-error `_keep` is not part of Turndown's public API, see `resetTurndownKeep` for more.
+  // @ts-expect-error `_keep` is not part of Turndown's public API, see above
   turndownService.rules._keep = [...BASE_TURNDOWN_KEEP]
   turndownService.rules.keepReplacement = BASE_TURNDOWN_KEEP_REPLACEMENT
 }

--- a/static/js/lib/ckeditor/turndown.ts
+++ b/static/js/lib/ckeditor/turndown.ts
@@ -211,7 +211,7 @@ class TurndownHtmlHelpers {
      * To address Issue #1, we'll mark places where HTML is inserted. Later, we
      * can remove all the markings except the ones that begin a new line.
      */
-    return `<raw_html_follows/>${clone.outerHTML}`
+    return `<raw_inline_html/>${clone.outerHTML}`
   }
 
   /**
@@ -224,8 +224,8 @@ class TurndownHtmlHelpers {
   turndown = (html: string) =>
     this.turndownInstance
       .turndown(html)
-      .replace(/^[ ]*<raw_html_follows\/>/g, "\u200b")
-      .replace(/<raw_html_follows\/>/g, "")
+      .replace(/^[ ]*<raw_inline_html\/>/g, "\u200b")
+      .replace(/<raw_inline_html\/>/g, "")
 }
 
 export const turndownHtmlHelpers = new TurndownHtmlHelpers(turndownService)

--- a/static/js/lib/ckeditor/turndown.ts
+++ b/static/js/lib/ckeditor/turndown.ts
@@ -139,5 +139,89 @@ export const resetTurndownService = () => {
    */
   // @ts-expect-error `_keep` is not part of Turndown's public API, see `resetTurndownKeep` for more.
   turndownService.rules._keep = [...BASE_TURNDOWN_KEEP]
-  turndownService.options.keepReplacement = BASE_TURNDOWN_KEEP_REPLACEMENT
+  turndownService.rules.keepReplacement = BASE_TURNDOWN_KEEP_REPLACEMENT
 }
+
+/**
+ * This class contains a few helpers that improve upon the default way in which
+ * Turndown includes raw HTML tags in the markdown output.
+ *
+ * When converting HTML -> MD, Turndown generally ignores HTML tags that have no
+ * markdown equivalent. (E.g., "span", "div", "sup", "sub", ...). This behavior
+ * can be customized in two ways:
+ *  1. its `keep` method tells Turndown which rules to keep
+ *  2. its `keepReplacement` function tells Turndown HOW to replace those tags
+ *
+ * The default behavior of `keepReplacement` has two drawbacks.
+ *
+ * Issue #1
+ * -----------
+ * The default behavior can result in HTML tags beginning a markdown line that would
+ * otherwise be a Markdown paragraph. For example:
+ * ```js
+ * const tds = new TurndownService()
+ * tds.keep(["sup"])
+ * tds.turndown("<p><sup>2</sup> Hello <strong>world</strong>!</p>")
+ * // => "<sup>2</sup> Hello **world**!"
+ * ```
+ * The output above is bad because when an HTML tag begins a markdown line, it
+ * begins a *block* of markdown, and subsequent characters on that line are
+ * NOT treated as Markdown. Hence the `**` above would be rendered as literal
+ * asterisks, not as bold.
+ *
+ * Issue #2
+ * ------------
+ * The default behavior is that the *content* of an HTML tag is not converted
+ * to Markdown. This is problematic for tags that contain shortcode HTML. For
+ * example, `<sup><a class="resource-link" data-uuid ... >2</a></sup>` should
+ * really needs its content to be converted to markdown in order for Hugo to
+ * recognize it as a shortcode.
+ */
+class TurndownHtmlHelpers {
+  private turndownInstance: Turndown
+
+  constructor(turndown: Turndown) {
+    this.turndownInstance = turndown
+  }
+
+  /**
+   * This function improves upon Turndown's default rule for including raw HTML
+   * tags in Markdown. In particular, it:
+   *  - ensures that the child content of an inline HTML node is also converted, which
+   *    we need in case the child content contains shortcode.
+   *  - ensures that an inline HTML tag never begins a line of Markdown.
+   */
+  keepReplacer: Turndown.ReplacementFunction = (content, node) => {
+    /**
+     * "isBlock" is a Turndown-specific addition to the DOM node interface.
+     * It appears to be part of their public API in that the author recommends
+     * using it in several issues.
+     */
+    const el = node as HTMLElement & { isBlock: boolean }
+
+    if (el.isBlock) {
+      throw new Error("Inclusion of block content not yet supported.")
+    }
+
+    /**
+     * Now convert the node's child content to Markdown.
+     * This addresses Issue #2 above.
+     */
+    const clone = el.cloneNode() as HTMLElement
+    clone.innerHTML = this.turndown(el.innerHTML)
+
+    /**
+     * To address Issue #1, we'll mark places where HTML is inserted. Later, we
+     * can remove all the markings except the ones that begin a new line.
+     */
+    return `<raw_html_follows/>${clone.outerHTML}`
+  }
+
+  turndown = (html: string) =>
+    this.turndownInstance
+      .turndown(html)
+      .replace(/^[ ]*<raw_html_follows\/>/g, "\u200b")
+      .replace(/<raw_html_follows\/>/g, "")
+}
+
+export const turndownHtmlHelpers = new TurndownHtmlHelpers(turndownService)

--- a/static/js/lib/ckeditor/turndown.ts
+++ b/static/js/lib/ckeditor/turndown.ts
@@ -224,7 +224,7 @@ class TurndownHtmlHelpers {
   turndown = (html: string) =>
     this.turndownInstance
       .turndown(html)
-      .replace(/^[ ]*<raw_inline><\/raw_inline>/g, "\u200b")
+      .replace(/(^|(?<=\n))[ ]*<raw_inline><\/raw_inline>/g, "\u200b")
       .replace(/<raw_inline><\/raw_inline>/g, "")
 }
 

--- a/static/js/lib/ckeditor/turndown.ts
+++ b/static/js/lib/ckeditor/turndown.ts
@@ -205,13 +205,13 @@ class TurndownHtmlHelpers {
      * This addresses Issue #2 above.
      */
     const clone = el.cloneNode() as HTMLElement
-    clone.innerHTML = this.turndown(el.innerHTML)
+    clone.innerHTML = this.turndownInstance.turndown(el.innerHTML)
 
     /**
      * To address Issue #1, we'll mark places where HTML is inserted. Later, we
      * can remove all the markings except the ones that begin a new line.
      */
-    return `<raw_inline_html/>${clone.outerHTML}`
+    return `<raw_inline></raw_inline>${clone.outerHTML}`
   }
 
   /**
@@ -224,8 +224,8 @@ class TurndownHtmlHelpers {
   turndown = (html: string) =>
     this.turndownInstance
       .turndown(html)
-      .replace(/^[ ]*<raw_inline_html\/>/g, "\u200b")
-      .replace(/<raw_inline_html\/>/g, "")
+      .replace(/^[ ]*<raw_inline><\/raw_inline>/g, "\u200b")
+      .replace(/<raw_inline><\/raw_inline>/g, "")
 }
 
 export const turndownHtmlHelpers = new TurndownHtmlHelpers(turndownService)

--- a/static/js/lib/ckeditor/turndown.ts
+++ b/static/js/lib/ckeditor/turndown.ts
@@ -144,15 +144,15 @@ export const resetTurndownService = () => {
  * When converting HTML -> MD, Turndown generally ignores HTML tags that have no
  * markdown equivalent. (E.g., "span", "div", "sup", "sub", ...). This behavior
  * can be customized in two ways:
- *  1. its `keep` method tells Turndown which rules to keep
- *  2. its `keepReplacement` function tells Turndown HOW to replace those tags
+ *  1. turndown's `keep` method tells Turndown which rules to keep
+ *  2. turndown's `keepReplacement` option tells Turndown HOW to replace those tags
  *
- * The default behavior of `keepReplacement` has two drawbacks.
+ * The default behavior of `keepReplacement` has two drawbacks:
  *
  * Issue #1
  * -----------
- * The default behavior can result in HTML tags beginning a markdown line that would
- * otherwise be a Markdown paragraph. For example:
+ * The default behavior can result in HTML tags beginning a markdown line that
+ * would otherwise be a Markdown paragraph. For example:
  * ```js
  * const tds = new TurndownService()
  * tds.keep(["sup"])
@@ -185,6 +185,8 @@ class TurndownHtmlHelpers {
    *  - ensures that the child content of an inline HTML node is also converted, which
    *    we need in case the child content contains shortcode.
    *  - ensures that an inline HTML tag never begins a line of Markdown.
+   *
+   * Should be used alongside {@link TurndownHtmlHelpers.turndown}
    */
   keepReplacer: Turndown.ReplacementFunction = (content, node) => {
     /**
@@ -212,6 +214,13 @@ class TurndownHtmlHelpers {
     return `<raw_html_follows/>${clone.outerHTML}`
   }
 
+  /**
+   * Convert HTML to markdown and insert a zero-width space before any HTML
+   * tag that begins what would otherwise be a Markdown paragraph. Should
+   * be used alongside {@link TurndownHtmlHelpers.keepReplacer}.
+   *
+   * See {@link TurndownHtmlHelpers} for more details.
+   */
   turndown = (html: string) =>
     this.turndownInstance
       .turndown(html)

--- a/static/js/lib/ckeditor/turndown.ts
+++ b/static/js/lib/ckeditor/turndown.ts
@@ -111,3 +111,33 @@ itemRule.replacement = (
     prefix + content + (node.nextSibling && !/\n$/.test(content) ? "\n" : "")
   )
 }
+
+const BASE_TURNDOWN_RULES = [...turndownService.rules.array]
+const BASE_TURNDOWN_KEEP = [
+  // @ts-expect-error `_keep` is not part of Turndown's public API, see `resetTurndownKeep` for more.
+  ...turndownService.rules._keep
+]
+const BASE_TURNDOWN_KEEP_REPLACEMENT = turndownService.rules.keepReplacement
+
+/**
+ * CKEditor's markdown plugin uses a single Turndown instance. We occasionally
+ * want to reset it to its initial state (e.g., for different editor instances).
+ */
+export const resetTurndownService = () => {
+  turndownService.rules.array = [...BASE_TURNDOWN_RULES]
+
+  /**
+   * By default, Turndown does not keep any HTML tags when converting from html -> md.
+   * We can tell turndown to keep some tags via a `turndown.keep(tags)`. Subsequent
+   * calls to `keep` ADD more tags that turndown should keep.
+   *
+   * Howevver, Turndown has no public API to remove tags from the keep list after
+   * they have been added.
+   *
+   * All of these machinations are only necessary because CKEditor's GFM plugin
+   * uses a single global turndown instance.
+   */
+  // @ts-expect-error `_keep` is not part of Turndown's public API, see `resetTurndownKeep` for more.
+  turndownService.rules._keep = [...BASE_TURNDOWN_KEEP]
+  turndownService.options.keepReplacement = BASE_TURNDOWN_KEEP_REPLACEMENT
+}

--- a/static/js/lib/site_content.test.ts
+++ b/static/js/lib/site_content.test.ts
@@ -429,18 +429,20 @@ describe("site_content", () => {
         embed:   ["resource"]
       })
       expect(widgetExtraProps(field)).toStrictEqual({
-        minimal: false,
-        link:    ["resource", "page"],
-        embed:   ["resource"]
+        minimal:     false,
+        link:        ["resource", "page"],
+        embed:       ["resource"],
+        allowedHtml: []
       })
     })
 
     it("sets minimal = true for markdown fields by default", () => {
       const field = makeWebsiteConfigField({ widget: WidgetVariant.Markdown })
       expect(widgetExtraProps(field)).toStrictEqual({
-        minimal: true,
-        link:    [],
-        embed:   []
+        minimal:     true,
+        link:        [],
+        embed:       [],
+        allowedHtml: []
       })
     })
 

--- a/static/js/lib/site_content.ts
+++ b/static/js/lib/site_content.ts
@@ -20,6 +20,7 @@ import {
   BaseConfigItem,
   ConfigField,
   EditableConfigItem,
+  MarkdownConfigField,
   RepeatableConfigItem,
   SingletonConfigItem,
   StringConfigField,
@@ -96,9 +97,10 @@ export function widgetExtraProps(field: ConfigField): Record<string, any> {
     return pick(SELECT_EXTRA_PROPS, field)
   case WidgetVariant.Markdown:
     return {
-      minimal: field.minimal ?? true,
-      link:    field.link ?? [],
-      embed:   field.embed ?? []
+      minimal:     field.minimal ?? true,
+      link:        field.link ?? [],
+      embed:       field.embed ?? [],
+      allowedHtml: field.allowed_html ?? []
     }
   case WidgetVariant.Relation:
     return pick(RELATION_EXTRA_PROPS, field)

--- a/static/js/lib/site_content.ts
+++ b/static/js/lib/site_content.ts
@@ -20,7 +20,6 @@ import {
   BaseConfigItem,
   ConfigField,
   EditableConfigItem,
-  MarkdownConfigField,
   RepeatableConfigItem,
   SingletonConfigItem,
   StringConfigField,

--- a/static/js/pages/MarkdownEditorTestPage.tsx
+++ b/static/js/pages/MarkdownEditorTestPage.tsx
@@ -64,6 +64,7 @@ function MarkdownEditorTestWrapper(props: Props) {
           minimal={minimal}
           embed={[]}
           link={[]}
+          allowedHtml={[]}
         />
       </div>
       <div className="w-75 m-auto">

--- a/static/js/types/ckeditor.d.ts
+++ b/static/js/types/ckeditor.d.ts
@@ -26,6 +26,10 @@ declare module '@ckeditor/ckeditor5-basic-styles/src/italic';
 
 declare module '@ckeditor/ckeditor5-basic-styles/src/bold';
 
+declare module '@ckeditor/ckeditor5-basic-styles/src/superscript';
+
+declare module '@ckeditor/ckeditor5-basic-styles/src/subscript';
+
 declare module '@ckeditor/ckeditor5-basic-styles/src/underline';
 
 declare module '@ckeditor/ckeditor5-autoformat/src/autoformat';

--- a/static/js/types/ckeditor_markdown.ts
+++ b/static/js/types/ckeditor_markdown.ts
@@ -9,4 +9,5 @@ export interface TurndownRule {
 export interface MarkdownConfig {
   showdownExtensions: Array<() => Showdown.ShowdownExtension[]>
   turndownRules: TurndownRule[]
+  allowedHtml: (keyof HTMLElementTagNameMap)[]
 }

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -53,6 +53,7 @@ export interface MarkdownConfigField extends ConfigFieldBaseProps {
   minimal?: boolean
   link?: string[]
   embed?: string[]
+  allowed_html?: string[]
 }
 
 export interface FileConfigField extends ConfigFieldBaseProps {

--- a/websites/config_schema/site-config-schema.yml
+++ b/websites/config_schema/site-config-schema.yml
@@ -24,6 +24,7 @@ field:
     label: str()
     name: str()
     minimal: bool(required=False)
+    allowed_html: list(str(), required=False)
     required: bool(required=False)
     help: str(required=False)
     fields: list(include('field'), required=False)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1061 

#### What's this PR do?
This PR adds support for subscripts and superscripts in markdown via inclusion of raw `<sub>` and `<sup>` tags. Arbitrary HTML is not permitted: only HTML tags whitelisted in the markdown widget config's `allow_html` list will be permitted. Additionally, the only non-markdown tags that our CKEditor setup will generate are sub/sup, and only if the tags are allowed.

This approach turned out to not be as quite "works out of the box" as I originally thought. Two issues came up, both having to do with the fact that while MD --> HTML conversion is well specified by CommonMark, there is no specification for  HTML --> MD conversion (which we need when extracting data from CKEditor). The two issues were:

1. **`<sup>` at start of paragraph:** Markdown literally cannot handle this. HTML at the beginning of a line creates an HTML block, and the remainder of the line is parsed as raw HTML rather than Markdown. So the two lines

    ```md
    <sup>1</sup>:  This renders raw html with **asterisks**

    x<sup>1</sup> This renders as markdown with **bold**.
    ```

    end up behaving very differently.
2. **MD inside html tags**: The default behavior for Turndown (our html->md converter) when including raw HTML in markdown is to not process the content of the HTML *at all*. But HTML tags are generally allowed to contain markdown[^1] content, and it's important to convert that content to markdown.

[^1]: This is absolutely true for [markdown inline html](https://spec.commonmark.org/0.30/#raw-html). The story is a little more complicated for [markdown block html](https://spec.commonmark.org/0.30/#html-blocks).

#### How should this be manually tested?
1. Load the course-v2 config from https://github.com/mitodl/ocw-hugo-projects/pull/234 into your local studio
2. Create a page and add subscripts/superscripts. Some things that are worth trying are subscripts/superscripts
    - at the beginning of a line
    - in links and resource links
    - in tables
    - bold inside the subscript/superscript *though we do not encourage authors to do this, ckeditor will not prevent it.*
3. Check the markdown in admin panel. It should look correct.
4. Check that the markdown renders correctly in ocw-hugo-themes using branch from https://github.com/mitodl/ocw-hugo-themes/pull/1004

#### Screenshots

<img width="1279" alt="Screen Shot 2022-11-30 at 9 05 59 AM" src="https://user-images.githubusercontent.com/9010790/204816853-1a0a69de-8daa-47a4-adbc-4637f2f6e7d5.png">

#### Other Context

HQ discussion: https://github.com/mitodl/hq/discussions/303