### PR TITLE
Bump pyyaml to 6.0.1 and yamale to 4.0.4

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -36,9 +36,9 @@ social-auth-core>=4
 social-auth-core[saml]>=4
 social-auth-app-django>=4
 uwsgi
-pyyaml
+pyyaml==6.0.1
 tqdm
-yamale
+yamale==4.0.4
 django-model-utils==4.2.0
 google-api-python-client
 google-auth

--- a/requirements.txt
+++ b/requirements.txt
@@ -288,7 +288,7 @@ pytz==2021.1
     #   django
     #   djangorestframework
     #   mitol-django-common
-pyyaml==5.4
+pyyaml==6.0.1
     # via
     #   -r requirements.in
     #   yamale
@@ -392,7 +392,7 @@ wrapt==1.15.0
     # via deprecated
 xmlsec==1.3.13
     # via python3-saml
-yamale==3.0.8
+yamale==4.0.4
     # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1890

# Description (What does it do?)
This PR bumps pyyaml to 6.0.1 and yamale to 4.0.4 and fixes ocw-studio build errors.

# How can this be tested?
Run `docker-compose build` and `docker-compose up`
Make sure everything works as expected.
