### PR TITLE
fix static-resources-subdirectory pathing

### DIFF
--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -384,12 +384,12 @@ class SitePipeline(BaseSitePipeline, GeneralPipeline):
 
         if self.WEBSITE.name == settings.ROOT_WEBSITE_NAME:
             base_url = ""
-            static_resources_subdirectory = self.WEBSITE.get_url_path()
+            static_resources_subdirectory = f"/{self.WEBSITE.get_url_path()}/"
             theme_created_trigger = "true"
             theme_deployed_trigger = "false"
         else:
             base_url = self.WEBSITE.get_url_path()
-            static_resources_subdirectory = ""
+            static_resources_subdirectory = "/"
             theme_created_trigger = "false"
             theme_deployed_trigger = "true"
         hugo_projects_url = urljoin(

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -357,6 +357,9 @@ def test_upsert_website_pipelines(
             in config_str
         )
         assert (
+            f"rm -rf ./output-online/{website.name}/*.mp4" in config_str
+        )
+        assert (
             f"aws s3 {expected_endpoint_prefix}sync course-markdown/output-online s3://{bucket}/ --metadata site-id={website.name}"
             in config_str
         )
@@ -365,6 +368,9 @@ def test_upsert_website_pipelines(
         assert (
             "cp -r ../build-artifacts/static_shared/. ./static/static_shared/"
             in config_str
+        )
+        assert (
+            f"rm -rf ./output-online/*.mp4" in config_str
         )
         assert (
             f"aws s3 {expected_endpoint_prefix}sync course-markdown/output-online s3://{bucket}/{website.url_path} --metadata site-id={website.name} --delete"

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -367,7 +367,7 @@ def test_upsert_website_pipelines(
             "cp -r ../build-artifacts/static_shared/. ./static/static_shared/"
             in config_str
         )
-        assert f"rm -rf ./output-online/*.mp4" in config_str
+        assert "rm -rf ./output-online/*.mp4" in config_str
         assert (
             f"aws s3 {expected_endpoint_prefix}sync course-markdown/output-online s3://{bucket}/{website.url_path} --metadata site-id={website.name} --delete"
             in config_str

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -356,9 +356,7 @@ def test_upsert_website_pipelines(
             f"cp -r -n ../static-resources/. ./output-online/{website.name}"
             in config_str
         )
-        assert (
-            f"rm -rf ./output-online/{website.name}/*.mp4" in config_str
-        )
+        assert f"rm -rf ./output-online/{website.name}/*.mp4" in config_str
         assert (
             f"aws s3 {expected_endpoint_prefix}sync course-markdown/output-online s3://{bucket}/ --metadata site-id={website.name}"
             in config_str
@@ -369,9 +367,7 @@ def test_upsert_website_pipelines(
             "cp -r ../build-artifacts/static_shared/. ./static/static_shared/"
             in config_str
         )
-        assert (
-            f"rm -rf ./output-online/*.mp4" in config_str
-        )
+        assert f"rm -rf ./output-online/*.mp4" in config_str
         assert (
             f"aws s3 {expected_endpoint_prefix}sync course-markdown/output-online s3://{bucket}/{website.url_path} --metadata site-id={website.name} --delete"
             in config_str

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -378,8 +378,8 @@ jobs:
             - |
               cp ../webpack-json/webpack.json ../ocw-hugo-themes/base-theme/data
               hugo ((hugo-args-online))
-              cp -r -n ../static-resources/. ./output-online/((static-resources-subdirectory))
-              rm -r ./output-online/((static-resources-subdirectory))/*.mp4
+              cp -r -n ../static-resources/. ./output-online((static-resources-subdirectory))
+              rm -rf ./output-online((static-resources-subdirectory))*.mp4
         on_failure:
           try:
             do:


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1776

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/1763, we altered `site-pipeline.yaml` to separate the online and offline builds into separate jobs within the same pipeline. As part of this, some code that does static file filtering was refactored and there is an issue with how the static files subdirectory is being templated into the pipeline definition. This template variable is necessary so that the root website defined by `ROOT_WEBSITE_NAME` does not push its static resources to the root of the S3 bucket and instead pushes them to a subfolder with the name of the root website. An error in the way this was implemented lead to this path being incorrect for non-root sites, and an error would be thrown when building a site with no videos. This PR fixes that error and adds a test to make sure the correct path is templated into the pipeline definition.

#### How should this be manually tested?
Use the same testing instructions as https://github.com/mitodl/ocw-studio/pull/1763, but make sure that the builds complete properly for a site *without* videos
