### PR TITLE
Configure uWSGI stats server

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3364,6 +3364,16 @@ files = [
 ]
 
 [[package]]
+name = "uwsgitop"
+version = "0.11"
+description = "uWSGI top-like interface"
+optional = false
+python-versions = "*"
+files = [
+    {file = "uwsgitop-0.11.tar.gz", hash = "sha256:99ca245119e4a0600840a62b7b4e020c9870fe90952b24eecfff0c9090c75d14"},
+]
+
+[[package]]
 name = "vine"
 version = "5.0.0"
 description = "Promises, promises, promises."
@@ -3574,4 +3584,4 @@ pyyaml = "*"
 [metadata]
 lock-version = "2.0"
 python-versions = "3.10.12"
-content-hash = "bf1b82db0f5af8a54fb019f6931b82584b807f94e0bad943cc0efb374421b653"
+content-hash = "2c8853d521ae43f4ea19704f10f67f64f6365b19cf2c62452f32d45b4b45193f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ tqdm = "^4.65.0"
 yamale = "4.0.4"
 django-model-utils = "4.2.0"
 ol-concourse = "0.4.4"
+uwsgitop = "^0.11"
 
 [tool.poetry.group.dev.dependencies]
 black = "22.6.0"

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -45,3 +45,4 @@ endif =
 if-not-env = UWSGI_POST_BUFFERING
 post-buffering = 65535
 endif =
+stats = /tmp/uwsgi-stats.sock


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1897

# Description (What does it do?)
This PR adds `uwsgitop` in project and configures uWSGI stats server. This will be used to monitor how workers are operating, their response time, etc.

# How can this be tested?
This can be locally tested by checkout out to this branch, running `docker-compose build`, `docker-compose up` and then `docker-compose exec web uwsgitop /tmp/uwsgi-stats.sock` in another terminal tab. Make sure that it runs.

Although we really want to test its working in RC though. But for now this will do until this PR merges.