### PR TITLE
fix: IntegrityError - duplicate key while creating resources

### DIFF
--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -426,6 +426,7 @@ def create_gdrive_resource_content(drive_file: DriveFile):
         resource_type = get_resource_type(drive_file)
         resource = drive_file.resource
         basename, extension = os.path.splitext(drive_file.name)
+        basename = f"{basename}_{extension.lstrip('.')}"
         if not resource:
             site_config = SiteConfig(drive_file.website.starter.config)
             config_item = site_config.find_item_by_name(name=CONTENT_TYPE_RESOURCE)

--- a/gdrive_sync/api_test.py
+++ b/gdrive_sync/api_test.py
@@ -545,7 +545,7 @@ def mock_gdrive_pdf(mocker):
 def test_create_gdrive_resource_content(mime_type, mock_get_s3_content_type):
     """create_resource_from_gdrive should create a WebsiteContent object linked to a DriveFile object"""
     filenames = ["word.docx", "word!.docx", "(word?).docx"]
-    deduped_names = ["word", "word2", "word3"]
+    deduped_names = ["word_docx", "word_docx2", "word_docx3"]
     website = WebsiteFactory.create()
     for filename, deduped_name in zip(filenames, deduped_names):
         drive_file = DriveFileFactory.create(
@@ -577,16 +577,13 @@ def test_create_gdrive_resource_content_forbidden_name(
 ):
     """content for a google drive file with a forbidden name should have its filename attribute modified"""
     drive_file = DriveFileFactory.create(
-        name=f"{CONTENT_FILENAMES_FORBIDDEN[0]}.pdf",
-        s3_key=f"test/path/{CONTENT_FILENAMES_FORBIDDEN[0]}.pdf",
-        mime_type="application/pdf",
+        name=f"{CONTENT_FILENAMES_FORBIDDEN[0]}",
+        s3_key=f"test/path/{CONTENT_FILENAMES_FORBIDDEN[0]}",
+        mime_type="text/plain",
     )
     create_gdrive_resource_content(drive_file)
     drive_file.refresh_from_db()
-    assert (
-        drive_file.resource.filename
-        == f"{CONTENT_FILENAMES_FORBIDDEN[0]}-{CONTENT_TYPE_RESOURCE}"
-    )
+    assert drive_file.resource.filename not in CONTENT_FILENAMES_FORBIDDEN
 
 
 def test_gdrive_pdf_failure(mock_get_s3_content_type, mocker):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [ ] Changes have been manually tested


#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1702

#### What's this PR do?

This PR:
- Changes how files are named. Now files will be named `filename_extX` instead of `filenameX` (where X is an optional collision prevention counter). As discussed here: https://github.com/mitodl/hq/discussions/391
- Changes the order in which WebsiteContent i.e. resources are created. Ealier resources for drive_files were created in parallel. Now we create all the resources in a separate task. Reason here: https://github.com/mitodl/ocw-studio/issues/1702#issuecomment-1453574957


#### How should this be manually tested?
(Required)

