### PR TITLE
overhaul theme assets pipeline definition

### DIFF
--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
@@ -51,6 +51,7 @@ class ThemeAssetsPipelineDefinition(Pipeline):
         preview_bucket(str): The S3 bucket where preview sites are to be stored
         publish_bucket(str): The S3 bucket where published sites are to be stored
         ocw_hugo_themes_branch(str): The branch of ocw-hugo-themes to clone
+        instance_vars:(str): Instance vars for the pipeline in query string format
     """
 
     _build_theme_assets_job_identifier = Identifier("build-theme-assets-job")

--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
@@ -13,6 +13,7 @@ from ol_concourse.lib.models.pipeline import (
 from ol_concourse.lib.resource_types import slack_notification_resource
 
 from content_sync.constants import DEV_ENDPOINT_URL
+from content_sync.pipelines.base import BaseThemeAssetsPipeline
 from content_sync.pipelines.definitions.concourse.common.identifiers import (
     OCW_HUGO_THEMES_GIT_IDENTIFIER,
 )
@@ -52,6 +53,7 @@ class ThemeAssetsPipelineDefinition(Pipeline):
         preview_bucket: str,
         publish_bucket: str,
         ocw_hugo_themes_branch: str,
+        instance_vars: str,
         **kwargs,
     ):
         base = super()
@@ -136,6 +138,9 @@ class ThemeAssetsPipelineDefinition(Pipeline):
                     name=self._clear_draft_cdn_cache_task_identifier,
                     fastly_var="fastly_draft",
                     purge_url="purge/ocw-hugo-themes",
+                    step_description="draft cdn cache clear step",
+                    pipeline_name=BaseThemeAssetsPipeline.PIPELINE_NAME,
+                    instance_vars=instance_vars,
                 )
             )
             tasks.append(
@@ -143,6 +148,9 @@ class ThemeAssetsPipelineDefinition(Pipeline):
                     name=self._clear_live_cdn_cache_identifier,
                     fastly_var="fastly_live",
                     purge_url="purge/ocw-hugo-themes",
+                    step_description="live cdn cache clear step",
+                    pipeline_name=BaseThemeAssetsPipeline.PIPELINE_NAME,
+                    instance_vars=instance_vars,
                 )
             )
             job.on_failure = SlackAlertStep(

--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
@@ -38,6 +38,21 @@ CLI_ENDPOINT_URL = f" --endpoint-url {DEV_ENDPOINT_URL}" if is_dev() else ""
 
 
 class ThemeAssetsPipelineDefinition(Pipeline):
+    """
+    A Pipeline that does the following:
+
+     - Fetch the ocw-hugo-themes git repository
+     - Run the Webpack build in ocw-hugo-themes
+     - Upload the Webpack manifest (webpack.json) to artifacts_bucket
+     - Upload the output to preview_bucket and publish_bucket
+
+    Args:
+        artifacts_bucket(str): An S3 bucket with versioning enabled for storing the Webpack manifest
+        preview_bucket(str): The S3 bucket where preview sites are to be stored
+        publish_bucket(str): The S3 bucket where published sites are to be stored
+        ocw_hugo_themes_branch(str): The branch of ocw-hugo-themes to clone
+    """
+
     _build_theme_assets_job_identifier = Identifier("build-theme-assets-job")
     _build_ocw_hugo_themes_identifier = Identifier("build-ocw-hugo-themes-task")
     _upload_theme_assets_task_identifier = Identifier("upload-theme-assets-task")

--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
@@ -96,8 +96,8 @@ class ThemeAssetsPipelineDefinition(Pipeline):
                         path="sh",
                         args=[
                             "-exc",
-                            """
-                            cd ocw-hugo-themes
+                            f"""
+                            cd {OCW_HUGO_THEMES_GIT_IDENTIFIER}
                             yarn install --immutable
                             npm run build:webpack
                             npm run build:githash
@@ -128,11 +128,11 @@ class ThemeAssetsPipelineDefinition(Pipeline):
                         args=[
                             "-exc",
                             f"""
