### PR TITLE
explicitly set inputs to a blank list on put steps that don't need them

### DIFF
--- a/content_sync/pipelines/definitions/concourse/common/steps.py
+++ b/content_sync/pipelines/definitions/concourse/common/steps.py
@@ -134,6 +134,7 @@ class SlackAlertStep(TryStep):
                         put=SLACK_ALERT_RESOURCE_IDENTIFIER,
                         timeout="1m",
                         params={"alert_type": alert_type, "text": text},
+                        inputs=[]
                     )
                 ]
             ),
@@ -196,6 +197,7 @@ class OcwStudioWebhookStep(TryStep):
                 params={
                     "text": json.dumps({"version": pipeline_name, "status": status})
                 },
+                inputs=[]
             ),
             **kwargs,
         )
@@ -225,6 +227,7 @@ class OpenDiscussionsWebhookStep(TryStep):
                         }
                     )
                 },
+                inputs=[]
             ),
             **kwargs,
         )

--- a/content_sync/pipelines/definitions/concourse/common/steps.py
+++ b/content_sync/pipelines/definitions/concourse/common/steps.py
@@ -134,7 +134,7 @@ class SlackAlertStep(TryStep):
                         put=SLACK_ALERT_RESOURCE_IDENTIFIER,
                         timeout="1m",
                         params={"alert_type": alert_type, "text": text},
-                        inputs=[]
+                        inputs=[],
                     )
                 ]
             ),
@@ -197,7 +197,7 @@ class OcwStudioWebhookStep(TryStep):
                 params={
                     "text": json.dumps({"version": pipeline_name, "status": status})
                 },
-                inputs=[]
+                inputs=[],
             ),
             **kwargs,
         )
@@ -227,7 +227,7 @@ class OpenDiscussionsWebhookStep(TryStep):
                         }
                     )
                 },
-                inputs=[]
+                inputs=[],
             ),
             **kwargs,
         )

--- a/content_sync/pipelines/definitions/concourse/common/steps_test.py
+++ b/content_sync/pipelines/definitions/concourse/common/steps_test.py
@@ -15,6 +15,7 @@ from content_sync.pipelines.definitions.concourse.common.steps import (
 
 @pytest.mark.parametrize("step_type", [GetStep, PutStep, TaskStep])
 def test_add_error_handling(step_type):
+    """ensure that add_error_handling has all the correct steps"""
     mock_step = step_type()
     add_error_handling(
         step=mock_step,
@@ -32,6 +33,7 @@ def test_add_error_handling(step_type):
 
 
 def test_add_error_handling_incorrect_type():
+    """calling add_error_handling with the wrong type of step should throw a TypeError"""
     with pytest.raises(TypeError):
         mock_step = Step()
         add_error_handling(
@@ -45,6 +47,7 @@ def test_add_error_handling_incorrect_type():
 
 @pytest.mark.parametrize("step_type", [GetStep, PutStep, TaskStep])
 def test_calling_add_error_handling_twice(step_type):
+    """calling add_error_handling twice on the same step should throw a ValueError"""
     mock_step = step_type()
     add_error_handling(
         step=mock_step,
@@ -64,6 +67,7 @@ def test_calling_add_error_handling_twice(step_type):
 
 
 def test_put_steps_empty_inputs():
+    """steps that extend PutStep and don't need inputs should explicitly set them to a blank list"""
     assert (
         json.loads(
             OcwStudioWebhookStep(

--- a/content_sync/pipelines/definitions/concourse/common/steps_test.py
+++ b/content_sync/pipelines/definitions/concourse/common/steps_test.py
@@ -1,10 +1,12 @@
 """Tests for Concourse Steps"""
+import json
 import pytest
 from ol_concourse.lib.models.pipeline import GetStep, PutStep, Step, TaskStep
 
 from content_sync.pipelines.definitions.concourse.common.steps import (
     ErrorHandlingStep,
     OcwStudioWebhookStep,
+    OpenDiscussionsWebhookStep,
     SlackAlertStep,
     add_error_handling,
 )
@@ -58,3 +60,31 @@ def test_calling_add_error_handling_twice(step_type):
             short_id="test-site",
             instance_vars="?site:test-site",
         )
+
+
+def test_put_steps_empty_inputs():
+    assert (
+        json.loads(
+            OcwStudioWebhookStep(
+                pipeline_name="test_pipeline", status="test_status"
+            ).model_dump_json(by_alias=True)
+        )["try"]["inputs"]
+        == []
+    )
+    assert (
+        json.loads(
+            OpenDiscussionsWebhookStep(
+                pipeline_name="test_pipeline",
+                site_url="http://ocw.mit.edu/courses/test_course",
+            ).model_dump_json(by_alias=True)
+        )["try"]["inputs"]
+        == []
+    )
+    assert (
+        json.loads(
+            SlackAlertStep(alert_type="test_alert", text="test alert").model_dump_json(
+                by_alias=True
+            )
+        )["try"]["do"][0]["inputs"]
+        == []
+    )

--- a/content_sync/pipelines/definitions/concourse/common/steps_test.py
+++ b/content_sync/pipelines/definitions/concourse/common/steps_test.py
@@ -1,5 +1,6 @@
 """Tests for Concourse Steps"""
 import json
+
 import pytest
 from ol_concourse.lib.models.pipeline import GetStep, PutStep, Step, TaskStep
 

--- a/content_sync/pipelines/definitions/concourse/mass_build_sites.py
+++ b/content_sync/pipelines/definitions/concourse/mass_build_sites.py
@@ -302,7 +302,7 @@ class MassBuildSitesPipelineDefinition(Pipeline):
                     PutStep(
                         put=f"{MASS_BUILD_SITES_BATCH_GATE_IDENTIFIER}-{batch_number}",
                         params={"mapping": "timestamp = now()"},
-                        inputs=[]
+                        inputs=[],
                     )
                 )
             jobs.append(

--- a/content_sync/pipelines/definitions/concourse/mass_build_sites.py
+++ b/content_sync/pipelines/definitions/concourse/mass_build_sites.py
@@ -302,6 +302,7 @@ class MassBuildSitesPipelineDefinition(Pipeline):
                     PutStep(
                         put=f"{MASS_BUILD_SITES_BATCH_GATE_IDENTIFIER}-{batch_number}",
                         params={"mapping": "timestamp = now()"},
+                        inputs=[]
                     )
                 )
             jobs.append(

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -773,7 +773,7 @@ class SitePipelineDefinition(Pipeline):
             step=PutStep(
                 put=self._offline_build_gate_identifier,
                 params={"mapping": "timestamp = now()"},
-                inputs=[]
+                inputs=[],
             ),
             step_description=f"{self._offline_build_gate_identifier} task step",
             pipeline_name=config.vars["pipeline_name"],

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -773,6 +773,7 @@ class SitePipelineDefinition(Pipeline):
             step=PutStep(
                 put=self._offline_build_gate_identifier,
                 params={"mapping": "timestamp = now()"},
+                inputs=[]
             ),
             step_description=f"{self._offline_build_gate_identifier} task step",
             pipeline_name=config.vars["pipeline_name"],


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1938

# Description (What does it do?)
This PR fixes an issue caused by not explicitly setting `inputs` to a blank list on objects of type `PutStep`. By default, the `put` step pulls in *all* outputs as inputs which causes major issues if any steps in the pipeline are outputting large amounts of data.

# How can this be tested?
This cannot actually be tested locally, because volume streaming is not a thing when running Concourse through Docker.

# Additional Context
This issue was found while testing the new `MassBuildSitesPipelineDefinition` in RC, where volume streaming is enabled and sites with large amounts of archive videos exist.
