### PR TITLE
Fix "publish to draft" causing sites to be hidden in mirror drive

### DIFF
--- a/websites/api.py
+++ b/websites/api.py
@@ -435,9 +435,9 @@ def get_website_in_root_website_metadata(website, version):
     ).metadata
     # We want this content to show up in lists, but not render pages
     site_metadata["_build"] = {"list": True, "render": False}
-    # Set the content to draft if the site has not been published or is unpublished
+    # Set the content to draft if the site is unpublished or has never been published to LIVE
     if website.unpublish_status is not None or (
-        version != VERSION_LIVE and website.publish_date is not None
+        version != VERSION_LIVE and website.publish_date is None
     ):
         site_metadata["draft"] = True
     # Carry over url_path for proper linking


### PR DESCRIPTION


# What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/1873

# Description (What does it do?)
This PR fixes a bug where if
- a course site has been previously published to live,
- that course site is subsequently published to draft
its status in the root website would erroneously be set to `draft: true`.


# How can this be tested?
With github integration enabled and `PREPUBLISH_ACTIONS='content_sync.tasks.update_website_in_root_website'` set in `.env`:

1. On `master`, publish a live site to draft. You should see a commit in your ocw-www repo indicating that the site is in draft mode.
2. Republish the site to live. 
3. On this branch, publish the site to `draft`. You should **not** see a `draft:true` commit in ocw-www.
4. More things you could test if desired:
    - Publishing a brand new site to draft or live
    - Publishing a site that had been manually unpublished (via the `unpublish_sites` management command).

The website object in the root site (i.e., in ocw-www) should only be set to `draft: true` if the site has never been published before.