### PR TITLE
Associate pre-existing captions with new OCW videos

### DIFF
--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -40,9 +40,9 @@ from websites.utils import get_dict_query_field, set_dict_field
 log = logging.getLogger()
 
 
-@app.task(bind=True)
+@app.task
 @single_task(timeout=settings.YT_UPLOAD_FREQUENCY, raise_block=False)
-def upload_youtube_videos(self):
+def upload_youtube_videos():
     """
     Upload public videos one at a time to YouTube (if not already there) until the daily maximum is reached.
     """
@@ -99,19 +99,12 @@ def start_transcript_job(video_id: int):
 
     title = video_resource.title
     video_filename = video_resource.filename
-
-    debug_file = open("debug_output.txt", "a")
-    debug_file.write(f"video filename: {video_filename}\n")
-
     captions = WebsiteContent.objects.filter(
         Q(website=video.website) & Q(filename=f"{video_filename}_captions")
     ).first()
-    debug_file.write(f"captions: {captions}\n")
     transcript = WebsiteContent.objects.filter(
         Q(website=video.website) & Q(filename=f"{video_filename}_transcript")
     ).first()
-    debug_file.write(f"transcript: {transcript}\n")
-    debug_file.close()
 
     if captions or transcript:  # check for existing captions or transcript
         if captions:
@@ -140,7 +133,7 @@ def start_transcript_job(video_id: int):
 
 
 @app.task(bind=True)
