### PR TITLE
remove static folder from offline builds

### DIFF
--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -349,7 +349,7 @@ def test_upsert_website_pipelines(
         )
     else:
         assert (
-            f"aws s3 {expected_endpoint_prefix}sync s3://{bucket}/static ./static"
+            f"aws s3 {expected_endpoint_prefix}sync s3://{bucket}/static_shared ./static/static_shared"
             in config_str
         )
         assert (

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -394,7 +394,6 @@ jobs:
                 aws s3((cli-endpoint-url)) sync s3://((ocw-bucket))/static_shared ./static/static_shared
                 hugo --config ../ocw-hugo-projects/((config-slug))/config-offline.yaml --themesDir ../ocw-hugo-themes/ ((build-drafts)) --destination output-offline
                 cd output-offline
-                aws s3((cli-endpoint-url)) sync s3://((ocw-bucket))/static ./static
                 zip ../../build-course-offline/((short-id)).zip -r ./
               else
                 echo "Offline configuration not found for site type ((config-slug))"


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1679

#### What's this PR do?
This PR removes a line from the single course publishing pipeline that syncs the `static` folder from the public facing S3 bucket to the offline build before zipping. This was not done as part of https://github.com/mitodl/ocw-studio/pull/1657 because https://github.com/mitodl/ocw-hugo-themes/pull/1056 needed to be released at the same time. If the line was removed too early, before that PR was released, then Hugo templates would be still pointing to it and JS / CSS would have broken in offline builds. Now that both PR's are released and all sites have been rebuilt pointing to `/static_shared`, we can safely remove this line and not sync `/static` to the offline build.

#### How should this be manually tested?
 - Spin up `ocw-studio`, making sure you have Concourse and Minio configured and the following in your `.env`:
```
OCW_HUGO_THEMES_BRANCH=main
OCW_HUGO_PROJECTS_BRANCH=main
```
 - Run `docker compose exec web ./manage.py upsert_theme_assets_pipeline` to ensure you have the latest version of the theme assets pipeline pushed up
 - Browse to the Concourse UI at http://localhost:3000 and go to the `ocw-theme-assets` group, finding the `main` branch version that we just pushed up
 - Unpause and trigger a build of the theme assets pipeline, waiting for it to complete
 - Run `docker compose exec web ./manage.py backpopulate_pipelines --filter 10-302-transport-processes-fall-2004`, optionally swapping out the ID for another course you wish to test
 - Publish the site from the `ocw-studio` UI
 - Log into the Minio web interface at http://localhost:9001
 - Browse to `ocw-content-live` and find your course's folder, then download the ZIP file for that course
 - Extract the ZIP file and verify that there is no `static` folder, just `static_shared` and `static_resources`
 - Double click on the `index.html` file to open the site and make sure:
   - There are no errors in the console
   - JS / CSS / Images load properly
   - Nav links work
   - Links to resources work
