### PR TITLE
fix: strip '/' from keys in populate_file_sizes

### DIFF
--- a/gdrive_sync/utils.py
+++ b/gdrive_sync/utils.py
@@ -22,6 +22,7 @@ def fetch_content_file_size(
     )
 
     if file_key:
+        file_key = file_key.strip("/")
         size = bucket.Object(file_key).content_length
     elif content.metadata.get("video_files", {}).get("archive_url"):
         # Some of our video resources are directly linked to YT videos, and their


### PR DESCRIPTION
# What are the relevant tickets?
https://github.com/mitodl/hq/issues/1683

https://github.com/mitodl/ocw-studio/pull/1861

# Description (What does it do?)

Normally course content would have a `file.name` as `course/abc/resource` but some of our legacy course content has `file.name` that starts with `/`, which makes an s3 key `/course/abc/resource`. This key is invalid (_when used directly to query size from s3_.)

This PR simply strips any `/` on the sides before querying s3 for file sizes.

Example: https://ocw-studio-rc.odl.mit.edu/admin/websites/websitecontent/489580/change/


# How can this be tested?
The issue does not appear locally. Both `/courses/abc/resource` and `courses/abc/resource` work the same in our local MinIO setup.

This cannot be tested locally. One could repeat the testing steps in https://github.com/mitodl/ocw-studio/pull/1861 but we won't know if this change worked until we move to RC.
