### PR TITLE
Process PDFs with missing metadata

### DIFF
--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -414,7 +414,7 @@ def get_pdf_title(drive_file: DriveFile) -> str:
     with io.BytesIO(GDriveStreamReader(drive_file).read()) as pdf_file:
         pdf_reader = PyPDF2.PdfReader(pdf_file)
         pdf_metadata = pdf_reader.metadata
-        if "/Title" in pdf_metadata and pdf_metadata["/Title"] != "":
+        if pdf_metadata and "/Title" in pdf_metadata and pdf_metadata["/Title"] != "":
             return pdf_metadata["/Title"]
         return drive_file.name
 


### PR DESCRIPTION
#### Pre-Flight checklist

- [X] Testing
  - [X] Code is tested
  - [X] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/1456 and closes https://github.com/mitodl/ocw-studio/issues/1807.

#### What's this PR do?
Adds a check for whether a PDF has metadata before processing its metadata. Although most PDFs will have metadata, there are examples of PDFs with missing metadata that need to be processed by Studio.

#### How should this be manually tested?
Upload a PDF with empty metadata to Google Drive (some examples are in the issue linked above), sync, and verify that a resource is properly created in Studio.