### PR TITLE
chore: upgrade actions' versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
           - 9200:9200
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: update
         run: sudo apt-get update -y
@@ -46,17 +46,10 @@ jobs:
         run: cat Aptfile | sudo xargs apt-get install
 
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.8.7"
-
-      - id: cache
-        uses: actions/cache@v1
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt', '**/test_requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
+          cache: pip
 
       - name: Install dependencies
         run: pip install -r requirements.txt -r test_requirements.txt
@@ -110,24 +103,13 @@ jobs:
   frontend-tests:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup NodeJS
-        uses: actions/setup-node@v2-beta
+        uses: actions/setup-node@v3
         with:
           node-version: "16.15.0"
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
-
-      - uses: actions/cache@v1
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          cache: yarn
 
       - name: Install dependencies
         run: yarn install --immutable

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -15,7 +15,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: release
       - uses: akhileshns/heroku-deploy@79ef2ae4ff9b897010907016b268fd0f88561820

--- a/.github/workflows/release-candiate.yml
+++ b/.github/workflows/release-candiate.yml
@@ -15,7 +15,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: release-candidate
       - uses: akhileshns/heroku-deploy@79ef2ae4ff9b897010907016b268fd0f88561820


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-hugo-themes/issues/922

# Description (What does it do?)

This PR:
- Updates versions of actions `checkout`, `setup-node`, and `setup-python`
- Removes the cache step because `actions/cache@v3` takes care of it

The original ticket was meant for ocw-hugo-theme repo, but since that was already done, I took the opportunity to update this repo's workflows.

# How can this be tested?

I believe that this can be tested online, there is no need to test it locally.

The tester only needs to verify four things:

- [x] The code is okay
- [x] actions/checkout@v3 works
- [x] actions/setup-note@v3 and actions/setup-python@v4 work.
- [ ] caching works

For these verifications, you can review the runner logs of the two workflow runs here:
- (First run) https://github.com/mitodl/ocw-studio/actions/runs/5254507265/jobs/9493198468
- (Second run) https://github.com/mitodl/ocw-studio/actions/runs/5254800744/jobs/9493867704

> One may choose to use [act](https://github.com/nektos/act). Though, I find it to be very slow.
