### PR TITLE
move webpack-json resource back to forked s3 resource type

### DIFF
--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -9,6 +9,11 @@ resource_types:
     type: registry-image
     source:
       repository: ghcr.io/cludden/concourse-keyval-resource
+  - name: s3-resource-iam
+    type: registry-image
+    source:
+      repository: governmentpaas/s3-resource
+      tag: latest
   # START NON-DEV
   - name: slack-alert
     type: registry-image
@@ -18,7 +23,7 @@ resource_types:
   # END NON-DEV
 resources:
   - name: webpack-json
-    type: s3
+    type: s3-resource-iam
     check_every: never
     source:
       # START DEV-ONLY


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1779

#### What's this PR do?
In https://github.com/mitodl/ocw-studio/pull/1763, the `governmentpaas/s3-resource` resource type was refactored out for the official S3 resource. Unfortunately, the official Concourse S3 resource still does not support IAM instance profiles, so the check for credentials fails in QA where these instance profiles are used. This PR moves back to using the forked version of the resource (https://github.com/alphagov/paas-s3-resource) for the time being to unblock publishing in RC / production.

#### How should this be manually tested?
I would say that the instructions in https://github.com/mitodl/ocw-studio/pull/1763 should be repeated, but that would be mostly pointless as the problem this solves only happens in our cloud environments where IAM instance profiles are used for authenticating with AWS. We should still verify that this works locally with Minio by at least doing:

 - Push up a pipeline with `./manage.py backpopulate_pipelines --filter <course_id>`
 - Go to `http://localhost:8080`, find the pipeline and check that the `webpack-json` resource successfully runs its check
