### PR TITLE
feat: show short_id in course list dropdown

### DIFF
--- a/static/js/components/widgets/WebsiteCollectionField.test.tsx
+++ b/static/js/components/widgets/WebsiteCollectionField.test.tsx
@@ -1,13 +1,14 @@
 import IntegrationTestHelper, {
   TestRenderer
 } from "../../util/integration_test_helper_old"
-import WebsiteCollectionField from "./WebsiteCollectionField"
+import WebsiteCollectionField, {
+  formatOptionsLabelWithShortId
+} from "./WebsiteCollectionField"
 
 import * as websiteHooks from "../../hooks/websites"
 import { Website } from "../../types/websites"
 import { makeWebsites } from "../../util/factories/websites"
 import { triggerSortableSelect } from "./test_util"
-import { Option } from "./SelectField"
 import SortableSelect from "./SortableSelect"
 
 jest.mock("../../hooks/websites", () => ({
@@ -23,7 +24,8 @@ describe("WebsiteCollectionField", () => {
     render: TestRenderer,
     onChange: jest.Mock,
     websites: Website[],
-    websiteOptions: Option[]
+    websiteOptions: websiteHooks.WebsiteOption[],
+    selectWebsiteOptions: websiteHooks.WebsiteOption[]
 
   beforeEach(() => {
     helper = new IntegrationTestHelper()
@@ -35,6 +37,7 @@ describe("WebsiteCollectionField", () => {
     })
     websites = makeWebsites()
     websiteOptions = websiteHooks.formatWebsiteOptions(websites, "name")
+    selectWebsiteOptions = formatOptionsLabelWithShortId(websiteOptions)
     useWebsiteSelectOptions.mockReturnValue({
       options:     websiteOptions,
       loadOptions: jest.fn()
@@ -61,8 +64,8 @@ describe("WebsiteCollectionField", () => {
     })
     const sortableSelect = wrapper.find(SortableSelect)
     expect(sortableSelect.prop("value")).toStrictEqual(value)
-    expect(sortableSelect.prop("options")).toStrictEqual(websiteOptions)
-    expect(sortableSelect.prop("defaultOptions")).toStrictEqual(websiteOptions)
+    expect(sortableSelect.prop("options")).toEqual(selectWebsiteOptions)
+    expect(sortableSelect.prop("defaultOptions")).toEqual(selectWebsiteOptions)
   })
 
   it("should let the user add a website, with UUID and title", async () => {

--- a/static/js/components/widgets/WebsiteCollectionField.tsx
+++ b/static/js/components/widgets/WebsiteCollectionField.tsx
@@ -2,12 +2,23 @@ import React, { useCallback, useEffect, useState } from "react"
 
 import SortableSelect, { SortableItem } from "./SortableSelect"
 import { Option } from "./SelectField"
-import { useWebsiteSelectOptions } from "../../hooks/websites"
+import { useWebsiteSelectOptions, WebsiteOption } from "../../hooks/websites"
+import _ from "lodash"
 
 interface Props {
   name: string
   onChange: (event: any) => void
   value: SortableItem[]
+}
+
+export function formatOptionsLabelWithShortId(
+  options: WebsiteOption[]
+): WebsiteOption[] {
+  const formattedOptions = _.cloneDeep(options)
+  formattedOptions.forEach(e => {
+    e.label = `${e.label} (${e.shortId})`
+  })
+  return formattedOptions
 }
 
 export default function WebsiteCollectionField(props: Props): JSX.Element {
@@ -55,13 +66,15 @@ export default function WebsiteCollectionField(props: Props): JSX.Element {
     [value]
   )
 
+  const formattedOptions = formatOptionsLabelWithShortId(options)
+
   return (
     <SortableSelect
       name={name}
       value={value}
       onChange={onChangeShim}
-      options={options}
-      defaultOptions={options}
+      options={formattedOptions}
+      defaultOptions={formattedOptions}
       loadOptions={loadOptions}
       isOptionDisabled={isOptionDisabled}
     />

--- a/static/js/hooks/websites.ts
+++ b/static/js/hooks/websites.ts
@@ -16,6 +16,13 @@ import { debouncedFetch } from "../lib/api/util"
 import { QueryState } from "redux-query"
 
 /**
+ * A SelectField Option that is specific to websites.
+ */
+export interface WebsiteOption extends Option {
+  shortId: string
+}
+
+/**
  * Hook for fetching and accessing a WebsiteContent object
  * given a uuid. As easy as:
  *
@@ -60,14 +67,15 @@ export function useWebsiteContent(
 export const formatWebsiteOptions = (
   websites: Website[],
   valueField: string
-): Option[] =>
+): WebsiteOption[] =>
   websites.map(website => ({
-    label: website.title,
-    value: website[valueField]
+    label:   website.title,
+    shortId: website.short_id,
+    value:   website[valueField]
   }))
 
 interface ReturnProps {
-  options: Option[]
+  options: WebsiteOption[]
   loadOptions: (
     inputValue: string,
     callback?: (options: Option[]) => void
@@ -85,10 +93,13 @@ export function useWebsiteSelectOptions(
   valueField = "uuid",
   published: boolean | undefined = undefined
 ): ReturnProps {
-  const [options, setOptions] = useState<Option[]>([])
+  const [options, setOptions] = useState<WebsiteOption[]>([])
 
   const loadOptions = useCallback(
-    async (inputValue: string, callback?: (options: Option[]) => void) => {
+    async (
+      inputValue: string,
+      callback?: (options: WebsiteOption[]) => void
+    ) => {
       const url = siteApiListingUrl
         .query({ offset: 0 })
         .param({ search: inputValue })


### PR DESCRIPTION
This PR is an alternative approach to https://github.com/mitodl/ocw-studio/pull/1375

#### Pre-Flight checklist

- [x] Screenshots and design review for any changes that affect layout or styling
- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #393 

#### What's this PR do?

This PR has the same effect as https://github.com/mitodl/ocw-studio/pull/1375. It achieves the same effect with a different approach: by creating a new type `WebsiteOption`.

#### How should this be manually tested?
- Checkout this branch.
- In `/sites`, go to `ocw-www`
- Add a new course list or edit an existing one.
- Open the courses dropdown and verify that the format is `title (short_id)`
- Select course(s).
- Save the course list and verify that the course list is successfully saved.


#### Where should the reviewer start?
https://github.com/mitodl/ocw-studio/pull/1375

#### Screenshots (if appropriate)
<img width="530" alt="Screenshot 2023-03-15 at 11 51 20 AM" src="https://user-images.githubusercontent.com/71316217/225229320-3880dd0b-344a-4968-8aa6-4eafba09421d.png">
<img width="514" alt="Screenshot 2023-03-15 at 11 51 15 AM" src="https://user-images.githubusercontent.com/71316217/225229333-1ab934b2-2106-4760-a643-13fd70953ecc.png">


