### PR TITLE
fix non-dev upsert_theme_assets_pipeline

### DIFF
--- a/content_sync/conftest.py
+++ b/content_sync/conftest.py
@@ -5,6 +5,12 @@ from types import SimpleNamespace
 import pytest
 
 
+@pytest.fixture(params=["dev", "not_dev"])
+def mock_environments(settings, request):
+    settings.OCW_STUDIO_ENVIRONMENT = request.param
+    settings.ENV_NAME = request.param
+
+
 @pytest.fixture
 def mock_branches(settings, mocker):
     """Return mock github branches with names"""

--- a/content_sync/conftest.py
+++ b/content_sync/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 @pytest.fixture(params=["dev", "not_dev"])
 def mock_environments(settings, request):
+    """Fixture that tests with dev vs non-dev environment"""
     settings.OCW_STUDIO_ENVIRONMENT = request.param
     settings.ENV_NAME = request.param
 

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -358,8 +358,6 @@ class ThemeAssetsPipeline(GeneralPipeline, BaseThemeAssetsPipeline):
         """Upsert the theme assets pipeline"""
         template_vars = get_template_vars()
         pipeline_definition = ThemeAssetsPipelineDefinition(
-            ocw_studio_url=template_vars["ocw_studio_url"],
-            pipeline_name=self.PIPELINE_NAME,
             artifacts_bucket=template_vars["artifacts_bucket_name"],
             preview_bucket=template_vars["preview_bucket_name"],
             publish_bucket=template_vars["publish_bucket_name"],

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -358,6 +358,8 @@ class ThemeAssetsPipeline(GeneralPipeline, BaseThemeAssetsPipeline):
         """Upsert the theme assets pipeline"""
         template_vars = get_template_vars()
         pipeline_definition = ThemeAssetsPipelineDefinition(
+            ocw_studio_url=template_vars["ocw_studio_url"],
+            pipeline_name=self.PIPELINE_NAME,
             artifacts_bucket=template_vars["artifacts_bucket_name"],
             preview_bucket=template_vars["preview_bucket_name"],
             publish_bucket=template_vars["publish_bucket_name"],

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -362,7 +362,6 @@ class ThemeAssetsPipeline(GeneralPipeline, BaseThemeAssetsPipeline):
             preview_bucket=template_vars["preview_bucket_name"],
             publish_bucket=template_vars["publish_bucket_name"],
             ocw_hugo_themes_branch=self.BRANCH,
-            instance_vars=self.instance_vars,
         )
         self.upsert_config(pipeline_definition.json(), self.PIPELINE_NAME)
 


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1940

# Description (What does it do?)
This PR removes the use of `add_error_handling` from `ThemeAssetsPipelineDefinition` and just adds the CDN cache clear steps on their own. Pipeline level Slack alerts are already added for this pipeline that will trigger in the event of failure. An issue with how `is_dev` was mocked in the test that led to this not being discovered was also fixed.

In https://github.com/mitodl/ocw-studio/pull/1896 we added an `ol-concourse` based pipeline definition for the theme assets pipeline, implementing it for use in https://github.com/mitodl/ocw-studio/pull/1929. It turns out that the way we were mocking `is_dev` in the tests does not actually work properly, although it seemed to locally if your `OCW_STUDIO_ENVIRONMENT` was set to `dev`. Upon actually trying to use `upsert_theme_assets_pipeline` in a prod-like environment where `is_dev` returns false, it was noticed that there was a problem. The `add_error_handling` function expects a site to call back to `ocw-studio` to set a status on with a webhook. With the theme assets pipeline we don't have that, so `ocw-studio` webhooks shouldn't have been added in the first place, although the error was caused by the resource for that not being added to the pipeline.

# How can this be tested?
 - Set your `OCW_STUDIO_ENVIRONMENT` value to `dev` in your `.env` file and run the following:
   - `docker-compose exec web pytest content_sync/pipelines/definitions/concourse/theme_assets_pipeline_test.py -vvvvvv -s` - The tests should pass
   - `docker-compose exec web ./manage.py upsert_theme_assets_pipeline` - The pipeline should be upserted successfully
 - Set `OCW_STUDIO_ENVIRONMENT` to `not_dev` and restart your containers, then repeat the above, assuring that both conditions are still met
 
Note that if you try and run the pipeline in Concourse after pushing it up with `not_dev`, the pipeline will fail because the Minio endpoint will not be set

# Additional Context
Related to the above, the mocking of `is_dev` is likely not functioning as intended elsewhere in the project and a follow-up PR should replace this with the use of the fixture added in this PR, `mock_environments`
