### PR TITLE
fix: site title and short_id shown on unpublish dialog

### DIFF
--- a/static/js/components/Dropdown.tsx
+++ b/static/js/components/Dropdown.tsx
@@ -1,14 +1,14 @@
 import React, { useCallback, useState } from "react"
 import { MaterialIcons } from "../types/common"
-import { WebsiteDropdown } from "../types/websites"
+import { WebsiteDropdown, WebsiteInitials } from "../types/websites"
 
 export default function Dropdown(props: {
-  websiteName: string
+  website?: WebsiteInitials
   dropdownBtnID: string
   materialIcon: MaterialIcons
   dropdownMenu: WebsiteDropdown[]
 }): JSX.Element | null {
-  const { websiteName, dropdownBtnID, materialIcon, dropdownMenu } = props
+  const { website, dropdownBtnID, materialIcon, dropdownMenu } = props
 
   const [menuOpen, setMenuOpen] = useState(false)
 
@@ -37,10 +37,10 @@ export default function Dropdown(props: {
       if (e) {
         e.preventDefault()
       }
-      clickHandler(websiteName)
+      clickHandler(website || null)
       closeMenu(e)
     },
-    [closeMenu, websiteName]
+    [closeMenu, website]
   )
 
   if (!dropdownMenu.length) {

--- a/static/js/components/UnpublishDialog.tsx
+++ b/static/js/components/UnpublishDialog.tsx
@@ -5,18 +5,20 @@ import { useMutation } from "redux-query-react"
 import { websiteUnpublishAction } from "../query-configs/websites"
 import { isErrorStatusCode } from "../lib/util"
 
+import { WebsiteInitials } from "../types/websites"
+
 export default function UnpublishDialog(props: {
-  websiteName: string
+  website: WebsiteInitials
   successCallback: () => void
   closeDialog: () => void
 }): JSX.Element {
-  const { websiteName, successCallback, closeDialog } = props
+  const { website, successCallback, closeDialog } = props
   const [isSiteUnpublished, setIsSiteUnpublished] = useState(false)
   const [siteUnpublishedMsg, setSiteUnpublishedMsg] = useState("")
   const [error, setError] = useState("")
 
   const [{ isPending }, unpublishPost] = useMutation(() =>
-    websiteUnpublishAction(websiteName, "POST")
+    websiteUnpublishAction(website.name, "POST")
   )
   const handleUnpublishPost = async () => {
     if (isPending) {
@@ -56,7 +58,11 @@ export default function UnpublishDialog(props: {
         <ModalBody>
           {!error ? (
             <div>
-              Are you sure you want to unpublish <b>{websiteName}</b>?
+              Are you sure you want to unpublish{" "}
+              <b>
+                {website.title} ({website.short_id})
+              </b>
+              ?
             </div>
           ) : (
             <div className="form-error">{error}</div>

--- a/static/js/pages/SitesDashboard.tsx
+++ b/static/js/pages/SitesDashboard.tsx
@@ -12,7 +12,7 @@ import {
 } from "../query-configs/websites"
 import { getWebsiteListingCursor } from "../selectors/websites"
 import { newSiteUrl, siteDetailUrl } from "../lib/urls"
-import { Website, WebsiteDropdown } from "../types/websites"
+import { Website, WebsiteDropdown, WebsiteInitials } from "../types/websites"
 import { MaterialIcons } from "../types/common"
 import DocumentTitle, { formatTitle } from "../components/DocumentTitle"
 import { StudioList, StudioListItem } from "../components/StudioList"
@@ -31,7 +31,10 @@ function getListingParams(search: string): WebsiteListingParams {
 }
 
 export default function SitesDashboard(): JSX.Element {
-  const [showUnpublishDialog, setShowUnpublishDialog] = useState("")
+  const [
+    websiteToUnpublish,
+    setWebsiteToUnpublish
+  ] = useState<WebsiteInitials | null>(null)
 
   const { listingParams, searchInput, setSearchInput } = useURLParamFilter(
     getListingParams
@@ -51,8 +54,8 @@ export default function SitesDashboard(): JSX.Element {
     {
       id:           "1",
       label:        "Unpublish",
-      clickHandler: (websiteName: string) => {
-        setShowUnpublishDialog(websiteName)
+      clickHandler: (website: WebsiteInitials) => {
+        setWebsiteToUnpublish(website)
       }
     }
   ]
@@ -101,7 +104,11 @@ export default function SitesDashboard(): JSX.Element {
                   <div className="text-dark">Draft</div>
                 )}
                 <Dropdown
-                  websiteName={site.name}
+                  website={{
+                    name:     site.name,
+                    title:    site.title,
+                    short_id: site.short_id
+                  }}
                   dropdownBtnID={`${site.uuid}_DropdownMenuButton`}
                   materialIcon={MaterialIcons.MoreVert}
                   dropdownMenu={
@@ -117,12 +124,12 @@ export default function SitesDashboard(): JSX.Element {
         <PaginationControls previous={pages.previous} next={pages.next} />
       </div>
 
-      {showUnpublishDialog ? (
+      {websiteToUnpublish ? (
         <UnpublishDialog
-          websiteName={showUnpublishDialog}
+          website={websiteToUnpublish}
           successCallback={unpublishSuccessCallback}
           closeDialog={() => {
-            setShowUnpublishDialog("")
+            setWebsiteToUnpublish(null)
           }}
         />
       ) : null}

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -322,3 +322,9 @@ export type WebsiteDropdown = {
   label: string
   clickHandler: (...args: any[]) => void
 }
+
+export interface WebsiteInitials {
+  name: string
+  title: string
+  short_id: string
+}


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested
- [ ] Settings
  - [ ] New settings are documented and present in `app.json`
  - [ ] New settings have reasonable development defaults, if applicable
  - [ ] Opened issue for DevOps regarding necessary configuration changes to deployed environments

#### What are the relevant tickets?
closes https://github.com/mitodl/ocw-studio/issues/1699

#### What's this PR do?
- Replaces website name with website title and short ID on unpublish confirmation dialog.

#### How should this be manually tested?
- Checkout this branch
- Go to /sites page
- Click unpublish for any website
- Verify that website's title and short id are shown in the unpublish confirmation dialog
- Proceed with unpublish and verify that the site is unpublished successfully.

#### Screenshots (if appropriate)

<img width="1397" alt="image" src="https://user-images.githubusercontent.com/93309234/222134655-bf2c1775-3b78-4022-901b-d36a59152fee.png">

<img width="538" alt="image" src="https://user-images.githubusercontent.com/93309234/222135730-714df48f-f09a-42cd-a613-d1c524d71d26.png">

<img width="537" alt="image" src="https://user-images.githubusercontent.com/93309234/222135926-388aad6d-8f6a-408a-bc59-6972bc8bffc7.png">


