### PR TITLE
fix: delete file error messages are not shown on the frontend

### DIFF
--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -189,7 +189,7 @@ def _get_or_create_drive_file(
             )
             existing_file_same_path.resource = None
             existing_file_same_path.save()
-            delete_drive_file(existing_file_same_path)
+            delete_drive_file(existing_file_same_path, sync_date)
 
         drive_file = DriveFile.objects.create(**file_data)
     return drive_file

--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -635,7 +635,7 @@ def find_missing_files(
     return [file for file in drive_files if file.file_id not in gdrive_file_ids]
 
 
-def delete_drive_file(drive_file: DriveFile):
+def delete_drive_file(drive_file: DriveFile, sync_datetime: datetime):
     """
     Deletes `drive_file` only if it is not being used in a page type content.
 
@@ -646,8 +646,9 @@ def delete_drive_file(drive_file: DriveFile):
 
     if dependencies:
         error_message = f"Cannot delete file {drive_file} because it is being used by {dependencies}."
-        log.error(error_message)
+        log.info(error_message)
         drive_file.sync_error = error_message
+        drive_file.sync_dt = sync_datetime
         drive_file.save()
         return
 

--- a/gdrive_sync/api_test.py
+++ b/gdrive_sync/api_test.py
@@ -891,7 +891,7 @@ def test_delete_drive_file(mocker, with_resource, is_used_in_content):
                 website=website,
             )
 
-    api.delete_drive_file(drive_file)
+    api.delete_drive_file(drive_file, sync_datetime=website.synced_on)
 
     drive_file_exists = DriveFile.objects.filter(file_id=drive_file.file_id).exists()
     if with_resource:

--- a/gdrive_sync/tasks.py
+++ b/gdrive_sync/tasks.py
@@ -44,14 +44,14 @@ def process_drive_file(drive_file_id: str):
 
 
 @app.task()
-def delete_drive_file(drive_file_id: str):
+def delete_drive_file(drive_file_id: str, sync_datetime: datetime):
     """
     Delete the DriveFile if it is not being used in website page content.
     See api.delete_drive_file for details.
     """
     drive_file = DriveFile.objects.filter(file_id=drive_file_id).first()
     if drive_file:
-        api.delete_drive_file(drive_file)
+        api.delete_drive_file(drive_file, sync_datetime=sync_datetime)
 
 
 def _get_gdrive_files(website: Website) -> Tuple[Dict[str, List[Dict]], List[str]]:
@@ -108,7 +108,7 @@ def import_website_files(self, name: str):
         sum(gdrive_subfolder_files.values(), []), website
     )
     delete_file_tasks = [
-        delete_drive_file.si(drive_file.file_id) for drive_file in deleted_drive_files
+        delete_drive_file.si(drive_file.file_id, website.synced_on) for drive_file in deleted_drive_files
     ]
 
     file_tasks = []

--- a/gdrive_sync/tasks.py
+++ b/gdrive_sync/tasks.py
@@ -108,7 +108,8 @@ def import_website_files(self, name: str):
         sum(gdrive_subfolder_files.values(), []), website
     )
     delete_file_tasks = [
-        delete_drive_file.si(drive_file.file_id, website.synced_on) for drive_file in deleted_drive_files
+        delete_drive_file.si(drive_file.file_id, website.synced_on)
+        for drive_file in deleted_drive_files
     ]
 
     file_tasks = []

--- a/gdrive_sync/tasks_test.py
+++ b/gdrive_sync/tasks_test.py
@@ -257,4 +257,6 @@ def test_delete_drive_file(mocker):
     drive_file = DriveFileFactory.create()
     mock_delete_drive_file = mocker.patch("gdrive_sync.api.delete_drive_file")
     delete_drive_file.delay(drive_file.file_id, drive_file.website.synced_on)
-    mock_delete_drive_file.assert_called_once_with(drive_file, sync_datetime=drive_file.website.synced_on)
+    mock_delete_drive_file.assert_called_once_with(
+        drive_file, sync_datetime=drive_file.website.synced_on
+    )

--- a/gdrive_sync/tasks_test.py
+++ b/gdrive_sync/tasks_test.py
@@ -256,5 +256,5 @@ def test_delete_drive_file(mocker):
     """Task delete_drive_file should delegate the delete action to api.delete_drive_file."""
     drive_file = DriveFileFactory.create()
     mock_delete_drive_file = mocker.patch("gdrive_sync.api.delete_drive_file")
-    delete_drive_file.delay(drive_file.file_id)
+    delete_drive_file.delay(drive_file.file_id, drive_file.website.synced_on)
     mock_delete_drive_file.assert_called_once_with(drive_file)

--- a/gdrive_sync/tasks_test.py
+++ b/gdrive_sync/tasks_test.py
@@ -212,7 +212,7 @@ def test_import_website_files_delete_missing(mocker, mocked_celery):
         import_website_files.delay(website.name)
     assert mock_delete_drive_file.call_count == 2
     for drive_file in drive_files:
-        mock_delete_drive_file.assert_any_call(drive_file.file_id)
+        mock_delete_drive_file.assert_any_call(drive_file.file_id, mocker.ANY)
 
 
 def test_update_website_status(mocker):
@@ -257,4 +257,4 @@ def test_delete_drive_file(mocker):
     drive_file = DriveFileFactory.create()
     mock_delete_drive_file = mocker.patch("gdrive_sync.api.delete_drive_file")
     delete_drive_file.delay(drive_file.file_id, drive_file.website.synced_on)
-    mock_delete_drive_file.assert_called_once_with(drive_file)
+    mock_delete_drive_file.assert_called_once_with(drive_file, sync_datetime=drive_file.website.synced_on)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1752

#### What's this PR do?

The error messages were being stored correctly, however, we also need to update the `sync_dt` on DriveFile to make the messages appear on the front end. This PR updates the sync_dt when the code fails to delete a file. For more information, you may see the implementation of `update_sync_status`.

Additionally, I have replaced a log.error statement with a log.info statement. This is to prevent the error from being reported to Sentry as this is expected behavior.

#### How should this be manually tested?
1. Navigate to your local ocw-studio directory.
2. Checkout `1752-error-message` branch.
3. Run Studio and create a new course or open an existing course with Google Sync set up.
4. Open the GDrive folder of your test course and add any file in `files_final` folder.
5. Head back to the resources tab of your course in studio.
6. Hit "Sync w/ Google Drive".
7. **Expected Behavior**: You should see your file(s) loaded after a successful sync.
8. Create a new page and embed one of your resources in it and save.
9. Back in the GDrive folder, delete the file that you linked in step 8.
10. Repeat steps 5 and 6.
11. **Expected Behavior**: The sync status shows as failed. The file is not deleted. Clicking on the red message shows the details. In the details you should see an error message similar to `f"Cannot delete file {drive_file} because it is being used by {dependencies}."`

#### Screenshots

<img width="1642" alt="Screenshot 2023-04-26 at 6 03 20 PM" src="https://user-images.githubusercontent.com/71316217/234583400-9891c2d4-7a15-4738-9977-0035e63f9a85.png">

<img width="1645" alt="Screenshot 2023-04-26 at 6 03 04 PM" src="https://user-images.githubusercontent.com/71316217/234583421-a87fbdb9-c4a0-4de4-ad92-338807f6d2db.png">

