### PR TITLE
Remove discontinued codecov package

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,5 @@
 black==20.8b1
 bpython
-codecov
 ddt
 django-debug-toolbar
 factory_boy


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
None

#### What's this PR do?
This PR removes codecov pypi package, since it no longer exists https://pypi.org/project/codecov/.

#### How should this be manually tested?
1. Clone a fresh copy of ocw-studio 
2. Run `cp .env.example .env` and then run `docker-compose build`
3. Make sure the build builds successfully.
