### PR TITLE
fix: duplicate 3play submissions

### DIFF
--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -119,7 +119,10 @@ def start_transcript_job(video_id: int):
 
         threeplay_file_id = response.get("data").get("id")
 
-        if threeplay_file_id and video.status != VideoStatus.SUBMITTED_FOR_TRANSCRIPTION:
+        if (
+            threeplay_file_id
+            and video.status != VideoStatus.SUBMITTED_FOR_TRANSCRIPTION
+        ):
             threeplay_api.threeplay_order_transcript_request(
                 video.id, threeplay_file_id
             )

--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -118,7 +118,7 @@ def start_transcript_job(video_id: int):
         )
 
         threeplay_file_id = response.get("data").get("id")
-        
+
         if (
             threeplay_file_id
             and video.status != VideoStatus.SUBMITTED_FOR_TRANSCRIPTION

--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -118,7 +118,7 @@ def start_transcript_job(video_id: int):
         )
 
         threeplay_file_id = response.get("data").get("id")
-
+        
         if (
             threeplay_file_id
             and video.status != VideoStatus.SUBMITTED_FOR_TRANSCRIPTION

--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -112,7 +112,7 @@ def start_transcript_job(video_id: int):
         video_resource.save()
 
     # if none and video is not already submitted, request a transcript through the 3Play API
-    elif video.status != VideoStatus.SUBMITTED_FOR_TRANSCRIPTION:
+    else:
         response = threeplay_api.threeplay_upload_video_request(
             folder_name, youtube_id, video_resource.title
         )

--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -119,7 +119,7 @@ def start_transcript_job(video_id: int):
 
         threeplay_file_id = response.get("data").get("id")
 
-        if threeplay_file_id:
+        if threeplay_file_id and video.status != VideoStatus.SUBMITTED_FOR_TRANSCRIPTION:
             threeplay_api.threeplay_order_transcript_request(
                 video.id, threeplay_file_id
             )

--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -111,7 +111,8 @@ def start_transcript_job(video_id: int):
             )
         video_resource.save()
 
-    else:  # if none, request a transcript through the 3Play API
+    # if none and video is not already submitted, request a transcript through the 3Play API
+    elif video.status != VideoStatus.SUBMITTED_FOR_TRANSCRIPTION:
         response = threeplay_api.threeplay_upload_video_request(
             folder_name, youtube_id, video_resource.title
         )
@@ -164,7 +165,8 @@ def update_youtube_statuses(self):
                         YT_THUMBNAIL_IMG.format(video_id=video_file.destination_id),
                     )
                     resource.save()
