### PR TITLE
template noindex variable into mass-build-sites pipeline

### DIFF
--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -689,6 +689,7 @@ class MassBuildSitesPipeline(
                     "offline_bucket": template_vars["offline_preview_bucket_name"],
                     "build_drafts": "--buildDrafts",
                     "resource_base_url": settings.RESOURCE_BASE_URL_DRAFT,
+                    "noindex": "true",
                 }
             )
         elif self.VERSION == VERSION_LIVE:
@@ -703,6 +704,9 @@ class MassBuildSitesPipeline(
                     "offline_bucket": template_vars["offline_publish_bucket_name"],
                     "build_drafts": "",
                     "resource_base_url": settings.RESOURCE_BASE_URL_LIVE,
+                    "noindex": "true"
+                    if settings.ENV_NAME not in PRODUCTION_NAMES
+                    else "false",
                 }
             )
         base_hugo_args = {
@@ -793,6 +797,7 @@ class MassBuildSitesPipeline(
                 "((ocw-hugo-themes-sentry-dsn))",
                 settings.OCW_HUGO_THEMES_SENTRY_DSN or "",
             )
+            .replace("((noindex))", template_vars["noindex"])
         )
         self.upsert_config(config_str, self.PIPELINE_NAME)
 

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -608,7 +608,7 @@ def test_upsert_mass_build_pipeline(
     prefix,
     starter,
     offline,
-):  # pylint:disable=too-many-locals,too-many-arguments,too-many-statements
+):  # pylint:disable=too-many-locals,too-many-arguments,too-many-statements,too-many-branches
     """The mass build pipeline should have expected configuration"""
     expected_template_vars = get_template_vars()
     hugo_projects_path = "https://github.com/org/repo"

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -690,6 +690,14 @@ def test_upsert_mass_build_pipeline(
     assert f'\\"branch\\": \\"{projects_branch}\\"' in config_str
     assert f"{hugo_projects_path}.git" in config_str
     assert static_api_url in config_str
+    if (
+        version == VERSION_DRAFT in config_str
+        or settings.ENV_NAME not in PRODUCTION_NAMES
+    ):
+        expected_noindex = '\\"NOINDEX\\": true'
+    else:
+        expected_noindex = '\\"NOINDEX\\": false'
+    assert expected_noindex in config_str
     if offline:
         assert "PULLING IN STATIC RESOURCES FOR $NAME" in config_str
         assert "touch ./content/static_resources/_index.md" in config_str


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1816

#### What's this PR do?
This PR fixes a bug caused by some code that was missed in https://github.com/mitodl/ocw-studio/pull/1813. The `NOINDEX` env variable was added to `mass-build-sites.yaml`, but the code to replace the `((noindex))` placeholder was not added to `concourse.py`. This PR adds that code, replacing the placeholder with the correct value based on the same conditions as the single site pipeline.

#### How should this be manually tested?
 - Push up the mass build pipelines with: `docker compose exec web ./manage.py upsert_mass_build_pipeline`
 - Using the Concourse `fly` CLI with a target called `local` configured to hit your locally running instance of Concourse, run the following:
   - `fly -t local get-pipeline -p "mass-build-sites/offline:false,prefix:'',projects_branch:main,starter:'',themes_branch:'main',version:draft"`
   - `fly -t local get-pipeline -p "mass-build-sites/offline:false,prefix:'',projects_branch:main,starter:'',themes_branch:'main',version:live"`
 - After running each of these, inspect the `params` section of the `get-repo-build-course-publish-course` task and ensure that you see `NOINDEX: "true"`
 - In your `.env` file, set `ENV_NAME=production` and restart your containers
 - Re-run the above, and for the pipeline with `version:live` assert that instead you see `NOINDEX: "false"`
