### PR TITLE
fix: too many upload success emails

### DIFF
--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -170,7 +170,8 @@ def update_youtube_statuses(self):
                     resource.save()
                     if video_file.status == VideoFileStatus.COMPLETE:
                         group_tasks.append(start_transcript_job.s(video_file.video.id))
-            mail_youtube_upload_success(video_file)
+            if video_file.status == VideoFileStatus.COMPLETE:
+                mail_youtube_upload_success(video_file)
 
         except IndexError:
             # Video might be a dupe or deleted, mark it as failed and continue to next one.


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
https://github.com/mitodl/hq/issues/1506

#### What's this PR do?
Large videos that take longer for YT to process, cause multiple success emails to be sent. This is because when a VideoFile is in an `Uploaded` state, the YT video remains in `processing` for some time. And during that time, each run of `update_youtube_statuses` sends a success email. This PR adds a check to fix that and adds a unit test to ensure only one success email is sent during different state transitions.

#### How should this be manually tested?
Since YT integration does not work locally, for testing this change we will use some manual intervention to recreate the scenario.

You might need some RC (Video objects) data for this test.

1. Navigate to your local setup of ocw-studio.
2. Checkout branch `hussaintaj/1506-too-many-emails`
3. In `.env` set `YT_STATUS_UPDATE_FREQUENCY=20` (default is 60).
4. Edit https://github.com/mitodl/ocw-studio/blob/4daed35475bce1f6aed573c1362412263b101477/videos/tasks.py#L139
    and comment-out the YT API calls and add print statements for convenience. For example,
    ```py
    # if not is_youtube_enabled():
    #     return
    videos_processing = VideoFile.objects.filter(
        Q(status=VideoFileStatus.UPLOADED) & Q(destination=DESTINATION_YOUTUBE)
    )
    if videos_processing.count() == 0:
        return
    # youtube = YouTubeApi()
    group_tasks = []
    for video_file in videos_processing:
        try:
            with transaction.atomic():
                # video_file.destination_status = youtube.video_status(
                #     video_file.destination_id
                # )
    .
    .
    .
            if video_file.status == VideoFileStatus.COMPLETE:
                print('A MAIL IS SENT')
                mail_youtube_upload_success(video_file)
    ```
5. Start/Restart ocw studio.
6. In http://localhost:8043/admin/videos/video/ select a video you'd like to test on.
7. In one of the YT video files on the video object, set `destination_status` to `processing` and `status` to `Uploaded` and save.
    **Expected Behavior**: Observe the celery logs. Whenever `update_youtube_statuses` are run, you should **not** see our custom message `A MAIL IS SENT`
    
    <img width="1318" alt="Screenshot 2023-06-01 at 5 18 30 PM" src="https://github.com/mitodl/ocw-studio/assets/71316217/e86354bf-a038-42f7-a56d-466c168ed1b1">

8. Now change `destination_status` to `processed` and save.
    **Expected Behavior**: Observe the celery logs. You should see your custom message "A MAIL IS SENT" now. You may ignore any errors following this message. (Unless they were occurring before step 4)
    **Expected Behavior**: You only see the custom message "A MAIL IS SENT" once. Subsequent runs of the task `update_youtube_statuses` do not print this message again.
    **Expected Behavior**: Reload your video object in the admin site. You should see the status has changed to `Complete`.



