### PR TITLE
set check_every: never on SiteContentGitResource

### DIFF
--- a/content_sync/pipelines/definitions/concourse/common/resources.py
+++ b/content_sync/pipelines/definitions/concourse/common/resources.py
@@ -208,4 +208,10 @@ class SiteContentGitResource(GitResource):
         else:
             uri = f"https://{settings.GIT_DOMAIN}/{settings.GIT_ORGANIZATION}/{short_id}.git"
             private_key = None
-        super().__init__(uri=uri, branch=branch, private_key=private_key, **kwargs)
+        super().__init__(
+            uri=uri,
+            branch=branch,
+            check_every="never",
+            private_key=private_key,
+            **kwargs,
+        )

--- a/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
@@ -145,6 +145,8 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
 
     # Assert that the expected resources exist and have the expected properties
     resources = rendered_definition["resources"]
+    for resource in resources:
+        assert resource["check_every"] == "never"
     webpack_manifest_s3_resource = get_dict_list_item_by_field(
         items=resources, field="name", value=WEBPACK_MANIFEST_S3_IDENTIFIER
     )


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1950

# Description (What does it do?)
This PR sets `check_every: never` on `SiteContentGitResource`. A test was also added to ensure that `check_every: never` is set on all resources in `SitePipelineDefinition`.

# How can this be tested?
There is no real way to test this locally, although you you could try to crash your local Concourse by running `docker compose exec web ./manage.py backpopulate_pipelines` on `master`. The argument prevents an automatic check being run on `site-content-git` for every site, as to not create thousands of simultaneous containers.