-                            aws s3{CLI_ENDPOINT_URL} cp ocw-hugo-themes/base-theme/dist s3://{preview_bucket} --recursive --metadata site-id=ocw-hugo-themes
-                            aws s3{CLI_ENDPOINT_URL} cp ocw-hugo-themes/base-theme/dist s3://{publish_bucket} --recursive --metadata site-id=ocw-hugo-themes
-                            aws s3{CLI_ENDPOINT_URL} cp ocw-hugo-themes/base-theme/static s3://{preview_bucket} --recursive --metadata site-id=ocw-hugo-themes
-                            aws s3{CLI_ENDPOINT_URL} cp ocw-hugo-themes/base-theme/static s3://{publish_bucket} --recursive --metadata site-id=ocw-hugo-themes
-                            aws s3{CLI_ENDPOINT_URL} cp ocw-hugo-themes/base-theme/data/webpack.json s3://{artifacts_bucket}/ocw-hugo-themes/{ocw_hugo_themes_branch}/webpack.json --metadata site-id=ocw-hugo-themes
+                            aws s3{CLI_ENDPOINT_URL} cp {OCW_HUGO_THEMES_GIT_IDENTIFIER}/base-theme/dist s3://{preview_bucket} --recursive --metadata site-id=ocw-hugo-themes
+                            aws s3{CLI_ENDPOINT_URL} cp {OCW_HUGO_THEMES_GIT_IDENTIFIER}/base-theme/dist s3://{publish_bucket} --recursive --metadata site-id=ocw-hugo-themes
+                            aws s3{CLI_ENDPOINT_URL} cp {OCW_HUGO_THEMES_GIT_IDENTIFIER}/base-theme/static s3://{preview_bucket} --recursive --metadata site-id=ocw-hugo-themes
+                            aws s3{CLI_ENDPOINT_URL} cp {OCW_HUGO_THEMES_GIT_IDENTIFIER}/base-theme/static s3://{publish_bucket} --recursive --metadata site-id=ocw-hugo-themes
+                            aws s3{CLI_ENDPOINT_URL} cp {OCW_HUGO_THEMES_GIT_IDENTIFIER}/base-theme/data/webpack.json s3://{artifacts_bucket}/ocw-hugo-themes/{ocw_hugo_themes_branch}/webpack.json --metadata site-id=ocw-hugo-themes
                             """,
                         ],
                     ),

--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
@@ -20,11 +20,6 @@ from content_sync.pipelines.definitions.concourse.common.image_resources import 
     AWS_CLI_REGISTRY_IMAGE,
     OCW_COURSE_PUBLISHER_REGISTRY_IMAGE,
 )
-from content_sync.pipelines.definitions.concourse.common.resource_types import (
-    HttpResourceType,
-    KeyvalResourceType,
-    S3IamResourceType,
-)
 from content_sync.pipelines.definitions.concourse.common.resources import (
     GitResource,
     OpenDiscussionsResource,
@@ -42,18 +37,14 @@ CLI_ENDPOINT_URL = f" --endpoint-url {DEV_ENDPOINT_URL}" if is_dev() else ""
 
 
 class ThemeAssetsPipelineDefinition(Pipeline):
-    http_resource_type = HttpResourceType()
-    keyval_resource_type = KeyvalResourceType()
-    s3_iam_resource_type = S3IamResourceType()
+    _build_theme_assets_job_identifier = Identifier("build-theme-assets-job")
+    _build_ocw_hugo_themes_identifier = Identifier("build-ocw-hugo-themes-task")
+    _upload_theme_assets_task_identifier = Identifier("upload-theme-assets-task")
+    _clear_draft_cdn_cache_task_identifier = Identifier("clear-draft-cdn-cache-task")
+    _clear_live_cdn_cache_identifier = Identifier("clear-live-cdn-cache-task")
 
-    build_theme_assets_job_identifier = Identifier("build-theme-assets-job")
-    build_ocw_hugo_themes_identifier = Identifier("build-ocw-hugo-themes-task")
-    upload_theme_assets_task_identifier = Identifier("upload-theme-assets-task")
-    clear_draft_cdn_cache_task_identifier = Identifier("clear-draft-cdn-cache-task")
-    clear_live_cdn_cache_identifier = Identifier("clear-live-cdn-cache-task")
-
-    open_discussions_resource = OpenDiscussionsResource()
-    slack_resource = SlackAlertResource()
+    _open_discussions_resource = OpenDiscussionsResource()
+    _slack_resource = SlackAlertResource()
 
     class Config:
         arbitrary_types_allowed = True
@@ -81,7 +72,7 @@ class ThemeAssetsPipelineDefinition(Pipeline):
                 trigger=(not is_dev()),
             ),
             TaskStep(
-                task=self.build_ocw_hugo_themes_identifier,
+                task=self._build_ocw_hugo_themes_identifier,
                 config=TaskConfig(
                     platform="linux",
                     image_resource=OCW_COURSE_PUBLISHER_REGISTRY_IMAGE,
@@ -96,8 +87,8 @@ class ThemeAssetsPipelineDefinition(Pipeline):
                         path="sh",
                         args=[
                             "-exc",
-                            f"""
-                            cd {OCW_HUGO_THEMES_GIT_IDENTIFIER}
+                            """
+                            cd ocw-hugo-themes
                             yarn install --immutable
                             npm run build:webpack
                             npm run build:githash
@@ -107,7 +98,7 @@ class ThemeAssetsPipelineDefinition(Pipeline):
                 ),
             ),
             TaskStep(
-                task=self.upload_theme_assets_task_identifier,
+                task=self._upload_theme_assets_task_identifier,
                 timeout="20m",
                 attempts=3,
                 config=TaskConfig(
@@ -128,31 +119,31 @@ class ThemeAssetsPipelineDefinition(Pipeline):
                         args=[
                             "-exc",
                             f"""
