### PR TITLE
consolidate shared static resources

### DIFF
--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -380,6 +380,7 @@ jobs:
                 cp ../webpack-json/webpack.json ../ocw-hugo-themes/base-theme/data
                 mkdir -p ./content/static_resources
                 mkdir -p ./static/static_resources
+                mkdir -p ./static/static_shared
                 if [ ! -z "$(ls -A ../static-resources)" ];
                 then
                   find ../static-resources ! -name '*.mp4' -type f | xargs cp -t ./content/static_resources
@@ -390,6 +391,7 @@ jobs:
                   mv ./content/static_resources/*.html ./static/static_resources
                 fi
                 touch ./content/static_resources/_index.md
+                aws s3((cli-endpoint-url)) sync s3://((ocw-bucket))/static_shared ./static/static_shared
                 hugo --config ../ocw-hugo-projects/((config-slug))/config-offline.yaml --themesDir ../ocw-hugo-themes/ ((build-drafts)) --destination output-offline
                 cd output-offline
                 aws s3((cli-endpoint-url)) sync s3://((ocw-bucket))/static ./static

--- a/content_sync/pipelines/definitions/concourse/theme-assets-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/theme-assets-pipeline.yml
@@ -73,6 +73,8 @@ jobs:
           - |
             aws s3((cli-endpoint-url)) cp ocw-hugo-themes/base-theme/dist s3://((ocw-bucket-draft)) --recursive --metadata site-id=ocw-hugo-themes
             aws s3((cli-endpoint-url)) cp ocw-hugo-themes/base-theme/dist s3://((ocw-bucket-live)) --recursive --metadata site-id=ocw-hugo-themes
+            aws s3((cli-endpoint-url)) cp ocw-hugo-themes/base-theme/static s3://((ocw-bucket-draft)) --recursive --metadata site-id=ocw-hugo-themes
+            aws s3((cli-endpoint-url)) cp ocw-hugo-themes/base-theme/static s3://((ocw-bucket-live)) --recursive --metadata site-id=ocw-hugo-themes
             aws s3((cli-endpoint-url)) cp ocw-hugo-themes/base-theme/data/webpack.json s3://((artifacts-bucket))/ocw-hugo-themes/((ocw-hugo-themes-branch))/webpack.json --metadata site-id=ocw-hugo-themes
   # START NON-DEV
   - task: clear-cdn-cache-draft


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1648

#### What's this PR do?
In response to https://github.com/mitodl/ocw-hugo-themes/pull/1056, this PR makes some adjustment to the theme assets and site pipelines. In the theme assets pipeline, new sync commands were added to sync not just the webpack build output, but also the `base-theme/static` folder from `ocw-hugo-themes` to the site bucket, ensuring that shared static assets such as images are available immediately after a theme assets build regardless of whether `ocw-www` has been republished or not. The site pipeline was adjusted so that the shared static assets deployed to the site bucket are synced down into individual offline site builds before they are zipped up.

#### How should this be manually tested?
 - Spin up `ocw-studio` on this branch
 - Run the following commands, replacing `docker compose` with `docker-compose` if you're not using `docker-compose-plugin`:
```
docker compose exec web ./manage.py upsert_theme_assets_pipeline
docker compose exec web ./manage.py backpopulate_pipelines
```
 - When you are done backpopulating pipelines, run a theme assets build from the Concourse UI at http://concourse:8080
 - Log into the Minio UI at http://localhost:9001 and verify that you see a `shared_static` folder at the root of the bucket
 - Publish any course of your choosing
 - Back in the Minio UI, browse to the course folder in `ocw-content-live` and find the offline site ZIP file. Decompress the site and double click on `index.html`
 - Verify that the site works properly and there is no missing CSS / JS / images / etc.
