### PR TITLE
skip syncing offline build if no offline config exists

### DIFF
--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -463,6 +463,7 @@ jobs:
         config:
           inputs:
             - name: build-course-offline
+            - name: ocw-hugo-projects
           platform: linux
           image_resource:
             type: registry-image
@@ -471,7 +472,13 @@ jobs:
             path: sh
             args:
             - -exc
-            - aws s3((cli-endpoint-url)) sync build-course-offline/ s3://((ocw-bucket))/((base-url)) --exclude='*' --include='((short-id)).zip' --metadata site-id=((site-name))
+            - |
+              if [ -f "../ocw-hugo-projects/((config-slug))/config-offline.yaml" ];
+              then
+                aws s3((cli-endpoint-url)) sync build-course-offline/ s3://((ocw-bucket))/((base-url)) --exclude='*' --include='((short-id)).zip' --metadata site-id=((site-name))
+              else
+                echo "Offline configuration not found for site type ((config-slug))"
+              fi
         on_failure:
           try:
             do:

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -473,7 +473,7 @@ jobs:
             args:
             - -exc
             - |
-              if [ -f "../ocw-hugo-projects/((config-slug))/config-offline.yaml" ];
+              if [ -f "ocw-hugo-projects/((config-slug))/config-offline.yaml" ];
               then
                 aws s3((cli-endpoint-url)) sync build-course-offline/ s3://((ocw-bucket))/((base-url)) --exclude='*' --include='((short-id)).zip' --metadata site-id=((site-name))
               else


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Follow-up hotfix for https://github.com/mitodl/ocw-studio/pull/1630

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/1630, we added functionality to the single site pipeline that builds the offline version of a site, zips it up and uploads it before the online build is run for the live site. An oversight was made in this PR. Before the offline build is run, a check is run to see if an offline configuration exists for the type of site being built. This is mostly for `ocw-www`, which does not have an offline configuration as it is the root website for the online version of OCW. This check was not added to the step that runs an `aws s3 sync` to push up the offline ZIP file. This causes the build to try and run a sync against the root of the site, which ends up taking a very long time as it has to scan the entire bucket. This PR adds the same check to see if the offline configuration actually exists before attempting to sync the ZIP file.

#### How should this be manually tested?
Follow the steps in https://github.com/mitodl/ocw-studio/pull/1630 specifically for `ocw-www`, noting that the `upload-offline-build` step should now be skipped with the message "Offline configuration not found for site type ocw-www."
