### PR TITLE
ZIPs with and without videos

### DIFF
--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -370,7 +370,7 @@ def test_upsert_website_pipelines(
         )
         assert f"rm -rf ./output-online/{website.name}/*.mp4" in config_str
         assert (
-            f"aws s3 {expected_endpoint_prefix}sync course-markdown/output-online s3://{bucket}/ --metadata site-id={website.name}"
+            f"aws s3 {expected_endpoint_prefix}sync course-markdown/output-online s3://{bucket}/ --exclude='{website.short_id}.zip' --exclude='{website.short_id}-video.zip' --metadata site-id={website.name}"
             in config_str
         )
     else:
@@ -381,12 +381,16 @@ def test_upsert_website_pipelines(
         )
         assert "rm -rf ./output-online/*.mp4" in config_str
         assert (
-            f"aws s3 {expected_endpoint_prefix}sync course-markdown/output-online s3://{bucket}/{website.url_path} --metadata site-id={website.name} --delete"
+            f"aws s3 {expected_endpoint_prefix}sync course-markdown/output-online s3://{bucket}/{website.url_path} --exclude='{website.short_id}.zip' --exclude='{website.short_id}-video.zip' --metadata site-id={website.name} --delete"
             in config_str
         )
 
         assert (
             f"aws s3 {expected_endpoint_prefix}sync build-course-offline/ s3://{bucket}/{website.url_path} --exclude='*' --include='{website.short_id}.zip' --metadata site-id={website.name}"
+            in config_str
+        )
+        assert (
+            f"aws s3 {expected_endpoint_prefix}sync build-course-offline/ s3://{bucket}/{website.url_path} --exclude='*' --include='{website.short_id}-video.zip' --metadata site-id={website.name}"
             in config_str
         )
         assert (

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -460,7 +460,7 @@ jobs:
             path: sh
             args:
             - -exc
-            - aws s3((cli-endpoint-url)) sync course-markdown/output-online s3://((web-bucket))/((base-url)) --metadata site-id=((site-name))((delete))
+            - aws s3((cli-endpoint-url)) sync course-markdown/output-online s3://((web-bucket))/((base-url)) --exclude='((short-id)).zip' --exclude='((short-id))-video.zip' --metadata site-id=((site-name))((delete))
         # START DEV-ONLY
         on_success:
           try:
@@ -1065,17 +1065,32 @@ jobs:
                 mkdir -p ./content/static_resources
                 mkdir -p ./static/static_resources
                 mkdir -p ./static/static_shared
+                mkdir -p ../videos
                 cp -r ../static-resources/. ./content/static_resources
                 HTML_COUNT="$(ls -1 ./content/static_resources/*.html 2>/dev/null | wc -l)"
                 if [ $HTML_COUNT != 0 ];
                 then
                   mv ./content/static_resources/*.html ./static/static_resources
                 fi
+                MP4_COUNT="$(ls -1 ./content/static_resources/*.mp4 2>/dev/null | wc -l)"
+                if [ $MP4_COUNT != 0 ];
+                then
+                  mv ./content/static_resources/*.mp4 ../videos
+                fi
                 touch ./content/static_resources/_index.md
                 cp -r ../build-artifacts/static_shared/. ./static/static_shared/
                 hugo ((hugo-args-offline))
                 cd output-offline
-                zip -r ../../build-course-offline/((short-id)).zip ./ -x \*.mp4
+                zip -r ../../build-course-offline/((short-id)).zip ./
+                rm -rf ./*
+                cd ..
+                if [ $MP4_COUNT != 0 ];
+                then
+                  mv ../videos/* ./content/static_resources
+                fi
+                hugo ((hugo-args-offline))
+                cd output-offline
+                zip -r ../../build-course-offline/((short-id))-video.zip ./
               else
                 echo "Offline configuration not found for site type ((config-slug))"
               fi
@@ -1160,6 +1175,7 @@ jobs:
               then
                 aws s3((cli-endpoint-url)) sync course-markdown/output-offline/ s3://((offline-bucket))/((base-url)) --metadata site-id=((site-name))((delete))
                 aws s3((cli-endpoint-url)) sync build-course-offline/ s3://((web-bucket))/((base-url)) --exclude='*' --include='((short-id)).zip' --metadata site-id=((site-name))
+                aws s3((cli-endpoint-url)) sync build-course-offline/ s3://((web-bucket))/((base-url)) --exclude='*' --include='((short-id))-video.zip' --metadata site-id=((site-name))
               else
                 echo "Offline configuration not found for site type ((config-slug))"
               fi


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1835

#### What's this PR do?
This PR modifies the single site pipeline definition, `site-pipeline.yaml`, to build 2 versions of the offline ZIP download; one with videos and one without. The version without videos is built first, then the videos are brought in and that version is built and also uploaded to the mirror drive buckets.

#### How should this be manually tested?
 - Spin up `ocw-studio` on this branch, making sure you have Concourse, Minio, Google Drive and Github configured properly for publishing websites, as well as a recent database restore from RC
 - Create a folder somewhere on your computer and pull down the static resources for the website we'll be using from S3 with `aws s3 sync s3://ol-ocw-studio-app-qa/courses/6-041sc-probabilistic-systems-analysis-and-applied-probability-fall-2013/ ./` in a bash terminal in the folder you want to download them in, using the credentials from `ocw-studio` RC
 - Browse to http://localhost:9001 and log in to the Minio web UI
 - In your `ol-ocw-studio-app` bucket, create a folder structure matching what we synced above, creating a `courses` folder with a `6-041sc-probabilistic-systems-analysis-and-applied-probability-fall-2013` folder under that
 - Inside this folder, upload the static resources we downloaded above
 - Refresh the pipeline definition for our test course by running `docker compose exec web ./manage.py backpopulate_pipelines --filter 6-041sc-probabilistic-systems-analysis-and-applied-probability-fall-2013`
 - In the `ocw-studio` UI at http://localhost:8043/sites/6-041sc-probabilistic-systems-analysis-and-applied-probability-fall-2013 publish our test site live
 - Browse to http://localhost:8080/teams/main/pipelines/live?vars.site=%226-041sc-probabilistic-systems-analysis-and-applied-probability-fall-2013%22 and confirm that the `build-online-ocw-site` job is running and that the `build-offline-ocw-site` job has not yet started
- After the offline job finishes, go back to the Minio UI at http://localhost:9001/ and:
  - Browse to `ocw-content-live/courses/6-041sc-probabilistic-systems-analysis-and-applied-probability-fall-2013` and download the `6.041sc-fall-2013.zip` file. Extract the file and ensure that it does not contain .mp4 videos in the `static_resources` folder.
  - Double click the `index.html` file at the root of the download, then click "Resource Index" and click any of the videos inside. You should be brought to a page with a YouTube player.
  - Back in Minio, download `6.041sc-fall-2013-video.zip`. Extract the file and ensure that it contains .mp4 videos in the `static_resources` folder.
  - Verify that the YouTube player loads in the same fashion as above, since https://github.com/mitodl/ocw-hugo-themes/pull/1160 is not merged yet

#### Where should the reviewer start?
`site-pipeline.yaml`

#### Any background context you want to provide?
This PR is being put up in preparation to merge https://github.com/mitodl/ocw-hugo-themes/pull/1160. Since the current strategy of filtering out mp4 files is done during the creation of the ZIP file and the videos are present during the Hugo build, if https://github.com/mitodl/ocw-hugo-themes/pull/1160 was merged before this change then the offline sites being built by the `site-pipeline.yaml` pipeline would render the local video player and the videos would be missing from the ZIP. This PR ensures that that doesn't happen.
