### PR TITLE
Fix a linting issue for renovate PR

### DIFF
--- a/static/js/types/modal_state.ts
+++ b/static/js/types/modal_state.ts
@@ -43,7 +43,7 @@ abstract class ModalStateVariant<T> {
  * related to the content being edited.
  */
 export class Editing<T> extends ModalStateVariant<T> {
-  state: "editing" = "editing"
+  state = "editing" as const
   /**
    * The value wrapped in the Editing state
    */
@@ -58,14 +58,14 @@ export class Editing<T> extends ModalStateVariant<T> {
  * Adding state, for when new content is being created.
  */
 class Adding<T> extends ModalStateVariant<T> {
-  state: "adding" = "adding"
+  state = "adding" as const
 }
 
 /**
  * Closed state, for when the drawer is closed and deactivated.
  */
 class Closed<T> extends ModalStateVariant<T> {
-  state: "closed" = "closed"
+  state = "closed" as const
 }
 
 /**


### PR DESCRIPTION
#### Pre-Flight checklist


- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
related to #1789 

#### What's this PR do?
Renovate wants to update some dependencies of dependencies in #1789 . Apparently this adds a new linting rule [`prefer-as-const`](https://typescript-eslint.io/rules/prefer-as-const/), which we currently break in three places.

#### How should this be manually tested?
I would not bother.

If you want to test this manually...
- Checkout branch `renovate/lock-file-maintenance` from  https://github.com/mitodl/ocw-studio/pull/1789
- cherry-pick the commit from this branch... `git cherry-pick 15146ff818b2eb0bf17e06c5c4e7260b66b26a64`
- run `yarn lint` and `yarn test` inside `docker compose exec watch bash`.