-                            aws s3{CLI_ENDPOINT_URL} cp {OCW_HUGO_THEMES_GIT_IDENTIFIER}/base-theme/dist s3://{preview_bucket} --recursive --metadata site-id=ocw-hugo-themes
-                            aws s3{CLI_ENDPOINT_URL} cp {OCW_HUGO_THEMES_GIT_IDENTIFIER}/base-theme/dist s3://{publish_bucket} --recursive --metadata site-id=ocw-hugo-themes
-                            aws s3{CLI_ENDPOINT_URL} cp {OCW_HUGO_THEMES_GIT_IDENTIFIER}/base-theme/static s3://{preview_bucket} --recursive --metadata site-id=ocw-hugo-themes
-                            aws s3{CLI_ENDPOINT_URL} cp {OCW_HUGO_THEMES_GIT_IDENTIFIER}/base-theme/static s3://{publish_bucket} --recursive --metadata site-id=ocw-hugo-themes
-                            aws s3{CLI_ENDPOINT_URL} cp {OCW_HUGO_THEMES_GIT_IDENTIFIER}/base-theme/data/webpack.json s3://{artifacts_bucket}/ocw-hugo-themes/{ocw_hugo_themes_branch}/webpack.json --metadata site-id=ocw-hugo-themes
+                            aws s3{CLI_ENDPOINT_URL} cp ocw-hugo-themes/base-theme/dist s3://{preview_bucket} --recursive --metadata site-id=ocw-hugo-themes
+                            aws s3{CLI_ENDPOINT_URL} cp ocw-hugo-themes/base-theme/dist s3://{publish_bucket} --recursive --metadata site-id=ocw-hugo-themes
+                            aws s3{CLI_ENDPOINT_URL} cp ocw-hugo-themes/base-theme/static s3://{preview_bucket} --recursive --metadata site-id=ocw-hugo-themes
+                            aws s3{CLI_ENDPOINT_URL} cp ocw-hugo-themes/base-theme/static s3://{publish_bucket} --recursive --metadata site-id=ocw-hugo-themes
+                            aws s3{CLI_ENDPOINT_URL} cp ocw-hugo-themes/base-theme/data/webpack.json s3://{artifacts_bucket}/ocw-hugo-themes/{ocw_hugo_themes_branch}/webpack.json --metadata site-id=ocw-hugo-themes
                             """,
                         ],
                     ),
                 ),
             ),
         ]
-        job = Job(name=self.build_theme_assets_job_identifier, serial=True)
+        job = Job(name=self._build_theme_assets_job_identifier, serial=True)
         if not is_dev():
             resource_types.append(slack_notification_resource())
-            resources.append(self.slack_resource)
+            resources.append(self._slack_resource)
             tasks.append(
                 ClearCdnCacheStep(
-                    name=self.clear_draft_cdn_cache_task_identifier,
+                    name=self._clear_draft_cdn_cache_task_identifier,
                     fastly_var="fastly_draft",
                     purge_url="purge/ocw-hugo-themes",
                 )
             )
             tasks.append(
                 ClearCdnCacheStep(
-                    name=self.clear_live_cdn_cache_identifier,
+                    name=self._clear_live_cdn_cache_identifier,
                     fastly_var="fastly_live",
                     purge_url="purge/ocw-hugo-themes",
                 )

--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
@@ -46,9 +46,6 @@ class ThemeAssetsPipelineDefinition(Pipeline):
     _open_discussions_resource = OpenDiscussionsResource()
     _slack_resource = SlackAlertResource()
 
-    class Config:
-        arbitrary_types_allowed = True
-
     def __init__(
         self,
         artifacts_bucket: str,

--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
@@ -84,8 +84,8 @@ class ThemeAssetsPipelineDefinition(Pipeline):
                         path="sh",
                         args=[
                             "-exc",
-                            """
-                            cd ocw-hugo-themes
+                            f"""
+                            cd {OCW_HUGO_THEMES_GIT_IDENTIFIER}
                             yarn install --immutable
                             npm run build:webpack
                             npm run build:githash
@@ -116,11 +116,11 @@ class ThemeAssetsPipelineDefinition(Pipeline):
                         args=[
                             "-exc",
                             f"""
