### PR TITLE
up timeout on offline build to 90 minutes

### DIFF
--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -1020,7 +1020,7 @@ jobs:
             - |
               jq 'recurse | select(type=="string")' ./webpack-json/webpack.json | tr -d '"' | xargs -I {} aws s3((cli-endpoint-url)) cp s3://((web-bucket)){} ./build-artifacts/{} --exclude *.js.map
       - task: build-course-offline
-        timeout: 20m
+        timeout: 90m
         attempts: 3
         params:
           API_BEARER_TOKEN: ((api-token))


### PR DESCRIPTION
#### Pre-Flight checklist

- [ ] Testing
  - [ ] Code is tested
  - [ ] Changes have been manually tested

#### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1839

#### What's this PR do?
During testing of https://github.com/mitodl/ocw-studio/pull/1836, it was discovered that the timeout of 20 minutes on the `build-course-offline` task was insufficient for some of the worst case scenario courses like 18.01sc. When testing the upper limits of the timeout, 18.01sc was found to finish the full offline job in 58 minutes. This PR sets the timeout to 90 minutes to be safe and cover the largest sites.

#### How should this be manually tested?
You could run the build locally, but it takes less time there anyway (mine took around 24 minutes) because the limiting factor seems to be disk I/O in the cloud. The only real effective test of this is once it's deployed to RC.
