### PR TITLE
Fixing S3 paths in captions/transcript sync

### DIFF
--- a/videos/management/commands/sync_transcripts.py
+++ b/videos/management/commands/sync_transcripts.py
@@ -129,9 +129,9 @@ class Command(BaseCommand):
             new_filename += "_captions"
         elif new_filename_ext == "pdf":
             new_filename += "_transcript"
-        new_s3_path = dest_course.s3_path + "/" + new_filename + "." + new_filename_ext
+        new_s3_path = f"{dest_course.s3_path.rstrip('/')}/{new_filename.lstrip('/')}.{new_filename_ext}"
         s3.Object(settings.AWS_STORAGE_BUCKET_NAME, new_s3_path).copy_from(
-            CopySource=settings.AWS_STORAGE_BUCKET_NAME + "/" + str(source_obj.file)
+            CopySource=f"{settings.AWS_STORAGE_BUCKET_NAME.rstrip('/')}/{str(source_obj.file).lstrip('/')}"
         )
         return new_s3_path
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
Follow up to https://github.com/mitodl/ocw-studio/pull/1612.

#### What's this PR do?
Addresses an issue with an extra slash in the S3 path in https://github.com/mitodl/ocw-studio/pull/1612. Minio appears to tolerate this but S3 does not.

#### How should this be manually tested?
Same as https://github.com/mitodl/ocw-studio/pull/1612. You can also print the paths to make sure that they look correct.
