### PR TITLE
ignore the s3 directory when running pytest and black

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ exclude = '''
   | build
   | dist
   | node_modules
+  | s3
 )/
 '''
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 addopts = --cov . --cov-report term --cov-report html --cov-report xml --ds=main.settings --reuse-db
-norecursedirs = node_modules .git static templates .* CVS _darcs {arch} *.egg
+norecursedirs = node_modules .git static templates .* CVS _darcs {arch} *.egg s3
 filterwarnings =
     error
     ignore::DeprecationWarning


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1958

# Description (What does it do?)
This PR adds the `s3` directory to a few more places where it should be ignored. In `pytest.ini`, it was added to `norecursedirs`, and in `pyproject.toml` it was added to the `exclude` property of `tool.black`

# How can this be tested?
 - Spin up `ocw-studio` on `master`
 - Put a bunch of files in your local Minio, either by building a lot of sites or manually uploading a lot (1000+) small files to it. The more files, the bigger difference you will notice.
 - Run `docker compose exec web pytest`
 - Depending on the amount of files in Minio, collecting tests could take a very long time. You do not need to let all the tests run.
 - Check out this PR branch
 - Run pytest again, and collecting tests should take a matter of seconds regardless of what you have in Minio
