### PR TITLE
themes branch argument for theme assets build

### DIFF
--- a/content_sync/api.py
+++ b/content_sync/api.py
@@ -52,11 +52,11 @@ def get_site_pipeline(website: Website, api: Optional[object] = None) -> BasePip
 
 
 @is_publish_pipeline_enabled
-def get_theme_assets_pipeline(api: Optional[object] = None) -> BasePipeline:
+def get_theme_assets_pipeline(themes_branch: Optional[str] = None, api: Optional[object] = None) -> BasePipeline:
     """ Get the configured theme asset pipeline """
     return import_string(
         f"content_sync.pipelines.{settings.CONTENT_SYNC_PIPELINE_BACKEND}.ThemeAssetsPipeline"
-    )(api=api)
+    )(themes_branch=themes_branch, api=api)
 
 
 @is_publish_pipeline_enabled

--- a/content_sync/api.py
+++ b/content_sync/api.py
@@ -52,7 +52,9 @@ def get_site_pipeline(website: Website, api: Optional[object] = None) -> BasePip
 
 
 @is_publish_pipeline_enabled
-def get_theme_assets_pipeline(themes_branch: Optional[str] = None, api: Optional[object] = None) -> BasePipeline:
+def get_theme_assets_pipeline(
+    themes_branch: Optional[str] = None, api: Optional[object] = None
+) -> BasePipeline:
     """ Get the configured theme asset pipeline """
     return import_string(
         f"content_sync.pipelines.{settings.CONTENT_SYNC_PIPELINE_BACKEND}.ThemeAssetsPipeline"

--- a/content_sync/management/commands/upsert_theme_assets_pipeline.py
+++ b/content_sync/management/commands/upsert_theme_assets_pipeline.py
@@ -62,7 +62,9 @@ class Command(BaseCommand):
             else:
                 self.stdout.error("No pipeline api configured")
 
-        task = upsert_theme_assets_pipeline.delay(unpause=unpause, themes_branch=themes_branch)
+        task = upsert_theme_assets_pipeline.delay(
+            unpause=unpause, themes_branch=themes_branch
+        )
         self.stdout.write(f"Started celery task {task} to upsert theme assets pipeline")
         self.stdout.write("Waiting on task...")
 

--- a/content_sync/management/commands/upsert_theme_assets_pipeline.py
+++ b/content_sync/management/commands/upsert_theme_assets_pipeline.py
@@ -28,6 +28,12 @@ class Command(BaseCommand):
             action="store_true",
             help="Delete existing theme assets pipelines first",
         )
+        parser.add_argument(
+            "-t",
+            "--themes-branch",
+            dest="themes_branch",
+            help="The branch of ocw-hugo-themes to build against",
+        )
 
     def handle(self, *args, **options):
 
@@ -40,6 +46,7 @@ class Command(BaseCommand):
         is_verbose = options["verbosity"] > 1
         unpause = options["unpause"]
         delete_all = options["delete_all"]
+        themes_branch = options["themes_branch"]
 
         if is_verbose:
             self.stdout.write("Upserting theme assets pipeline")
@@ -55,7 +62,7 @@ class Command(BaseCommand):
             else:
                 self.stdout.error("No pipeline api configured")
 
-        task = upsert_theme_assets_pipeline.delay(unpause=unpause)
+        task = upsert_theme_assets_pipeline.delay(unpause=unpause, themes_branch=themes_branch)
         self.stdout.write(f"Started celery task {task} to upsert theme assets pipeline")
         self.stdout.write("Waiting on task...")
 

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -491,10 +491,10 @@ class ThemeAssetsPipeline(GeneralPipeline, BaseThemeAssetsPipeline):
         "SEARCH_API_URL",
     ]
 
-    def __init__(self, api: Optional[PipelineApi] = None):
+    def __init__(self, themes_branch: Optional[str] = None, api: Optional[PipelineApi] = None):
         """Initialize the pipeline API instance"""
         super().__init__(api=api)
-        self.BRANCH = get_theme_branch()
+        self.BRANCH = themes_branch or get_theme_branch()
         self.set_instance_vars({"branch": settings.GITHUB_WEBHOOK_BRANCH})
 
     def upsert_pipeline(self):

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -491,7 +491,9 @@ class ThemeAssetsPipeline(GeneralPipeline, BaseThemeAssetsPipeline):
         "SEARCH_API_URL",
     ]
 
-    def __init__(self, themes_branch: Optional[str] = None, api: Optional[PipelineApi] = None):
+    def __init__(
+        self, themes_branch: Optional[str] = None, api: Optional[PipelineApi] = None
+    ):
         """Initialize the pipeline API instance"""
         super().__init__(api=api)
         self.BRANCH = themes_branch or get_theme_branch()

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -495,7 +495,7 @@ class ThemeAssetsPipeline(GeneralPipeline, BaseThemeAssetsPipeline):
         """Initialize the pipeline API instance"""
         super().__init__(api=api)
         self.BRANCH = themes_branch or get_theme_branch()
