### PR TITLE
Exclude JS Map assets from builds

### DIFF
--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -363,7 +363,7 @@ def test_upsert_website_pipelines(
     else:
         assert "cp -r -n ../static-resources/. ./output-online/" in config_str
         assert (
-            f"aws s3 {expected_endpoint_prefix}sync s3://{bucket}/static_shared ./static/static_shared"
+            f"aws s3 {expected_endpoint_prefix}sync s3://{bucket}/static_shared --exclude *.js.map ./static/static_shared"
             in config_str
         )
         assert (

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -363,7 +363,7 @@ def test_upsert_website_pipelines(
     else:
         assert "cp -r -n ../static-resources/. ./output-online/" in config_str
         assert (
-            f"aws s3 {expected_endpoint_prefix}sync s3://{bucket}/static_shared ./static/static_shared --exclude *.js.map" 
+            f"aws s3 {expected_endpoint_prefix}sync s3://{bucket}/static_shared ./static/static_shared --exclude *.js.map"
             in config_str
         )
         assert (

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -690,7 +690,7 @@ def test_upsert_mass_build_pipeline(
         assert "$SHORT_ID.zip" in config_str
         if settings.ENVIRONMENT == "dev":
             assert (
-                f"STUDIO_S3_RESULT=$(aws s3{endpoint_url} sync s3://{settings.AWS_STORAGE_BUCKET_NAME}/$S3_PATH ./content/static_resources --exclude *.mp4 --exclude *.js.map --only-show-errors) || STUDIO_S3_RESULT=1"
+                f"STUDIO_S3_RESULT=$(aws s3{endpoint_url} sync s3://{settings.AWS_STORAGE_BUCKET_NAME}/$S3_PATH ./content/static_resources --exclude *.mp4 --only-show-errors) || STUDIO_S3_RESULT=1"
                 in config_str
             )
     else:

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -363,7 +363,7 @@ def test_upsert_website_pipelines(
     else:
         assert "cp -r -n ../static-resources/. ./output-online/" in config_str
         assert (
-            f"aws s3 {expected_endpoint_prefix}sync s3://{bucket}/static_shared --exclude *.js.map ./static/static_shared"
+            f"aws s3 {expected_endpoint_prefix}sync s3://{bucket}/static_shared ./static/static_shared --exclude *.js.map" 
             in config_str
         )
         assert (

--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -118,7 +118,8 @@ jobs:
           npm run build:webpack
           npm run build:githash
           mkdir -p ./base-theme/static/static_shared/
-          cp -r ./base-theme/dist/static_shared/* ./base-theme/static/static_shared/
+          find ./base-theme/dist/static_shared/* ! -name '*.js.map' -type f | xargs cp -t ./base-theme/static/static_shared/
+          
   # END OFFLINE-ONLY
   - task: get-sites
     timeout: 2m
@@ -215,7 +216,7 @@ jobs:
               # END ONLINE-ONLY
               # START OFFLINE-ONLY
               echo "PULLING IN STATIC RESOURCES FOR $NAME" > /dev/tty
-              STUDIO_S3_RESULT=$(aws s3((cli-endpoint-url)) sync s3://((ocw-studio-bucket))/$S3_PATH ./content/static_resources --exclude *.mp4 --exclude *.js.map --only-show-errors) || STUDIO_S3_RESULT=1
+              STUDIO_S3_RESULT=$(aws s3((cli-endpoint-url)) sync s3://((ocw-studio-bucket))/$S3_PATH ./content/static_resources --exclude *.mp4 --only-show-errors) || STUDIO_S3_RESULT=1
               if [[ $STUDIO_S3_RESULT == 1 ]]
               then
                 echo "SYNCING s3://((ocw-studio-bucket))/$S3_PATH to ./content/static_resources FAILED FOR $NAME" > /dev/tty

--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -118,7 +118,8 @@ jobs:
           npm run build:webpack
           npm run build:githash
           mkdir -p ./base-theme/static/static_shared/
-          find ./base-theme/dist/static_shared/* ! -name '*.js.map' -type f | xargs cp -t ./base-theme/static/static_shared/
+          cp -r ./base-theme/dist/static_shared/* ./base-theme/static/static_shared/
+          find ./base-theme/static/static_shared -name "*.js.map" -type f -delete
           
   # END OFFLINE-ONLY
   - task: get-sites

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -383,7 +383,7 @@ jobs:
                 mkdir -p ./static/static_shared
                 if [ ! -z "$(ls -A ../static-resources)" ];
                 then
-                  find ../static-resources ! -name '*.mp4' ! -name '*.js.map' -type f | xargs cp -t ./content/static_resources
+                  find ../static-resources ! -name '*.mp4' -type f | xargs cp -t ./content/static_resources
                 fi
                 HTML_COUNT="$(ls -1 ./content/static_resources/*.html 2>/dev/null | wc -l)"
                 if [ $HTML_COUNT != 0 ];
@@ -391,7 +391,7 @@ jobs:
                   mv ./content/static_resources/*.html ./static/static_resources
                 fi
                 touch ./content/static_resources/_index.md
-                aws s3((cli-endpoint-url)) sync s3://((web-bucket))/static_shared ./static/static_shared
+                aws s3((cli-endpoint-url)) sync s3://((web-bucket))/static_shared --exclude *.js.map ./static/static_shared
                 hugo ((hugo-args-offline))
                 cd output-offline
                 zip ../../build-course-offline/((short-id)).zip -r ./

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -391,7 +391,7 @@ jobs:
                   mv ./content/static_resources/*.html ./static/static_resources
                 fi
                 touch ./content/static_resources/_index.md
-                aws s3((cli-endpoint-url)) sync s3://((web-bucket))/static_shared --exclude *.js.map ./static/static_shared
+                aws s3((cli-endpoint-url)) sync s3://((web-bucket))/static_shared ./static/static_shared --exclude *.js.map
                 hugo ((hugo-args-offline))
                 cd output-offline
                 zip ../../build-course-offline/((short-id)).zip -r ./


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Screenshots and design review for any changes that affect layout or styling
- [ ] Migrations
  - [ ] Migration is backwards-compatible with current production code
- [ ] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1646

#### What's this PR do?
It helps to filter .js.map extension files to be excluded from the offline build of a course

#### How should this be manually tested?
- Publish a course
- Run the concourse pipelines
- Download the course from localhost:3000
- Navigate to course files, /static_shared folder
- .js.map files should not exist 
