### PR TITLE
Revert "feat: show short_id in course list dropdown"

### DIFF
--- a/static/js/components/widgets/WebsiteCollectionField.test.tsx
+++ b/static/js/components/widgets/WebsiteCollectionField.test.tsx
@@ -1,14 +1,13 @@
 import IntegrationTestHelper, {
   TestRenderer
 } from "../../util/integration_test_helper_old"
-import WebsiteCollectionField, {
-  formatOptionsLabelWithShortId
-} from "./WebsiteCollectionField"
+import WebsiteCollectionField from "./WebsiteCollectionField"
 
 import * as websiteHooks from "../../hooks/websites"
 import { Website } from "../../types/websites"
 import { makeWebsites } from "../../util/factories/websites"
 import { triggerSortableSelect } from "./test_util"
+import { Option } from "./SelectField"
 import SortableSelect from "./SortableSelect"
 
 jest.mock("../../hooks/websites", () => ({
@@ -24,8 +23,7 @@ describe("WebsiteCollectionField", () => {
     render: TestRenderer,
     onChange: jest.Mock,
     websites: Website[],
-    websiteOptions: websiteHooks.WebsiteOption[],
-    selectWebsiteOptions: websiteHooks.WebsiteOption[]
+    websiteOptions: Option[]
 
   beforeEach(() => {
     helper = new IntegrationTestHelper()
@@ -37,7 +35,6 @@ describe("WebsiteCollectionField", () => {
     })
     websites = makeWebsites()
     websiteOptions = websiteHooks.formatWebsiteOptions(websites, "name")
-    selectWebsiteOptions = formatOptionsLabelWithShortId(websiteOptions)
     useWebsiteSelectOptions.mockReturnValue({
       options:     websiteOptions,
       loadOptions: jest.fn()
@@ -64,8 +61,8 @@ describe("WebsiteCollectionField", () => {
     })
     const sortableSelect = wrapper.find(SortableSelect)
     expect(sortableSelect.prop("value")).toStrictEqual(value)
-    expect(sortableSelect.prop("options")).toEqual(selectWebsiteOptions)
-    expect(sortableSelect.prop("defaultOptions")).toEqual(selectWebsiteOptions)
+    expect(sortableSelect.prop("options")).toStrictEqual(websiteOptions)
+    expect(sortableSelect.prop("defaultOptions")).toStrictEqual(websiteOptions)
   })
 
   it("should let the user add a website, with UUID and title", async () => {

--- a/static/js/components/widgets/WebsiteCollectionField.tsx
+++ b/static/js/components/widgets/WebsiteCollectionField.tsx
@@ -2,23 +2,12 @@ import React, { useCallback, useEffect, useState } from "react"
 
 import SortableSelect, { SortableItem } from "./SortableSelect"
 import { Option } from "./SelectField"
-import { useWebsiteSelectOptions, WebsiteOption } from "../../hooks/websites"
-import _ from "lodash"
+import { useWebsiteSelectOptions } from "../../hooks/websites"
 
 interface Props {
   name: string
   onChange: (event: any) => void
   value: SortableItem[]
-}
-
-export function formatOptionsLabelWithShortId(
-  options: WebsiteOption[]
-): WebsiteOption[] {
-  const formattedOptions = _.cloneDeep(options)
-  formattedOptions.forEach(e => {
-    e.label = `${e.label} (${e.shortId})`
-  })
-  return formattedOptions
 }
 
 export default function WebsiteCollectionField(props: Props): JSX.Element {
@@ -66,15 +55,13 @@ export default function WebsiteCollectionField(props: Props): JSX.Element {
     [value]
   )
 
-  const formattedOptions = formatOptionsLabelWithShortId(options)
-
   return (
     <SortableSelect
       name={name}
       value={value}
       onChange={onChangeShim}
-      options={formattedOptions}
-      defaultOptions={formattedOptions}
+      options={options}
+      defaultOptions={options}
       loadOptions={loadOptions}
       isOptionDisabled={isOptionDisabled}
     />

--- a/static/js/hooks/websites.ts
+++ b/static/js/hooks/websites.ts
@@ -16,13 +16,6 @@ import { debouncedFetch } from "../lib/api/util"
 import { QueryState } from "redux-query"
 
 /**
- * A SelectField Option that is specific to websites.
- */
-export interface WebsiteOption extends Option {
-  shortId: string
-}
-
-/**
  * Hook for fetching and accessing a WebsiteContent object
  * given a uuid. As easy as:
  *
@@ -67,15 +60,14 @@ export function useWebsiteContent(
 export const formatWebsiteOptions = (
   websites: Website[],
   valueField: string
-): WebsiteOption[] =>
+): Option[] =>
   websites.map(website => ({
-    label:   website.title,
-    shortId: website.short_id,
-    value:   website[valueField]
+    label: website.title,
+    value: website[valueField]
   }))
 
 interface ReturnProps {
-  options: WebsiteOption[]
+  options: Option[]
   loadOptions: (
     inputValue: string,
     callback?: (options: Option[]) => void
@@ -93,13 +85,10 @@ export function useWebsiteSelectOptions(
   valueField = "uuid",
   published: boolean | undefined = undefined
 ): ReturnProps {
-  const [options, setOptions] = useState<WebsiteOption[]>([])
+  const [options, setOptions] = useState<Option[]>([])
 
   const loadOptions = useCallback(
-    async (
-      inputValue: string,
-      callback?: (options: WebsiteOption[]) => void
-    ) => {
+    async (inputValue: string, callback?: (options: Option[]) => void) => {
       const url = siteApiListingUrl
         .query({ offset: 0 })
         .param({ search: inputValue })


### PR DESCRIPTION
What this PR does?

Reverts mitodl/ocw-studio#1715

Search results do not show short_id.

How to test this PR

- Checkout this branch.
- In `/sites`, go to `ocw-www`
- Add a new course list or edit an existing one.
- Open the courses dropdown and verify that the format is `title`
- Select course(s).
- Save the course list and verify that the course list is successfully saved.

