### PR TITLE
fix: use all starters to discover references

### DIFF
--- a/websites/models.py
+++ b/websites/models.py
@@ -476,7 +476,7 @@ class WebsiteStarter(TimestampedModel):
     @staticmethod
     def iter_all_config_items(website: Website) -> Iterator[Tuple[bool, ConfigItem]]:
         """
-        Yields ConfigItem for all active starters.
+        Yields ConfigItem for all starters.
 
         Args:
             website (Website): The website being scanned.
@@ -490,9 +490,7 @@ class WebsiteStarter(TimestampedModel):
                 f"Website {website} does not have a starter. Cannot iterate config."
             )
 
-        all_starters = WebsiteStarter.objects.filter(
-            status__in=WebsiteStarterStatus.ALLOWED_STATUSES
-        )
+        all_starters = WebsiteStarter.objects.all()
 
         for starter in all_starters:
             for item in SiteConfig(starter.config).iter_items():


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1814

#### What's this PR do?
Uses all starters instead of only active starters in `iter_all_configs`.

#### How should this be manually tested?

1. Navigate to your local setup of ocw-studio and checkout `hussaintaj/enable-inactive-starters`.
2. Start/restart studio.
3. Open ocw-studio admin site and ensure that the website starter `www` or others of its kind are all `inactive`.
4. Create/Select a course site.
5. Open the GDrive folder for this site, and upload a test file (say example.txt).
6. Navigate to the course's resources tab and hit Sync w/ Google Drive.
7. Once the sync is successful, publish the course to live.
8. Open ocw-www website. Create a Resource Collection, and add example.txt to it.
9. Delete example.txt from GDrive folder.
10. Navigate back to the course's resources tab and hit Sync w/ Google Drive.
11. **Expected Behavior**: You should see an error stating that the resource could not be deleted because it is being used.
12. Delete the file from GDrive that you create in step 5.
13. Delete the resource reference from the collection you created in step 8.
14. Navigate back to the course's resources tab and hit Sync w/ Google Drive.
15. **Expected Behavior**: this time the sync is successful and the resource example.txt is deleted.



