### PR TITLE
Fix S3 path for missing captions

### DIFF
--- a/videos/utils.py
+++ b/videos/utils.py
@@ -2,6 +2,7 @@
 A collection of helper functions for generating s3 file paths and filenames.
 This module provides several utility functions that simplify the task of working with file path and name generation
 """
+import os
 import re
 
 from main.utils import get_dirpath_and_filename, get_file_extension
@@ -22,7 +23,9 @@ def generate_s3_path(file_or_webcontent, website):
     elif new_filename_ext == "pdf":
         new_filename += "_transcript"
 
-    return f"/{website.s3_path.rstrip('/').lstrip('/')}/{new_filename.lstrip('/')}.{new_filename_ext}"
+    new_filename = f"{new_filename.strip(os.path.sep)}.{new_filename_ext}"
+
+    return os.path.join(website.s3_path.strip(os.path.sep), new_filename)
 
 
 def clean_uuid_filename(filename):


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1791.

#### What's this PR do?
Reverts https://github.com/mitodl/ocw-studio/pull/1795 (i.e., re-implements https://github.com/mitodl/ocw-studio/pull/1792).

#### How should this be manually tested?
Testing is identical to testing for https://github.com/mitodl/ocw-studio/pull/1792, although as mentioned in [this comment](https://github.com/mitodl/ocw-studio/pull/1772#issuecomment-1539181405), it is suggested that `docker-compose exec web ./manage.py sync_missing_captions --filter <course_id>` be used for running the management command instead. 

