### PR TITLE
change offline mass build webpack output to be stored in static_shared

### DIFF
--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -117,8 +117,8 @@ jobs:
           yarn install --immutable
           npm run build:webpack
           npm run build:githash
-          mkdir -p ./base-theme/static/static/
-          cp -r ./base-theme/dist/static/* ./base-theme/static/static/
+          mkdir -p ./base-theme/static/static_shared/
+          cp -r ./base-theme/dist/static_shared/* ./base-theme/static/static_shared/
   # END OFFLINE-ONLY
   - task: get-sites
     timeout: 2m


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1685

#### What's this PR do?
In https://github.com/mitodl/ocw-hugo-themes/pull/1056, we changed `ocw-hugo-themes` to collect and store all shared static assets (webpack build output, shared static images, etc.) into a folder called `static_shared`. The purpose of this was to isolate static resources shared by all themes into one folder. This way, it's easier to copy all the necessary static resources into any given offline build of a site built with any theme that inherits `base-theme`.

In https://github.com/mitodl/ocw-studio/pull/1680, we changed the single site publishing pipeline (`site-pipeline.yaml`) to sync `static_shared` from the root of the live site bucket into the offline build instead of `static`, which closed the loop on that for single site builds. One thing that was missed was the offline mass build, and that's what this PR takes care of. The offline mass build does its own webpack build before building all of the offline sites, and this change ensures that the output goes into `static_shared` instead of `static`.

#### How should this be manually tested?
 - Make sure you are pointing at the `main` branches of `ocw-hugo-themes` and `ocw-hugo-projects` by setting this in your `.env`:
```
OCW_HUGO_THEMES_BRANCH=main
OCW_HUGO_PROJECTS_BRANCH=main
```
 - We're going to want to make sure we limit the amount of sites built by the mass build pipeline locally, otherwise the build will take forever. This can be accomplished by changing like 341 of `websites/views.py` to: `sites = sites.prefetch_related("starter").order_by("name")[:10]`
 - Spin up `ocw-studio` on this branch and ensure you have Concourse and Minio configured properly (see the readme for more info)
 - You can skip these steps if you already have theme assets generated on the `main` branch:
   - Run `docker compose exec web ./manage.py upsert_theme_assets_pipeline`
   - Visit the Concourse web UI at http://localhost:8080
   - Find the theme assets pipeline for the `main` branch and trigger a build, then wait for it to complete
 - Upsert the offline mass build pipeline with `docker compose exec web ./manage.py upsert_mass_build_pipeline --offline --starter ocw-course-v2`
 - Find the offline mass build pipeline we just upserted, unpause it if necessary and trigger a build
 - After the build is complete, log into the Minio web UI at http://localhost:9001
 - Browse to any course built by the offline mass build and download the ZIP file in the course root
 - Extract the ZIP file, verify that the webpack build output is stored in `static_shared`
 - Double click the `index.html` file and verify that:
   - There are no errors in the console
   - Nav links work
   - Resource links to PDFs and such work
   - Nothing else seems weird or off about the site
