### PR TITLE
clean publish for individual sites

### DIFF
--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -339,20 +339,20 @@ def test_upsert_website_pipelines(
     storage_bucket_name = expected_template_vars["storage_bucket_name"]
     if home_page:
         assert (
-            f"s3 {expected_endpoint_prefix}sync s3://{storage_bucket_name}/{website.name} s3://{bucket}/{website.name}"
+            f"s3 {expected_endpoint_prefix}sync s3://{storage_bucket_name}/{website.name} s3://{bucket}/{website.name} --metadata site-id={website.name}"
             in config_str
         )
         assert (
-            f"aws s3 {expected_endpoint_prefix}sync course-markdown/public s3://{bucket}/"
+            f"aws s3 {expected_endpoint_prefix}sync course-markdown/public s3://{bucket}/ --metadata site-id={website.name}"
             in config_str
         )
     else:
         assert (
-            f"s3 {expected_endpoint_prefix}sync s3://{storage_bucket_name}/courses/{website.name} s3://{bucket}/{website.url_path}"
+            f"s3 {expected_endpoint_prefix}sync s3://{storage_bucket_name}/courses/{website.name} course-markdown/public"
             in config_str
         )
         assert (
-            f"aws s3 {expected_endpoint_prefix}sync course-markdown/public s3://{bucket}/{website.url_path}"
+            f"aws s3 {expected_endpoint_prefix}sync course-markdown/public s3://{bucket}/{website.url_path} --metadata site-id={website.name} --delete"
             in config_str
         )
 

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -428,8 +428,8 @@ jobs:
             args:
             - -exc
             - |
-              aws s3((cli-endpoint-url)) sync s3://((ocw-studio-bucket))/((s3-path)) s3://((ocw-bucket))/((site-url)) --metadata site-id=((site-name))
-              aws s3((cli-endpoint-url)) sync course-markdown/public s3://((ocw-bucket))/((base-url)) --metadata site-id=((site-name))
+              aws s3((cli-endpoint-url)) sync s3://((ocw-studio-bucket))/((s3-path)) course-markdown/public
+              aws s3((cli-endpoint-url)) sync course-markdown/public s3://((ocw-bucket))/((base-url)) --metadata site-id=((site-name)) --delete
         # START DEV-ONLY
         on_success:
           try:

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -428,8 +428,14 @@ jobs:
             args:
             - -exc
             - |
-              aws s3((cli-endpoint-url)) sync s3://((ocw-studio-bucket))/((s3-path)) course-markdown/public
-              aws s3((cli-endpoint-url)) sync course-markdown/public s3://((ocw-bucket))/((base-url)) --metadata site-id=((site-name)) --delete
+              if [ -z "((base-url))" ]
+              then
+                aws s3((cli-endpoint-url)) sync s3://((ocw-studio-bucket))/((s3-path)) s3://((ocw-bucket))/((site-url)) --metadata site-id=((site-name))
+                aws s3((cli-endpoint-url)) sync course-markdown/public s3://((ocw-bucket))/((base-url)) --metadata site-id=((site-name))
+              else
+                aws s3((cli-endpoint-url)) sync s3://((ocw-studio-bucket))/((s3-path)) course-markdown/public
+                aws s3((cli-endpoint-url)) sync course-markdown/public s3://((ocw-bucket))/((base-url)) --metadata site-id=((site-name)) --delete
+              fi
         # START DEV-ONLY
         on_success:
           try:


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1189

#### What's this PR do?
This PR makes a change to the individual site publishing pipeline definition (`site-pipeline.yaml`) that ensures that stale content will be removed during the publish process. The current process is as follows:

 - Build the site with `hugo`
 - Sync `ocw-studio` S3 bucket with draft / live publish bucket by doing a bucket to bucket sync
 - Sync built Hugo site to the draft / live publish bucket

The new process syncs the static resources from the `ocw-studio` bucket to the Concourse build container first:

 - Build the site with `hugo`
 - Sync `ocw-studio` S3 bucket to the Concourse container into the Hugo build output folder
 - Sync built Hugo site including static resources to the draft / live publish bucket with the `--delete` flag to remove stale content

One caveat to this is that if the site in question has a blank base url, the old way of syncing will be used instead. This only currently applies to `ocw-www` and will avoid a situation where content is unintentionally removed from the site.

#### How should this be manually tested?
 - First of all, make sure you have the following prerequisites set up (check the readme if you're unsure about any of them):
   - Custom test Github org
   - Minio
   - Concourse
   - Google Drive integration (if creating a new test course)
   - An `ocw-www` site in your local `ocw-studio`
 - Create a test course (or use an existing one) in your local OCW studio
 - If you're creating a new course upload some resources to Google drive and sync them to your course, also make sure you have some test pages and your course level metadata is filled out
 - If you're using an existing / imported course, browse to the `ol-ocw-studio-app` bucket in Minio at http://localhost:9001 and under the `courses` folder create a folder matching the `short_id` of your course, then drop your static assets in there
 - Run the following management commands to update the pipeline definitions in your local Concourse, replacing the short_id in the second command with the one from your test site:
```
docker-compose exec web ./manage.py backpopulate_pipelines --filter ocw-www
docker-compose exec web ./manage.py backpopulate_pipelines --filter <short_id of your test site>
```
 - Browse to your local Concourse at http://localhost:8080 and find the live pipeline for your test site, then trigger a build
 - Go back to Minio at http://localhost:9001 and browse to the `ocw-content-live` bucket and find your test site under `courses`, verifying that the built output of your site is there
 - In the Minio interface, manually upload any test file (a text document called `test.txt` or something is fine) directly to the site root
 - Back in Concourse trigger another build of your test site, and after the build is complete expand the `copy-s3-buckets` section and look for a `delete:` line showing your test file you uploaded in the previous step being removed
 - Back in Minio, verify that the file has indeed been removed
 - Back in Concourse, find the live pipeline for `ocw-www` and trigger a build
 - Once the build is complete, expand the `copy-s3-buckets` step and ensure no files were deleted
 - Back in Minio, check to make sure that your site was not deleted from the `ocw-content-live` bucket

#### Any background context you want to provide?
This PR was created in response to various situations in which stale content needs to be removed from the OCW site as a way to solve all of them:

 - Site published live, then a page is retroactively set to draft and the site is published live again
 - Content takedown requests; deleting pages / resources

This change doesn't handle bringing in the static assets in the exact same way as the [offline site build](https://github.com/mitodl/ocw-studio/pull/1453), where the static assets are placed in the `content/static_resources` folder before the Hugo build so that the offline theme can build relative links to them and instead copies them into the root of the built site *after* the Hugo build is run. This is because the online site currently expects all static assets to be at the root of the site. A future PR could consolidate this functionality between how the offline site build works and how online publishing works for single sites. The `mass-build-sites` pipeline has not been modified, as the build currently takes 2-3 hours and pulling in the static assets to the build directly would double that to 4-6 hours. When this was discussed, the time penalty of doing this was deemed acceptable for publishing a single course. Since most of these situations are dealt with in the context of an issue with a single course, it's a good solution for now.
