### PR TITLE
fix ClearCdnCacheStep

### DIFF
--- a/content_sync/conftest.py
+++ b/content_sync/conftest.py
@@ -12,6 +12,12 @@ def mock_environments(settings, request):
     settings.ENV_NAME = request.param
 
 
+@pytest.fixture(params=[True, False])
+def mock_concourse_hard_purge(settings, request):
+    """Fixture that tests with True and False for settings.CONCOURSE_HARD_PURGE"""
+    settings.CONCOURSE_HARD_PURGE = request.param
+
+
 @pytest.fixture
 def mock_branches(settings, mocker):
     """Return mock github branches with names"""

--- a/content_sync/pipelines/definitions/concourse/common/steps.py
+++ b/content_sync/pipelines/definitions/concourse/common/steps.py
@@ -173,7 +173,7 @@ class ClearCdnCacheStep(TaskStep):
             config=TaskConfig(
                 platform="linux",
                 image_resource=CURL_REGISTRY_IMAGE,
-                run=Command(path="sh", args=curl_args),
+                run=Command(path="curl", args=curl_args),
             ),
             **kwargs,
         )

--- a/content_sync/pipelines/definitions/concourse/common/steps.py
+++ b/content_sync/pipelines/definitions/concourse/common/steps.py
@@ -161,7 +161,7 @@ class ClearCdnCacheStep(TaskStep):
             "-H",
             f"Fastly-Key: (({fastly_var}.api_token))",
         ]
-        if settings.CONCOURSE_HARD_PURGE:
+        if not settings.CONCOURSE_HARD_PURGE:
             curl_args.extend(["-H", "Fastly-Soft-Purge: 1"])
         curl_args.append(
             f"https://api.fastly.com/service/(({fastly_var}.service_id))/purge/{site_name}"

--- a/content_sync/pipelines/definitions/concourse/common/steps.py
+++ b/content_sync/pipelines/definitions/concourse/common/steps.py
@@ -159,10 +159,10 @@ class ClearCdnCacheStep(TaskStep):
             "-X",
             "POST",
             "-H",
-            f"Fastly-Key: '(({fastly_var}.api_token))'",
+            f"Fastly-Key: (({fastly_var}.api_token))",
         ]
         if settings.CONCOURSE_HARD_PURGE:
-            curl_args.extend(["-H", "'Fastly-Soft-Purge: 1'"])
+            curl_args.extend(["-H", "Fastly-Soft-Purge: 1"])
         curl_args.append(
             f"https://api.fastly.com/service/(({fastly_var}.service_id))/purge/{site_name}"
         )

--- a/content_sync/pipelines/definitions/concourse/common/steps_test.py
+++ b/content_sync/pipelines/definitions/concourse/common/steps_test.py
@@ -153,9 +153,9 @@ def test_clear_cdn_cache_step(settings, mock_concourse_hard_purge):
         assert "'" not in arg
     assert f"Fastly-Key: (({fastly_var}.api_token))" in rendered_args
     if settings.CONCOURSE_HARD_PURGE:
-        assert f"Fastly-Soft-Purge: 1" not in rendered_args
+        assert "Fastly-Soft-Purge: 1" not in rendered_args
     else:
-        assert f"Fastly-Soft-Purge: 1" in rendered_args
+        assert "Fastly-Soft-Purge: 1" in rendered_args
     assert (
         f"https://api.fastly.com/service/(({fastly_var}.service_id))/purge/{site_name}"
         in rendered_args

--- a/content_sync/pipelines/definitions/concourse/common/steps_test.py
+++ b/content_sync/pipelines/definitions/concourse/common/steps_test.py
@@ -148,7 +148,6 @@ def test_clear_cdn_cache_step(settings, mock_concourse_hard_purge):
         site_name=site_name,
     )
     rendered_step = json.loads(clear_cdn_cache_step.model_dump_json())
-    print(rendered_step)
     rendered_args = rendered_step["config"]["run"]["args"]
     for arg in rendered_args:
         assert "'" not in arg

--- a/content_sync/pipelines/definitions/concourse/common/steps_test.py
+++ b/content_sync/pipelines/definitions/concourse/common/steps_test.py
@@ -3,12 +3,19 @@ import json
 
 import pytest
 from django.test import override_settings