-        self.set_instance_vars({"branch": settings.GITHUB_WEBHOOK_BRANCH})
+        self.set_instance_vars({"branch": self.BRANCH})
 
     def upsert_pipeline(self):
         """Upsert the theme assets pipeline"""

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -511,7 +511,7 @@ def test_upsert_pipeline(
     settings, pipeline_settings, mocker, mock_auth, pipeline_exists
 ):  # pylint:disable=too-many-locals
     """ Test upserting the theme assets pipeline """
-    instance_vars = f"%7B%22branch%22%3A%20%22{settings.GITHUB_WEBHOOK_BRANCH}%22%7D"
+    instance_vars = f"%7B%22branch%22%3A%20%22{get_theme_branch()}%22%7D"
     url_path = f"/api/v1/teams/{settings.CONCOURSE_TEAM}/pipelines/ocw-theme-assets/config?vars={instance_vars}"
 
     if not pipeline_exists:

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -528,7 +528,7 @@ def test_upsert_pipeline(
         "content_sync.pipelines.concourse.PipelineApi.put_with_headers"
     )
     api = PipelineApi("http://test.edu", "test", "test", "myteam")
-    pipeline = ThemeAssetsPipeline(api)
+    pipeline = ThemeAssetsPipeline(api=api)
     pipeline.upsert_pipeline()
     mock_get.assert_any_call(url_path)
     mock_put_headers.assert_any_call(

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -156,9 +156,9 @@ def upsert_pipelines(
 
 
 @app.task(acks_late=True)
-def upsert_theme_assets_pipeline(unpause=False) -> bool:
+def upsert_theme_assets_pipeline(unpause=False, themes_branch=None) -> bool:
     """ Upsert the theme assets pipeline """
-    pipeline = api.get_theme_assets_pipeline()
+    pipeline = api.get_theme_assets_pipeline(themes_branch=themes_branch)
     pipeline.upsert_pipeline()
     if unpause:
         pipeline.unpause()

--- a/websites/views.py
+++ b/websites/views.py
@@ -338,7 +338,7 @@ class WebsiteMassBuildViewSet(viewsets.ViewSet):
         # If a starter has been specified by the query, only return sites made with that starter
         if starter:
             sites = sites.filter(starter=WebsiteStarter.objects.get(slug=starter))
-        sites = sites.prefetch_related("starter").order_by("name")
+        sites = sites.prefetch_related("starter").order_by("name")[:10]
         serializer = WebsiteMassBuildSerializer(instance=sites, many=True)
         return Response({"sites": serializer.data})
 

--- a/websites/views.py
+++ b/websites/views.py
@@ -338,7 +338,7 @@ class WebsiteMassBuildViewSet(viewsets.ViewSet):
         # If a starter has been specified by the query, only return sites made with that starter
         if starter:
             sites = sites.filter(starter=WebsiteStarter.objects.get(slug=starter))
-        sites = sites.prefetch_related("starter").order_by("name")[:10]
+        sites = sites.prefetch_related("starter").order_by("name")
         serializer = WebsiteMassBuildSerializer(instance=sites, many=True)
         return Response({"sites": serializer.data})
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1551

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/1421, we added support for emulating the S3 storage backend using Minio and running Concourse pipelines to publish sites to it. Something missing from this was the ability to set a branch on the theme assets pipeline generated by `upsert_theme_assets_pipeline`. This PR adds that functionality. This is useful in local development if you are testing a change in the theme that includes JS / CSS changes to the bundles and you need to test a site deployed as if it were in production.

#### How should this be manually tested?
 - First of all, make sure you have the following prerequisites set up (check the readme if you're unsure about any of them):
   - Custom test Github org
   - Minio
   - Concourse
   - In `websites/views.py`, modify line 341 of `WebsiteMassBuildViewSet` to be `sites = sites.prefetch_related("starter").order_by("name")[:10]` to artificially limit the amount of sites built by the mass build pipeline
 - Run the following:
```
docker-compose exec web ./manage.py upsert_theme_assets_pipeline --themes-branch cg/alternate-theme-branch-test
docker-compose exec web ./manage.py upsert_mass_build_pipeline --themes-branch cg/alternate-theme-branch-test --projects-branch main --starter ocw-course-v2
```
 - Verify that the theme assets pipeline with the custom branch was pushed up [here](http://concourse:8080/teams/main/pipelines/ocw-theme-assets?vars.branch=%22cg%2Falternate-theme-branch-test%22) and unpause the pipeline and trigger a build
 - Once the build is complete, browse to the custom mass build pipeline [here](http://concourse:8080/teams/main/pipelines/mass-build-sites?vars.offline=false&vars.prefix=%22%22&vars.projects_branch=%22main%22&vars.starter=%22ocw-course-v2%22&vars.themes_branch=%22cg%2Falternate-theme-branch-test%22&vars.version=%22live%22) and unpause it and trigger a build
 - Once the builds are complete, expand the `get-repo-build-course-publish-course` section and copy one of the site ID's, pasting it into a url like http://localhost:8045/courses/10-01-ethics-for-engineers-artificial-intelligence-spring-2020/; you should see an obvious clue that the site was built with the alternate branch
