### PR TITLE
Adding management command to sync captions/transcripts for any videos missing them from one course to another

### DIFF
--- a/videos/management/commands/sync_transcripts.py
+++ b/videos/management/commands/sync_transcripts.py
@@ -46,47 +46,45 @@ class Command(BaseCommand):
         to_course_videos = WebsiteContent.objects.filter(
             Q(website__name=to_course.name) & Q(metadata__resourcetype="Video")
         )
-        from_course_youtube = self.courses_to_youtube_dict(from_course_videos)
-        to_course_youtube = self.courses_to_youtube_dict(to_course_videos)
+        from_course_videos = self.courses_to_youtube_dict(from_course_videos)
+        to_course_videos = self.courses_to_youtube_dict(to_course_videos)
         captions_ctr, transcript_ctr = 0, 0
-        for video in to_course_youtube:
-            if to_course_youtube[video][0] is None:  # missing captions
+        for video in to_course_videos:
+            if to_course_videos[video][0] is None:  # missing captions
                 self.stdout.write("Missing captions: " + video + "\n")
                 if (
-                    video in from_course_youtube
-                    and from_course_youtube[video][0] is not None
+                    video in from_course_videos
+                    and from_course_videos[video][0] is not None
                 ):
                     captions_ctr += 1
                     self.stdout.write("Captions found in source course. Syncing.\n")
                     source_captions = WebsiteContent.objects.get(
-                        file=from_course_youtube[video][0]
+                        file=from_course_videos[video][0]
                     )
                     new_captions = self.create_new_content(source_captions, to_course)
-                    video_obj = to_course_youtube[video][2]
-                    video_obj.metadata["video_files"]["video_captions_file"] = str(
-                        new_captions.file
-                    )
-                    video_obj.save()
+                    to_course_videos[video][2].metadata["video_files"][
+                        "video_captions_file"
+                    ] = str(new_captions.file)
+                    to_course_videos[video][2].save()
 
-            if to_course_youtube[video][1] is None:  # missing transcript
+            if to_course_videos[video][1] is None:  # missing transcript
                 self.stdout.write("Missing transcript: " + video + "\n")
                 if (
-                    video in from_course_youtube
-                    and from_course_youtube[video][1] is not None
+                    video in from_course_videos
+                    and from_course_videos[video][1] is not None
                 ):
                     transcript_ctr += 1
                     self.stdout.write("Transcript found in source course. Syncing.\n")
                     source_transcript = WebsiteContent.objects.get(
-                        file=from_course_youtube[video][1]
+                        file=from_course_videos[video][1]
                     )
                     new_transcript = self.create_new_content(
                         source_transcript, to_course
                     )
-                    video_obj = to_course_youtube[video][2]
-                    video_obj.metadata["video_files"]["video_transcript_file"] = str(
-                        new_transcript.file
-                    )
-                    video_obj.save()
+                    to_course_videos[video][2].metadata["video_files"][
+                        "video_transcript_file"
+                    ] = str(new_transcript.file)
+                    to_course_videos[video][2].save()
 
         self.stdout.write(
             str(captions_ctr)


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
Once this command is run on the relevant resources, closes https://github.com/mitodl/ocw-hugo-themes/issues/774 and closes https://github.com/mitodl/ocw-studio/issues/1614.

#### What's this PR do?
Adds a management command for syncing captions and transcripts for any videos missing them from one course (from_course) to another (to_course).

#### How should this be manually tested?
For testing locally, make sure that Minio is properly configured. Copy the RC or production data for  `18-02-multivariable-calculus-fall-2007` and `18-02sc-multivariable-calculus-fall-2010` from S3 to your local Minio instance, and then run `docker compose run --rm web ./manage.py sync_transcripts --from_course 18-02-multivariable-calculus-fall-2007 --to_course 18-02sc-multivariable-calculus-fall-2010`. Verify that the captions and transcripts have been linked in Django admin.
