### PR TITLE
fix common pipeline vars

### DIFF
--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -39,8 +39,8 @@ from content_sync.pipelines.definitions.concourse.theme_assets_pipeline import (
 )
 from content_sync.utils import (
     check_mandatory_settings,
-    get_hugo_arg_string,
     get_common_pipeline_vars,
+    get_hugo_arg_string,
     get_theme_branch,
     strip_dev_lines,
     strip_non_dev_lines,

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -40,7 +40,7 @@ from content_sync.pipelines.definitions.concourse.theme_assets_pipeline import (
 from content_sync.utils import (
     check_mandatory_settings,
     get_hugo_arg_string,
-    get_template_vars,
+    get_common_pipeline_vars,
     get_theme_branch,
     strip_dev_lines,
     strip_non_dev_lines,
@@ -356,7 +356,7 @@ class ThemeAssetsPipeline(GeneralPipeline, BaseThemeAssetsPipeline):
 
     def upsert_pipeline(self):
         """Upsert the theme assets pipeline"""
-        template_vars = get_template_vars()
+        template_vars = get_common_pipeline_vars()
         pipeline_definition = ThemeAssetsPipelineDefinition(
             artifacts_bucket=template_vars["artifacts_bucket_name"],
             preview_bucket=template_vars["preview_bucket_name"],
@@ -456,20 +456,21 @@ class SitePipeline(BaseSitePipeline, GeneralPipeline):
                 else settings.OCW_STUDIO_LIVE_URL,
             },
         ]:
-            branch_vars.update(get_template_vars())
-            branch = branch_vars["branch"]
-            pipeline_name = branch_vars["pipeline_name"]
-            static_api_url = branch_vars["static_api_url"]
-            storage_bucket_name = branch_vars["storage_bucket_name"]
-            artifacts_bucket = branch_vars["artifacts_bucket_name"]
+            vars = get_common_pipeline_vars()
+            vars.update(branch_vars)
+            branch = vars["branch"]
+            pipeline_name = vars["pipeline_name"]
+            static_api_url = vars["static_api_url"]
+            storage_bucket_name = vars["storage_bucket_name"]
+            artifacts_bucket = vars["artifacts_bucket_name"]
             if branch == settings.GIT_BRANCH_PREVIEW:
-                web_bucket = branch_vars["preview_bucket_name"]
-                offline_bucket = branch_vars["offline_preview_bucket_name"]
-                resource_base_url = branch_vars["resource_base_url_draft"]
+                web_bucket = vars["preview_bucket_name"]
+                offline_bucket = vars["offline_preview_bucket_name"]
+                resource_base_url = vars["resource_base_url_draft"]
             elif branch == settings.GIT_BRANCH_RELEASE:
-                web_bucket = branch_vars["publish_bucket_name"]
-                offline_bucket = branch_vars["offline_publish_bucket_name"]
-                resource_base_url = branch_vars["resource_base_url_live"]
+                web_bucket = vars["publish_bucket_name"]
+                offline_bucket = vars["offline_publish_bucket_name"]
+                resource_base_url = vars["resource_base_url_live"]
             if (
                 branch == settings.GIT_BRANCH_PREVIEW
                 or settings.ENV_NAME not in PRODUCTION_NAMES
@@ -527,7 +528,7 @@ class SitePipeline(BaseSitePipeline, GeneralPipeline):
                 .replace("((ocw-hugo-themes-uri))", OCW_HUGO_THEMES_GIT)
                 .replace("((ocw-hugo-projects-branch))", ocw_hugo_projects_branch)
                 .replace("((ocw-hugo-projects-uri))", hugo_projects_url)
-                .replace("((ocw-studio-url))", branch_vars["ocw_studio_url"] or "")
+                .replace("((ocw-studio-url))", vars["ocw_studio_url"] or "")
                 .replace("((static-api-base-url))", static_api_url)
                 .replace(
                     "((ocw-import-starter-slug))", settings.OCW_COURSE_STARTER_SLUG
@@ -646,7 +647,7 @@ class MassBuildSitesPipeline(
         """
         Create or update the concourse pipeline
         """
-        template_vars = get_template_vars()
+        template_vars = get_common_pipeline_vars()
         starter = Website.objects.get(name=settings.ROOT_WEBSITE_NAME).starter
         starter_path_url = urlparse(starter.path)
         hugo_projects_url = urljoin(
@@ -805,7 +806,7 @@ class UnpublishedSiteRemovalPipeline(
         """
         Create or update the concourse pipeline
         """
-        template_vars = get_template_vars()
+        template_vars = get_common_pipeline_vars()
         web_bucket = template_vars["publish_bucket_name"]
         offline_bucket = template_vars["offline_publish_bucket_name"]
 

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -456,21 +456,21 @@ class SitePipeline(BaseSitePipeline, GeneralPipeline):
                 else settings.OCW_STUDIO_LIVE_URL,
             },
         ]:
-            vars = get_common_pipeline_vars()
-            vars.update(branch_vars)
-            branch = vars["branch"]
-            pipeline_name = vars["pipeline_name"]
-            static_api_url = vars["static_api_url"]
-            storage_bucket_name = vars["storage_bucket_name"]
-            artifacts_bucket = vars["artifacts_bucket_name"]
+            pipeline_vars = get_common_pipeline_vars()
+            pipeline_vars.update(branch_vars)
+            branch = pipeline_vars["branch"]
+            pipeline_name = pipeline_vars["pipeline_name"]
+            static_api_url = pipeline_vars["static_api_url"]
+            storage_bucket_name = pipeline_vars["storage_bucket_name"]
+            artifacts_bucket = pipeline_vars["artifacts_bucket_name"]
             if branch == settings.GIT_BRANCH_PREVIEW:
-                web_bucket = vars["preview_bucket_name"]
-                offline_bucket = vars["offline_preview_bucket_name"]
-                resource_base_url = vars["resource_base_url_draft"]
+                web_bucket = pipeline_vars["preview_bucket_name"]
+                offline_bucket = pipeline_vars["offline_preview_bucket_name"]
+                resource_base_url = pipeline_vars["resource_base_url_draft"]
             elif branch == settings.GIT_BRANCH_RELEASE:
-                web_bucket = vars["publish_bucket_name"]
-                offline_bucket = vars["offline_publish_bucket_name"]
-                resource_base_url = vars["resource_base_url_live"]
+                web_bucket = pipeline_vars["publish_bucket_name"]
+                offline_bucket = pipeline_vars["offline_publish_bucket_name"]
+                resource_base_url = pipeline_vars["resource_base_url_live"]
             if (
                 branch == settings.GIT_BRANCH_PREVIEW
                 or settings.ENV_NAME not in PRODUCTION_NAMES
@@ -528,7 +528,7 @@ class SitePipeline(BaseSitePipeline, GeneralPipeline):
                 .replace("((ocw-hugo-themes-uri))", OCW_HUGO_THEMES_GIT)
                 .replace("((ocw-hugo-projects-branch))", ocw_hugo_projects_branch)
                 .replace("((ocw-hugo-projects-uri))", hugo_projects_url)
-                .replace("((ocw-studio-url))", vars["ocw_studio_url"] or "")
+                .replace("((ocw-studio-url))", pipeline_vars["ocw_studio_url"] or "")
                 .replace("((static-api-base-url))", static_api_url)
                 .replace(
                     "((ocw-import-starter-slug))", settings.OCW_COURSE_STARTER_SLUG

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -19,7 +19,7 @@ from content_sync.pipelines.concourse import (
     ThemeAssetsPipeline,
     UnpublishedSiteRemovalPipeline,
 )
-from content_sync.utils import get_template_vars, get_theme_branch
+from content_sync.utils import get_common_pipeline_vars, get_theme_branch
 from main.constants import PRODUCTION_NAMES
 from main.utils import is_dev
 from websites.constants import STARTER_SOURCE_GITHUB, STARTER_SOURCE_LOCAL
@@ -125,7 +125,6 @@ def pipeline_settings(settings, request):
         settings.AWS_ARTIFACTS_BUCKET_NAME = "artifact_buckets_dev"
         settings.OCW_HUGO_THEMES_BRANCH = "themes_dev"
         settings.OCW_HUGO_PROJECTS_BRANCH = "projects_dev"
-        settings.STATIC_API_BASE_URL = "https://ocw.mit.edu"
         settings.RESOURCE_BASE_URL_DRAFT = "https://draft.ocw.mit.edu"
         settings.RESOURCE_BASE_URL_LIVE = "https://live.ocw.mit.edu"
 
@@ -280,7 +279,7 @@ def test_upsert_website_pipelines(
     """The correct concourse API args should be made for a website"""
     # Set AWS expectations based on environment
     env = settings.ENVIRONMENT
-    expected_template_vars = get_template_vars()
+    expected_template_vars = get_common_pipeline_vars()
     expected_endpoint_prefix = (
         "--endpoint-url http://10.1.0.100:9000 " if env == "dev" else ""
     )
@@ -580,7 +579,7 @@ def test_upsert_pipeline(
     )
     _, kwargs = mock_put_headers.call_args_list[0]
     config_str = json.dumps(kwargs)
-    expected_template_vars = get_template_vars()
+    expected_template_vars = get_common_pipeline_vars()
     expected_branch = get_theme_branch()
     preview_bucket_name = expected_template_vars["preview_bucket_name"]
     publish_bucket_name = expected_template_vars["publish_bucket_name"]
@@ -614,7 +613,7 @@ def test_upsert_mass_build_pipeline(
     offline,
 ):  # pylint:disable=too-many-locals,too-many-arguments,too-many-statements,too-many-branches
     """The mass build pipeline should have expected configuration"""
-    expected_template_vars = get_template_vars()
+    expected_template_vars = get_common_pipeline_vars()
     hugo_projects_path = "https://github.com/org/repo"
     WebsiteFactory.create(
         starter=WebsiteStarterFactory.create(
@@ -751,7 +750,7 @@ def test_unpublished_site_removal_pipeline(
     settings, pipeline_settings, mocker, mock_auth, pipeline_exists, version
 ):  # pylint:disable=too-many-locals,too-many-arguments
     """The unpublished sites removal pipeline should have expected configuration"""
-    template_vars = get_template_vars()
+    template_vars = get_common_pipeline_vars()
     url_path = f"/api/v1/teams/{settings.CONCOURSE_TEAM}/pipelines/{BaseUnpublishedSiteRemovalPipeline.PIPELINE_NAME}/config"
 
     if not pipeline_exists:

--- a/content_sync/pipelines/definitions/concourse/mass_build_sites.py
+++ b/content_sync/pipelines/definitions/concourse/mass_build_sites.py
@@ -212,7 +212,7 @@ class MassBuildSitesPipelineDefinition(Pipeline):
 
     def __init__(self, config: MassBuildSitesPipelineDefinitionConfig, **kwargs):
         base = super()
-        vars = get_common_pipeline_vars()
+        pipeline_vars = get_common_pipeline_vars()
         namespace = ".:site."
         resource_types = MassBuildSitesPipelineResourceTypes()
         resources = MassBuildSitesResources(config=config)
@@ -244,15 +244,15 @@ class MassBuildSitesPipelineDefinition(Pipeline):
             across_var_values = []
             site_pipeline_definition_vars = get_site_pipeline_definition_vars(namespace)
             if config.version == VERSION_DRAFT:
-                static_api_url = vars["static_api_base_url_draft"]
-                web_bucket = vars["preview_bucket_name"]
-                offline_bucket = vars["offline_preview_bucket_name"]
-                resource_base_url = vars["resource_base_url_draft"]
+                static_api_url = pipeline_vars["static_api_base_url_draft"]
+                web_bucket = pipeline_vars["preview_bucket_name"]
+                offline_bucket = pipeline_vars["offline_preview_bucket_name"]
+                resource_base_url = pipeline_vars["resource_base_url_draft"]
             else:
-                static_api_url = vars["static_api_base_url_live"]
-                web_bucket = vars["publish_bucket_name"]
-                offline_bucket = vars["offline_publish_bucket_name"]
-                resource_base_url = vars["resource_base_url_live"]
+                static_api_url = pipeline_vars["static_api_base_url_live"]
+                web_bucket = pipeline_vars["publish_bucket_name"]
+                offline_bucket = pipeline_vars["offline_publish_bucket_name"]
+                resource_base_url = pipeline_vars["resource_base_url_live"]
             for site in batch:
                 site_config = SitePipelineDefinitionConfig(
                     site=site,
@@ -260,12 +260,12 @@ class MassBuildSitesPipelineDefinition(Pipeline):
                     instance_vars=f"?vars={quote(json.dumps({'site': site.name}))}",
                     site_content_branch=config.site_content_branch,
                     static_api_url=static_api_url,
-                    storage_bucket=vars["storage_bucket_name"],
-                    artifacts_bucket=vars["artifacts_bucket_name"],
+                    storage_bucket=pipeline_vars["storage_bucket_name"],
+                    artifacts_bucket=pipeline_vars["artifacts_bucket_name"],
                     web_bucket=web_bucket,
                     offline_bucket=offline_bucket,
                     resource_base_url=resource_base_url,
-                    ocw_studio_url=vars["ocw_studio_url"],
+                    ocw_studio_url=pipeline_vars["ocw_studio_url"],
                     ocw_hugo_themes_branch=config.ocw_hugo_themes_branch,
                     ocw_hugo_projects_branch=config.ocw_hugo_projects_branch,
                     namespace=namespace,

--- a/content_sync/utils.py
+++ b/content_sync/utils.py
@@ -105,7 +105,7 @@ def move_s3_object(from_path, to_path):
 
 def get_common_pipeline_vars():
     """Get an object with all the template vars we need in pipelines based on env"""
-    vars = {
+    pipeline_vars = {
         "preview_bucket_name": settings.AWS_PREVIEW_BUCKET_NAME,
         "publish_bucket_name": settings.AWS_PUBLISH_BUCKET_NAME,
         "offline_preview_bucket_name": settings.AWS_OFFLINE_PREVIEW_BUCKET_NAME,
@@ -119,14 +119,14 @@ def get_common_pipeline_vars():
         "ocw_studio_url": settings.SITE_BASE_URL,
     }
     if is_dev():
-        vars.update(
+        pipeline_vars.update(
             {
                 "resource_base_url_draft": settings.RESOURCE_BASE_URL_DRAFT,
                 "resource_base_url_live": settings.RESOURCE_BASE_URL_LIVE,
                 "ocw_studio_url": "http://10.1.0.102:8043",
             }
         )
-    return vars
+    return pipeline_vars
 
 
 def get_theme_branch():

--- a/content_sync/utils.py
+++ b/content_sync/utils.py
@@ -118,13 +118,14 @@ def get_common_pipeline_vars():
         "resource_base_url_live": "",
         "ocw_studio_url": settings.SITE_BASE_URL,
     }
-    dev_vars = {
-        "resource_base_url_draft": settings.RESOURCE_BASE_URL_DRAFT,
-        "resource_base_url_live": settings.RESOURCE_BASE_URL_LIVE,
-        "ocw_studio_url": "http://10.1.0.102:8043",
-    }
     if is_dev():
-        vars.update(dev_vars)
+        vars.update(
+            {
+                "resource_base_url_draft": settings.RESOURCE_BASE_URL_DRAFT,
+                "resource_base_url_live": settings.RESOURCE_BASE_URL_LIVE,
+                "ocw_studio_url": "http://10.1.0.102:8043",
+            }
+        )
     return vars
 
 

--- a/content_sync/utils.py
+++ b/content_sync/utils.py
@@ -103,29 +103,29 @@ def move_s3_object(from_path, to_path):
     s3.Object(bucket, from_path).delete()
 
 
-def get_template_vars():
+def get_common_pipeline_vars():
     """Get an object with all the template vars we need in pipelines based on env"""
-    base_vars = {
+    vars = {
         "preview_bucket_name": settings.AWS_PREVIEW_BUCKET_NAME,
         "publish_bucket_name": settings.AWS_PUBLISH_BUCKET_NAME,
         "offline_preview_bucket_name": settings.AWS_OFFLINE_PREVIEW_BUCKET_NAME,
         "offline_publish_bucket_name": settings.AWS_OFFLINE_PUBLISH_BUCKET_NAME,
         "storage_bucket_name": settings.AWS_STORAGE_BUCKET_NAME,
         "artifacts_bucket_name": "ol-eng-artifacts",
-    }
-    default_vars = {
+        "static_api_base_url_draft": settings.OCW_STUDIO_DRAFT_URL,
+        "static_api_base_url_live": settings.OCW_STUDIO_LIVE_URL,
         "resource_base_url_draft": "",
         "resource_base_url_live": "",
         "ocw_studio_url": settings.SITE_BASE_URL,
     }
-    default_vars.update(base_vars)
     dev_vars = {
         "resource_base_url_draft": settings.RESOURCE_BASE_URL_DRAFT,
         "resource_base_url_live": settings.RESOURCE_BASE_URL_LIVE,
         "ocw_studio_url": "http://10.1.0.102:8043",
     }
-    dev_vars.update(base_vars)
-    return dev_vars if is_dev() else default_vars
+    if is_dev():
+        vars.update(dev_vars)
+    return vars
 
 
 def get_theme_branch():

--- a/content_sync/utils_test.py
+++ b/content_sync/utils_test.py
@@ -171,27 +171,27 @@ def test_get_common_pipeline_vars(settings, mocker, is_dev):
     """get_common_pipeline_vars should return the correct values based on environment"""
     mock_is_dev = mocker.patch("content_sync.utils.is_dev")
     mock_is_dev.return_value = is_dev
-    vars = get_common_pipeline_vars()
-    assert vars["preview_bucket_name"] == settings.AWS_PREVIEW_BUCKET_NAME
-    assert vars["publish_bucket_name"] == settings.AWS_PUBLISH_BUCKET_NAME
+    pipeline_vars = get_common_pipeline_vars()
+    assert pipeline_vars["preview_bucket_name"] == settings.AWS_PREVIEW_BUCKET_NAME
+    assert pipeline_vars["publish_bucket_name"] == settings.AWS_PUBLISH_BUCKET_NAME
     assert (
-        vars["offline_preview_bucket_name"] == settings.AWS_OFFLINE_PREVIEW_BUCKET_NAME
+        pipeline_vars["offline_preview_bucket_name"] == settings.AWS_OFFLINE_PREVIEW_BUCKET_NAME
     )
     assert (
-        vars["offline_publish_bucket_name"] == settings.AWS_OFFLINE_PUBLISH_BUCKET_NAME
+        pipeline_vars["offline_publish_bucket_name"] == settings.AWS_OFFLINE_PUBLISH_BUCKET_NAME
     )
-    assert vars["storage_bucket_name"] == settings.AWS_STORAGE_BUCKET_NAME
-    assert vars["artifacts_bucket_name"] == "ol-eng-artifacts"
-    assert vars["static_api_base_url_draft"] == settings.OCW_STUDIO_DRAFT_URL
-    assert vars["static_api_base_url_live"] == settings.OCW_STUDIO_LIVE_URL
+    assert pipeline_vars["storage_bucket_name"] == settings.AWS_STORAGE_BUCKET_NAME
+    assert pipeline_vars["artifacts_bucket_name"] == "ol-eng-artifacts"
+    assert pipeline_vars["static_api_base_url_draft"] == settings.OCW_STUDIO_DRAFT_URL
+    assert pipeline_vars["static_api_base_url_live"] == settings.OCW_STUDIO_LIVE_URL
     if is_dev:
-        assert vars["resource_base_url_draft"] == settings.RESOURCE_BASE_URL_DRAFT
-        assert vars["resource_base_url_live"] == settings.RESOURCE_BASE_URL_LIVE
-        assert vars["ocw_studio_url"] == "http://10.1.0.102:8043"
+        assert pipeline_vars["resource_base_url_draft"] == settings.RESOURCE_BASE_URL_DRAFT
+        assert pipeline_vars["resource_base_url_live"] == settings.RESOURCE_BASE_URL_LIVE
+        assert pipeline_vars["ocw_studio_url"] == "http://10.1.0.102:8043"
     else:
-        assert vars["resource_base_url_draft"] == ""
-        assert vars["resource_base_url_live"] == ""
-        assert vars["ocw_studio_url"] == settings.SITE_BASE_URL
+        assert pipeline_vars["resource_base_url_draft"] == ""
+        assert pipeline_vars["resource_base_url_live"] == ""
+        assert pipeline_vars["ocw_studio_url"] == settings.SITE_BASE_URL
 
 
 @pytest.mark.parametrize("build_target", [TARGET_OFFLINE, TARGET_ONLINE])

--- a/content_sync/utils_test.py
+++ b/content_sync/utils_test.py
@@ -175,18 +175,24 @@ def test_get_common_pipeline_vars(settings, mocker, is_dev):
     assert pipeline_vars["preview_bucket_name"] == settings.AWS_PREVIEW_BUCKET_NAME
     assert pipeline_vars["publish_bucket_name"] == settings.AWS_PUBLISH_BUCKET_NAME
     assert (
-        pipeline_vars["offline_preview_bucket_name"] == settings.AWS_OFFLINE_PREVIEW_BUCKET_NAME
+        pipeline_vars["offline_preview_bucket_name"]
+        == settings.AWS_OFFLINE_PREVIEW_BUCKET_NAME
     )
     assert (
-        pipeline_vars["offline_publish_bucket_name"] == settings.AWS_OFFLINE_PUBLISH_BUCKET_NAME
+        pipeline_vars["offline_publish_bucket_name"]
+        == settings.AWS_OFFLINE_PUBLISH_BUCKET_NAME
     )
     assert pipeline_vars["storage_bucket_name"] == settings.AWS_STORAGE_BUCKET_NAME
     assert pipeline_vars["artifacts_bucket_name"] == "ol-eng-artifacts"
     assert pipeline_vars["static_api_base_url_draft"] == settings.OCW_STUDIO_DRAFT_URL
     assert pipeline_vars["static_api_base_url_live"] == settings.OCW_STUDIO_LIVE_URL
     if is_dev:
-        assert pipeline_vars["resource_base_url_draft"] == settings.RESOURCE_BASE_URL_DRAFT
-        assert pipeline_vars["resource_base_url_live"] == settings.RESOURCE_BASE_URL_LIVE
+        assert (
+            pipeline_vars["resource_base_url_draft"] == settings.RESOURCE_BASE_URL_DRAFT
+        )
+        assert (
+            pipeline_vars["resource_base_url_live"] == settings.RESOURCE_BASE_URL_LIVE
+        )
         assert pipeline_vars["ocw_studio_url"] == "http://10.1.0.102:8043"
     else:
         assert pipeline_vars["resource_base_url_draft"] == ""


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1936

# Description (What does it do?)
This PR:
 - Renames `content_sync/utils/get_template_vars` to `get_common_pipeline_vars` to more accurately describe what it does
 - Adds a test for said function
 - Adds `static_api_base_url_draft` and `static_api_base_url_live` to the dict returned by said function, setting them to `settings.OCW_STUDIO_DRAFT_URL` and `settings.OCW_STUDIO_LIVE_URL` respectively

# How can this be tested?
 - Make sure you have a recently restored `ocw-studio` database from production
 - In your `.env`, set:
```
OCW_STUDIO_DRAFT_URL=https://draft.ocw.mit.edu/
OCW_STUDIO_LIVE_URL=https://live.ocw.mit.edu/
```
 - Run `docker-compose exec web ./manage.py shell` and execute the following:
```python
import json
from urllib.parse import quote
from content_sync.constants import VERSION_DRAFT, VERSION_LIVE
from websites.models import *
from content_sync.pipelines.definitions.concourse.mass_build_sites import (
    MassBuildSitesPipelineDefinitionConfig,
    MassBuildSitesPipelineDefinition
)

version = VERSION_DRAFT
offline = False

publish_date_field = (
    "publish_date" if version == VERSION_LIVE else "draft_publish_date"
)

# Get all sites, minus any sites that have never been successfully published
sites = Website.objects.exclude(
    Q(**{f"{publish_date_field}__isnull": True}) | Q(url_path__isnull=True)
)
sites = sites.prefetch_related("starter").order_by("name")
pipeline_config = MassBuildSitesPipelineDefinitionConfig(
    sites=sites,
    version=version,
    ocw_studio_url="http://10.1.0.102:8043",
    artifacts_bucket="ol-eng-artifacts",
    site_content_branch="preview",
    ocw_hugo_themes_branch="main",
    ocw_hugo_projects_branch="main",
    offline=offline,
    instance_vars=f"?vars={quote(json.dumps({'offline': offline, 'prefix': '', 'projects_branch': 'main', 'themes_branch': 'main', 'starter': '', 'version': 'draft'}))}"
)
pipeline_definition = MassBuildSitesPipelineDefinition(config=pipeline_config)
f = open(f"mass-build-pipeline-test-{'offline' if offline else 'online'}.json", "w")
f.write(pipeline_definition.json(indent=2, by_alias=True))
f.close()
```
 - Inspect the resulting `mass-build-pipeline-test-online.json` pipeline definition and ensure that you see `"static_api_url": "https://draft.ocw.mit.edu/"` in the `across` section
 - Push the pipeline up to your local Concourse using the instructions in [this PR](https://github.com/mitodl/ocw-studio/pull/1923) and run it, ensuring you can get through at least one batch of sites

# Additional Context
This PR does not address the usage of `settings.STATIC_API_BASE_URL` in `concourse.py`, as the code that generates the site and mass build pipelines there will soon be replaced by https://github.com/mitodl/ocw-studio/pull/1931 and the soon to come PR that will start using `MassBuildSitesPipelineDefinition` there as well.
