### PR TITLE
allow overriding hugo build arguments

### DIFF
--- a/content_sync/api.py
+++ b/content_sync/api.py
@@ -72,6 +72,7 @@ def get_mass_build_sites_pipeline(  # pylint:disable=too-many-arguments
     projects_branch: Optional[str] = None,
     starter: Optional[str] = None,
     offline: Optional[bool] = None,
+    hugo_args: Optional[str] = None,
 ) -> object:
     """Get the mass build sites pipeline if the backend has one"""
     return import_string(
@@ -84,6 +85,7 @@ def get_mass_build_sites_pipeline(  # pylint:disable=too-many-arguments
         projects_branch=projects_branch,
         starter=starter,
         offline=offline,
+        hugo_args=hugo_args,
     )
 
 

--- a/content_sync/api.py
+++ b/content_sync/api.py
@@ -44,7 +44,9 @@ def get_pipeline_api() -> BasePipeline:
 
 
 @is_publish_pipeline_enabled
-def get_site_pipeline(website: Website, hugo_args: Optional[str] = "", api: Optional[object] = None) -> BasePipeline:
+def get_site_pipeline(
+    website: Website, hugo_args: Optional[str] = "", api: Optional[object] = None
+) -> BasePipeline:
     """ Get the configured sync publishing pipeline """
     return import_string(
         f"content_sync.pipelines.{settings.CONTENT_SYNC_PIPELINE_BACKEND}.SitePipeline"

--- a/content_sync/api.py
+++ b/content_sync/api.py
@@ -44,11 +44,11 @@ def get_pipeline_api() -> BasePipeline:
 
 
 @is_publish_pipeline_enabled
-def get_site_pipeline(website: Website, api: Optional[object] = None) -> BasePipeline:
+def get_site_pipeline(website: Website, hugo_args: Optional[str] = "", api: Optional[object] = None) -> BasePipeline:
     """ Get the configured sync publishing pipeline """
     return import_string(
         f"content_sync.pipelines.{settings.CONTENT_SYNC_PIPELINE_BACKEND}.SitePipeline"
-    )(website, api=api)
+    )(website, hugo_args=hugo_args, api=api)
 
 
 @is_publish_pipeline_enabled

--- a/content_sync/api_test.py
+++ b/content_sync/api_test.py
@@ -192,14 +192,15 @@ def test_get_pipeline_api(settings, mocker):
     import_string_mock.assert_called_once_with()
 
 
+@pytest.mark.parametrize("hugo_args", [None, "--baseUrl /"])
 @pytest.mark.parametrize("pipeline_api", [None, {}])
-def test_get_site_pipeline(settings, mocker, pipeline_api):
+def test_get_site_pipeline(settings, mocker, hugo_args, pipeline_api):
     """ Verify that get_site_pipeline() imports the pipeline class based on settings.py """
     settings.CONTENT_SYNC_PIPELINE_BACKEND = "concourse"
     import_string_mock = mocker.patch("content_sync.pipelines.concourse.SitePipeline")
     website = WebsiteFactory.create()
-    api.get_site_pipeline(website, api=pipeline_api)
-    import_string_mock.assert_any_call(website, api=pipeline_api)
+    api.get_site_pipeline(website, hugo_args=hugo_args, api=pipeline_api)
+    import_string_mock.assert_any_call(website, hugo_args=hugo_args, api=pipeline_api)
 
 
 @pytest.mark.parametrize("prepublish", [True, False])

--- a/content_sync/constants.py
+++ b/content_sync/constants.py
@@ -1,6 +1,8 @@
 """Constants for content_sync"""
 VERSION_LIVE = "live"
 VERSION_DRAFT = "draft"
+TARGET_ONLINE = "online"
+TARGET_OFFLINE = "offline"
 START_TAG_PREFIX = "# START "
 END_TAG_PREFIX = "# END "
 DEV_START = f"{START_TAG_PREFIX}DEV-ONLY"

--- a/content_sync/management/commands/backpopulate_pipelines.py
+++ b/content_sync/management/commands/backpopulate_pipelines.py
@@ -19,6 +19,13 @@ class Command(WebsiteFilterCommand):
     def add_arguments(self, parser):
         super().add_arguments(parser)
         parser.add_argument(
+            "-hu",
+            "--hugo_args",
+            dest="hugo_args",
+            default="",
+            help="If specified, override Hugo command line arguments with supplied args",
+        )
+        parser.add_argument(
             "-s",
             "--starter",
             dest="starter",
@@ -69,6 +76,7 @@ class Command(WebsiteFilterCommand):
 
         self.stdout.write("Creating website pipelines")
 
+        hugo_args = options["hugo_args"]
         starter_str = options["starter"]
         source_str = options["source"]
         chunk_size = int(options["chunk_size"])
@@ -112,6 +120,7 @@ class Command(WebsiteFilterCommand):
             chunk_size=chunk_size,
             create_backend=create_backend,
             unpause=unpause,
+            hugo_args=hugo_args,
         )
 
         self.stdout.write(

--- a/content_sync/management/commands/upsert_mass_build_pipeline.py
+++ b/content_sync/management/commands/upsert_mass_build_pipeline.py
@@ -63,6 +63,13 @@ class Command(BaseCommand):
             action="store_true",
             help="Upserts an alternate version of the pipeline to mass-build-sites-offline",
         )
+        parser.add_argument(
+            "-hu",
+            "--hugo_args",
+            dest="hugo_args",
+            default="",
+            help="If specified, override Hugo command line arguments with supplied args",
+        )
 
     def handle(self, *args, **options):
 
@@ -79,6 +86,7 @@ class Command(BaseCommand):
         projects_branch = options["projects-branch"]
         starter = options["starter"]
         offline = options["offline"]
+        hugo_args = options["hugo_args"]
         start = now_in_utc()
 
         if delete_all:
@@ -98,6 +106,7 @@ class Command(BaseCommand):
                 projects_branch=projects_branch,
                 starter=starter,
                 offline=offline,
+                hugo_args=hugo_args,
             )
             pipeline.upsert_pipeline()
             self.stdout.write(f"Created {version} mass build pipeline")

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -350,7 +350,7 @@ class SitePipeline(BaseSitePipeline, GeneralPipeline):
     def __init__(
         self,
         website: Website,
-        hugo_args: Optional[str],
+        hugo_args: Optional[str] = None,
         api: Optional[PipelineApi] = None,
     ):
         """Initialize the pipeline API instance"""

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -20,8 +20,8 @@ from requests import HTTPError
 
 from content_sync.constants import (
     DEV_ENDPOINT_URL,
-    TARGET_ONLINE,
     TARGET_OFFLINE,
+    TARGET_ONLINE,
     VERSION_DRAFT,
     VERSION_LIVE,
 )

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -435,13 +435,11 @@ class SitePipeline(BaseSitePipeline, GeneralPipeline):
                 markdown_uri = f"https://{settings.GIT_DOMAIN}/{settings.GIT_ORGANIZATION}/{self.WEBSITE.short_id}.git"
                 private_key_var = ""
             starter_slug = self.WEBSITE.starter.slug
