### PR TITLE
fix @types/react versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "@types/node": "^16.4.11",
     "@types/pluralize": "^0.0.29",
     "@types/ramda": "^0.27.44",
-    "@types/react": "^17.0.15",
-    "@types/react-dom": "^17.0.9",
+    "@types/react": "^16.9.46",
+    "@types/react-dom": "^16.9.8",
     "@types/react-outside-click-handler": "^1.3.0",
     "@types/react-redux": "^7.1.18",
     "@types/react-router": "^5.1.16",
@@ -167,7 +167,9 @@
     "> 1%"
   ],
   "resolutions": {
-    "turndown": "7.0.0"
+    "turndown": "7.0.0",
+    "@types/react": "^16.9.46",
+    "@types/react-dom": "^16.9.8"
   },
   "packageManager": "yarn@3.1.0"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2674,21 +2674,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:*, @types/react-dom@npm:>=16.9.0, @types/react-dom@npm:^17.0.9":
-  version: 17.0.14
-  resolution: "@types/react-dom@npm:17.0.14"
+"@types/react-dom@npm:^16.9.8":
+  version: 16.9.19
+  resolution: "@types/react-dom@npm:16.9.19"
   dependencies:
-    "@types/react": "*"
-  checksum: b54cd0ef573236b3d87fe7493e6d1c36d8b4ca37a3b46364272a5c91ac178e3296b68ea1aeb299ce68f12ad663c5720ee890d0539b14881c6754bdcbdb0befa0
-  languageName: node
-  linkType: hard
-
-"@types/react-dom@npm:<18.0.0":
-  version: 17.0.15
-  resolution: "@types/react-dom@npm:17.0.15"
-  dependencies:
-    "@types/react": ^17
-  checksum: 7b90372bd7207d3860e1043ebfe10fd21fbd9ec3417a29593ca14359774830c888ba4ebb25cf0510628607496f8d35b09d23d329ea709b9311f5866185c5fd67
+    "@types/react": ^16
+  checksum: c696f137aba09be0ea87ad6e99a083607b4fc574857d92c264cc6518ee929ef7e94855362436c2ef5fefb70ebfc9b7413634bb3a2f3a8c2b7522521faaac7d62
   languageName: node
   linkType: hard
 
@@ -2764,25 +2755,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*, @types/react@npm:>=16.9.0, @types/react@npm:^17.0.15":
-  version: 17.0.43
-  resolution: "@types/react@npm:17.0.43"
+"@types/react@npm:^16.9.46":
+  version: 16.14.42
+  resolution: "@types/react@npm:16.14.42"
   dependencies:
     "@types/prop-types": "*"
     "@types/scheduler": "*"
     csstype: ^3.0.2
-  checksum: 981b0993f5b3ea9d3488b8cc883201e8ae47ba7732929f788f450a79fd72829e658080d5084e67caa008e58d989b0abc1d5f36ff0a1cda09315ea3a3c0c9dc11
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:^17":
-  version: 17.0.44
-  resolution: "@types/react@npm:17.0.44"
-  dependencies:
-    "@types/prop-types": "*"
-    "@types/scheduler": "*"
-    csstype: ^3.0.2
-  checksum: ebee02778ca08f954c316dc907802264e0121c87b8fa2e7e0156ab0ef2a1b0a09d968c016a3600ec4c9a17dc09b4274f292d9b15a1a5369bb7e4072def82808f
+  checksum: b28d101c5811907927ed5a42bde0a4b55e19d2f4303bab6a57014faace55bc3d3d58d1194c2e95bae7d36951ac27e3645cb829f7c532c554a73f606ca1e22897
   languageName: node
   linkType: hard
 
@@ -10599,8 +10579,8 @@ __metadata:
     "@types/node": ^16.4.11
     "@types/pluralize": ^0.0.29
     "@types/ramda": ^0.27.44
-    "@types/react": ^17.0.15
-    "@types/react-dom": ^17.0.9
+    "@types/react": ^16.9.46
+    "@types/react-dom": ^16.9.8
     "@types/react-outside-click-handler": ^1.3.0
     "@types/react-redux": ^7.1.18
     "@types/react-router": ^5.1.16


### PR DESCRIPTION
#### Pre-Flight checklist

- [x] Testing
  - [x] Code is tested
  - [x] Changes have been manually tested

#### What are the relevant tickets?
To help renovate with #1789 

#### What's this PR do?
This PR:
- has no runtime affects; it only affects our type declarations for Typescript typechecking 
- makes us use a consistent version of `@types/react` and `@types/react-dom`

See "Background" for more.

#### How should this be manually tested?
Because this only affects typechecking, I'm not sure any manual testing is required.

#### Any background context you want to provide?

If you look at [`yarn.lock` diff](https://github.com/mitodl/ocw-studio/pull/1828/files#diff-51e4f558fae534656963876761c95b83b6ef5da5103c4adef6768219ed76c2deL2769-R2760) you'll see that we were previously installing multiple versions of `@types/react`:
```
# one place
  resolution: "@types/react@npm:17.0.43"
# elsewhere
  resolution: "@types/react@npm:17.0.44"
```
These two versions seem compatible enough—typechecking passes on master. But this problem was about to get worse in #1789 (where it is causing failures). And since we only use one version of react, we should only be using one version of the types.

**Why did we have multiple versions of `types@/react`?** 

1. Some NPM packages do not provide their own type declarations (e.g., because they are not written in Typescript). When that happens, we install type declarations from [DefinitelyTyped](https://github.com/DefinitelyTyped/DefinitelyTyped), a repo maintained by the Typescript people where the community adds type declarations. (Similar to [typeshed](https://github.com/python/typeshed) in Python).
2. When specifying dependencies, DefinitelyTyped uses (a)`dependencies` not `peerDependencies`, and (b) specifies the version as `*`, meaning "any version".  _This is a choice made by the maintainers of DefinitelyTyped, not by the community members who contribute types; the package.json files are constructed by the DefinitelyTyped publishing process._ 
3. Yarn uses the latest possible version when installing `*`-dependencies.

So we manually specify `@types/react@16` version 16 because that what we use, but `@types/react-dom` specifies `@types/react@*`, and we end up with multiple versions.

For more, see:
- https://github.com/yarnpkg/yarn/issues/4489#issuecomment-1308694300 from the creator of Yarn
- https://github.com/facebook/react/issues/24304#issuecomment-1111559894, from react maintainers
- https://github.com/microsoft/DefinitelyTyped-tools/issues/433, where a proper fix is proposed and discussed

In the meantime, we can tell `yarn` to resolve `@types/react` and `@types/react-dom` to specific versions.

