### PR TITLE
Fixing typo in GDrive creation management command

### DIFF
--- a/gdrive_sync/management/commands/create_missing_gdrive_folders.py
+++ b/gdrive_sync/management/commands/create_missing_gdrive_folders.py
@@ -8,7 +8,7 @@ from websites.models import Website
 
 
 class Command(BaseCommand):
-    """Creates a gdrive folder for video uploads for websites that don't already have one"""
+    """Creates a Google drive folder for websites that don't already have one"""
 
     help = __doc__
 
@@ -67,7 +67,7 @@ class Command(BaseCommand):
             task = create_gdrive_folders_chunked.delay(short_ids, chunk_size=chunk_size)
 
             self.stdout.write(
-                f"Started celery task {task} to upsert pipelines for {len(short_ids)} sites."
+                f"Started celery task {task} to create Google drive folders for {len(short_ids)} sites."
             )
             if is_verbose:
                 self.stdout.write(f"{','.join(short_ids)}")


### PR DESCRIPTION
#### Pre-Flight checklist
- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1609.

#### What's this PR do?
Updates the text in the `create_missing_gdrive_folders` management command.

#### How should this be manually tested?
This does not affect functionality, only the displayed messages for running this management command, but running the management command to see that the message looks correct.