-                    group_tasks.append(start_transcript_job.s(video_file.video.id))
+                    if video_file.status == VideoFileStatus.COMPLETE:
+                        group_tasks.append(start_transcript_job.s(video_file.video.id))
             mail_youtube_upload_success(video_file)
 
         except IndexError:

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -184,6 +184,8 @@ def test_upload_youtube_quota_exceeded(mocker, youtube_video_files_new, msg, sta
         assert video_file.destination_status is None
         assert video_file.destination_id is None
 
+
+# pylint: disable=unused-argument
 def test_threeplay_submission_called_once_per_video(mocker, settings):
     """
     Test that the threeplay_submission function is called only once per video.

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -202,8 +202,6 @@ def test_start_transcript_job(
         destination=DESTINATION_YOUTUBE,
         destination_id=youtube_id,
     )
-    # if transcript_exists:
-    #     video_file.status=VideoStatus.SUBMITTED_FOR_TRANSCRIPTION
 
     video = video_file.video
     video.source_key = "the/file"

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -67,7 +67,7 @@ def create_video(youtube_id, title):
 
 def create_content(website, youtube_id, title):
     """
-    Creates website content with the given website, YouTube ID, and title.
+    Creates website content with the given website, youtube_id, and title.
     """
     return WebsiteContentFactory.create(
         website=website,

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -289,7 +289,7 @@ def test_start_transcript_job(
 # pylint:disable=unused-variable
 def test_threeplay_submission_called_once_per_video(mocker, settings):
     """
-    Test that the threeplay_submission function is called only once per video.
+    Test that the threeplay_order_transcript_request function is called only once per video.
     """
     youtube_id = "test"
     threeplay_file_id = 1

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -256,16 +256,18 @@ def test_start_transcript_job(
     )
 
     if not transcript_exists and not caption_exists:
-        mock_threeplay_upload_video_request.assert_called_once_with(
-            video.website.short_id, youtube_id, title
-        )
-        mock_order_transcript_request_request.assert_called_once_with(
-            video.id, threeplay_file_id
-        )
+        if threeplay_file_id and video.status != VideoStatus.SUBMITTED_FOR_TRANSCRIPTION:
+            mock_order_transcript_request_request.assert_called_once_with(
+                video.id, threeplay_file_id
+            )
+        else:
+            mock_threeplay_upload_video_request.assert_called_once_with(
+                video.website.short_id, youtube_id, title
+            )
+            mock_order_transcript_request_request.assert_not_called()
     else:
         mock_threeplay_upload_video_request.assert_not_called()
         mock_order_transcript_request_request.assert_not_called()
-
 
 @pytest.mark.parametrize("is_enabled", [True, False])
 def test_update_youtube_statuses(  # pylint:disable=too-many-arguments

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -259,7 +259,7 @@ def test_start_transcript_job(
     mock_order_transcript_request_request = mocker.patch(
         "videos.tasks.threeplay_api.threeplay_order_transcript_request"
     )
-    
+
     start_transcript_job(video.id)
 
     video_content.refresh_from_db()

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -48,6 +48,34 @@ from websites.utils import get_dict_field, set_dict_field
 pytestmark = pytest.mark.django_db
 
 
+def create_video(youtube_id, title):
+    """
+    Creates video file with the given youtube_id and title.
+    """
+    video_file = VideoFileFactory.create(
+        status=VideoStatus.CREATED,
+        destination=DESTINATION_YOUTUBE,
+        destination_id=youtube_id,
+    )
+
+    video = video_file.video
+    video.source_key = "the/file"
+    video.save()
+
+    return video
+
+
+def create_content(website, youtube_id, title):
+    """
+    Creates website content with the given website, YouTube ID, and title.
+    """
+    return WebsiteContentFactory.create(
+        website=website,
+        metadata={"video_metadata": {"youtube_id": youtube_id}},
+        title=title,
+    )
+
+
 def set_nested_dicts(obj, field_path, value):
     """Set the value of a potentially nested dict path"""
     fields = field_path.split(".")
@@ -255,34 +283,6 @@ def test_start_transcript_job(
         )
     else:
         mock_order_transcript_request_request.assert_not_called()
-
-
-def create_video(youtube_id, title):
-    """
-    Creates video file with the given youtube_id and title.
-    """
-    video_file = VideoFileFactory.create(
-        status=VideoStatus.CREATED,
-        destination=DESTINATION_YOUTUBE,
-        destination_id=youtube_id,
-    )
-
-    video = video_file.video
-    video.source_key = "the/file"
-    video.save()
-
-    return video
-
-
-def create_content(website, youtube_id, title):
-    """
-    Creates website content with the given website, YouTube ID, and title.
-    """
-    return WebsiteContentFactory.create(
-        website=website,
-        metadata={"video_metadata": {"youtube_id": youtube_id}},
-        title=title,
-    )
 
 
 # pylint: disable=unused-argument

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -259,6 +259,7 @@ def test_start_transcript_job(
     mock_order_transcript_request_request = mocker.patch(
         "videos.tasks.threeplay_api.threeplay_order_transcript_request"
     )
+    
     start_transcript_job(video.id)
 
     video_content.refresh_from_db()

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -256,7 +256,10 @@ def test_start_transcript_job(
     )
 
     if not transcript_exists and not caption_exists:
-        if threeplay_file_id and video.status != VideoStatus.SUBMITTED_FOR_TRANSCRIPTION:
+        if (
+            threeplay_file_id
+            and video.status != VideoStatus.SUBMITTED_FOR_TRANSCRIPTION
+        ):
             mock_order_transcript_request_request.assert_called_once_with(
                 video.id, threeplay_file_id
             )
@@ -268,6 +271,7 @@ def test_start_transcript_job(
     else:
         mock_threeplay_upload_video_request.assert_not_called()
         mock_order_transcript_request_request.assert_not_called()
+
 
 @pytest.mark.parametrize("is_enabled", [True, False])
 def test_update_youtube_statuses(  # pylint:disable=too-many-arguments

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -286,7 +286,7 @@ def test_start_transcript_job(
         mock_order_transcript_request_request.assert_not_called()
 
 
-# pylint: disable=unused-argument
+# pylint:disable=unused-argument,redefined-outer-name
 def test_threeplay_submission_called_once_per_video(mocker, settings):
     """
     Test that the threeplay_submission function is called only once per video.

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -286,7 +286,7 @@ def test_start_transcript_job(
         mock_order_transcript_request_request.assert_not_called()
 
 
-# pylint:disable=unused-argument,redefined-outer-name
+# pylint:disable=unused-variable
 def test_threeplay_submission_called_once_per_video(mocker, settings):
     """
     Test that the threeplay_submission function is called only once per video.

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -258,7 +258,7 @@ def test_start_transcript_job(
     assert get_dict_field(video_content.metadata, settings.YT_FIELD_TRANSCRIPT) == (
         f"{base_path}_transcript.pdf" if transcript_exists else None
     )
-    
+
     if not transcript_exists and not caption_exists:
         mock_threeplay_upload_video_request.assert_called_once_with(
             video.website.short_id, youtube_id, title


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/1151

#### What's this PR do?
This PR resolves duplicate 3play submissions for a single video when it is uploaded to YouTube.

#### How should this be manually tested?
You will need to test it using a large video file. I used a random video lecture I had about 1 hour long (and 130 mb in size). You should download and then use any course's lecture video that meets similar requirements. (it's okay if the size or length is more). And I had named it "lecture10.mp4" (without spaces to avoid any `POST` request syntax related errors for spaces-related stuff)

**Testing the fix:**
1. Checkout to this branch. And run `docker-compose up`
2. Go to Google Drive’s shared folder for RC. Open any test course folder and go to "videos_final" directory. 
    - Note: You could use an existing one, or make your own new test course regarding that. If you use an existing one, make sure to delete your video afterwards. For the sake of this example I'll be sharing steps with respect to "peter's test site for unpublishing" which has a short id of "test101-spring-2023" (but an updated name of "test101-spring-2023-newname")
3. Upload a large video file inside the “videos_final” folder inside the course’s folder in Google Drive.
4. Go to `localhost:8043/sites/`. Open your respective course, and sync resources with Google Drive. Wait for it to sync successfully.
5. Go to `localhost:8043/admin/` and login. Copy the `File Id` from DriveFiles and `VideoJob` id from `Videos` related to the video you just uploaded/synced.
6. Open Postman to make a `POST` request to URL: `localhost:8043/api/transcode-jobs/` with body as in: test_videos_webhook/cloudwatch_sns_complete.json. You’ll have to replace the required values with RC’s values, and the DriveFile id, and the VideoJob id that you acquired earlier. You'll be putting "`VideoJob`" id twice, and `DriveFile` id thrice.
    - `VideoJob` id As in: 
    - `  "resources": [
    "arn:aws:mediaconvert:AWS_REGION:AWS_ACCOUNT_ID:jobs/<VIDEO_JOB_ID>"
  ],`
    - `    "jobId": "VIDEO_JOB_ID"`
    -  And `DriveFile` id in the places where it says `DRIVE_FILE_ID`
7. Make sure you follow the file path format correctly. Eg.:               `"s3://AWS_BUCKET/TRANSCODE_PREFIX/SHORT_ID/DRIVE_FILE_ID/testvid_youtube.mp4"`
  - The "testvid" part will be replaced with name of your video, so it will become like: `"..path/<video_name_youtube.mp4"`
8. Make sure you specify the body as “JSON” in POSTMAN. And use “Authorization” header with value `“Bearer <RC’s API_BEARER_TOKEN”` and “Content-Type” header with a value of `“application/json”`.
The POST request will cause the Video to have Completed VideoJob, and you will see 3 s3 paths next to the VideoFiles, with  destination=youtube, and status="Created" for one of them.
9. The video will take some time to upload because it's a large file. After a while it will update its status, first `VideoFile` will update to "Uploaded" and after some time of it, you should see `Video` status to `submitted_for_transcription` on django-admin, then you can confirm that it has been submitted to 3play. 
10. Login to 3play's website with RC login data. Go to files. Wait for its status to change from pending to complete. And see if there is only one submission for your video.
11. Repeat the steps again on master branch for the same video but name it different this time so you can differentiate. Confirm that the video gets submitted multiple times to 3play. 

**At the end of this process, make sure the previous video was submitted only once, and the one from master branch was submitted more than once.**

**Testing code:**
Although we could specify the test functions (`test_start_transcript_job` and `test_threeplay_submission_called_once_per_video`) but for the sake of completeness, let's run all the video tests:

`docker-compose run --rm web pytest videos/tasks_test.py`
Run the above docker command about 10 times and make sure all test cases pass.
(10 times because in each time the "video statuses" are different, eg. `created`, `failed`, `transcoding`, `submitted for transcription`, and `complete`. So to make sure there is no flakiness - because I did encounter it while writing the unit test but took care of it. It was for case: `video status= submitted for transcription`)