### PR TITLE
mp4 filtering fix take 2

### DIFF
--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -381,10 +381,8 @@ jobs:
                 mkdir -p ./content/static_resources
                 mkdir -p ./static/static_resources
                 mkdir -p ./static/static_shared
-                if [ ! -z "$(ls -A ../static-resources)" ];
-                then
-                  find ../static-resources ! -name '*.mp4' -type f | xargs cp -t ./content/static_resources
-                fi
+                cp -r ../static-resources/. ./content/static_resources
+                find ./content/static_resources -name "*.mp4" -type f -delete
                 HTML_COUNT="$(ls -1 ./content/static_resources/*.html 2>/dev/null | wc -l)"
                 if [ $HTML_COUNT != 0 ];
                 then


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1741

#### What's this PR do?
This PR revises the code in https://github.com/mitodl/ocw-studio/pull/1742 and fixes a pathing issue that went unnoticed. The modified `cp` command was missing a `/.` at the end of it which resulted in the static resources retaining their path from the Concourse resource, resulting in incorrect pathing in the offline build.

#### How should this be manually tested?
This should be tested using the same testing instructions in https://github.com/mitodl/ocw-studio/pull/1742, but pay special attention to the pathing in the ZIP file when you download it. The `static_resources` folder should contain the static resources of the course; PDF's, subtitles, images, etc.
