### PR TITLE
recursive redirects to /static_shared for local development

### DIFF
--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -50,6 +50,11 @@ server {
         proxy_set_header Connection "";
         chunked_transfer_encoding off;
 
+        # Rewrite requests to shared static assets to the root shared_static folder
+        location ~ ^/courses/.*/static_shared/.* {
+            rewrite ^/courses/.*/static_shared/(.*)$ /static_shared/$1 last;
+        }
+
         # If our URI doesn't contain a period and also doesn't have a slash at the end, add one
         rewrite ^([^.]*[^/])$ $1/ permanent;
         # If our URI ends with a slash, add index.html to the end
@@ -82,6 +87,11 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Connection "";
         chunked_transfer_encoding off;
+
+        # Rewrite requests to shared static assets to the root shared_static folder
+        location ~ ^/courses/.*/static_shared/.* {
+            rewrite ^/courses/.*/static_shared/(.*)$ /static_shared/$1 last;
+        }
 
         # If our URI doesn't contain a period and also doesn't have a slash at the end, add one
         rewrite ^([^.]*[^/])$ $1/ permanent;


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Partly solves https://github.com/mitodl/ocw-studio/issues/1667

#### What's this PR do?
This PR adds a few blocks to the nginx configuration for the draft / live configuration used in local development. They handle a recursive redirect, rewriting any requests containing `/static_shared/` in them at any directory level under `/courses` back to the root of the site, returning the file from the `static_shared` folder at the root.

#### How should this be manually tested?
 - Make sure you are all set up for local publishing and have Concourse and Minio configured and running. See the readme for more details if you are new to `ocw-studio`
 - Go to Django admin (http://localhost:8043/admin) and find the `ocw-course` starter. Change the `slug` property to `ocw-course-v3` and save the starter.
 - Run the following management commands:
```
docker compose exec web ./manage.py upsert_theme_assets_pipeline
docker compose exec web ./manage.py upsert_mass_build_pipeline
docker compose exec web ./manage.py backpopulate_pipelines (optionally add --filter here with a course_id to test one course, pushing up all pipelines may take a while)
```
 - Log into Concourse at http://concourse:8080 and find the theme assets pipeline. Trigger a build and wait for it to finish.
 - Once the build is complete, publish a course of your choice. You must first backpopulate the pipeline though, as pointed out above.
 - Open the publish drawer again and click the link to browse to your course once publishing is complete. It should look something like http://localhost:8045/courses/course-1.
 - On the course home page, the CSS, JS and shared images in the header and footer should load without issue. If you inspect the HTML of the page, you should see something like `<link href="./static_shared/css/course_v2.b1e10.css" rel="stylesheet">`, indicating that the CSS is being requested with a URL relative to the course root.
 - Copy the link to the CSS and paste it into your URL bar relative to the course root, which should look something like http://localhost:8045/courses/course-1/static_shared/css/course_v2.b1e10.css. The CSS should load properly.


#### Out of scope

Note that while following the testing procedure, links in the course will not work properly because of https://github.com/mitodl/ocw-studio/issues/1664. Since these changes have been broken out into a separate theme (`course-v3`), we can address this in a separate PR.

#### Any background context you want to provide?
https://github.com/mitodl/ocw-hugo-themes/issues/1013 is an epic that is tracking efforts to consolidate URL overrides we have done in the `course-offline` theme in `ocw-hugo-themes`. The goal is to take a more universal approach to rendering URLs by making them relative to the course root, so that we don't have to do as many hacks to support all of the use cases of an OCW site. The basic framework for this was set up by adding the `course-v3` theme in https://github.com/mitodl/ocw-hugo-themes/pull/1068 and https://github.com/mitodl/ocw-hugo-projects/pull/244. In `course-v3`, the Hugo `relativeUrls` setting is enabled in the config which tells Hugo to rewrite all URLs as relative to the context root after rendering HTML.

On the live site at ocw.mit.edu, courses are embedded into the larger OCW site at `/courses/course_id`. The context root when rendering a course site is at the root of the course, so this presents a problem when trying to link to a number of different things:

 - Links to shared static assets (JS, CSS, images) would be rendered incorrectly
 - Links to other courses would be rendered incorrectly
 - Links in the sitemaps would be rendered incorrectly
 - Hard coded links in shared partials such as `/about` in the header would be rendered incorrectly

With `relativeUrls` enabled, Hugo writes in these links relative to the course root, not the site root. The `baseUrl` setting does not help us in this matter, primarily because of the issue described in https://github.com/mitodl/ocw-studio/issues/1664.
