### PR TITLE
purge cache on build failures; add alerts

### DIFF
--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -11,6 +11,12 @@ resource_types:
       repository: governmentpaas/s3-resource
       tag: latest
 resources:
+  - name: slack-webhook
+    type: slack-alert
+    check_every: never
+    source:
+      url: ((slack-url))
+      disabled: false
   - name: ocw-hugo-themes
     type: git
     source:
@@ -33,6 +39,7 @@ resources:
       bucket: ((artifacts-bucket))
       versioned_file: ocw-hugo-themes/((ocw-hugo-themes-branch))/webpack.json
   # END ONLINE-ONLY
+
 # START ONLINE-ONLY
 task-config: &webhook-config
   platform: linux
@@ -40,6 +47,34 @@ task-config: &webhook-config
     type: registry-image
     source: {repository: curlimages/curl}
 # END ONLINE-ONLY
+
+task-purge-cdn-cache: &task-purge-cdn-cache
+  task: clear-cdn-cache
+  timeout: 1m
+  attempts: 3
+  config:
+    platform: linux
+    image_resource:
+      type: registry-image
+      source: {repository: curlimages/curl}
+    # START NON-DEV
+    run:
+      path: curl
+      args:
+        - -f
+        - -X
+        - POST
+        - -H
+        - 'Fastly-Key: ((fastly_((version)).api_token))'
+        - -H
+        - 'Fastly-Soft-Purge: 1'
+        - https://api.fastly.com/service/((fastly_((version)).service_id))/purge_all
+    # END NON-DEV
+    # START DEV-ONLY
+      path: echo
+      args: [Skipping cdn cache purge (this is a dev environment)]
+    # END DEV-ONLY
+
 jobs:
 - name: mass-publish
   serial: true
@@ -265,26 +300,28 @@ jobs:
               echo "ALL BUILDS SUCCEEDED" > /dev/tty
               exit 0
             fi
+    # START ONLINE-ONLY
+    on_failure:
+      try:
+        do:
+         - << : *task-purge-cdn-cache
+    # END ONLINE-ONLY
   # START ONLINE-ONLY
-  # START NON-DEV
-  - task: clear-cdn-cache
-    timeout: 1m
-    attempts: 3
-    config:
-      platform: linux
-      image_resource:
-        type: registry-image
-        source: {repository: curlimages/curl}
-      run:
-        path: curl
-        args:
-          - -f
-          - -X
-          - POST
-          - -H
-          - 'Fastly-Key: ((fastly_((version)).api_token))'
-          - -H
-          - 'Fastly-Soft-Purge: 1'
-          - https://api.fastly.com/service/((fastly_((version)).service_id))/purge_all
-  # END NON-DEV
+  - << : *task-purge-cdn-cache
   # END ONLINE-ONLY
+  on_failure:
+    try:
+      do:
+      - put: slack-webhook
+        timeout: 1m
+        params:
+          alert_type: failed
+          text: Mass publish has failed. See Concourse ui (link below) for details.
+  on_abort:
+    try:
+      do:
+      - put: slack-webhook
+        timeout: 1m
+        params:
+          alert_type: aborted
+          text: User aborted during mass publish. See Concourse ui (link below) for details.

--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -57,8 +57,8 @@ task-purge-cdn-cache: &task-purge-cdn-cache
     image_resource:
       type: registry-image
       source: {repository: curlimages/curl}
-    # START NON-DEV
     run:
+      # START NON-DEV
       path: curl
       args:
         - -f


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
#1621 

#### What's this PR do?
This PR changes alerting and cache purging for the mass build pipeline:
- we now get an alert if the overall mass build job fails or is aborted
- we now purge the cdn cache if EITHER the job is successful, OR the hugo build step fails. *The point is: if 2500 courses succeed and 10 fail, we want to purge the cache. Currently there is no checking as to how many failed. Basically, the cache is always purged if the job gets to the hugo build step. (unless the job is aborted during that step).*

#### How should this be manually tested?
This PR involves a slack webhook. If you want to see that webhook actually work, set up a slack app as described in https://github.com/mitodl/ocw-studio/pull/1576#issue-1454008273. **But:** imo, you don't really need to check this functionality. you can still see the slack webhook fire, it will just fail since there's no valid URL. _on the other hand, it's not htat hard to set up._

1. You will be running the mass build. You don't want to build all the courses, so manually edit `WebsiteMassBuildViewSet` in websites/views to a filter, something like (modify as you see fit):
    ```py
    sites = sites.filter(Q(short_id="1.00-spring-2012") | Q(short_id="17.810-spring-2001"))
    sites = sites.prefetch_related("starter").order_by("name")
    ```
2. Re-upsert the mass build pipeline: `docker compose exec web ./manage.py upsert_mass_build_pipeline`
3. Run the pipeline in local concourse (http://concourse:8080/). It should succeed.
    - check that the cdn is purged *It won't actually be purged, but there will be a message about it.*
4. Make one of the courses fail...somehow. One way to do this is to manually commit a bad instructor uuid to the course repo.
5.  Run the pipeline in local concourse (http://concourse:8080/). It should fail, AND:
    - cdn purging message should still appear
    - a slack alert should be issued _if you didn't set up slack alerting, you'll just see some message about an invalid slack url_
