### PR TITLE
abort onReady if no editor

### DIFF
--- a/static/js/components/widgets/MarkdownEditor.tsx
+++ b/static/js/components/widgets/MarkdownEditor.tsx
@@ -50,7 +50,16 @@ export default function MarkdownEditor(props: Props): JSX.Element {
   const editor = useRef<Editor>()
   const onReady = useCallback((editorInstance: Editor) => {
     editor.current = editorInstance
-    if (process.env.NODE_ENV === "development" && editor.current) {
+    if (!editor.current) {
+      /**
+       * It is unclear to me why this happens.
+       * It seems like when our MarkdownEditor opens, an editor is created,
+       * immediately destroyed, onReady is called (with null), and then
+       * re-created, and onReady is called again (with real editor)
+       */
+      return
+    }
+    if (process.env.NODE_ENV === "development") {
       CKEditorInspector.attach(editor)
     }
     editor.current.model.schema.addAttributeCheck(checkNotSubAndSup)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested


#### What are the relevant tickets?
Small followup to #1627 

#### What's this PR do?
See comment.

#### How should this be manually tested?
When you open the editor, you should not see the 'reading "model"' error below
<img width="815" alt="Screenshot 2022-12-21 at 2 05 17 PM" src="https://user-images.githubusercontent.com/9010790/208985337-24e104c1-85ac-444c-a57a-f87821ba6889.png">
