### PR TITLE
add s3 folder to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ htmlcov
 .coverage
 node_modules
 staticfiles/
+s3/


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1760

#### What's this PR do?
This PR adds `s3/` (the Minio data mount point) to the `.dockerignore` file. Without it there, all the data you've uploaded to Minio gets copied into the Docker daemon as context when running `docker compose build`. This PR prevents that from happening.

#### How should this be manually tested?
 - Start `ocw-studio`, log into the Minio UI at http://localhost:9001 and upload some large file, noting the size
 - Run `docker compose build` and verify that on the step that copies the context to the docker daemon, it should only amount to something around 300MB and not include the data you copied into Minio.
