### PR TITLE
properly clone private repos in SiteContentGitTaskStep

### DIFF
--- a/content_sync/pipelines/definitions/concourse/common/steps_test.py
+++ b/content_sync/pipelines/definitions/concourse/common/steps_test.py
@@ -5,6 +5,9 @@ import pytest
 from django.test import override_settings
 from ol_concourse.lib.models.pipeline import GetStep, PutStep, Step, TaskStep
 
+from content_sync.pipelines.definitions.concourse.common.identifiers import (
+    SITE_CONTENT_GIT_IDENTIFIER,
+)
 from content_sync.pipelines.definitions.concourse.common.steps import (
     ErrorHandlingStep,
     OcwStudioWebhookStep,

--- a/content_sync/pipelines/definitions/concourse/common/steps_test.py
+++ b/content_sync/pipelines/definitions/concourse/common/steps_test.py
@@ -1,13 +1,16 @@
 """Tests for Concourse Steps"""
 import json
-
 import pytest
+from django.test import override_settings
 from ol_concourse.lib.models.pipeline import GetStep, PutStep, Step, TaskStep
+from content_sync.pipelines.definitions.concourse.common.identifiers import (
+    SITE_CONTENT_GIT_IDENTIFIER,
+)
 
 from content_sync.pipelines.definitions.concourse.common.steps import (
     ErrorHandlingStep,
     OcwStudioWebhookStep,
-    OpenDiscussionsWebhookStep,
+    SiteContentGitTaskStep,
     SlackAlertStep,
     add_error_handling,
 )

--- a/content_sync/pipelines/definitions/concourse/common/steps_test.py
+++ b/content_sync/pipelines/definitions/concourse/common/steps_test.py
@@ -1,12 +1,13 @@
 """Tests for Concourse Steps"""
 import json
+
 import pytest
 from django.test import override_settings
 from ol_concourse.lib.models.pipeline import GetStep, PutStep, Step, TaskStep
+
 from content_sync.pipelines.definitions.concourse.common.identifiers import (
     SITE_CONTENT_GIT_IDENTIFIER,
 )
-
 from content_sync.pipelines.definitions.concourse.common.steps import (
     ErrorHandlingStep,
     OcwStudioWebhookStep,


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1934

# Description (What does it do?)
This PR addresses some issues with `SiteContentGitTaskStep` where using the git private key variable was not done properly if `settings.CONCOURSE_IS_PRIVATE_REPO` is true

# How can this be tested?
This will need to be functionally evaluated on RC, but you can at least verify that the correct step structure is build by doing the following:

 - Set `CONCOURSE_IS_PRIVATE_REPO=True` in your `.env`
 - Spin up `ocw-studio` with `docker-compose up`
 - Run `docker-compose exec web ./manage.py shell`:
```python
import json
from urllib.parse import quote
from content_sync.constants import VERSION_DRAFT, VERSION_LIVE
from websites.models import *
from content_sync.pipelines.definitions.concourse.mass_build_sites import (
    MassBuildSitesPipelineDefinitionConfig,
    MassBuildSitesPipelineDefinition
)

version = VERSION_DRAFT
offline = False

publish_date_field = (
    "publish_date" if version == VERSION_LIVE else "draft_publish_date"
)

# Get all sites, minus any sites that have never been successfully published
sites = Website.objects.exclude(
    Q(**{f"{publish_date_field}__isnull": True}) | Q(url_path__isnull=True)
)
sites = sites.prefetch_related("starter").order_by("name")
pipeline_config = MassBuildSitesPipelineDefinitionConfig(
    sites=sites,
    version=version,
    ocw_studio_url="http://10.1.0.102:8043",
    artifacts_bucket="ol-eng-artifacts",
    site_content_branch="preview",
    ocw_hugo_themes_branch="main",
    ocw_hugo_projects_branch="main",
    offline=offline,
    instance_vars=f"?vars={quote(json.dumps({'offline': offline, 'prefix': '', 'projects_branch': 'main', 'themes_branch': 'main', 'starter': '', 'version': 'draft'}))}"
)
pipeline_definition = MassBuildSitesPipelineDefinition(config=pipeline_config)
f = open(f"mass-build-pipeline-test-{'offline' if offline else 'online'}.json", "w")
f.write(pipeline_definition.json(indent=2, by_alias=True))
f.close()
```
 - Open the resulting `mass-build-pipeline-test-online.json` file and search for `site-content-git`
 - Assure that under `params` you see `"GIT_PRIVATE_KEY": "((git-private-key))"`
 - Assure that under `config.run.args` that the bash commands in the second argument look correct and match what should be rendering to properly utilize the private key

# Additional Context
You could push this up to your local Concourse and try and run it, but you would get an error that `((git-private-key))` is undefined. In MIT's production environments this variable is set and loaded with the Hashicorp Vault plugin. I attempted to inject the private key directly into the pipeline by changing line 256 of `content_sync/pipelines/definitions/concourse/common/steps.py` to `params = {"GIT_PRIVATE_KEY": "settings.GITHUB_APP_PRIVATE_KEY"}` after setting it there, but this ended up not working. For some reason, locally running containers under `containerd` in Concourse are unable to hit `github.mit.edu` and the task times out.
