### PR TITLE
consolidate arguments in new pipeline definitions

### DIFF
--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -45,6 +45,7 @@ from content_sync.utils import (
     check_mandatory_settings,
     get_common_pipeline_vars,
     get_hugo_arg_string,
+    get_ocw_studio_api_url,
     get_theme_branch,
     strip_dev_lines,
     strip_non_dev_lines,
@@ -479,7 +480,6 @@ class SitePipeline(BaseSitePipeline, GeneralPipeline):
                 web_bucket=web_bucket,
                 offline_bucket=offline_bucket,
                 resource_base_url=resource_base_url,
-                ocw_studio_url=pipeline_vars["ocw_studio_url"],
                 ocw_hugo_themes_branch=ocw_hugo_themes_branch,
                 ocw_hugo_projects_branch=ocw_hugo_projects_branch,
                 hugo_override_args=self.HUGO_ARGS,
@@ -654,7 +654,7 @@ class MassBuildSitesPipeline(
             .replace("((ocw-hugo-projects-uri))", hugo_projects_url)
             .replace("((ocw-import-starter-slug))", settings.OCW_COURSE_STARTER_SLUG)
             .replace("((ocw-course-starter-slug))", settings.OCW_COURSE_STARTER_SLUG)
-            .replace("((ocw-studio-url))", template_vars["ocw_studio_url"] or "")
+            .replace("((ocw-studio-url))", get_ocw_studio_api_url() or "")
             .replace("((static-api-base-url))", template_vars["static_api_url"] or "")
             .replace("((ocw-studio-bucket))", settings.AWS_STORAGE_BUCKET_NAME or "")
             .replace("((ocw-site-repo-branch))", template_vars["branch"] or "")
@@ -722,7 +722,7 @@ class UnpublishedSiteRemovalPipeline(
             )
             .replace("((web-bucket))", web_bucket)
             .replace("((offline-bucket))", offline_bucket)
-            .replace("((ocw-studio-url))", template_vars["ocw_studio_url"] or "")
+            .replace("((ocw-studio-url))", get_ocw_studio_api_url() or "")
             .replace("((version))", VERSION_LIVE)
             .replace("((api-token))", settings.API_BEARER_TOKEN or "")
             .replace("((open-discussions-url))", settings.OPEN_DISCUSSIONS_URL)

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -31,6 +31,7 @@ from content_sync.pipelines.definitions.concourse.common.identifiers import (
 from content_sync.utils import (
     get_common_pipeline_vars,
     get_hugo_arg_string,
+    get_ocw_studio_api_url,
     get_theme_branch,
 )
 from main.constants import PRODUCTION_NAMES
@@ -344,7 +345,6 @@ def test_upsert_website_pipelines(  # noqa: PLR0913, PLR0915
         data=mocker.ANY,
         headers=({"X-Concourse-Config-Version": "3"} if pipeline_exists else None),
     )
-    expected_ocw_studio_url = expected_template_vars["ocw_studio_url"]
     if version == VERSION_DRAFT:
         _, kwargs = mock_put_headers.call_args_list[0]
         expected_site_content_branch = settings.GIT_BRANCH_PREVIEW
@@ -419,7 +419,6 @@ def test_upsert_website_pipelines(  # noqa: PLR0913, PLR0915
     assert settings.OCW_GTM_ACCOUNT_ID in config_str
     assert settings.OCW_IMPORT_STARTER_SLUG in config_str
     assert settings.OCW_COURSE_STARTER_SLUG in config_str
-    assert expected_ocw_studio_url in config_str
     assert f"aws s3 {expected_endpoint_prefix}sync" in config_str
     assert f'\\"is_root_website\\": {expected_is_root_website}' in config_str
     assert f'\\"short_id\\": \\"{website.short_id}\\"' in config_str
@@ -447,7 +446,6 @@ def test_upsert_website_pipelines(  # noqa: PLR0913, PLR0915
     assert f'\\"web_bucket\\": \\"{expected_web_bucket}\\"' in config_str
     assert f'\\"offline_bucket\\": \\"{expected_offline_bucket}\\"' in config_str
     assert f'\\"resource_base_url\\": \\"{expected_resource_base_url}\\"' in config_str
-    assert f'\\"ocw_studio_url\\": \\"{expected_ocw_studio_url}\\"' in config_str
     assert (
         f'\\"site_content_branch\\": \\"{expected_site_content_branch}\\"' in config_str
     )
@@ -808,7 +806,7 @@ def test_unpublished_site_removal_pipeline(  # noqa: PLR0913
     )
     _, kwargs = mock_put_headers.call_args_list[0]
     config_str = json.dumps(kwargs)
-    assert template_vars["ocw_studio_url"] in config_str
+    assert get_ocw_studio_api_url() in config_str
     assert template_vars["publish_bucket_name"] in config_str
     assert VERSION_LIVE in config_str
 

--- a/content_sync/pipelines/definitions/concourse/common/resources.py
+++ b/content_sync/pipelines/definitions/concourse/common/resources.py
@@ -16,6 +16,7 @@ from content_sync.pipelines.definitions.concourse.common.identifiers import (
     S3_IAM_RESOURCE_TYPE_IDENTIFIER,
     SLACK_ALERT_RESOURCE_IDENTIFIER,
 )
+from content_sync.utils import get_ocw_studio_api_url
 from main.utils import is_dev
 from websites.constants import OCW_HUGO_THEMES_GIT
 
@@ -90,18 +91,17 @@ class OcwStudioWebhookResource(Resource):
     A Resource for making API calls ocw-studio to set a Website's status
 
     args:
-        ocw_studio_url(str): The URL to the instance of ocw-studio to POST to
         site_name(str): The name of the site the status is in reference to
         api_token(str): The ocw-studio API token
     """
 
     def __init__(
         self,
-        ocw_studio_url: str,
         site_name: str,
         api_token: str,
         **kwargs,
     ):
+        ocw_studio_url = get_ocw_studio_api_url()
         api_path = os.path.join(  # noqa: PTH118
             "api", "websites", site_name, "pipeline_status"
         )  # noqa: PTH118, RUF100

--- a/content_sync/pipelines/definitions/concourse/mass_build_sites_test.py
+++ b/content_sync/pipelines/definitions/concourse/mass_build_sites_test.py
@@ -28,6 +28,7 @@ from content_sync.pipelines.definitions.concourse.site_pipeline import (
     FILTER_WEBPACK_ARTIFACTS_IDENTIFIER,
     SitePipelineDefinitionConfig,
 )
+from content_sync.utils import get_ocw_studio_api_url
 from main.utils import get_dict_list_item_by_field
 from websites.constants import OCW_HUGO_THEMES_GIT, STARTER_SOURCE_GITHUB
 from websites.factories import WebsiteFactory, WebsiteStarterFactory
@@ -111,11 +112,10 @@ def test_generate_mass_build_sites_definition(  # noqa: C901, PLR0913, PLR0915
     )
     instance_vars = f"?vars={quote(json.dumps({'offline': False, 'prefix': '', 'projects_branch': 'main', 'themes_branch': 'main', 'starter': '', 'version': 'draft'}))}"
     ocw_hugo_projects_url = f"{ocw_hugo_projects_path}.git"
-    ocw_studio_url = settings.SITE_BASE_URL
+    ocw_studio_url = get_ocw_studio_api_url()
     pipeline_config = MassBuildSitesPipelineDefinitionConfig(
         sites=websites,
         version=version,
-        ocw_studio_url=ocw_studio_url,
         artifacts_bucket=artifacts_bucket,
         site_content_branch=site_content_branch,
         ocw_hugo_themes_branch=ocw_hugo_themes_branch,
@@ -258,7 +258,6 @@ def test_generate_mass_build_sites_definition(  # noqa: C901, PLR0913, PLR0915
                         web_bucket=web_bucket,
                         offline_bucket=offline_bucket,
                         resource_base_url="",
-                        ocw_studio_url=ocw_studio_url,
                         ocw_hugo_themes_branch=ocw_hugo_themes_branch,
                         ocw_hugo_projects_branch=ocw_hugo_projects_branch,
                         hugo_override_args="",

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -386,8 +386,8 @@ class StaticResourcesTaskStep(TaskStep):
     A TaskStep to fetch the static resources for a site from S3
 
     Args:
-        config(SitePipelineDefinitonConfig): The site pipeline configuration for the site we are fetching static resources for
-    """  # noqa: E501
+        pipeline_vars(dict): A dictionary of site pipeline variables
+    """
 
     def __init__(self, pipeline_vars: dict):
         super().__init__(
@@ -425,8 +425,9 @@ class SitePipelineOnlineTasks(list[StepModifierMixin]):
     The tasks used in the online site job
 
     Args:
-        config(SitePipelineDefinitionConfig): The site pipeline configuration object
-    """
+        pipeline_vars(dict): A dictionary of site pipeline variables
+        fastly_var(str): A string to append to fastly_ and form a var name where Fastly connection info is stored
+    """  # noqa: E501
 
     def __init__(self, pipeline_vars: dict, fastly_var: str):
         static_resources_task_step = StaticResourcesTaskStep(
@@ -567,8 +568,9 @@ class SitePipelineOfflineTasks(list[StepModifierMixin]):
     The tasks used in the offline site job
 
     Args:
-        config(SitePipelineDefinitionConfig): The site pipeline configuration object
-    """
+        pipeline_vars(dict): A dictionary of site pipeline variables
+        fastly_var(str): A string to append to fastly_ and form a var name where Fastly connection info is stored
+    """  # noqa: E501
 
     def __init__(self, pipeline_vars: dict, fastly_var: str):
         static_resources_task_step = StaticResourcesTaskStep(

--- a/content_sync/utils.py
+++ b/content_sync/utils.py
@@ -8,6 +8,7 @@ from django.core.exceptions import ImproperlyConfigured
 
 from content_sync.constants import (
     DEV_END,
+    DEV_ENDPOINT_URL,
     DEV_START,
     END_TAG_PREFIX,
     NON_DEV_END,
@@ -114,17 +115,23 @@ def get_common_pipeline_vars():
         "static_api_base_url_live": settings.OCW_STUDIO_LIVE_URL,
         "resource_base_url_draft": "",
         "resource_base_url_live": "",
-        "ocw_studio_url": settings.SITE_BASE_URL,
     }
     if is_dev():
         pipeline_vars.update(
             {
                 "resource_base_url_draft": settings.RESOURCE_BASE_URL_DRAFT,
                 "resource_base_url_live": settings.RESOURCE_BASE_URL_LIVE,
-                "ocw_studio_url": "http://10.1.0.102:8043",
             }
         )
     return pipeline_vars
+
+
+def get_cli_endpoint_url():
+    return f" --endpoint-url {DEV_ENDPOINT_URL}" if is_dev() else ""
+
+
+def get_ocw_studio_api_url():
+    return "http://10.1.0.102:8043" if is_dev() else settings.SITE_BASE_URL
 
 
 def get_theme_branch():

--- a/content_sync/utils_test.py
+++ b/content_sync/utils_test.py
@@ -7,6 +7,7 @@ from moto import mock_s3
 
 from content_sync.constants import (
     DEV_END,
+    DEV_ENDPOINT_URL,
     DEV_START,
     NON_DEV_END,
     NON_DEV_START,
@@ -25,10 +26,12 @@ from content_sync.test_constants import (
 )
 from content_sync.utils import (
     check_matching_tags,
+    get_cli_endpoint_url,
     get_common_pipeline_vars,
     get_destination_filepath,
     get_destination_url,
     get_hugo_arg_string,
+    get_ocw_studio_api_url,
     move_s3_object,
     strip_lines_between,
 )
@@ -202,11 +205,31 @@ def test_get_common_pipeline_vars(settings, mocker, is_dev):
         assert (
             pipeline_vars["resource_base_url_live"] == settings.RESOURCE_BASE_URL_LIVE
         )
-        assert pipeline_vars["ocw_studio_url"] == "http://10.1.0.102:8043"
     else:
         assert pipeline_vars["resource_base_url_draft"] == ""
         assert pipeline_vars["resource_base_url_live"] == ""
-        assert pipeline_vars["ocw_studio_url"] == settings.SITE_BASE_URL
+
+
+@pytest.mark.parametrize("is_dev", [True, False])
+def test_get_cli_endpoint_url(settings, mocker, is_dev):
+    """get_cli_endpoint_url should return the correct value based on environment"""
+    mock_is_dev = mocker.patch("content_sync.utils.is_dev")
+    mock_is_dev.return_value = is_dev
+    cli_endpoint_url = get_cli_endpoint_url()
+    expected_cli_endpoint_url = f" --endpoint-url {DEV_ENDPOINT_URL}" if is_dev else ""
+    assert cli_endpoint_url == expected_cli_endpoint_url
+
+
+@pytest.mark.parametrize("is_dev", [True, False])
+def test_get_ocw_studio_api_url(settings, mocker, is_dev):
+    """get_cli_endpoint_url should return the correct value based on environment"""
+    mock_is_dev = mocker.patch("content_sync.utils.is_dev")
+    mock_is_dev.return_value = is_dev
+    ocw_studio_api_url = get_ocw_studio_api_url()
+    expected_ocw_studio_api_url = (
+        "http://10.1.0.102:8043" if is_dev else settings.SITE_BASE_URL
+    )
+    assert ocw_studio_api_url == expected_ocw_studio_api_url
 
 
 @pytest.mark.parametrize("build_target", [TARGET_OFFLINE, TARGET_ONLINE])


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1962

# Description (What does it do?)
This PR restructures the arguments in `SitePipelineOnlineTasks` and `SitePipelineOfflineTasks` for better use in `MassBuildSitesPipelineDefinition`. Since `MassBuildSitesPipelineDefinition` implements the tasks in these classes on a batch level rather than a site level, it doesn't make sense to get the vars from `SitePipelineDefinitionConfig`. Instead, a dict of vars is passed in along with the Fastly var to use for cache clearing, based on the pipeline being draft or live.

# How can this be tested?
 - Follow the instructions in https://github.com/mitodl/ocw-studio/pull/1931 to smoke test the individual site pipeline
 - Follow the instructions in https://github.com/mitodl/ocw-studio/pull/1923 to smoke test the mass build pipeline