-from ol_concourse.lib.models.pipeline import GetStep, PutStep, Step, TaskStep
+from ol_concourse.lib.models.pipeline import (
+    GetStep,
+    Identifier,
+    PutStep,
+    Step,
+    TaskStep,
+)
 
 from content_sync.pipelines.definitions.concourse.common.identifiers import (
     SITE_CONTENT_GIT_IDENTIFIER,
 )
 from content_sync.pipelines.definitions.concourse.common.steps import (
+    ClearCdnCacheStep,
     ErrorHandlingStep,
     OcwStudioWebhookStep,
     OpenDiscussionsWebhookStep,
@@ -128,3 +135,29 @@ def test_site_content_git_task_step(
         else:
             assert f"git clone -b {branch} https://{settings.GIT_DOMAIN}/{settings.GIT_ORGANIZATION}/{short_id}.git ./{SITE_CONTENT_GIT_IDENTIFIER}"
             assert step_output["params"] == {}
+
+
+def test_clear_cdn_cache_step(settings, mock_concourse_hard_purge):
+    """assert that the ClearCdnCacheStep renders with the correct attributes"""
+    name = Identifier("clear-cdn-cache-test")
+    fastly_var = "fastly_test"
+    site_name = "test_site"
+    clear_cdn_cache_step = ClearCdnCacheStep(
+        name=name,
+        fastly_var=fastly_var,
+        site_name=site_name,
+    )
+    rendered_step = json.loads(clear_cdn_cache_step.model_dump_json())
+    print(rendered_step)
+    rendered_args = rendered_step["config"]["run"]["args"]
+    for arg in rendered_args:
+        assert "'" not in arg
+    assert f"Fastly-Key: (({fastly_var}.api_token))" in rendered_args
+    if settings.CONCOURSE_HARD_PURGE:
+        assert f"Fastly-Soft-Purge: 1" not in rendered_args
+    else:
+        assert f"Fastly-Soft-Purge: 1" in rendered_args
+    assert (
+        f"https://api.fastly.com/service/(({fastly_var}.service_id))/purge/{site_name}"
+        in rendered_args
+    )

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -532,7 +532,7 @@ class SitePipelineOnlineTasks(list[StepModifierMixin]):
         clear_cdn_cache_online_step = add_error_handling(
             step=ClearCdnCacheStep(
                 name=CLEAR_CDN_CACHE_IDENTIFIER,
-                fastly_var="fastly",
+                fastly_var=f"fastly_{config.values['pipeline_name']}",
                 site_name=config.vars["site_name"],
             ),
             step_description="clear cdn cache",
@@ -707,7 +707,7 @@ class SitePipelineOfflineTasks(list[StepModifierMixin]):
         clear_cdn_cache_offline_step = add_error_handling(
             ClearCdnCacheStep(
                 name=CLEAR_CDN_CACHE_IDENTIFIER,
-                fastly_var="fastly",
+                fastly_var=f"fastly_{config.values['pipeline_name']}",
                 site_name=config.vars["site_name"],
             ),
             step_description="clear cdn cache",


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1943

# Description (What does it do?)
This PR fixes a number of issues with `ClearCdnCacheStep`, including:

 - The `path` property on the `Command` in the `run` property is just plain wrong; it's `sh` when it should be `curl`
 - When pushing up JSON pipeline definitions to Concourse, strings in the `args` field that have a space in them are automatically wrapped in single quotes. If you add manual single quotes, you will get doubles. This isn't the case for YAML, where if you wrap a string in single quotes you only end up with that set of single quotes.
 - The `settings.CONCOURSE_HARD_PURGE` boolean was being evaluated incorrectly
 - The use of `ClearCdnCacheStep` in the online and offline steps of `site_pipeline.py` were not properly setting `fastly_var`

A new test was added to make sure `ClearCdnCacheStep` renders properly.

# How can this be tested?
This needs to be tested in RC, as the fastly service ID and API token are stored in Vault. Nonetheless, you should still be able to run `docker-compose exec web ./manage.py upsert_theme_assets_pipeline` with your `OCW_STUDIO_ENVIRONMENT` set to values other than `dev` and not get an error.  If you try and run the pipeline, you will get an error about the `fastly_draft` / `fastly_live` vars missing.

