### PR TITLE
use a safer strategy for filtering out mp4 files from zip downloads

### DIFF
--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -381,10 +381,8 @@ jobs:
                 mkdir -p ./content/static_resources
                 mkdir -p ./static/static_resources
                 mkdir -p ./static/static_shared
-                if [ ! -z "$(ls -A ../static-resources)" ];
-                then
-                  find ../static-resources ! -name '*.mp4' -type f | xargs cp -t ./content/static_resources
-                fi
+                cp -r ../static-resources ./content/static_resources
+                find ./content/static_resources -name "*.mp4" -type f -delete
                 HTML_COUNT="$(ls -1 ./content/static_resources/*.html 2>/dev/null | wc -l)"
                 if [ $HTML_COUNT != 0 ];
                 then


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1741

#### What's this PR do?
This PR alters the logic in the single site pipeline `site-pipeline.yaml` that filters out mp4 files in the offline build. In https://github.com/mitodl/ocw-studio/pull/1630, we added the steps to the single pipeline that build the offline site and deploy it, including logic to filter out mp4 files. This was done in bash with a combination of `find` and `xargs cp`, with a check to make sure the directory wasn't empty first. If there are only mp4 files in the `static-resources` directory, then nothing will be found in the `find` command and you will get `cp: missing file operand`. The logic has been altered to be more safe, simply copying all the static resources in and then removing mp4 files afterward.

#### How should this be manually tested?
 - Make sure you have the following prerequisites set up (if unsure, check the readme):
   - Recent DB restore from production or RC with sync states and gdrive folders reset
   - Local Concourse integration configured and running
   - Local Minio integration configured and running
   - Theme assets pipeline pushed up to Concourse and run at least once
   - In your `.env`, these are the settings I used minus the minio user / password and aws access keys:
```
AWS_STORAGE_BUCKET_NAME=ol-ocw-studio-app
AWS_PREVIEW_BUCKET_NAME=ocw-content-draft
AWS_PUBLISH_BUCKET_NAME=ocw-content-live
AWS_ARTIFACTS_BUCKET_NAME=ol-eng-artifacts
RESOURCE_BASE_URL_DRAFT=https://draft.ocw.mit.edu
RESOURCE_BASE_URL_LIVE=https://live.ocw.mit.edu
STATIC_API_BASE_URL=https://live.ocw.mit.edu
OCW_HUGO_THEMES_BRANCH=main
OCW_HUGO_PROJECTS_BRANCH=main
```
 - Pick any imported course to test publishing with
 - In the Minio UI, create a folder in `ol-ocw-studio-app` called `courses` if it doesn't exist already, and under that create a folder matching the `name` property of your test site, if it doesn't exist yet. Since the DB restore does not pull in static resources, there should be no data in `ol-ocw-studio-app` for our test course, but if any exists, remove it using the Minio UI at http://localhost:9001.
 - Inside this folder, copy in some example .mp4 files
 - Run `docker compose exec web ./manage.py backpopulate_pipelines`, optionally using `--filter` to specify your test site if you want it to run faster
 - Publish the site and it should succeed
 - In `ocw-content-live`, under your test site's folder, download the ZIP file and confirm that there are no mp4 files included

#### Where should the reviewer start?
`site-pipeline.yaml`
