### PR TITLE
don't generate or sync zips for the root website

### DIFF
--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -539,6 +539,10 @@ class SitePipeline(BaseSitePipeline, GeneralPipeline):
                     if self.WEBSITE.name == settings.ROOT_WEBSITE_NAME
                     else " --delete",
                 )
+                .replace(
+                    "((is-root-website))",
+                    str(self.WEBSITE.name == settings.ROOT_WEBSITE_NAME),
+                )
                 .replace("((noindex))", noindex)
             )
             self.upsert_config(config_str, pipeline_name)

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -1186,7 +1186,7 @@ jobs:
               if [ -f "ocw-hugo-projects/((config-slug))/config-offline.yaml" ];
               then
                 aws s3((cli-endpoint-url)) sync course-markdown/output-offline/ s3://((offline-bucket))/((base-url)) --metadata site-id=((site-name))((delete))
-                if [ "$IS_ROOT_WEBSITE" = true ];
+                if [ "$IS_ROOT_WEBSITE" = false ];
                 then
                   aws s3((cli-endpoint-url)) sync build-course-offline/ s3://((web-bucket))/((base-url)) --exclude='*' --include='((short-id)).zip' --metadata site-id=((site-name))
                   aws s3((cli-endpoint-url)) sync build-course-offline/ s3://((web-bucket))/((base-url)) --exclude='*' --include='((short-id))-video.zip' --metadata site-id=((site-name))

--- a/content_sync/pipelines/definitions/concourse/site-pipeline.yml
+++ b/content_sync/pipelines/definitions/concourse/site-pipeline.yml
@@ -444,11 +444,12 @@ jobs:
       - task: upload-online-build
         timeout: 40m
         attempts: 3
-        # START DEV-ONLY
         params:
+          IS_ROOT_WEBSITE: ((is-root-website))
+          # START DEV-ONLY
           AWS_ACCESS_KEY_ID: ((minio-root-user))
           AWS_SECRET_ACCESS_KEY: ((minio-root-password))
-        # END DEV-ONLY
+          # END DEV-ONLY
         config:
           inputs:
             - name: course-markdown
@@ -460,7 +461,13 @@ jobs:
             path: sh
             args:
             - -exc
-            - aws s3((cli-endpoint-url)) sync course-markdown/output-online s3://((web-bucket))/((base-url)) --exclude='((short-id)).zip' --exclude='((short-id))-video.zip' --metadata site-id=((site-name))((delete))
+            - |
+              if [ "$IS_ROOT_WEBSITE" = true ];
+              then
+                aws s3((cli-endpoint-url)) sync course-markdown/output-online s3://((web-bucket))/((base-url)) --metadata site-id=((site-name))((delete))
+              else
+                aws s3((cli-endpoint-url)) sync course-markdown/output-online s3://((web-bucket))/((base-url)) --exclude='((short-id)).zip' --exclude='((short-id))-video.zip' --metadata site-id=((site-name))((delete))
+              fi
         # START DEV-ONLY
         on_success:
           try:
@@ -1032,6 +1039,7 @@ jobs:
           SITEMAP_DOMAIN: ((sitemap-domain))
           SENTRY_DSN: ((ocw-hugo-themes-sentry-dsn))
           NOINDEX: ((noindex))
+          IS_ROOT_WEBSITE: ((is-root-website))
           # START DEV-ONLY
           RESOURCE_BASE_URL: ((resource-base-url))
           AWS_ACCESS_KEY_ID: ((minio-root-user))
@@ -1080,17 +1088,20 @@ jobs:
                 touch ./content/static_resources/_index.md
                 cp -r ../build-artifacts/static_shared/. ./static/static_shared/
                 hugo ((hugo-args-offline))