-                            aws s3{CLI_ENDPOINT_URL} cp ocw-hugo-themes/base-theme/dist s3://{preview_bucket} --recursive --metadata site-id=ocw-hugo-themes
-                            aws s3{CLI_ENDPOINT_URL} cp ocw-hugo-themes/base-theme/dist s3://{publish_bucket} --recursive --metadata site-id=ocw-hugo-themes
-                            aws s3{CLI_ENDPOINT_URL} cp ocw-hugo-themes/base-theme/static s3://{preview_bucket} --recursive --metadata site-id=ocw-hugo-themes
-                            aws s3{CLI_ENDPOINT_URL} cp ocw-hugo-themes/base-theme/static s3://{publish_bucket} --recursive --metadata site-id=ocw-hugo-themes
-                            aws s3{CLI_ENDPOINT_URL} cp ocw-hugo-themes/base-theme/data/webpack.json s3://{artifacts_bucket}/ocw-hugo-themes/{ocw_hugo_themes_branch}/webpack.json --metadata site-id=ocw-hugo-themes
+                            aws s3{CLI_ENDPOINT_URL} cp {OCW_HUGO_THEMES_GIT_IDENTIFIER}/base-theme/dist s3://{preview_bucket} --recursive --metadata site-id=ocw-hugo-themes
+                            aws s3{CLI_ENDPOINT_URL} cp {OCW_HUGO_THEMES_GIT_IDENTIFIER}/base-theme/dist s3://{publish_bucket} --recursive --metadata site-id=ocw-hugo-themes
+                            aws s3{CLI_ENDPOINT_URL} cp {OCW_HUGO_THEMES_GIT_IDENTIFIER}/base-theme/static s3://{preview_bucket} --recursive --metadata site-id=ocw-hugo-themes
+                            aws s3{CLI_ENDPOINT_URL} cp {OCW_HUGO_THEMES_GIT_IDENTIFIER}/base-theme/static s3://{publish_bucket} --recursive --metadata site-id=ocw-hugo-themes
+                            aws s3{CLI_ENDPOINT_URL} cp {OCW_HUGO_THEMES_GIT_IDENTIFIER}/base-theme/data/webpack.json s3://{artifacts_bucket}/ocw-hugo-themes/{ocw_hugo_themes_branch}/webpack.json --metadata site-id=ocw-hugo-themes
                             """,
                         ],
                     ),

--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
@@ -1,0 +1,180 @@
+from django.conf import settings
+from ol_concourse.lib.models.pipeline import (
+    Command,
+    GetStep,
+    Identifier,
+    Input,
+    Job,
+    Output,
+    Pipeline,
+    TaskConfig,
+    TaskStep,
+)
+from ol_concourse.lib.resource_types import slack_notification_resource
+
+from content_sync.constants import DEV_ENDPOINT_URL
+from content_sync.pipelines.definitions.concourse.common.identifiers import (
+    OCW_HUGO_THEMES_GIT_IDENTIFIER,
+)
+from content_sync.pipelines.definitions.concourse.common.image_resources import (
+    AWS_CLI_REGISTRY_IMAGE,
+    OCW_COURSE_PUBLISHER_REGISTRY_IMAGE,
+)
+from content_sync.pipelines.definitions.concourse.common.resource_types import (
+    HttpResourceType,
+    KeyvalResourceType,
+    S3IamResourceType,
+)
+from content_sync.pipelines.definitions.concourse.common.resources import (
+    GitResource,
+    OpenDiscussionsResource,
+    SlackAlertResource,
+)
+from content_sync.pipelines.definitions.concourse.common.steps import (
+    ClearCdnCacheStep,
+    SlackAlertStep,
+)
+from main.utils import is_dev
+from websites.constants import OCW_HUGO_THEMES_GIT
+
+
+CLI_ENDPOINT_URL = f" --endpoint-url {DEV_ENDPOINT_URL}" if is_dev() else ""
+
+
+class ThemeAssetsPipelineDefinition(Pipeline):
+    http_resource_type = HttpResourceType()
+    keyval_resource_type = KeyvalResourceType()
+    s3_iam_resource_type = S3IamResourceType()
+
+    build_theme_assets_job_identifier = Identifier("build-theme-assets-job")
+    build_ocw_hugo_themes_identifier = Identifier("build-ocw-hugo-themes-task")
+    upload_theme_assets_task_identifier = Identifier("upload-theme-assets-task")
+    clear_draft_cdn_cache_task_identifier = Identifier("clear-draft-cdn-cache-task")
+    clear_live_cdn_cache_identifier = Identifier("clear-live-cdn-cache-task")
+
+    open_discussions_resource = OpenDiscussionsResource()
+    slack_resource = SlackAlertResource()
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    def __init__(
+        self,
+        artifacts_bucket: str,
+        preview_bucket: str,
+        publish_bucket: str,
+        ocw_hugo_themes_branch: str,
+        **kwargs,
+    ):
+        base = super()
+        base.__init__(**kwargs)
+        ocw_hugo_themes_resource = GitResource(
+            name=OCW_HUGO_THEMES_GIT_IDENTIFIER,
+            uri=OCW_HUGO_THEMES_GIT,
+            branch=ocw_hugo_themes_branch,
+        )
+        resource_types = []
+        resources = [ocw_hugo_themes_resource]
+        tasks = [
+            GetStep(
+                get=OCW_HUGO_THEMES_GIT_IDENTIFIER,
+                trigger=(not is_dev()),
+            ),
+            TaskStep(
+                task=self.build_ocw_hugo_themes_identifier,
+                config=TaskConfig(
+                    platform="linux",
+                    image_resource=OCW_COURSE_PUBLISHER_REGISTRY_IMAGE,
+                    inputs=[Input(name=OCW_HUGO_THEMES_GIT_IDENTIFIER)],
+                    outputs=[Output(name=OCW_HUGO_THEMES_GIT_IDENTIFIER)],
+                    params={
+                        "SEARCH_API_URL": settings.SEARCH_API_URL,
+                        "SENTRY_DSN": settings.OCW_HUGO_THEMES_SENTRY_DSN,
+                        "SENTRY_ENV": settings.ENVIRONMENT,
+                    },
+                    run=Command(
+                        path="sh",
+                        args=[
+                            "-exc",
+                            """
+                            cd ocw-hugo-themes
+                            yarn install --immutable
+                            npm run build:webpack
+                            npm run build:githash
+                            """,
+                        ],
+                    ),
+                ),
+            ),
+            TaskStep(
+                task=self.upload_theme_assets_task_identifier,
+                timeout="20m",
+                attempts=3,
+                config=TaskConfig(
+                    platform="linux",
+                    image_resource=AWS_CLI_REGISTRY_IMAGE,
+                    inputs=[Input(name=OCW_HUGO_THEMES_GIT_IDENTIFIER)],
+                    params=(
+                        {}
+                        if not is_dev()
+                        else {
+                            "AWS_ACCESS_KEY_ID": settings.AWS_ACCESS_KEY_ID or "",
+                            "AWS_SECRET_ACCESS_KEY": settings.AWS_SECRET_ACCESS_KEY
+                            or "",
+                        }
+                    ),
+                    run=Command(
+                        path="sh",
+                        args=[
+                            "-exc",
+                            f"""
+                            aws s3{CLI_ENDPOINT_URL} cp ocw-hugo-themes/base-theme/dist s3://{preview_bucket} --recursive --metadata site-id=ocw-hugo-themes
+                            aws s3{CLI_ENDPOINT_URL} cp ocw-hugo-themes/base-theme/dist s3://{publish_bucket} --recursive --metadata site-id=ocw-hugo-themes
+                            aws s3{CLI_ENDPOINT_URL} cp ocw-hugo-themes/base-theme/static s3://{preview_bucket} --recursive --metadata site-id=ocw-hugo-themes
+                            aws s3{CLI_ENDPOINT_URL} cp ocw-hugo-themes/base-theme/static s3://{publish_bucket} --recursive --metadata site-id=ocw-hugo-themes
+                            aws s3{CLI_ENDPOINT_URL} cp ocw-hugo-themes/base-theme/data/webpack.json s3://{artifacts_bucket}/ocw-hugo-themes/{ocw_hugo_themes_branch}/webpack.json --metadata site-id=ocw-hugo-themes
+                            """,
+                        ],
+                    ),
+                ),
+            ),
+        ]
+        job = Job(name=self.build_theme_assets_job_identifier, serial=True)
+        if not is_dev():
+            resource_types.append(slack_notification_resource())
+            resources.append(self.slack_resource)
+            tasks.append(
+                ClearCdnCacheStep(
+                    name=self.clear_draft_cdn_cache_task_identifier,
+                    fastly_var="fastly_draft",
+                    purge_url="purge/ocw-hugo-themes",
+                )
+            )
+            tasks.append(
+                ClearCdnCacheStep(
+                    name=self.clear_live_cdn_cache_identifier,
+                    fastly_var="fastly_live",
+                    purge_url="purge/ocw-hugo-themes",
+                )
+            )
+            job.on_failure = SlackAlertStep(
+                alert_type="failed",
+                text=f"""
+                Failed to build theme assets.
+
+                Append `?vars.branch={ocw_hugo_themes_branch}` to the url below for more details.
+                """,
+            )
+            job.on_abort = SlackAlertStep(
+                alert_type="aborted",
+                text=f"""
+                User aborted while building theme assets.
+
+                Append `?vars.branch={ocw_hugo_themes_branch}` to the url below for more details.
+                """,
+            )
+
+        job.plan = tasks
+        base.__init__(
+            resource_types=resource_types, resources=resources, jobs=[job], **kwargs
+        )

--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline_test.py
@@ -14,6 +14,9 @@ from content_sync.pipelines.definitions.concourse.theme_assets_pipeline import (
 
 @pytest.mark.parametrize("is_dev", [True, False])
 def test_generate_theme_assets_pipeline_definition(mocker, is_dev):
+    """
+    The theme assets pipeline definition should contain the expected properties
+    """
     mock_is_dev = mocker.patch(
         "content_sync.pipelines.definitions.concourse.theme_assets_pipeline.is_dev"
     )

--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline_test.py
@@ -1,0 +1,77 @@
+import json
+from urllib.parse import quote
+
+import pytest
+
+from content_sync.constants import DEV_ENDPOINT_URL
+from content_sync.pipelines.definitions.concourse.common.identifiers import (
+    OCW_HUGO_THEMES_GIT_IDENTIFIER,
+)
+from content_sync.pipelines.definitions.concourse.theme_assets_pipeline import (
+    ThemeAssetsPipelineDefinition,
+)
+
+
+@pytest.mark.parametrize("is_dev", [True, False])
+def test_generate_theme_assets_pipeline_definition(mocker, is_dev):
+    mock_is_dev = mocker.patch(
+        "content_sync.pipelines.definitions.concourse.theme_assets_pipeline.is_dev"
+    )
+    mock_is_dev.return_value = is_dev
+    artifacts_bucket = "ol-eng-artifacts"
+    preview_bucket = "ocw-content-preview"
+    publish_bucket = "ocw-content-publish"
+    ocw_hugo_themes_branch = "main"
+    instance_vars = f"?vars={quote(json.dumps({'branch': ocw_hugo_themes_branch}))}"
+    pipeline_definition = ThemeAssetsPipelineDefinition(
+        artifacts_bucket=artifacts_bucket,
+        preview_bucket=preview_bucket,
+        publish_bucket=publish_bucket,
+        ocw_hugo_themes_branch=ocw_hugo_themes_branch,
+        instance_vars=instance_vars,
+    )
+    rendered_definition = json.loads(pipeline_definition.json(indent=2))
+    git_resources = [
+        resource
+        for resource in rendered_definition["resources"]
+        if resource["name"] == OCW_HUGO_THEMES_GIT_IDENTIFIER
+    ]
+    assert len(git_resources) == 1
+    git_resource = git_resources[0]
+    assert git_resource["source"]["branch"] == ocw_hugo_themes_branch
+
+    jobs = [
+        job
+        for job in rendered_definition["jobs"]
+        if job["name"] == pipeline_definition._build_theme_assets_job_identifier
+    ]
+    assert len(jobs) == 1
+    build_theme_assets_job = jobs[0]
+    build_ocw_hugo_themes_tasks = [
+        task
+        for task in build_theme_assets_job["plan"]
+        if task.get("task") == pipeline_definition._build_ocw_hugo_themes_identifier
+    ]
+    assert len(build_ocw_hugo_themes_tasks) == 1
+    build_ocw_hugo_themes_task = build_ocw_hugo_themes_tasks[0]
+    build_ocw_hugo_themes_command = " ".join(
+        build_ocw_hugo_themes_task["config"]["run"]["args"]
+    )
+    assert OCW_HUGO_THEMES_GIT_IDENTIFIER in build_ocw_hugo_themes_command
+    upload_theme_assets_tasks = [
+        task
+        for task in build_theme_assets_job["plan"]
+        if task.get("task") == pipeline_definition._upload_theme_assets_task_identifier
+    ]
+    assert len(upload_theme_assets_tasks) == 1
+    upload_theme_assets_task = upload_theme_assets_tasks[0]
+    upload_theme_assets_command = " ".join(
+        upload_theme_assets_task["config"]["run"]["args"]
+    )
+    assert artifacts_bucket in upload_theme_assets_command
+    assert preview_bucket in upload_theme_assets_command
+    assert publish_bucket in upload_theme_assets_command
+    if is_dev:
+        assert f" --endpoint-url {DEV_ENDPOINT_URL}" in upload_theme_assets_command
+        assert "AWS_ACCESS_KEY_ID" in upload_theme_assets_task["config"]["params"]
+        assert "AWS_SECRET_ACCESS_KEY" in upload_theme_assets_task["config"]["params"]


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1899

# Description (What does it do?)
This PR re-writes the `theme-assets-pipeline.yml` pipeline definition as a class called `ThemeAssetsPipelineDefinition` that extends the `ol-concourse` `Pipeline` class.

# How can this be tested?
 - Make sure the following variables are set in your env, and make sure that you have Minio configured:
```
OCW_STUDIO_ENVIRONMENT=dev
AWS_ARTIFACTS_BUCKET_NAME=ol-eng-artifacts
AWS_PREVIEW_BUCKET_NAME=ocw-content-draft
AWS_PUBLISH_BUCKET_NAME=ocw-content-live
```
- Open a Django shell with `docker-compose exec web ./manage.py shell` and run the following:
```
content_sync.pipelines.definitions.concourse.theme_assets_pipeline import ThemeAssetsPipelineDefinition
from django.conf import settings
import quote from urllib
from urllib.parse import quote
theme_assets_pipeline_definition = ThemeAssetsPipelineDefinition(
    artifacts_bucket="ol-eng-artifacts",
    preview_bucket=settings.AWS_PREVIEW_BUCKET_NAME,
    publish_bucket=settings.AWS_PUBLISH_BUCKET_NAME,
    ocw_hugo_themes_branch="main",
    instance_vars=f"?vars={quote(json.dumps({'branch': 'main'}))}"
)
f = open("theme-assets-pipeline-test.yml", "w")
f.write(theme_assets_pipeline_definition.json(indent=2, by_alias=True))
f.close()
```
 - You should have a file in the root of your `ocw-studio` repo now called `theme-assets-pipeline-test.yml`
 - You will need the `fly` CLI set up for the next part with your locally running Concourse instance added as a target, see https://concourse-ci.org/fly.html#fly-login for more info about how to use `fly login` to do that
 - Assuming you now have a fly target called `local`, run `fly -t local set-pipeline -p ocw-theme-assets-test --instance-var branch="main" -c theme-assets-pipeline-test.yml` and hit y at the prompt to push up the pipeline
 - Visit the Concourse web UI at http://localhost:8080 and login with test / test
 - Find the pipeline we just pushed up, `ocw-theme-assets-test`, unpause the pipeline and run it
 - Verify that the pipeline succeeds, look at the logs and confirm that the build completed successfully and the artifacts were uploaded to all the proper places
 - Change your `OCW_STUDIO_ENVIRONMENT` to `qa` and repeat the above steps, but stop before you push the pipeline up
 - Compare the pipeline definition to the `dev` one, the main differences should be:
   - No AWS connection info
   - Open Discussions webhook present
   - Slack alerts present