-            base_hugo_args = {
-                "--config": f"../ocw-hugo-projects/{starter_slug}/config.yaml",
-                "--themesDir": "../ocw-hugo-themes/",
-            }
+            base_hugo_args = {"--themesDir": "../ocw-hugo-themes/"}
             base_online_args = base_hugo_args.copy()
             base_online_args.update(
                 {
+                    "--config": f"../ocw-hugo-projects/{starter_slug}/config.yaml",
                     "--baseUrl": f"/{base_url}",
                     "--destination": "output-online",
                 }
@@ -449,6 +447,7 @@ class SitePipeline(BaseSitePipeline, GeneralPipeline):
             base_offline_args = base_hugo_args.copy()
             base_offline_args.update(
                 {
+                    "--config": f"../ocw-hugo-projects/{starter_slug}/config-offline.yaml",
                     "--baseUrl": "/",
                     "--destination": "output-offline",
                 }
@@ -685,14 +684,23 @@ class MassBuildSitesPipeline(
                 }
             )
         base_hugo_args = {
-            "--config": "../ocw-hugo-projects/$STARTER_SLUG/config.yaml",
             "--themesDir": "../ocw-hugo-themes/",
             "--quiet": "",
         }
         base_online_args = base_hugo_args.copy()
-        base_online_args.update({"--baseUrl": "$PREFIX/$BASE_URL"})
+        base_online_args.update(
+            {
+                "--baseUrl": "$PREFIX/$BASE_URL",
+                "--config": "../ocw-hugo-projects/$STARTER_SLUG/config.yaml",
+            }
+        )
         base_offline_args = base_hugo_args.copy()
-        base_offline_args.update({"--baseUrl": "/"})
+        base_offline_args.update(
+            {
+                "--baseUrl": "/",
+                "--config": "../ocw-hugo-projects/$STARTER_SLUG/config-offline.yaml",
+            }
+        )
         hugo_args_online = get_hugo_arg_string(
             TARGET_ONLINE,
             self.VERSION,

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -437,7 +437,7 @@ class SitePipeline(BaseSitePipeline, GeneralPipeline):
             config_str = (
                 self.get_pipeline_definition("definitions/concourse/site-pipeline.yml")
                 .replace("((hugo-args-online))", hugo_args_online)
-                .replace("((hugo-args-offline", hugo_args_offline)
+                .replace("((hugo-args-offline))", hugo_args_offline)
                 .replace("((markdown-uri))", markdown_uri)
                 .replace("((git-private-key-var))", private_key_var)
                 .replace("((gtm-account-id))", settings.OCW_GTM_ACCOUNT_ID)

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -18,7 +18,13 @@ from concoursepy.api import Api
 from django.conf import settings
 from requests import HTTPError
 
-from content_sync.constants import DEV_ENDPOINT_URL, TARGET_ONLINE, TARGET_OFFLINE, VERSION_DRAFT, VERSION_LIVE
+from content_sync.constants import (
+    DEV_ENDPOINT_URL,
+    TARGET_ONLINE,
+    TARGET_OFFLINE,
+    VERSION_DRAFT,
+    VERSION_LIVE,
+)
 from content_sync.decorators import retry_on_failure
 from content_sync.pipelines.base import (
     BaseGeneralPipeline,
@@ -429,10 +435,18 @@ class SitePipeline(BaseSitePipeline, GeneralPipeline):
                 markdown_uri = f"https://{settings.GIT_DOMAIN}/{settings.GIT_ORGANIZATION}/{self.WEBSITE.short_id}.git"
                 private_key_var = ""
             hugo_args_online = get_hugo_arg_string(
-                base_url, self.WEBSITE.starter.slug, pipeline_name, TARGET_ONLINE, self.HUGO_ARGS
+                base_url,
+                self.WEBSITE.starter.slug,
+                pipeline_name,
+                TARGET_ONLINE,
+                self.HUGO_ARGS,
             )
             hugo_args_offline = get_hugo_arg_string(
-                base_url, self.WEBSITE.starter.slug, pipeline_name, TARGET_OFFLINE, self.HUGO_ARGS
+                base_url,
+                self.WEBSITE.starter.slug,
+                pipeline_name,
+                TARGET_OFFLINE,
+                self.HUGO_ARGS,
             )
             config_str = (
                 self.get_pipeline_definition("definitions/concourse/site-pipeline.yml")

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -597,7 +597,7 @@ def test_upsert_mass_build_pipeline(
         stripped_prefix = prefix[1:] if prefix.startswith("/") else prefix
     else:
         stripped_prefix = ""
-    build_drafts = "--buildDrafts" if version == VERSION_DRAFT else ""
+    build_drafts = " --buildDrafts" if version == VERSION_DRAFT else ""
     endpoint_url = (
         " --endpoint-url http://10.1.0.100:9000"
         if settings.ENVIRONMENT == "dev"
@@ -658,7 +658,7 @@ def test_upsert_mass_build_pipeline(
     if offline:
         assert "PULLING IN STATIC RESOURCES FOR $NAME" in config_str
         assert "touch ./content/static_resources/_index.md" in config_str
-        assert f"HUGO_RESULT=$(hugo --config ../ocw-hugo-projects/$STARTER_SLUG/config.yaml --themesDir ../ocw-hugo-themes/ {build_drafts} --quiet) || HUGO_RESULT=1"
+        assert f"HUGO_RESULT=$(hugo --themesDir ../ocw-hugo-themes/ --quiet --baseUrl / --config ../ocw-hugo-projects/$STARTER_SLUG/config.yaml{build_drafts}) || HUGO_RESULT=1"
         if settings.ENVIRONMENT == "dev":
             assert (
                 f"STUDIO_S3_RESULT=$(aws s3{endpoint_url} sync s3://{settings.AWS_STORAGE_BUCKET_NAME}/$S3_PATH ./content/static_resources --exclude *.mp4 --only-show-errors) || STUDIO_S3_RESULT=1"
@@ -670,7 +670,7 @@ def test_upsert_mass_build_pipeline(
             in config_str
         )
         assert (
-            f"HUGO_RESULT=$(hugo --config ../ocw-hugo-projects/$STARTER_SLUG/config.yaml --baseUrl $PREFIX/$BASE_URL --themesDir ../ocw-hugo-themes/ {build_drafts} --quiet) || HUGO_RESULT=1"
+            f"HUGO_RESULT=$(hugo --themesDir ../ocw-hugo-themes/ --quiet --baseUrl $PREFIX/$BASE_URL --config ../ocw-hugo-projects/$STARTER_SLUG/config.yaml{build_drafts}) || HUGO_RESULT=1"
             in config_str
         )
         assert (

--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -230,10 +230,10 @@ jobs:
               # END OFFLINE-ONLY
               echo "RUNNING HUGO BUILD FOR $NAME" > /dev/tty
               # START ONLINE-ONLY
-              HUGO_RESULT=$(hugo --config ../ocw-hugo-projects/$STARTER_SLUG/config.yaml --baseUrl $PREFIX/$BASE_URL --themesDir ../ocw-hugo-themes/ ((build-drafts)) --quiet) || HUGO_RESULT=1
+              HUGO_RESULT=$(hugo ((hugo-args-online))) || HUGO_RESULT=1
               # END ONLINE-ONLY
               # START OFFLINE-ONLY
-              HUGO_RESULT=$(hugo --config ../ocw-hugo-projects/$STARTER_SLUG/config-offline.yaml --themesDir ../ocw-hugo-themes/ ((build-drafts)) --quiet) || HUGO_RESULT=1
+              HUGO_RESULT=$(hugo ((hugo-args-offline))) || HUGO_RESULT=1
               # END OFFLINE-ONLY
               if [[ $HUGO_RESULT == 1 ]]
               then

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -576,7 +576,7 @@ jobs:
             - -exc
             - |
               cp ../webpack-json/webpack.json ../ocw-hugo-themes/base-theme/data
-              hugo --config ../ocw-hugo-projects/((config-slug))/config.yaml --baseUrl /((base-url)) --themesDir ../ocw-hugo-themes/ ((build-drafts)) --destination output-online
+              hugo ((hugo-args))
               cp -r -n ../static-resources/. ./output-online
               if [ -f "../build-course-offline/((short-id)).zip" ];
               then

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -392,7 +392,7 @@ jobs:
                 fi
                 touch ./content/static_resources/_index.md
                 aws s3((cli-endpoint-url)) sync s3://((ocw-bucket))/static_shared ./static/static_shared
-                hugo --config ../ocw-hugo-projects/((config-slug))/config-offline.yaml --themesDir ../ocw-hugo-themes/ ((build-drafts)) --destination output-offline
+                hugo ((hugo-args-offline))
                 cd output-offline
                 zip ../../build-course-offline/((short-id)).zip -r ./
               else
@@ -576,7 +576,7 @@ jobs:
             - -exc
             - |
               cp ../webpack-json/webpack.json ../ocw-hugo-themes/base-theme/data
-              hugo ((hugo-args))
+              hugo ((hugo-args-online))
               cp -r -n ../static-resources/. ./output-online
               if [ -f "../build-course-offline/((short-id)).zip" ];
               then

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -138,7 +138,7 @@ def upsert_website_pipeline_batch(
 
 
 @app.task(bind=True)
-def upsert_pipelines( # pylint: disable=too-many-arguments
+def upsert_pipelines(  # pylint: disable=too-many-arguments
     self,
     website_names: List[str],
     chunk_size=500,

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -112,7 +112,7 @@ def upsert_website_publishing_pipeline(website_name: str):
 
 @app.task(acks_late=True)
 def upsert_website_pipeline_batch(
-    website_names: List[str], create_backend=False, unpause=False
+    website_names: List[str], create_backend=False, unpause=False, hugo_args=""
 ):
     """ Create/update publishing pipelines for multiple websites"""
     api_instance = None
@@ -123,7 +123,7 @@ def upsert_website_pipeline_batch(
             api.throttle_git_backend_calls(backend)
             backend.create_website_in_backend()
             backend.sync_all_content_to_backend()
-        pipeline = api.get_site_pipeline(website, api=api_instance)
+        pipeline = api.get_site_pipeline(website, hugo_args=hugo_args, api=api_instance)
         if not api_instance:
             # Keep using the same api instance to minimize multiple authentication calls
             api_instance = pipeline.api
@@ -139,7 +139,7 @@ def upsert_website_pipeline_batch(
 
 @app.task(bind=True)
 def upsert_pipelines(
-    self, website_names: List[str], chunk_size=500, create_backend=False, unpause=False
+    self, website_names: List[str], chunk_size=500, create_backend=False, unpause=False, hugo_args=""
 ):
     """ Chunk and group batches of pipeline upserts for a specified list of websites"""
     tasks = []
@@ -149,7 +149,7 @@ def upsert_pipelines(
     ):
         tasks.append(
             upsert_website_pipeline_batch.s(
-                website_subset, create_backend=create_backend, unpause=unpause
+                website_subset, create_backend=create_backend, unpause=unpause, hugo_args=hugo_args
             )
         )
     raise self.replace(celery.group(tasks))

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -139,7 +139,12 @@ def upsert_website_pipeline_batch(
 
 @app.task(bind=True)
 def upsert_pipelines(
-    self, website_names: List[str], chunk_size=500, create_backend=False, unpause=False, hugo_args=""
+    self,
+    website_names: List[str],
+    chunk_size=500,
+    create_backend=False,
+    unpause=False,
+    hugo_args="",
 ):
     """ Chunk and group batches of pipeline upserts for a specified list of websites"""
     tasks = []
@@ -149,7 +154,10 @@ def upsert_pipelines(
     ):
         tasks.append(
             upsert_website_pipeline_batch.s(
-                website_subset, create_backend=create_backend, unpause=unpause, hugo_args=hugo_args
+                website_subset,
+                create_backend=create_backend,
+                unpause=unpause,
+                hugo_args=hugo_args,
             )
         )
     raise self.replace(celery.group(tasks))

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -138,7 +138,7 @@ def upsert_website_pipeline_batch(
 
 
 @app.task(bind=True)
-def upsert_pipelines(
+def upsert_pipelines( # pylint: disable=too-many-arguments
     self,
     website_names: List[str],
     chunk_size=500,

--- a/content_sync/tasks_test.py
+++ b/content_sync/tasks_test.py
@@ -336,7 +336,7 @@ def test_upsert_theme_assets_pipeline(  # pylint:disable=unused-argument
 @pytest.mark.parametrize("unpause", [True, False])
 @pytest.mark.parametrize("hugo_args", [None, "--baseUrl /"])
 @pytest.mark.parametrize("check_limit", [True, False])
-def test_upsert_website_pipeline_batch(
+def test_upsert_website_pipeline_batch(  # pylint:disable=too-many-arguments
     mocker, settings, create_backend, unpause, hugo_args, check_limit
 ):
     """upsert_website_pipeline_batch should make the expected function calls"""

--- a/content_sync/test_constants.py
+++ b/content_sync/test_constants.py
@@ -11,3 +11,26 @@ foo: line 1
 # END DEV-ONLY
 bar: line 2
 qux: line 4"""
+TEST_DEFAULT_HUGO_ARGS = {
+    "--themesDir": "../ocw-hugo-themes",
+    "--quiet": "",
+    "--baseUrl": "/courses/course-1",
+    "--config": "../ocw-hugo-projects/ocw-course-v2/config.yaml",
+}
+HUGO_ARG_TEST_OVERRIDES = [
+    {"input": "--verbose", "output": {"--verbose": ""}},
+    {"input": "--baseUrl / --verbose", "output": {"--baseUrl": "/", "--verbose": ""}},
+    {
+        "input": "--baseUrl / --verbose --debug",
+        "output": {"--baseUrl": "/", "--verbose": "", "--debug": ""},
+    },
+    {
+        "input": "--baseUrl / --verbose --debug --destination ./test_output",
+        "output": {
+            "--baseUrl": "/",
+            "--verbose": "",
+            "--debug": "",
+            "--destination": "./test_output",
+        },
+    },
+]

--- a/content_sync/utils.py
+++ b/content_sync/utils.py
@@ -140,7 +140,9 @@ def get_theme_branch():
     )
 
 
-def get_hugo_arg_string(base_url, starter_slug, pipeine_group, build_target, override_args):
+def get_hugo_arg_string(
+    base_url, starter_slug, pipeine_group, build_target, override_args
+):
     """
     Builds a string of arguments to be passed to the hugo command inserted into pipelines
 

--- a/content_sync/utils.py
+++ b/content_sync/utils.py
@@ -154,7 +154,7 @@ def get_hugo_arg_string(build_target, pipeline_name, default_args, override_args
     """
     hugo_args = default_args.copy()
     if pipeline_name == VERSION_DRAFT:
-        default_args["--buildDrafts"] = ""
+        hugo_args["--buildDrafts"] = ""
     if override_args:
         split_override_args = override_args.split(" ")
         for index, arg in enumerate(split_override_args):

--- a/content_sync/utils.py
+++ b/content_sync/utils.py
@@ -18,7 +18,6 @@ from content_sync.constants import (
     ONLINE_START,
     START_TAG_PREFIX,
     TARGET_OFFLINE,
-    TARGET_ONLINE,
     VERSION_DRAFT,
 )
 from main.s3_utils import get_boto3_resource

--- a/content_sync/utils_test.py
+++ b/content_sync/utils_test.py
@@ -19,16 +19,16 @@ from content_sync.test_constants import (
     EVEN_TAGS_TEST_FILE,
     EXPECTED_REMAINING_STRING_DEV,
     EXPECTED_REMAINING_STRING_NON_DEV,
-    UNEVEN_TAGS_TEST_FILE,
-    TEST_DEFAULT_HUGO_ARGS,
     HUGO_ARG_TEST_OVERRIDES,
+    TEST_DEFAULT_HUGO_ARGS,
+    UNEVEN_TAGS_TEST_FILE,
 )
 from content_sync.utils import (
     check_matching_tags,
     get_destination_filepath,
     get_destination_url,
-    move_s3_object,
     get_hugo_arg_string,
+    move_s3_object,
     strip_lines_between,
 )
 from main.s3_utils import get_boto3_client

--- a/websites/views.py
+++ b/websites/views.py
@@ -338,7 +338,7 @@ class WebsiteMassBuildViewSet(viewsets.ViewSet):
         # If a starter has been specified by the query, only return sites made with that starter
         if starter:
             sites = sites.filter(starter=WebsiteStarter.objects.get(slug=starter))
-        sites = sites.prefetch_related("starter").order_by("name")
+        sites = sites.prefetch_related("starter").order_by("name")[:10]
         serializer = WebsiteMassBuildSerializer(instance=sites, many=True)
         return Response({"sites": serializer.data})
 

--- a/websites/views.py
+++ b/websites/views.py
@@ -338,7 +338,7 @@ class WebsiteMassBuildViewSet(viewsets.ViewSet):
         # If a starter has been specified by the query, only return sites made with that starter
         if starter:
             sites = sites.filter(starter=WebsiteStarter.objects.get(slug=starter))
-        sites = sites.prefetch_related("starter").order_by("name")[:10]
+        sites = sites.prefetch_related("starter").order_by("name")
         serializer = WebsiteMassBuildSerializer(instance=sites, many=True)
         return Response({"sites": serializer.data})
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [x] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1664

#### What's this PR do?
This PR adds an argument to the management commands `backpopulate_pipelines` as well as `upsert_mass_build_pipeline` called `hugo_args` that allows you to pass a string of arguments to append / override in the Hugo commands used by pipelines. While this PR gives you a method of bypassing the issues faced in https://github.com/mitodl/ocw-studio/issues/1664, it is more generally useful in that while developing locally and testing different things with Hugo builds in Concourse pipelines you can arbitrarily change the arguments passed to `hugo`.

Since we have decided to not pursue unifying the online and offline builds, we reverted the `course-v3` and `course-offline-v2` themes in https://github.com/mitodl/ocw-hugo-themes/pull/1081 and https://github.com/mitodl/ocw-hugo-projects/pull/245, therefore the issue in https://github.com/mitodl/ocw-studio/issues/1664 cannot be reproduced on the `main` branches of `ocw-hugo-themes` and `ocw-hugo-projects`.

#### How should this be manually tested?
Since https://github.com/mitodl/ocw-hugo-themes/pull/1081 and https://github.com/mitodl/ocw-hugo-projects/pull/245 have been reverted, we cannot exactly reproduce the issue from https://github.com/mitodl/ocw-studio/issues/1664 so we will verify that everything is working by enabling the `--templateMetrics` flag in a single course build:

 - Spin up `ocw-studio` with `docker compose up`, making sure you have set up Concourse and Minio as described in the readme
 - Run `docker compose exec web ./manage.py backpopulate_pipelines --filter 10-302-transport-processes-fall-2004 --hugo_args="--templateMetrics"`, replacing the filter string with the course of your choice if desired
 - Publish the course from the `ocw-studio` UI
 - Go to the Concourse web UI at http://concourse:8080 and look for the pipeline matching the site you published by putting the ID in the search box
 - Open the `build-course-offline` or `build-course-online` steps and verify that you see template metrics in the terminal output