-                cd output-offline
-                zip -r ../../build-course-offline/((short-id)).zip ./
-                rm -rf ./*
-                cd ..
-                if [ $MP4_COUNT != 0 ];
+                if [ "$IS_ROOT_WEBSITE" = false ];
                 then
-                  mv ../videos/* ./content/static_resources
+                  cd output-offline
+                  zip -r ../../build-course-offline/((short-id)).zip ./
+                  rm -rf ./*
+                  cd ..
+                  if [ $MP4_COUNT != 0 ];
+                  then
+                    mv ../videos/* ./content/static_resources
+                  fi
+                  hugo ((hugo-args-offline))
+                  cd output-offline
+                  zip -r ../../build-course-offline/((short-id))-video.zip ./
                 fi
-                hugo ((hugo-args-offline))
-                cd output-offline
-                zip -r ../../build-course-offline/((short-id))-video.zip ./
               else
                 echo "Offline configuration not found for site type ((config-slug))"
               fi
@@ -1152,11 +1163,12 @@ jobs:
       - task: upload-offline-build
         timeout: 40m
         attempts: 3
-        # START DEV-ONLY
         params:
+          IS_ROOT_WEBSITE: ((is-root-website))
+          # START DEV-ONLY
           AWS_ACCESS_KEY_ID: ((minio-root-user))
           AWS_SECRET_ACCESS_KEY: ((minio-root-password))
-        # END DEV-ONLY
+          # END DEV-ONLY
         config:
           inputs:
             - name: course-markdown
@@ -1174,8 +1186,11 @@ jobs:
               if [ -f "ocw-hugo-projects/((config-slug))/config-offline.yaml" ];
               then
                 aws s3((cli-endpoint-url)) sync course-markdown/output-offline/ s3://((offline-bucket))/((base-url)) --metadata site-id=((site-name))((delete))
-                aws s3((cli-endpoint-url)) sync build-course-offline/ s3://((web-bucket))/((base-url)) --exclude='*' --include='((short-id)).zip' --metadata site-id=((site-name))
-                aws s3((cli-endpoint-url)) sync build-course-offline/ s3://((web-bucket))/((base-url)) --exclude='*' --include='((short-id))-video.zip' --metadata site-id=((site-name))
+                if [ "$IS_ROOT_WEBSITE" = true ];
+                then
+                  aws s3((cli-endpoint-url)) sync build-course-offline/ s3://((web-bucket))/((base-url)) --exclude='*' --include='((short-id)).zip' --metadata site-id=((site-name))
+                  aws s3((cli-endpoint-url)) sync build-course-offline/ s3://((web-bucket))/((base-url)) --exclude='*' --include='((short-id))-video.zip' --metadata site-id=((site-name))
+                fi
               else
                 echo "Offline configuration not found for site type ((config-slug))"
               fi


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1858

# Description (What does it do?)
This PR adds the boolean env variable `IS_ROOT_WEBSITE` to the appropriate tasks in `site-pipeline` and based on this value will generate ZIP files if it is false or not if it is true.

# How can this be tested?
 - Make sure your docker containers are running and you have a fairly recent database restore
 - Run the following commands to refresh some pipelines:
   - `docker compose exec web ./manage.py backpopulate_pipelines --filter ocw-www`
   - `docker compose exec web ./manage.py backpopulate_pipelines --filter course-id` (replace `course-id` with any course you want to test)
 - Trigger a build of `ocw-www` through the Studio UI
 - Browse to the Concourse UI at http://localhost:8080
 - Search for `ocw-www` and open the pipeline that is running
 - Open the `build-online-ocw-site` job
 - In the `upload-online-build` task, you should see the lines `'[' true = true ']'` and `aws s3 --endpoint-url http://10.1.0.100:9000 sync course-markdown/output-online s3://ocw-content-live/ --metadata site-id=ocw-www`, note that the sync command does not contain `--include` or `--exclude` rules
 - Go back to the pipeline and click on the `build-offline-ocw-site` job
 - In the `build-course-offline` task, you should see `[ true = false ]` as the last line with nothing further after that, indicating that the building of zips has been skipped
 - In the `upload-offline-build` task, you should see `'[' true = false ']` as the last line with nothing further after that, indicating that the syncing of zips has been skipped
 - Browse to the pipeline for the course site that you updated earlier and repeat the above, but expect the opposite result