-@single_task(timeout=settings.YT_STATUS_UPDATE_FREQUENCY)
+@single_task(timeout=settings.YT_STATUS_UPDATE_FREQUENCY, raise_block=False)
 def update_youtube_statuses(self):
     """
     Update the status of recently uploaded YouTube videos if complete

--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -108,23 +108,25 @@ def start_transcript_job(video_id: int):
     else:
         title = video.source_key.split("/")[-1]
         video_filename = title
-
+    log.exception(f"video filename: {video_filename}")
     captions = WebsiteContent.objects.filter(
         Q(website=video.website) & Q(filename=f"{video_filename}_captions")
     ).first()
-
+    log.exception(f"captions: {captions}")
     transcript = WebsiteContent.objects.filter(
         Q(website=video.website) & Q(filename=f"{video_filename}_transcript")
     ).first()
-
+    log.exception(f"transcript: {transcript}")
     if captions or transcript:  # check for existing captions or transcript
         if captions:
-            video.metadata["video_files"]["video_captions_file"] = str(captions.file)
+            video_resource.metadata["video_files"]["video_captions_file"] = str(
+                captions.file
+            )
         if transcript:
-            video.metadata["video_files"]["video_transcript_file"] = str(
+            video_resource.metadata["video_files"]["video_transcript_file"] = str(
                 transcript.file
             )
-        video.save()
+        video_resource.save()
 
     else:  # if none, request a transcript through the 3Play API
         response = threeplay_api.threeplay_upload_video_request(

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -124,11 +124,7 @@ def test_upload_youtube_videos(
         "status": {"uploadStatus": "uploaded"},
     }
 
-    if is_enabled:
-        with pytest.raises(mocked_celery.replace_exception_class):
-            upload_youtube_videos.delay()
-    else:
-        upload_youtube_videos.delay()
+    upload_youtube_videos.delay()
     assert mock_uploader.call_count == (min(3, max_uploads) if is_enabled else 0)
     assert mock_youtube.call_count == (1 if is_enabled else 0)
     if is_enabled:
@@ -189,7 +185,7 @@ def test_upload_youtube_quota_exceeded(mocker, youtube_video_files_new, msg, sta
         assert video_file.destination_id is None
 
 
-def test_start_transcript_job(mocker, settings):
+def test_start_transcript_job(mocker, settings, mocked_celery):
     """test start_transcript_job"""
     youtube_id = "test"
     threeplay_file_id = 1
@@ -218,6 +214,8 @@ def test_start_transcript_job(mocker, settings):
     WebsiteContentFactory.create(
         website=video.website, metadata={"youtube_id": youtube_id}, title=title
     )
+
+    update_youtube_statuses.delay()
 
     start_transcript_job(video.id)
 

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -230,7 +230,7 @@ def test_start_transcript_job(mocker, settings):
     )
 
 
-# pylint:disable=no-value-for-parameter
+# pylint:disable=no-value-for-parameter, too-many-arguments
 @pytest.mark.parametrize("is_enabled", [True, False])
 def test_update_youtube_statuses(
     settings,

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -230,6 +230,7 @@ def test_start_transcript_job(mocker, settings):
     )
 
 
+# pylint:disable=no-value-for-parameter
 @pytest.mark.parametrize("is_enabled", [True, False])
 def test_update_youtube_statuses(
     settings,

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -185,7 +185,7 @@ def test_upload_youtube_quota_exceeded(mocker, youtube_video_files_new, msg, sta
         assert video_file.destination_id is None
 
 
-def test_start_transcript_job(mocker, settings, mocked_celery):
+def test_start_transcript_job(mocker, settings):
     """test start_transcript_job"""
     youtube_id = "test"
     threeplay_file_id = 1
@@ -214,7 +214,7 @@ def test_start_transcript_job(mocker, settings, mocked_celery):
 
     WebsiteContentFactory.create(
         website=video.website,
-        metadata={"video_metadata": {"youtube_id": youtube_id}},
+        metadata={"youtube_id": youtube_id},
         title=title,
     )
 

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -41,7 +41,7 @@ from videos.youtube import API_QUOTA_ERROR_MSG
 from websites.constants import RESOURCE_TYPE_VIDEO
 from websites.factories import WebsiteContentFactory, WebsiteFactory
 from websites.messages import VideoTranscriptingCompleteMessage
-from websites.utils import get_dict_field
+from websites.utils import get_dict_field, set_dict_field
 
 
 # pylint:disable=unused-argument,redefined-outer-name
@@ -185,11 +185,14 @@ def test_upload_youtube_quota_exceeded(mocker, youtube_video_files_new, msg, sta
         assert video_file.destination_id is None
 
 
-def test_start_transcript_job(mocker, settings):
+@pytest.mark.parametrize("caption_exists", [True, False])
+@pytest.mark.parametrize("transcript_exists", [True, False])
+def test_start_transcript_job(mocker, settings, caption_exists, transcript_exists):
     """test start_transcript_job"""
     youtube_id = "test"
     threeplay_file_id = 1
-    settings.YT_FIELD_ID = "youtube_id"
+    settings.YT_FIELD_ID = "video_metadata.youtube_id"
+    title = "title"
 
     video_file = VideoFileFactory.create(
         status=VideoStatus.CREATED,
@@ -201,6 +204,28 @@ def test_start_transcript_job(mocker, settings):
     video.source_key = "the/file"
     video.save()
 
+    video_content = WebsiteContentFactory.create(
+        website=video.website,
+        metadata={"video_metadata": {"youtube_id": youtube_id}},
+        title=title,
+    )
+
+    base_path = f"/some/path/to/{video_content.filename}"
+
+    if caption_exists:
+        WebsiteContentFactory.create(
+            website=video.website,
+            filename=f"{video_content.filename}_captions",
+            file=f"{base_path}_captions.srt",
+        )
+
+    if transcript_exists:
+        WebsiteContentFactory.create(
+            website=video.website,
+            filename=f"{video_content.filename}_transcript",
+            file=f"{base_path}_transcript.pdf",
+        )
+
     mock_threeplay_upload_video_request = mocker.patch(
         "videos.tasks.threeplay_api.threeplay_upload_video_request",
         return_value={"data": {"id": threeplay_file_id}},
@@ -210,29 +235,30 @@ def test_start_transcript_job(mocker, settings):
         "videos.tasks.threeplay_api.threeplay_order_transcript_request"
     )
 
-    title = "title"
-
-    WebsiteContentFactory.create(
-        website=video.website,
-        metadata={"youtube_id": youtube_id},
-        title=title,
-    )
-
-    update_youtube_statuses.delay()
-
     start_transcript_job(video.id)
 
-    mock_threeplay_upload_video_request.assert_called_once_with(
-        video.website.short_id, youtube_id, title
+    video_content.refresh_from_db()
+    assert get_dict_field(video_content.metadata, settings.YT_FIELD_CAPTIONS) == (
+        f"{base_path}_captions.srt" if caption_exists else None
     )
-    mock_order_transcript_request_request.assert_called_once_with(
-        video.id, threeplay_file_id
+    assert get_dict_field(video_content.metadata, settings.YT_FIELD_TRANSCRIPT) == (
+        f"{base_path}_transcript.pdf" if transcript_exists else None
     )
 
+    if not transcript_exists and not caption_exists:
+        mock_threeplay_upload_video_request.assert_called_once_with(
+            video.website.short_id, youtube_id, title
+        )
+        mock_order_transcript_request_request.assert_called_once_with(
+            video.id, threeplay_file_id
+        )
+    else:
+        mock_threeplay_upload_video_request.assert_not_called()
+        mock_order_transcript_request_request.assert_not_called()
 
-# pylint:disable=no-value-for-parameter, too-many-arguments
+
 @pytest.mark.parametrize("is_enabled", [True, False])
-def test_update_youtube_statuses(
+def test_update_youtube_statuses(  # pylint:disable=too-many-arguments
     settings,
     mocker,
     youtube_video_files_processing,
@@ -298,7 +324,7 @@ def test_update_youtube_statuses_api_quota_exceeded(
             MockHttpErrorResponse(403), str.encode(API_QUOTA_ERROR_MSG, "utf-8")
         ),
     )
-    update_youtube_statuses()
+    update_youtube_statuses.delay()
     mock_video_status.assert_called_once()
 
 
@@ -314,7 +340,7 @@ def test_update_youtube_statuses_http_error(mocker, youtube_video_files_processi
         "videos.tasks.mail_youtube_upload_failure"
     )
     mock_log = mocker.patch("videos.tasks.log.exception")
-    update_youtube_statuses()
+    update_youtube_statuses.delay()
     for video_file in youtube_video_files_processing:
         mock_video_status.assert_any_call(video_file.destination_id)
         mock_log.assert_any_call(
@@ -335,7 +361,7 @@ def test_update_youtube_statuses_index_error(mocker, youtube_video_files_process
     mock_mail_youtube_upload_failure = mocker.patch(
         "videos.tasks.mail_youtube_upload_failure"
     )
-    update_youtube_statuses()
+    update_youtube_statuses.delay()
     for video_file in youtube_video_files_processing:
         mock_log.assert_any_call(
             "Status of YouTube video not found: youtube_id %s",
@@ -347,7 +373,7 @@ def test_update_youtube_statuses_index_error(mocker, youtube_video_files_process
 def test_update_youtube_statuses_no_videos(mocker):
     """Youtube API should not be instantiated if there are no videos to process"""
     mock_youtube = mocker.patch("videos.tasks.YouTubeApi")
-    update_youtube_statuses()
+    update_youtube_statuses.delay()
     mock_youtube.assert_not_called()
 
 
@@ -540,6 +566,79 @@ def test_update_transcripts_for_updated_videos(mocker):
     updated_files_mock.assert_called_once()
     update_transcript_mock.assert_called_once_with(video_file.video.id)
     remove_tags_mock.assert_called_once_with(6737396)
+
+
+@pytest.mark.parametrize(
+    "caption_exists, transcript_exists",
+    [
+        [True, False],
+        [False, True],
+    ],
+)
+def test_update_transcripts_for_video_no_3play(
+    mocker, caption_exists, transcript_exists
+):
+    """if there are caption/transcript resources, avoid calling 3play"""
+    mocker.patch("videos.tasks.is_ocw_site", return_value=True)
+
+    videofile = VideoFileFactory.create(
+        destination=DESTINATION_YOUTUBE, destination_id="expected_id"
+    )
+    video = videofile.video
+    resource = WebsiteContentFactory.create(website=video.website, metadata={})
+    metadata = resource.metadata
+    base_path = f"{resource.website.s3_path}/{resource.filename}"
+
+    if caption_exists:
+        WebsiteContentFactory.create(
+            website=video.website,
+            filename=f"{resource.filename}_captions",
+            file=f"{base_path}_captions.srt",
+        )
+
+    if transcript_exists:
+        WebsiteContentFactory.create(
+            website=video.website,
+            filename=f"{resource.filename}_transcript",
+            file=f"{base_path}_transcript.pdf",
+        )
+
+    set_dict_field(metadata, settings.FIELD_RESOURCETYPE, RESOURCE_TYPE_VIDEO)
+    set_dict_field(metadata, settings.YT_FIELD_ID, "expected_id")
+    set_dict_field(
+        metadata,
+        settings.YT_FIELD_CAPTIONS,
+        (f"{base_path}_captions.srt" if caption_exists else None),
+    )
+    set_dict_field(
+        metadata,
+        settings.YT_FIELD_TRANSCRIPT,
+        (f"{base_path}_transcript.pdf" if transcript_exists else None),
+    )
+    resource.save()
+
+    if caption_exists:
+        assert video.caption_transcript_resources()[0] is not None
+    if transcript_exists:
+        assert video.caption_transcript_resources()[1] is not None
+
+    mock_3play = mocker.patch("videos.tasks.threeplay_api.update_transcripts_for_video")
+
+    update_transcripts_for_video(video.id)
+    resource.refresh_from_db()
+
+    mock_3play.assert_not_called()
+
+    assert get_dict_field(resource.metadata, settings.YT_FIELD_CAPTIONS) == (
+        f"{video.website.url_path}/{resource.filename}_captions.srt"
+        if caption_exists
+        else None
+    )
+    assert get_dict_field(resource.metadata, settings.YT_FIELD_TRANSCRIPT) == (
+        f"{video.website.url_path}/{resource.filename}_transcript.pdf"
+        if transcript_exists
+        else None
+    )
 
 
 def test_attempt_to_update_missing_transcripts(mocker):

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -211,8 +211,11 @@ def test_start_transcript_job(mocker, settings, mocked_celery):
     )
 
     title = "title"
+
     WebsiteContentFactory.create(
-        website=video.website, metadata={"youtube_id": youtube_id}, title=title
+        website=video.website,
+        metadata={"video_metadata": {"youtube_id": youtube_id}},
+        title=title,
     )
 
     update_youtube_statuses.delay()


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1656.

#### What's this PR do?
Allows for pre-existing captions/transcripts to be included with newly-uploaded videos, bypassing the 3Play captioning service.

#### How should this be manually tested?
- Use the same values for `YT_*` and `AWS_*` and `OCW_COURSE_STARTER_SLUG` as RC.  Note that AWS S3 buckets need to be used for testing (as opposed to local Minio storage) - so comment out your minio .env settings and set `OCW_STUDIO_ENVIRONMENT=devdev`. Also ensure that `PREPUBLISH_ACTIONS=videos.tasks.update_transcripts_for_website`
- For a course based on the the OCW starter, place a sample video with the name `<video_name>.mp4` in the `videos_final` folder on Google Drive. Place sample captions with names `<video_name>_captions.vtt` and `<video_name>_transcript.pdf` into the `files_final` folder on Google Drive. Note that the file names must be *exactly* those. Sync OCW Studio with Google Drive, and once the video has been uploaded to YouTube (either a custom channel or the RC channel via a POST request as in https://github.com/mitodl/ocw-studio/pull/469), confirm that the video resource object in Studio is properly associated with the captions and transcript files via the video `WebsiteContent` metdata field.
- Publish the site to draft.  In django admin or the corresponding git repo, find the `WebsiteContent` resource for the video and verify that the transcript and caption sections of the metadata are updated to include the website's url path.