### PR TITLE
optimize site_pipeline_test and mass_build_sites_test

### DIFF
--- a/content_sync/conftest.py
+++ b/content_sync/conftest.py
@@ -4,6 +4,15 @@ from types import SimpleNamespace
 
 import pytest
 
+from websites.models import Website, WebsiteStarter
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_keyboard_interrupt(excinfo):  # noqa: ARG001
+    """If tests are aborted locally with SIGINT, clean up models"""
+    Website.objects.all().delete()
+    WebsiteStarter.objects.all().delete()
+
 
 @pytest.fixture(params=["dev", "not_dev"])
 def mock_environments(settings, request):  # noqa: PT004

--- a/content_sync/pipelines/definitions/concourse/mass_build_sites_test.py
+++ b/content_sync/pipelines/definitions/concourse/mass_build_sites_test.py
@@ -1,6 +1,5 @@
 import json
 import os
-from itertools import chain
 from urllib.parse import quote, urljoin
 
 import pytest
@@ -32,8 +31,29 @@ from content_sync.pipelines.definitions.concourse.site_pipeline import (
 from main.utils import get_dict_list_item_by_field
 from websites.constants import OCW_HUGO_THEMES_GIT, STARTER_SOURCE_GITHUB
 from websites.factories import WebsiteFactory, WebsiteStarterFactory
+from websites.models import Website, WebsiteStarter
 
 pytestmark = pytest.mark.django_db
+total_sites = 6
+ocw_hugo_projects_path = "https://github.com/org/repo"
+
+
+@pytest.fixture(scope="module")
+def websites(django_db_setup, django_db_blocker):
+    with django_db_blocker.unblock():
+        root_starter = WebsiteStarterFactory.create(
+            source=STARTER_SOURCE_GITHUB,
+            path=ocw_hugo_projects_path,
+            slug="root-website",
+        )
+        starter = WebsiteStarterFactory.create(
+            source=STARTER_SOURCE_GITHUB, path=ocw_hugo_projects_path
+        )
+        WebsiteFactory.create(starter=root_starter)
+        WebsiteFactory.create_batch(total_sites, starter=starter)
+        yield Website.objects.all()
+        Website.objects.all().delete()
+        WebsiteStarter.objects.all().delete()
 
 
 @pytest.mark.parametrize("version", [VERSION_DRAFT, VERSION_LIVE])
@@ -44,6 +64,7 @@ pytestmark = pytest.mark.django_db
 @pytest.mark.parametrize("offline", [True, False])
 @pytest.mark.parametrize("is_dev", [True, False])
 def test_generate_mass_build_sites_definition(  # noqa: C901, PLR0913, PLR0915
+    websites,
     settings,
     mocker,
     version,
@@ -65,7 +86,6 @@ def test_generate_mass_build_sites_definition(  # noqa: C901, PLR0913, PLR0915
     settings.OCW_MASS_BUILD_BATCH_SIZE = 2
     settings.OCW_MASS_BUILD_MAX_IN_FLIGHT = 2
     settings.ENV_NAME = env_name
-    total_sites = 6
     batch_count = total_sites / settings.OCW_MASS_BUILD_BATCH_SIZE
     mock_is_dev = mocker.patch(
         "content_sync.pipelines.definitions.concourse.site_pipeline.is_dev"
@@ -88,25 +108,10 @@ def test_generate_mass_build_sites_definition(  # noqa: C901, PLR0913, PLR0915
         else settings.AWS_OFFLINE_PUBLISH_BUCKET_NAME
     )
     instance_vars = f"?vars={quote(json.dumps({'offline': False, 'prefix': '', 'projects_branch': 'main', 'themes_branch': 'main', 'starter': '', 'version': 'draft'}))}"
-    ocw_hugo_projects_path = "https://github.com/org/repo"
     ocw_hugo_projects_url = f"{ocw_hugo_projects_path}.git"
     ocw_studio_url = settings.SITE_BASE_URL
-    root_starter = WebsiteStarterFactory.create(
-        source=STARTER_SOURCE_GITHUB,
-        path=ocw_hugo_projects_path,
-        slug=settings.ROOT_WEBSITE_NAME,
-    )
-    starter = WebsiteStarterFactory.create(
-        source=STARTER_SOURCE_GITHUB, path=ocw_hugo_projects_path
-    )
-    sites = list(
-        chain(
-            WebsiteFactory.create_batch(1, starter=root_starter),
-            WebsiteFactory.create_batch(total_sites, starter=starter),
-        )
-    )
     pipeline_config = MassBuildSitesPipelineDefinitionConfig(
-        sites=sites,
+        sites=websites,
         version=version,
         ocw_studio_url=ocw_studio_url,
         artifacts_bucket=artifacts_bucket,
@@ -239,7 +244,7 @@ def test_generate_mass_build_sites_definition(  # noqa: C901, PLR0913, PLR0915
                 across_vars = step["across"][0]
                 assert across_vars["var"] == "site"
                 for across_values in across_vars["values"]:
-                    site = sites.get(short_id=across_values["short_id"])
+                    site = websites.get(short_id=across_values["short_id"])
                     site_config = SitePipelineDefinitionConfig(
                         site=site,
                         pipeline_name="test",


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1954

# Description (What does it do?)
This PR takes the tests in `mass_build_sites_test.py` and `site_pipeline_test.py` and breaks out their database activities to module scoped fixtures. The tests in these files are parameterized, running hundreds of copies of the same tests with lots of combinations of inputs. Currently, they access the database and create objects with each parameterized run. This PR uses a module scoped fixture and `django_db_blocker.unblock()` to create the necessary objects once before the parameterized tests run and then clean up afterward, greatly reducing the amount of time the tests take to run.

# How can this be tested?
 - Spin up `ocw-studio` on the `master` branch
 - Run the following tests:
   - `docker-compose exec web pytest content_sync/pipelines/definitions/concourse/site_pipeline_test.py -vvvvvv`
   - `docker-compose exec web pytest content_sync/pipelines/definitions/concourse/mass_build_sites_test.py -vvvvvv`
 - Check out `cg/optimize-tests` and run the same commands, verify that they run faster
 - Run the above multiple times on this branch to confirm that you get the same results every time
 - In the middle of one of the runs, hit ctrl c to stop the tests, then try them again and verify that they still pass
