### PR TITLE
SENTRY_ENV added to the themes-pipelines

### DIFF
--- a/app.json
+++ b/app.json
@@ -286,10 +286,6 @@
       "description": "The sentry DSN that will be used in ocw-hugo-themes",
       "required": false
     },
-    "OCW_HUGO_THEMES_SENTRY_ENV": {
-      "description": "The sentry ENV that will be used in ocw-studio",
-      "required": false
-    },
     "OCW_IMPORT_STARTER_SLUG": {
       "description": "The slug of the WebsiteStarter to assign to courses imported from ocw-to-hugo",
       "required": false

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -590,7 +590,7 @@ class ThemeAssetsPipeline(GeneralPipeline, BaseThemeAssetsPipeline):
             )
             .replace(
                 "((ocw-hugo-themes-sentry-env))",
-                settings.OCW_HUGO_THEMES_SENTRY_ENV or "",
+                settings.ENVIRONMENT or "",
             )
             .replace("((atc-search-params))", self.instance_vars)
         )

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -588,6 +588,10 @@ class ThemeAssetsPipeline(GeneralPipeline, BaseThemeAssetsPipeline):
                 "((ocw-hugo-themes-sentry-dsn))",
                 settings.OCW_HUGO_THEMES_SENTRY_DSN or "",
             )
+            .replace(
+                "((ocw-hugo-themes-sentry-env))",
+                settings.OCW_HUGO_THEMES_SENTRY_ENV or "",
+            )
             .replace("((atc-search-params))", self.instance_vars)
         )
         self.upsert_config(config_str, self.PIPELINE_NAME)

--- a/content_sync/pipelines/definitions/concourse/theme-assets-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/theme-assets-pipeline.yml
@@ -42,6 +42,7 @@ jobs:
       params:
         SEARCH_API_URL: ((search-api-url))
         SENTRY_DSN: ((ocw-hugo-themes-sentry-dsn))
+        SENTRY_ENV: ((ocw-hugo-themes-sentry-env))
       run:
         path: sh
         args:

--- a/main/settings.py
+++ b/main/settings.py
@@ -1142,8 +1142,3 @@ OCW_HUGO_THEMES_SENTRY_DSN = get_string(
     required=False,
     description="The sentry DSN that will be used in ocw-hugo-themes",
 )
-OCW_HUGO_THEMES_SENTRY_ENV = get_string(
-    name="OCW_HUGO_THEMES_SENTRY_ENV",
-    default="qa",
-    description="The sentry ENV that will be used in ocw-studio",
-)


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
closes #1686

#### What's this PR do?
This PR adds the `SENTRY_ENV` in the theme-assests-pipeline in the concourse

#### How should this be manually tested?
1. Checkout to this branch
2. Make sure docker containers are up, `docker-compose up`
3. Run `docker-compose exec web ./manage.py upsert_theme_assets_pipeline`
4. Go to `concourse:8080` and trigger a `ocw-theme-assests` build
5. The build should complete successfully
