### PR TITLE
Fix static resources path for root website

### DIFF
--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -519,7 +519,9 @@ class SitePipeline(BaseSitePipeline, GeneralPipeline):
                     f" --endpoint-url {DEV_ENDPOINT_URL}" if is_dev() else "",
                 )
                 .replace("((resource-base-url))", resource_base_url or "")
-                .replace("((static-resources-subdirectory))", static_resources_subdirectory)
+                .replace(
+                    "((static-resources-subdirectory))", static_resources_subdirectory
+                )
                 .replace(
                     "((ocw-hugo-themes-sentry-dsn))",
                     settings.OCW_HUGO_THEMES_SENTRY_DSN or "",

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -384,10 +384,12 @@ class SitePipeline(BaseSitePipeline, GeneralPipeline):
 
         if self.WEBSITE.name == settings.ROOT_WEBSITE_NAME:
             base_url = ""
+            static_resources_subdirectory = self.WEBSITE.get_url_path()
             theme_created_trigger = "true"
             theme_deployed_trigger = "false"
         else:
             base_url = self.WEBSITE.get_url_path()
+            static_resources_subdirectory = ""
             theme_created_trigger = "false"
             theme_deployed_trigger = "true"
         hugo_projects_url = urljoin(
@@ -517,6 +519,7 @@ class SitePipeline(BaseSitePipeline, GeneralPipeline):
                     f" --endpoint-url {DEV_ENDPOINT_URL}" if is_dev() else "",
                 )
                 .replace("((resource-base-url))", resource_base_url or "")
+                .replace("((static-resources-subdirectory))", static_resources_subdirectory)
                 .replace(
                     "((ocw-hugo-themes-sentry-dsn))",
                     settings.OCW_HUGO_THEMES_SENTRY_DSN or "",

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -352,11 +352,13 @@ def test_upsert_website_pipelines(
         in config_str
     )
     if home_page:
+        assert f"cp -r -n ../static-resources/. ./output-online/{website.name}" in config_str
         assert (
             f"aws s3 {expected_endpoint_prefix}sync course-markdown/output-online s3://{bucket}/ --metadata site-id={website.name}"
             in config_str
         )
     else:
+        assert "cp -r -n ../static-resources/. ./output-online/" in config_str
         assert (
             f"aws s3 {expected_endpoint_prefix}sync s3://{bucket}/static_shared ./static/static_shared"
             in config_str

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -352,7 +352,10 @@ def test_upsert_website_pipelines(
         in config_str
     )
     if home_page:
-        assert f"cp -r -n ../static-resources/. ./output-online/{website.name}" in config_str
+        assert (
+            f"cp -r -n ../static-resources/. ./output-online/{website.name}"
+            in config_str
+        )
         assert (
             f"aws s3 {expected_endpoint_prefix}sync course-markdown/output-online s3://{bucket}/ --metadata site-id={website.name}"
             in config_str

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -579,7 +579,7 @@ jobs:
             - |
               cp ../webpack-json/webpack.json ../ocw-hugo-themes/base-theme/data
               hugo ((hugo-args-online))
-              cp -r -n ../static-resources/. ./output-online
+              cp -r -n ../static-resources/. ./output-online/((static-resources-subdirectory))
               if [ -f "../build-course-offline/((short-id)).zip" ];
               then
                 cp ../build-course-offline/((short-id)).zip  ./output-online


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/944

#### What's this PR do?
This PR fixes an issue with the static resources for the root website (`ocw-www`) not being copied into the right place in the web bucket. In https://github.com/mitodl/ocw-studio/pull/1611 and subsequently https://github.com/mitodl/ocw-studio/pull/1630, changes were made that consolidate all of of the content to be copied up to the web bucket (hugo output and static resources) into one S3 sync. For sites that are *not* the root website, this sync is run with the `--delete` flag so that publishes are "clean," aka they remove all content from the bucket that does not match what is being synced up. This is not done for the root website, because it syncs to the root of the bucket and using `--delete` would remove all other content. Coping the static resources into the root of the site works for course sites, where the expected path to resources is equal to the base URL but for the root website these are different; `/ocw-www` and `/` respectively. This PR corrects that by setting a separate subdirectory to copy static resources into before the s3 sync, which is `ocw-www` for the root website and blank for other sites.

#### How should this be manually tested?
 - Spin up `ocw-studio` on this branch, making sure you have Concourse, Minio, Google Drive and Github configured properly for publishing websites
 - Make sure you have a root website, likely called `ocw-www` using the `ocw-www` starter from `ocw-hugo-projects`
 - Run `docker-compose exec web ./manage.py backpopulate_pipelines` to update your pipeline definitions
 - Go into `ocw-www` and add a new image resource, syncing it from GDrive so `ocw-studio` copies it into your Minio `ol-ocw-studio-app` bucket
 - Create a new Promo and link the image to it
 - Publish the site and verify that the promo shows up properly along with the image.
