### PR TITLE
Update concourse to v7.9.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,8 +317,6 @@ Currently, the default Docker image for Concourse is not compatible with Apple S
 cp docker-compose-arm64.yml docker-compose.override.yml
 ```
 
-Note: we are currently using concourse v7.7.1 on Apple Silicon and concourse v7.9.0 on Intel architectures.
-
 # Enabling YouTube integration
 
 - Create a new project at https://console.cloud.google.com/apis/dashboard

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -2,4 +2,4 @@ version: '3.7'
 
 services:
   concourse:
-    image: rdclda/concourse:7.7.1
+    image: rdclda/concourse:7.9.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -151,7 +151,7 @@ services:
       - default-network
 
   concourse:
-    image: concourse/concourse:7.9.0
+    image: concourse/concourse:7.9.1
     command: quickstart
     privileged: true
     depends_on: [concourse-db]


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1783.

#### What's this PR do?
Updates the concourse version to `v7.9.1` to be consistent with RC/prod.

#### How should this be manually tested?
If running on Apple Silicon, first run `cp docker-compose-arm64.yml docker-compose.override.yml`. 

Run `docker compose up --build`, navigate to `http://concourse:8080` and verify that `version: v7.9.1` is shown at the bottom of the page. Verify that pipelines still work as intended.

The theme assets build, in particular, should be tested. This can be done by running `docker compose exec web ./manage.py upsert_theme_assets_pipeline` and then triggering the build through the concourse UI.