### PR TITLE
add offline build to single course pipeline

### DIFF
--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -445,7 +445,7 @@ class SitePipeline(BaseSitePipeline, GeneralPipeline):
                 .replace("((ocw-studio-bucket))", storage_bucket_name or "")
                 .replace("((open-discussions-url))", settings.OPEN_DISCUSSIONS_URL)
                 .replace("((open-webhook-key))", settings.OCW_NEXT_SEARCH_WEBHOOK_KEY)
-                .replace("((ocw-site-repo))", self.WEBSITE.short_id)
+                .replace("((short-id))", self.WEBSITE.short_id)
                 .replace("((ocw-site-repo-branch))", branch)
                 .replace("((config-slug))", self.WEBSITE.starter.slug)
                 .replace("((s3-path))", self.WEBSITE.s3_path)
@@ -473,6 +473,12 @@ class SitePipeline(BaseSitePipeline, GeneralPipeline):
                 .replace(
                     "((ocw-hugo-themes-sentry-dsn))",
                     settings.OCW_HUGO_THEMES_SENTRY_DSN or "",
+                )
+                .replace(
+                    "((delete))",
+                    ""
+                    if self.WEBSITE.name == settings.ROOT_WEBSITE_NAME
+                    else " --delete",
                 )
             )
             self.upsert_config(config_str, pipeline_name)

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -336,23 +336,28 @@ def test_upsert_website_pipelines(
     assert settings.OCW_COURSE_STARTER_SLUG in config_str
     assert api_url in config_str
 
+    # Check various s3 syncs
     storage_bucket_name = expected_template_vars["storage_bucket_name"]
+    assert (
+        f"aws s3 {expected_endpoint_prefix}sync s3://{storage_bucket_name}/{website.s3_path} ./static-resources"
+        in config_str
+    )
     if home_page:
         assert (
-            f"s3 {expected_endpoint_prefix}sync s3://{storage_bucket_name}/{website.name} s3://{bucket}/{website.name} --metadata site-id={website.name}"
-            in config_str
-        )
-        assert (
-            f"aws s3 {expected_endpoint_prefix}sync course-markdown/public s3://{bucket}/ --metadata site-id={website.name}"
+            f"aws s3 {expected_endpoint_prefix}sync course-markdown/output-online s3://{bucket}/ --metadata site-id={website.name}"
             in config_str
         )
     else:
         assert (
-            f"s3 {expected_endpoint_prefix}sync s3://{storage_bucket_name}/courses/{website.name} course-markdown/public"
+            f"aws s3 {expected_endpoint_prefix}sync s3://{bucket}/static ./static"
             in config_str
         )
         assert (
-            f"aws s3 {expected_endpoint_prefix}sync course-markdown/public s3://{bucket}/{website.url_path} --metadata site-id={website.name} --delete"
+            f"aws s3 {expected_endpoint_prefix}sync build-course-offline/ s3://{bucket}/{website.url_path} --exclude='*' --include='{website.short_id}.zip' --metadata site-id={website.name}"
+            in config_str
+        )
+        assert (
+            f"aws s3 {expected_endpoint_prefix}sync course-markdown/output-online s3://{bucket}/{website.url_path} --metadata site-id={website.name} --delete"
             in config_str
         )
 

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -471,7 +471,7 @@ jobs:
             path: sh
             args:
             - -exc
-            - aws s3((cli-endpoint-url)) sync build-course-offline/ s3://((ocw-bucket))/((base-url)) --exclude="*" --include="((short-id)).zip" --metadata site-id=((site-name))
+            - aws s3((cli-endpoint-url)) sync build-course-offline/ s3://((ocw-bucket))/((base-url)) --exclude='*' --include='((short-id)).zip' --metadata site-id=((site-name))
         on_failure:
           try:
             do:

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -317,10 +317,30 @@ jobs:
                 alert_type: aborted
                 text: "User Aborted while getting course-markdown : ((pipeline_name))/((site-name))"
             # END NON-DEV
-      - task: build-course-task
+      - task: static-resources
+        timeout: 40m
+        attempts: 3
+        # START DEV-ONLY
+        params:
+          AWS_ACCESS_KEY_ID: ((minio-root-user))
+          AWS_SECRET_ACCESS_KEY: ((minio-root-password))
+        # END DEV-ONLY
+        config:
+          outputs:
+            - name: static-resources
+          platform: linux
+          image_resource:
+            type: registry-image
+            source: {repository: amazon/aws-cli, tag: latest}
+          run:
+            path: sh
+            args:
+            - -exc
+            - aws s3((cli-endpoint-url)) sync s3://((ocw-studio-bucket))/((s3-path)) ./static-resources
+      - task: build-course-offline
         timeout: 20m
         attempts: 3
-        params:
+        params: &build-course-params
           API_BEARER_TOKEN: ((api-token))
           GTM_ACCOUNT_ID: ((gtm-account-id))
           OCW_STUDIO_BASE_URL: ((ocw-studio-url))
@@ -331,6 +351,8 @@ jobs:
           SENTRY_DSN: ((ocw-hugo-themes-sentry-dsn))
           # START DEV-ONLY
           RESOURCE_BASE_URL: ((resource-base-url))
+          AWS_ACCESS_KEY_ID: ((minio-root-user))
+          AWS_SECRET_ACCESS_KEY: ((minio-root-password))
           # END DEV-ONLY
         config:
           platform: linux
@@ -339,22 +361,42 @@ jobs:
             source: {repository: mitodl/ocw-course-publisher, tag: 0.3}
           inputs:
             - name: ocw-hugo-themes
-            - name: course-markdown
             - name: ocw-hugo-projects
+            - name: course-markdown
+            - name: static-resources
             - name: webpack-json
           outputs:
             - name: course-markdown
             - name: ocw-hugo-themes
+            - name: build-course-offline
           run:
             dir: course-markdown
             path: sh
             args:
             - -exc
             - |
-              cp ../webpack-json/webpack.json ../ocw-hugo-themes/base-theme/data
-              hugo --config ../ocw-hugo-projects/((config-slug))/config.yaml --baseUrl /((base-url)) --themesDir ../ocw-hugo-themes/ ((build-drafts))
+              if [ -f "../ocw-hugo-projects/((config-slug))/config-offline.yaml" ];
+              then
+                cp ../webpack-json/webpack.json ../ocw-hugo-themes/base-theme/data
+                mkdir -p ./content/static_resources
+                mkdir -p ./static/static_resources
+                if [ ! -z "$(ls -A ../static-resources)" ];
+                then
+                  find ../static-resources ! -name '*.mp4' -type f | xargs cp -t ./content/static_resources
+                fi
+                HTML_COUNT="$(ls -1 ./content/static_resources/*.html 2>/dev/null | wc -l)"
+                if [ $HTML_COUNT != 0 ];
+                then
+                  mv ./content/static_resources/*.html ./static/static_resources
+                fi
+                touch ./content/static_resources/_index.md
+                hugo --config ../ocw-hugo-projects/((config-slug))/config-offline.yaml --themesDir ../ocw-hugo-themes/ ((build-drafts)) --destination output
+                zip ../build-course-offline/((short-id)).zip -r ./output
+              else
+                echo "Offline configuration not found for site type ((config-slug))"
+              fi
         on_failure:
-          try:
+          try: &build-failure-webhooks
             do:
             - put: ocw-studio-webhook
               timeout: 1m
@@ -373,7 +415,7 @@ jobs:
                 text: "Failed on build-course-task : ((pipeline_name))/((site-name))"
             # END NON-DEV
         on_error:
-          try:
+          try: &build-error-webhooks
             do:
             - put: ocw-studio-webhook
               timeout: 1m
@@ -391,7 +433,7 @@ jobs:
                 text: "Concourse System Error during build-course-task : ((pipeline_name))/((site-name))"
             # END NON-DEV
         on_abort:
-          try:
+          try: &build-abort-webhooks
             do:
             - put: ocw-studio-webhook
               timeout: 1m
@@ -408,6 +450,45 @@ jobs:
                 alert_type: aborted
                 text: "User Aborted during build-course-task : ((pipeline_name))/((site-name))"
             # END NON-DEV
+      - task: build-course-online
+        timeout: 20m
+        attempts: 3
+        params: 
+          << : *build-course-params
+        config:
+          platform: linux
+          image_resource:
+            type: registry-image
+            source: {repository: mitodl/ocw-course-publisher, tag: 0.3}
+          inputs:
+            - name: ocw-hugo-themes
+            - name: ocw-hugo-projects
+            - name: course-markdown
+            - name: build-course-offline
+            - name: static-resources
+            - name: webpack-json
+          outputs:
+            - name: course-markdown
+            - name: ocw-hugo-themes
+          run:
+            dir: course-markdown
+            path: sh
+            args:
+            - -exc
+            - |
+              cp ../webpack-json/webpack.json ../ocw-hugo-themes/base-theme/data
+              hugo --config ../ocw-hugo-projects/((config-slug))/config.yaml --baseUrl /((base-url)) --themesDir ../ocw-hugo-themes/ ((build-drafts)) --destination output
+              cp -r ../static-resources/. ./output
+              if [ -f "../build-course-offline/((short-id)).zip" ];
+              then
+                cp ../build-course-offline/((short-id)).zip  ./output
+              fi
+        on_failure:
+          << : *build-failure-webhooks
+        on_error:
+          << : *build-error-webhooks
+        on_abort:
+          << : *build-abort-webhooks
       - task: copy-s3-buckets
         timeout: 40m
         attempts: 3
@@ -427,15 +508,7 @@ jobs:
             path: sh
             args:
             - -exc
-            - |
-              if [ -z "((base-url))" ]
-              then
-                aws s3((cli-endpoint-url)) sync s3://((ocw-studio-bucket))/((s3-path)) s3://((ocw-bucket))/((site-url)) --metadata site-id=((site-name))
-                aws s3((cli-endpoint-url)) sync course-markdown/public s3://((ocw-bucket))/((base-url)) --metadata site-id=((site-name))
-              else
-                aws s3((cli-endpoint-url)) sync s3://((ocw-studio-bucket))/((s3-path)) course-markdown/public
-                aws s3((cli-endpoint-url)) sync course-markdown/public s3://((ocw-bucket))/((base-url)) --metadata site-id=((site-name)) --delete
-              fi
+            - aws s3((cli-endpoint-url)) sync course-markdown/output s3://((ocw-bucket))/((base-url)) --metadata site-id=((site-name))((delete))
         # START DEV-ONLY
         on_success:
           try:

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -569,7 +569,7 @@ jobs:
             - |
               cp ../webpack-json/webpack.json ../ocw-hugo-themes/base-theme/data
               hugo --config ../ocw-hugo-projects/((config-slug))/config.yaml --baseUrl /((base-url)) --themesDir ../ocw-hugo-themes/ ((build-drafts)) --destination output-online
-              cp -r ../static-resources/. ./output-online
+              cp -r -n ../static-resources/. ./output-online
               if [ -f "../build-course-offline/((short-id)).zip" ];
               then
                 cp ../build-course-offline/((short-id)).zip  ./output-online

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -340,7 +340,7 @@ jobs:
       - task: build-course-offline
         timeout: 20m
         attempts: 3
-        params: &build-course-params
+        params:
           API_BEARER_TOKEN: ((api-token))
           GTM_ACCOUNT_ID: ((gtm-account-id))
           OCW_STUDIO_BASE_URL: ((ocw-studio-url))
@@ -390,13 +390,15 @@ jobs:
                   mv ./content/static_resources/*.html ./static/static_resources
                 fi
                 touch ./content/static_resources/_index.md
-                hugo --config ../ocw-hugo-projects/((config-slug))/config-offline.yaml --themesDir ../ocw-hugo-themes/ ((build-drafts)) --destination output
-                zip ../build-course-offline/((short-id)).zip -r ./output
+                hugo --config ../ocw-hugo-projects/((config-slug))/config-offline.yaml --themesDir ../ocw-hugo-themes/ ((build-drafts)) --destination output-offline
+                cd output-offline
+                aws s3((cli-endpoint-url)) sync s3://((ocw-bucket))/static ./static
+                zip ../../build-course-offline/((short-id)).zip -r ./
               else
                 echo "Offline configuration not found for site type ((config-slug))"
               fi
         on_failure:
-          try: &build-failure-webhooks
+          try:
             do:
             - put: ocw-studio-webhook
               timeout: 1m
@@ -415,7 +417,7 @@ jobs:
                 text: "Failed on build-course-task : ((pipeline_name))/((site-name))"
             # END NON-DEV
         on_error:
-          try: &build-error-webhooks
+          try:
             do:
             - put: ocw-studio-webhook
               timeout: 1m
@@ -433,7 +435,7 @@ jobs:
                 text: "Concourse System Error during build-course-task : ((pipeline_name))/((site-name))"
             # END NON-DEV
         on_abort:
-          try: &build-abort-webhooks
+          try:
             do:
             - put: ocw-studio-webhook
               timeout: 1m
@@ -450,11 +452,100 @@ jobs:
                 alert_type: aborted
                 text: "User Aborted during build-course-task : ((pipeline_name))/((site-name))"
             # END NON-DEV
+      - task: upload-offline-build
+        timeout: 40m
+        attempts: 3
+        # START DEV-ONLY
+        params:
+          AWS_ACCESS_KEY_ID: ((minio-root-user))
+          AWS_SECRET_ACCESS_KEY: ((minio-root-password))
+        # END DEV-ONLY
+        config:
+          inputs:
+            - name: build-course-offline
+          platform: linux
+          image_resource:
+            type: registry-image
+            source: {repository: amazon/aws-cli, tag: latest}
+          run:
+            path: sh
+            args:
+            - -exc
+            - aws s3((cli-endpoint-url)) sync build-course-offline/ s3://((ocw-bucket))/((base-url)) --exclude="*" --include="((short-id)).zip" --metadata site-id=((site-name))
+        on_failure:
+          try:
+            do:
+            - put: ocw-studio-webhook
+              timeout: 1m
+              attempts: 3
+              params:
+                  text: |
+                    {
+                      "version": "((pipeline_name))",
+                      "status": "errored"
+                    }
+            # START NON-DEV
+            - put: slack-webhook
+              timeout: 1m
+              params:
+                alert_type: failed
+                text: "Failed on upload-offline-build : ((pipeline_name))/((site-name))"
+            # END NON-DEV
+        on_error:
+          try:
+            do:
+            - put: ocw-studio-webhook
+              timeout: 1m
+              attempts: 3
+              params:
+                  text: |
+                    {
+                      "version": "((pipeline_name))",
+                      "status": "errored"
+                    }
+            # START NON-DEV
+            - put: slack-webhook
+              timeout: 1m
+              params:
+                alert_type: errored
+                text: "Concourse System Error during upload-offline-build : ((pipeline_name))/((site-name))"
+            # END NON-DEV
+        on_abort:
+          try:
+            do:
+            - put: ocw-studio-webhook
+              timeout: 1m
+              attempts: 3
+              params:
+                  text: |
+                    {
+                      "version": "((pipeline_name))",
+                      "status": "aborted"
+                    }
+            # START NON-DEV
+            - put: slack-webhook
+              timeout: 1m
+              params:
+                alert_type: aborted
+                text: "User Aborted during upload-offline-build : ((pipeline_name))/((site-name))"
+            # END NON-DEV
       - task: build-course-online
         timeout: 20m
         attempts: 3
-        params: 
-          << : *build-course-params
+        params:
+          API_BEARER_TOKEN: ((api-token))
+          GTM_ACCOUNT_ID: ((gtm-account-id))
+          OCW_STUDIO_BASE_URL: ((ocw-studio-url))
+          STATIC_API_BASE_URL: ((static-api-base-url))
+          OCW_IMPORT_STARTER_SLUG: ((ocw-import-starter-slug))
+          OCW_COURSE_STARTER_SLUG: ((ocw-course-starter-slug))
+          SITEMAP_DOMAIN: ((sitemap-domain))
+          SENTRY_DSN: ((ocw-hugo-themes-sentry-dsn))
+          # START DEV-ONLY
+          RESOURCE_BASE_URL: ((resource-base-url))
+          AWS_ACCESS_KEY_ID: ((minio-root-user))
+          AWS_SECRET_ACCESS_KEY: ((minio-root-password))
+          # END DEV-ONLY
         config:
           platform: linux
           image_resource:
@@ -477,19 +568,68 @@ jobs:
             - -exc
             - |
               cp ../webpack-json/webpack.json ../ocw-hugo-themes/base-theme/data
-              hugo --config ../ocw-hugo-projects/((config-slug))/config.yaml --baseUrl /((base-url)) --themesDir ../ocw-hugo-themes/ ((build-drafts)) --destination output
-              cp -r ../static-resources/. ./output
+              hugo --config ../ocw-hugo-projects/((config-slug))/config.yaml --baseUrl /((base-url)) --themesDir ../ocw-hugo-themes/ ((build-drafts)) --destination output-online
+              cp -r ../static-resources/. ./output-online
               if [ -f "../build-course-offline/((short-id)).zip" ];
               then
-                cp ../build-course-offline/((short-id)).zip  ./output
+                cp ../build-course-offline/((short-id)).zip  ./output-online
               fi
         on_failure:
-          << : *build-failure-webhooks
+          try:
+            do:
+            - put: ocw-studio-webhook
+              timeout: 1m
+              attempts: 3
+              params:
+                  text: |
+                    {
+                      "version": "((pipeline_name))",
+                      "status": "errored"
+                    }
+            # START NON-DEV
+            - put: slack-webhook
+              timeout: 1m
+              params:
+                alert_type: failed
+                text: "Failed on build-course-online : ((pipeline_name))/((site-name))"
+            # END NON-DEV
         on_error:
-          << : *build-error-webhooks
+          try:
+            do:
+            - put: ocw-studio-webhook
+              timeout: 1m
+              params:
+                  text: |
+                    {
+                      "version": "((pipeline_name))",
+                      "status": "errored"
+                    }
+            # START NON-DEV
+            - put: slack-webhook
+              timeout: 1m
+              params:
+                alert_type: errored
+                text: "Concourse System Error during build-course-online : ((pipeline_name))/((site-name))"
+            # END NON-DEV
         on_abort:
-          << : *build-abort-webhooks
-      - task: copy-s3-buckets
+          try:
+            do:
+            - put: ocw-studio-webhook
+              timeout: 1m
+              params:
+                  text: |
+                    {
+                      "version": "((pipeline_name))",
+                      "status": "aborted"
+                    }
+            # START NON-DEV
+            - put: slack-webhook
+              timeout: 1m
+              params:
+                alert_type: aborted
+                text: "User Aborted during build-course-online : ((pipeline_name))/((site-name))"
+            # END NON-DEV
+      - task: upload-online-build
         timeout: 40m
         attempts: 3
         # START DEV-ONLY
@@ -508,7 +648,7 @@ jobs:
             path: sh
             args:
             - -exc
-            - aws s3((cli-endpoint-url)) sync course-markdown/output s3://((ocw-bucket))/((base-url)) --metadata site-id=((site-name))((delete))
+            - aws s3((cli-endpoint-url)) sync course-markdown/output-online s3://((ocw-bucket))/((base-url)) --metadata site-id=((site-name))((delete))
         # START DEV-ONLY
         on_success:
           try:


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1625

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/1453, we added the `--offline` argument to `upsert_mass_build_pipeline`, which pushes up an alternate mass build pipeline that builds all courses with the `course-offline` theme, zipping them up for download. This PR adds the offline build to the single course publishing pipeline. The steps have been broken down as follows into tasks:

 - Sync static resources from `ol-ocw-studio-app`, the storage bucket for resources in `ocw-studio`, to a Concourse container
 - Build the offline site and pack it into a ZIP
 - Upload that ZIP to `ocw-content-storage`, the bucket hosting the draft or live site
 - Build the online site and upload it to `ocw-content-storage`

This ensures not only that the downloadable version of a site will be rebuilt every time the site is published, but also that it will be available by the time the first Hugo build for the online site is run. That way, it will be detected by Hugo during the build and the download button will be available the first time.

#### How should this be manually tested?
 - Make sure you have the following prerequisites set up (if unsure, check the readme):
   - Recent DB restore from production or RC with sync states and gdrive folders reset
   - Local Concourse integration configured and running
   - Local Minio integration configured and running
   - Theme assets pipeline pushed up to Concourse and run at least once
   - In your `.env`, these are the settings I used minus the minio user / password and aws access keys:
```
AWS_STORAGE_BUCKET_NAME=ol-ocw-studio-app
AWS_PREVIEW_BUCKET_NAME=ocw-content-draft
AWS_PUBLISH_BUCKET_NAME=ocw-content-live
AWS_ARTIFACTS_BUCKET_NAME=ol-eng-artifacts
RESOURCE_BASE_URL_DRAFT=https://draft.ocw.mit.edu
RESOURCE_BASE_URL_LIVE=https://live.ocw.mit.edu
STATIC_API_BASE_URL=http://10.1.0.102:8045
OCW_HUGO_THEMES_BRANCH=main
OCW_HUGO_PROJECTS_BRANCH=main
```
 - For testing the changes to the pipeline, we'll need 3 test courses, some of which we will leave as-is and one we will modify:
   - An unmodified course site which will be used to test the scenario of there being no static resources in the `ol-ocw-studio-app` bucket
   - An unmodified `ocw-www` site
   - Another course site with a significant amount of static resources (including videos) that we will load into our `ol-ocw-studio-app` bucket in Minio using the following process:
     - Obtain production S3 credentials from `ocw-studio` in Heroku and configure your `aws` CLI to use them
     - Pull down the static resources to a folder on your machine using `aws s3 sync s3://ol-ocw-studio-app-production/courses/<course_id> /path/to/your/folder`
     - Log into the Minio web UI at http://localhost:9001 and browse to the `ol-ocw-studio-app` bucket, creating the `courses` folder as well as a folder under there with the name matching your course's `name` property (the course ID)
     - Upload the static resources you downloaded from S3 into this folder
     - Create an HTML file called `example.html` with some basic HTML content in it and upload it to the same folder
 - Update the pipelines in your local Concourse instance by running `docker-compose exec web ./manage.py backpopulate_pipelines`
 - You may also need to run `docker-compose exec web ./manage.py sync_website_to_backend --filter <course_id> --delete` for each of the courses above if you have old versions of them in your custom Github test org
 - For each of the sites above, browse to them in the `ocw-studio` UI and publish them live
 - Verify the following:
   - For the unmodified course site, first of all verify that it built correctly. You should see a green success indicator in the publish drawer, with a link to the site. Follow the link and ensure that the site renders properly. This example covers a situation you would only run into in local development, where you've imported the `ocw-studio` database but don't have any of the uploaded static resources in your Minio bucket. The site should still be browseable, loading static resources from what you have set on `RESOURCE_BASE_URL_LIVE`. If you click on the "Download Course" link in the course info drawer,  you should see the "Download Course" button at the top of the page and be able to download the ZIP file. The site won't look right, because your Minio `ol-ocw-studio-app` bucket doesn't contain the static resources for this course, but the download button should at least appear, indicating that the ZIP file was detected by the time the online build ran.
   - For the course that we imported static resources on, follow the same procedure, ensuring that the course built correctly and that you can browse it. In this course, we want to also verify that the offline version of the site works properly, as we uploaded all the static resources into place and it should. Download the ZIP file and extract it, then double click on `index.html` to open it in your browser. The site should be browsable, and in the `static_resources` folder at the root of the ZIP file you should also see the `example.html` file that we uploaded manually earlier.
   - To verify that `ocw-www` built as expected, we should first log into our local Concourse instance at http://localhost:8080 and find the live `ocw-www` pipeline. Open the most recent build and expand the `build-course-offline` section. Since `ocw-www` doesn't have a `config-offline.yaml` file in `ocw-hugo-projects`, you should see the following:   
```
selected worker: 9ac204f4454a
+ [ -f ../ocw-hugo-projects/ocw-www/config-offline.yaml ]
+ echo Offline configuration not found for site type ocw-www
Offline configuration not found for site type ocw-www
```
Under `upload-offline-build`, you should see:
```
selected worker: 9ac204f4454a
+ aws s3 --endpoint-url http://10.1.0.100:9000 sync build-course-offline/ s3://ocw-content-live/ '--exclude=*' --include=ocw-www.zip --metadata site-id=ocw-www
```
You should see `ocw-www` rendered at http://localhost:8045/, but the featured courses and new courses sections will not show anything unless you have those particular courses published in your local Minio live bucket, since we pointed `STATIC_API_BASE_URL` at `http://10.1.0.102:8045` to simulate the online build checking for the existence of the freshly created ZIP files from the offline builds.