### PR TITLE
Revert "Incorrect files path for Sync missing captions"

### DIFF
--- a/videos/utils.py
+++ b/videos/utils.py
@@ -2,7 +2,6 @@
 A collection of helper functions for generating s3 file paths and filenames.
 This module provides several utility functions that simplify the task of working with file path and name generation
 """
-import os
 import re
 
 from main.utils import get_dirpath_and_filename, get_file_extension
@@ -23,9 +22,7 @@ def generate_s3_path(file_or_webcontent, website):
     elif new_filename_ext == "pdf":
         new_filename += "_transcript"
 
-    new_filename = f"{new_filename.strip(os.path.sep)}.{new_filename_ext}"
-
-    return os.path.join(website.s3_path.strip(os.path.sep), new_filename)
+    return f"/{website.s3_path.rstrip('/').lstrip('/')}/{new_filename.lstrip('/')}.{new_filename_ext}"
 
 
 def clean_uuid_filename(filename):


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [ ] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes #1791 

#### What's this PR do?
This PR fixes the trailing slash which was being appended before courses. This caused caption/ transcripts requests to yield 404

#### How should this be manually tested?
- Make sure you have latest database dump locally
   - This is to ensure you have courses with missing captions/transcripts locally
- Make sure to add following .env variables: 
   - **Threeplay variables** 
      - `THREEPLAY_API_KEY`,  `THREEPLAY_CALLBACK_KEY`,  `THREEPLAY_PROJECT_ID`
   - **AWS variables**   
     - `AWS_STORAGE_BUCKET_NAME`,  `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
-  Checkout to this branch
- **Running the command to:**
  - **Test all courses**
     - Run command `docker exec -it ocw-studio-web-1 python3 manage.py sync_missing_captions`
  - **Test single course**
     - Run command `docker exec -it ocw-studio-web-1 python3 manage.py sync_missing_captions --filter <course-short_id>`
   - Add comma separated course names to be parsed
- Head to `http://localhost:9001` (Local Minio)
- Go to `ol-ocw-studio-app/courses/<course-name>`
- You should see new captions (\*_captions.webvtt) and transcripts (\*_transcript.pdf) file with some `Size` value (previously empty **-**)

**Note:**  Please refer to this https://github.com/mitodl/ocw-studio/pull/1717 for more context
