### PR TITLE
remove codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,11 +107,6 @@ jobs:
           SECRET_KEY: "secret"  # pragma: allowlist secret
           CONTENT_SYNC_BACKEND:
 
-      - name: Upload coverage to CodeCov
-        uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage.xml
-
   frontend-tests:
     runs-on: ubuntu-20.04
     steps:
@@ -156,6 +151,3 @@ jobs:
 
       - name: Webpack build
         run: npm run build
-
-      - name: Upload test coverage to CodeCov
-        uses: codecov/codecov-action@v1

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,5 @@
 black==20.8b1
 bpython
-codecov
 ddt
 django-debug-toolbar
 factory_boy

--- a/travis/python_tests.sh
+++ b/travis/python_tests.sh
@@ -17,7 +17,6 @@ function run_test {
 }
 
 run_test pytest
-run_test ./travis/codecov_python.sh
 run_test ./scripts/test/detect_missing_migrations.sh
 run_test ./scripts/test/no_auto_migrations.sh
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested


#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1746

#### What's this PR do?
This PR removes usage of the `codecov` Python package which has been deprecated: https://about.codecov.io/blog/message-regarding-the-pypi-package/

The Github Action has also been removed until we can figure out a transition to the new Github App: https://about.codecov.io/blog/codecov-is-updating-its-github-integration/

#### How should this be manually tested?
All that should be required is that the Github Actions tests pass, although you should also be able to spin up `ocw-studio` locally without error. To test this you could rebuild your web container with `docker compose build web`, which should install the prerequisites in `test_requirements.txt`. You certainly shouldn't see `No matching distribution found for codecov`.
