### PR TITLE
Subscript and Superscript support in CKEditor

### DIFF
--- a/static/js/components/widgets/MarkdownEditor.test.tsx
+++ b/static/js/components/widgets/MarkdownEditor.test.tsx
@@ -15,6 +15,7 @@ import {
   ADD_RESOURCE_EMBED,
   ADD_RESOURCE_LINK,
   CKEDITOR_RESOURCE_UTILS,
+  MARKDOWN_CONFIG_KEY,
   RESOURCE_EMBED,
   RESOURCE_LINK
 } from "../../lib/ckeditor/plugins/constants"
@@ -38,7 +39,7 @@ jest.mock("@ckeditor/ckeditor5-react", () => ({
 }))
 
 const render = (props = {}) =>
-  shallow(<MarkdownEditor link={[]} embed={[]} {...props} />)
+  shallow(<MarkdownEditor allowedHtml={[]} link={[]} embed={[]} {...props} />)
 
 describe("MarkdownEditor", () => {
   let sandbox: SinonSandbox
@@ -55,7 +56,7 @@ describe("MarkdownEditor", () => {
   ;[
     [true, MinimalEditorConfig],
     [false, FullEditorConfig]
-  ].forEach(([minimal, expectedComponent]) => {
+  ].forEach(([minimal, expectedConfig]) => {
     [
       ["value", "value"],
       [null, ""]
@@ -66,14 +67,23 @@ describe("MarkdownEditor", () => {
         const wrapper = render({
           minimal,
           value,
-          embed: ["resource"],
-          link:  ["page"]
+          /**
+           * The settings below make MarkdownEditor render the full FullEditorConfig.
+           * MarkdownEditor dynamically changes the config a bit, e.g., to remove
+           * resource link / resource embed if link/embed are empty.
+           */
+          embed:       ["resource"],
+          link:        ["page"],
+          allowedHtml: ["sub", "sup"]
         })
-        const ckWrapper = wrapper.find("CKEditor")
+        const ckWrapper = wrapper.find(CKEditor)
         expect(ckWrapper.prop("editor")).toBe(ClassicEditor)
-        expect(
-          omit([CKEDITOR_RESOURCE_UTILS], ckWrapper.prop("config"))
-        ).toEqual(expectedComponent)
+
+        const config = omit(
+          [CKEDITOR_RESOURCE_UTILS, MARKDOWN_CONFIG_KEY],
+          ckWrapper.prop("config")
+        )
+        expect(config).toEqual(expectedConfig)
         expect(ckWrapper.prop("data")).toBe(expectedPropValue)
       })
     })
@@ -151,6 +161,22 @@ describe("MarkdownEditor", () => {
       expect(editorConfig.toolbar.items.includes(ADD_RESOURCE_LINK)).toBe(
         hasTool
       )
+    }
+  )
+
+  it.each([
+    { tool: "superscript", tag: "sup", allowedHtml: ["sup"], hasTool: true },
+    { tool: "superscript", tag: "sup", allowedHtml: [], hasTool: false },
+    { tool: "subscript", tag: "sub", allowedHtml: ["sub"], hasTool: true },
+    { tool: "subscript", tag: "sub", allowedHtml: [], hasTool: false }
+  ])(
+    "includes $toolbar if and only if $tag is allowed. Allowed html: $allowedHtml",
+    ({ tool, hasTool, allowedHtml }) => {
+      const wrapper = render({ minimal: false, allowedHtml })
+      const ckWrapper = wrapper.find(CKEditor)
+      const items = (ckWrapper.prop("config") as any).toolbar.items
+
+      expect(items.includes(tool)).toBe(hasTool)
     }
   )
 

--- a/static/js/components/widgets/MarkdownEditor.tsx
+++ b/static/js/components/widgets/MarkdownEditor.tsx
@@ -18,7 +18,8 @@ import {
   ResourceCommandMap,
   ResourceDialogMode,
   ADD_RESOURCE_EMBED,
-  RESOURCE_LINK
+  RESOURCE_LINK,
+  MARKDOWN_CONFIG_KEY
 } from "../../lib/ckeditor/plugins/constants"
 import ResourcePickerDialog from "./ResourcePickerDialog"
 import useThrowSynchronously from "../../hooks/useAsyncError"
@@ -31,6 +32,7 @@ export interface Props {
   minimal?: boolean
   embed: string[]
   link: string[]
+  allowedHtml: string[]
 }
 
 type RenderQueueEntry = [string, HTMLElement]
@@ -41,7 +43,7 @@ type RenderQueueEntry = [string, HTMLElement]
  * pass minimal: true to get a minimal version.
  */
 export default function MarkdownEditor(props: Props): JSX.Element {
-  const { link, embed, value, name, onChange, minimal } = props
+  const { link, embed, value, name, onChange, minimal, allowedHtml } = props
   const throwSynchronously = useThrowSynchronously()
 
   const editor = useRef<editor.Editor>()
@@ -100,6 +102,12 @@ export default function MarkdownEditor(props: Props): JSX.Element {
       if (item === ADD_RESOURCE_EMBED) {
         return embed.length > 0
       }
+      if (item === "superscript") {
+        return allowedHtml.includes("sup")
+      }
+      if (item === "subscript") {
+        return allowedHtml.includes("sub")
+      }
       return true
     }
 
@@ -128,10 +136,13 @@ export default function MarkdownEditor(props: Props): JSX.Element {
         toolbar: {
           ...FullEditorConfig.toolbar,
           items: FullEditorConfig.toolbar.items.filter(toolbarItemsFilter)
+        },
+        [MARKDOWN_CONFIG_KEY]: {
+          allowedHtml
         }
       }
     }
-  }, [minimal, renderResource, openResourcePicker, link, embed])
+  }, [minimal, renderResource, openResourcePicker, link, embed, allowedHtml])
 
   const onChangeCB = useCallback(
     (_event: any, editor: any) => {

--- a/static/js/lib/ckeditor/CKEditor.ts
+++ b/static/js/lib/ckeditor/CKEditor.ts
@@ -1,6 +1,8 @@
 import EssentialsPlugin from "@ckeditor/ckeditor5-essentials/src/essentials"
 import AutoformatPlugin from "@ckeditor/ckeditor5-autoformat/src/autoformat"
 import BoldPlugin from "@ckeditor/ckeditor5-basic-styles/src/bold"
+import SubscriptPlugin from "@ckeditor/ckeditor5-basic-styles/src/subscript"
+import SuperscriptPlugin from "@ckeditor/ckeditor5-basic-styles/src/superscript"
 import ItalicPlugin from "@ckeditor/ckeditor5-basic-styles/src/italic"
 import BlockQuotePlugin from "@ckeditor/ckeditor5-block-quote/src/blockquote"
 import HeadingPlugin from "@ckeditor/ckeditor5-heading/src/heading"
@@ -86,6 +88,8 @@ export const FullEditorConfig = {
     ResourcePicker,
     ResourceLink,
     ResourceLinkMarkdownSyntax,
+    SubscriptPlugin,
+    SuperscriptPlugin,
     TableMarkdownSyntax,
     MathSyntax, // Needs to go before MarkdownListSyntax
     MarkdownListSyntax,
@@ -100,6 +104,8 @@ export const FullEditorConfig = {
       "|",
       "bold",
       "italic",
+      "subscript",
+      "superscript",
       "link",
       "bulletedList",
       "numberedList",

--- a/static/js/lib/ckeditor/plugins/Markdown.ts
+++ b/static/js/lib/ckeditor/plugins/Markdown.ts
@@ -6,7 +6,11 @@ import { editor } from "@ckeditor/ckeditor5-core"
 import MarkdownConfigPlugin from "./MarkdownConfigPlugin"
 import { ATTRIBUTE_REGEX } from "./constants"
 
-import { turndownService } from "../turndown"
+import {
+  resetTurndownService,
+  turndownService,
+  turndownHtmlHelpers
+} from "../turndown"
 import Turndown from "turndown"
 import { buildAttrsString } from "./util"
 import { validateHtml2md } from "./validateMdConversion"
@@ -70,8 +74,6 @@ export class MarkdownDataProcessor extends GFMDataProcessor {
 const TD_CONTENT_REGEX = /<td.*?>([\S\s]*?)<\/td>/g
 const TH_CONTENT_REGEX = /<th(?!ead).*?>([\S\s]*?)<\/th>/g
 
-const BASE_TURNDOWN_RULES = [...turndownService.rules.array]
-
 /**
  * Plugin implementing Markdown for CKEditor
  *
@@ -82,10 +84,16 @@ const BASE_TURNDOWN_RULES = [...turndownService.rules.array]
 export default class Markdown extends MarkdownConfigPlugin {
   turndownRules: Turndown.Rule[]
 
+  allowedHtml: (keyof HTMLElementTagNameMap)[]
+
   constructor(editor: editor.Editor) {
     super(editor)
 
-    const { showdownExtensions, turndownRules } = this.getMarkdownConfig()
+    const {
+      showdownExtensions,
+      turndownRules,
+      allowedHtml
+    } = this.getMarkdownConfig()
 
     const converter = new Converter({
       extensions: showdownExtensions
@@ -93,11 +101,12 @@ export default class Markdown extends MarkdownConfigPlugin {
 
     converter.setFlavor("github")
 
-    turndownService.rules.array = [...BASE_TURNDOWN_RULES]
+    resetTurndownService()
     turndownRules.forEach(({ name, rule }) =>
       turndownService.addRule(name, rule)
     )
     this.turndownRules = [...turndownService.rules.array]
+    this.allowedHtml = allowedHtml
 
     function formatTableCell(
       el: string,
@@ -153,9 +162,13 @@ export default class Markdown extends MarkdownConfigPlugin {
   turndown = (html: string) => {
     try {
       turndownService.rules.array = this.turndownRules
-      return turndownService.turndown(html)
+
+      turndownService.rules.keepReplacement = turndownHtmlHelpers.keepReplacer
+      turndownService.keep(this.allowedHtml)
+
+      return turndownHtmlHelpers.turndown(html)
     } finally {
-      turndownService.rules.array = BASE_TURNDOWN_RULES
+      resetTurndownService()
     }
   }
 

--- a/static/js/lib/ckeditor/plugins/MarkdownConfigPlugin.ts
+++ b/static/js/lib/ckeditor/plugins/MarkdownConfigPlugin.ts
@@ -2,8 +2,7 @@ import Plugin from "@ckeditor/ckeditor5-core/src/plugin"
 import { editor } from "@ckeditor/ckeditor5-core"
 
 import { MarkdownConfig } from "../../../types/ckeditor_markdown"
-
-const MARKDOWN_CONFIG_KEY = "markdown-config"
+import { MARKDOWN_CONFIG_KEY } from "./constants"
 
 /**
  * Abstract class providing functionality to get and set the
@@ -11,6 +10,11 @@ const MARKDOWN_CONFIG_KEY = "markdown-config"
  * syntax rules need to inherit from this plugin.
  */
 export default abstract class MarkdownConfigPlugin extends Plugin {
+  static defaults = {
+    showdownExtensions: [],
+    turndownRules:      []
+  }
+
   constructor(editor: editor.Editor) {
     super(editor)
   }
@@ -19,12 +23,9 @@ export default abstract class MarkdownConfigPlugin extends Plugin {
    * Returns the Markdown configuration set on this.editor
    */
   getMarkdownConfig(): MarkdownConfig {
-    return (
-      this.editor.config.get(MARKDOWN_CONFIG_KEY) ?? {
-        showdownExtensions: [],
-        turndownRules:      []
-      }
-    )
+    const provided = this.editor.config.get(MARKDOWN_CONFIG_KEY)
+
+    return { ...MarkdownConfigPlugin.defaults, ...provided }
   }
 
   /**

--- a/static/js/lib/ckeditor/plugins/MarkdownSyntaxPlugin.ts
+++ b/static/js/lib/ckeditor/plugins/MarkdownSyntaxPlugin.ts
@@ -25,6 +25,7 @@ export default abstract class MarkdownSyntaxPlugin extends MarkdownConfigPlugin 
   loadMarkdownSyntax(): void {
     const currentConfig = this.getMarkdownConfig()
     const newConfig = {
+      ...currentConfig,
       showdownExtensions: [
         ...currentConfig.showdownExtensions,
         this.showdownExtension

--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.test.ts
@@ -110,4 +110,66 @@ describe("ResourceLink plugin", () => {
     )}">{{&lt; sup 2 &gt;}}</a> Woof</p>`
     markdownTest(editor, md, html)
   })
+
+  it.each([
+    {
+      allowedHtml: ["sup"],
+      sup:         (x: string) => `<sup>${x}</sup>`
+    },
+    {
+      allowedHtml: [""],
+      sup:         (x: string) => x
+    }
+  ])(
+    "Preserves superscripts in the link title iff sub tag is permitted",
+    async ({ allowedHtml, sup }) => {
+      const editor = await getEditor("", {
+        "markdown-config": { allowedHtml }
+      })
+      const { md2html, html2md } = getConverters(editor)
+
+      const html = `<p>Dogs <sup>x</sup> <a class="resource-link" data-uuid="${encode(
+        "uuid123"
+      )}">Einstein says E=mc<sup>2</sup></a> Woof</p>`
+
+      const md =
+        'Dogs <sup>x</sup> {{% resource_link "uuid123" "Einstein says E=mc<sup>2</sup>" %}} Woof'
+      /**
+       * md -> html always keeps extra tags
+       */
+      expect(md2html(md)).toBe(html)
+
+      /**
+       * html -> md only keeps extra tags if specified by allowedHtml
+       */
+      expect(html2md(html)).toBe(
+        `Dogs ${sup("x")} {{% resource_link "uuid123" "Einstein says E=mc${sup(
+          "2"
+        )}" %}} Woof`
+      )
+    }
+  )
+
+  /**
+   * It seems that this scenario cannot actually be constructed in CKEditor.
+   * CKEditor treats subscripts, subscripts, links, and resource links as
+   * attributes on a text node, not as some sort of tree structure (like html)
+   * with nesting. It's unclear how the conversion order from "attributes on
+   * text node" to an HTML tree is performed, but it seems that resource_link
+   * always ends up on the outside.
+   *
+   * Still, nice that this works.
+   */
+  it("Preserves resource links inside superscripts if sup enabled", async () => {
+    const editor = await getEditor("", {
+      "markdown-config": { allowedHtml: ["sup"] }
+    })
+    const md =
+      'Cool reference<sup>{{% resource_link "uuid123" "\\[1\\]" %}}</sup>'
+    const html = `<p>Cool reference<sup><a class="resource-link" data-uuid="${encode(
+      "uuid123"
+    )}">[1]</a></sup></p>`
+
+    markdownTest(editor, md, html)
+  })
 })

--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
@@ -10,6 +10,7 @@ import {
   RESOURCE_LINK
 } from "@mitodl/ckeditor5-resource-link/src/constants"
 import { Shortcode, escapeShortcodes } from "./util"
+import { turndownService } from "../turndown"
 
 export const encodeShortcodeArgs = (...args: (string | undefined)[]) =>
   encodeURIComponent(JSON.stringify(args))
@@ -76,15 +77,22 @@ export default class ResourceLinkMarkdownSyntax extends MarkdownSyntaxPlugin {
             )
           },
           replacement: (_content: string, node: Turndown.Node): string => {
-            const [uuid, anchor] = decodeShortcodeArgs(
-              (node as any).getAttribute("data-uuid") as string
+            const anchor = node as HTMLAnchorElement
+            const [uuid, fragment] = decodeShortcodeArgs(
+              anchor.getAttribute("data-uuid") as string
             )
 
-            const text = node.textContent
+            const text = turndownService
+              .turndown(anchor.innerHTML)
+              /**
+               * When turndown converts innerHTML to markdown, it will convert
+               * `{{&lt;` to `{{\<`. So we need to unescape that.
+               */
+              .replace(/{{\\</g, "{{<")
 
             if (text === null) return ""
 
-            return Shortcode.resourceLink(uuid, text, anchor).toHugo()
+            return Shortcode.resourceLink(uuid, text, fragment).toHugo()
           }
         }
       }

--- a/static/js/lib/ckeditor/plugins/constants.ts
+++ b/static/js/lib/ckeditor/plugins/constants.ts
@@ -10,6 +10,8 @@ export const RESOURCE_LINK = "resourceLink"
 
 export const RESOURCE_EMBED_COMMAND = "insertResourceEmbed"
 
+export const MARKDOWN_CONFIG_KEY = "markdown-config"
+
 import { RESOURCE_LINK_COMMAND } from "@mitodl/ckeditor5-resource-link/src/constants"
 import TurndownService from "turndown"
 

--- a/static/js/lib/ckeditor/plugins/test_util.ts
+++ b/static/js/lib/ckeditor/plugins/test_util.ts
@@ -5,11 +5,17 @@ import { MarkdownDataProcessor } from "./Markdown"
 
 class ClassicTestEditor extends ClassicEditorBase {}
 
-export const createTestEditor = (plugins: any[]) => async (
-  initialData = ""
+export const createTestEditor = (
+  plugins: unknown[],
+  remainingConfig: Record<string, unknown> = {}
+) => async (
+  initialData = "",
+  configOverrides: Record<string, unknown> = {}
 ): Promise<editor.Editor & { getData(): string }> => {
   const editor = await ClassicTestEditor.create(initialData, {
-    plugins
+    plugins,
+    ...remainingConfig,
+    ...configOverrides
   })
   return editor
 }

--- a/static/js/lib/ckeditor/turndown.ts
+++ b/static/js/lib/ckeditor/turndown.ts
@@ -111,3 +111,121 @@ itemRule.replacement = (
     prefix + content + (node.nextSibling && !/\n$/.test(content) ? "\n" : "")
   )
 }
+
+const BASE_TURNDOWN_RULES = [...turndownService.rules.array]
+const BASE_TURNDOWN_KEEP = [
+  // @ts-expect-error `_keep` is not part of Turndown's public API, see `resetTurndownService` for more.
+  ...turndownService.rules._keep
+]
+const BASE_TURNDOWN_KEEP_REPLACEMENT = turndownService.rules.keepReplacement
+
+/**
+ * CKEditor's markdown plugin uses a single Turndown instance. We occasionally
+ * want to reset it to its initial state (e.g., for different editor instances).
+ */
+export const resetTurndownService = () => {
+  turndownService.rules.array = [...BASE_TURNDOWN_RULES]
+
+  /**
+   * We need to access `_keep` in order to "reset" what HTML tags Turndown will
+   * keep when converting HTML to Markdown. Turndown has a public API for
+   * adding tags to its "keep" list, but not for removing tags or resetting its
+   * list.
+   */
+  // @ts-expect-error `_keep` is not part of Turndown's public API, see above
+  turndownService.rules._keep = [...BASE_TURNDOWN_KEEP]
+  turndownService.rules.keepReplacement = BASE_TURNDOWN_KEEP_REPLACEMENT
+}
+
+/**
+ * This class contains a few helpers that improve upon the default way in which
+ * Turndown includes raw HTML tags in the markdown output.
+ *
+ * When converting HTML -> MD, Turndown generally ignores HTML tags that have no
+ * markdown equivalent. (E.g., "span", "div", "sup", "sub", ...). This behavior
+ * can be customized in two ways:
+ *  1. turndown's `keep` method tells Turndown which rules to keep
+ *  2. turndown's `keepReplacement` option tells Turndown HOW to replace those tags
+ *
+ * The default behavior of `keepReplacement` has two drawbacks:
+ *
+ * Issue #1
+ * -----------
+ * The default behavior can result in HTML tags beginning a markdown line that
+ * would otherwise be a Markdown paragraph. For example:
+ * ```js
+ * const tds = new TurndownService()
+ * tds.keep(["sup"])
+ * tds.turndown("<p><sup>2</sup> Hello <strong>world</strong>!</p>")
+ * // => "<sup>2</sup> Hello **world**!"
+ * ```
+ * The output above is bad because when an HTML tag begins a markdown line, it
+ * begins a *block* of markdown, and subsequent characters on that line are
+ * NOT treated as Markdown. Hence the `**` above would be rendered as literal
+ * asterisks, not as bold.
+ *
+ * Issue #2
+ * ------------
+ * The default behavior is that the *content* of an HTML tag is not converted
+ * to Markdown. This is problematic for tags that contain shortcode HTML. For
+ * example, `<sup><a class="resource-link" data-uuid ... >2</a></sup>` should
+ * really needs its content to be converted to markdown in order for Hugo to
+ * recognize it as a shortcode.
+ */
+class TurndownHtmlHelpers {
+  private turndownInstance: Turndown
+
+  constructor(turndown: Turndown) {
+    this.turndownInstance = turndown
+  }
+
+  /**
+   * This function improves upon Turndown's default rule for including raw HTML
+   * tags in Markdown. In particular, it:
+   *  - ensures that the child content of an inline HTML node is also converted, which
+   *    we need in case the child content contains shortcode.
+   *  - ensures that an inline HTML tag never begins a line of Markdown.
+   *
+   * Should be used alongside {@link TurndownHtmlHelpers.turndown}
+   */
+  keepReplacer: Turndown.ReplacementFunction = (content, node) => {
+    /**
+     * "isBlock" is a Turndown-specific addition to the DOM node interface.
+     * It appears to be part of their public API in that the author recommends
+     * using it in several issues.
+     */
+    const el = node as HTMLElement & { isBlock: boolean }
+
+    if (el.isBlock) {
+      throw new Error("Inclusion of block content not yet supported.")
+    }
+
+    /**
+     * Now convert the node's child content to Markdown.
+     * This addresses Issue #2 above.
+     */
+    const clone = el.cloneNode() as HTMLElement
+    clone.innerHTML = this.turndownInstance.turndown(el.innerHTML)
+
+    /**
+     * To address Issue #1, we'll mark places where HTML is inserted. Later, we
+     * can remove all the markings except the ones that begin a new line.
+     */
+    return `<raw_inline></raw_inline>${clone.outerHTML}`
+  }
+
+  /**
+   * Convert HTML to markdown and insert a zero-width space before any HTML
+   * tag that begins what would otherwise be a Markdown paragraph. Should
+   * be used alongside {@link TurndownHtmlHelpers.keepReplacer}.
+   *
+   * See {@link TurndownHtmlHelpers} for more details.
+   */
+  turndown = (html: string) =>
+    this.turndownInstance
+      .turndown(html)
+      .replace(/(^|(?<=\n))[ ]*<raw_inline><\/raw_inline>/g, "\u200b")
+      .replace(/<raw_inline><\/raw_inline>/g, "")
+}
+
+export const turndownHtmlHelpers = new TurndownHtmlHelpers(turndownService)

--- a/static/js/lib/site_content.test.ts
+++ b/static/js/lib/site_content.test.ts
@@ -429,18 +429,20 @@ describe("site_content", () => {
         embed:   ["resource"]
       })
       expect(widgetExtraProps(field)).toStrictEqual({
-        minimal: false,
-        link:    ["resource", "page"],
-        embed:   ["resource"]
+        minimal:     false,
+        link:        ["resource", "page"],
+        embed:       ["resource"],
+        allowedHtml: []
       })
     })
 
     it("sets minimal = true for markdown fields by default", () => {
       const field = makeWebsiteConfigField({ widget: WidgetVariant.Markdown })
       expect(widgetExtraProps(field)).toStrictEqual({
-        minimal: true,
-        link:    [],
-        embed:   []
+        minimal:     true,
+        link:        [],
+        embed:       [],
+        allowedHtml: []
       })
     })
 

--- a/static/js/lib/site_content.ts
+++ b/static/js/lib/site_content.ts
@@ -96,9 +96,10 @@ export function widgetExtraProps(field: ConfigField): Record<string, any> {
     return pick(SELECT_EXTRA_PROPS, field)
   case WidgetVariant.Markdown:
     return {
-      minimal: field.minimal ?? true,
-      link:    field.link ?? [],
-      embed:   field.embed ?? []
+      minimal:     field.minimal ?? true,
+      link:        field.link ?? [],
+      embed:       field.embed ?? [],
+      allowedHtml: field.allowed_html ?? []
     }
   case WidgetVariant.Relation:
     return pick(RELATION_EXTRA_PROPS, field)

--- a/static/js/pages/MarkdownEditorTestPage.tsx
+++ b/static/js/pages/MarkdownEditorTestPage.tsx
@@ -64,6 +64,7 @@ function MarkdownEditorTestWrapper(props: Props) {
           minimal={minimal}
           embed={[]}
           link={[]}
+          allowedHtml={[]}
         />
       </div>
       <div className="w-75 m-auto">

--- a/static/js/types/ckeditor.d.ts
+++ b/static/js/types/ckeditor.d.ts
@@ -26,6 +26,10 @@ declare module '@ckeditor/ckeditor5-basic-styles/src/italic';
 
 declare module '@ckeditor/ckeditor5-basic-styles/src/bold';
 
+declare module '@ckeditor/ckeditor5-basic-styles/src/superscript';
+
+declare module '@ckeditor/ckeditor5-basic-styles/src/subscript';
+
 declare module '@ckeditor/ckeditor5-basic-styles/src/underline';
 
 declare module '@ckeditor/ckeditor5-autoformat/src/autoformat';

--- a/static/js/types/ckeditor_markdown.ts
+++ b/static/js/types/ckeditor_markdown.ts
@@ -9,4 +9,5 @@ export interface TurndownRule {
 export interface MarkdownConfig {
   showdownExtensions: Array<() => Showdown.ShowdownExtension[]>
   turndownRules: TurndownRule[]
+  allowedHtml: (keyof HTMLElementTagNameMap)[]
 }

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -53,6 +53,7 @@ export interface MarkdownConfigField extends ConfigFieldBaseProps {
   minimal?: boolean
   link?: string[]
   embed?: string[]
+  allowed_html?: string[]
 }
 
 export interface FileConfigField extends ConfigFieldBaseProps {

--- a/websites/config_schema/site-config-schema.yml
+++ b/websites/config_schema/site-config-schema.yml
@@ -24,6 +24,7 @@ field:
     label: str()
     name: str()
     minimal: bool(required=False)
+    allowed_html: list(str(), required=False)
     required: bool(required=False)
     help: str(required=False)
     fields: list(include('field'), required=False)


### PR DESCRIPTION


#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1061 

#### What's this PR do?
This is a new version of #1588, which we reverted because of a CKEditor issue. We believe that updating from v31 to v35 of CKEditor resolved that issue.

This PR adds support for subscripts and superscripts in markdown via inclusion of raw `<sub>` and `<sup>` tags. Arbitrary HTML is not permitted: only HTML tags whitelisted in the markdown widget config's `allow_html` list will be permitted. Additionally, the only non-markdown tags that our CKEditor setup will generate are sub/sup, and only if the tags are allowed.

This approach turned out to not be as quite "works out of the box" as I originally thought. Two issues came up, both having to do with the fact that while MD --> HTML conversion is well specified by CommonMark, there is no specification for  HTML --> MD conversion (which we need when extracting data from CKEditor). The two issues were:

1. **`<sup>` at start of paragraph:** Markdown literally cannot handle this. HTML at the beginning of a line creates an HTML block, and the remainder of the line is parsed as raw HTML rather than Markdown. So the two lines

    ```md
    <sup>1</sup>:  This renders raw html with **asterisks**

    x<sup>1</sup> This renders as markdown with **bold**.
    ```

    end up behaving very differently.
2. **MD inside html tags**: The default behavior for Turndown (our html->md converter) when including raw HTML in markdown is to not process the content of the HTML *at all*. But HTML tags are generally allowed to contain markdown[^1] content, and it's important to convert that content to markdown.

[^1]: This is absolutely true for [markdown inline html](https://spec.commonmark.org/0.30/#raw-html). The story is a little more complicated for [markdown block html](https://spec.commonmark.org/0.30/#html-blocks).

#### How should this be manually tested?
1. Load the course-v2 config from https://github.com/mitodl/ocw-hugo-projects/pull/234 into your local studio
2. Create a page and add subscripts/superscripts. Some things that are worth trying are subscripts/superscripts
    - at the beginning of a line
    - in links and resource links
    - in tables
    - bold inside the subscript/superscript *though we do not encourage authors to do this, ckeditor will not prevent it.*
3. Check the markdown in admin panel. It should look correct.
4. Check that the markdown renders correctly in ocw-hugo-themes using branch from https://github.com/mitodl/ocw-hugo-themes/pull/1004
5. ⚠️ Try to reproduce  the bug shown here https://github.com/mitodl/ocw-studio/issues/1061#issuecomment-1335839283 ... you'll need to watch the dev console locally. The bug should not be reproducible now that we've updated to CKEditor 35.

#### Screenshots

<img width="1279" alt="Screen Shot 2022-11-30 at 9 05 59 AM" src="https://user-images.githubusercontent.com/9010790/204816853-1a0a69de-8daa-47a4-adbc-4637f2f6e7d5.png">

#### Other Context

HQ discussion: https://github.com/mitodl/hq/discussions/303