### PR TITLE
filter out videos during online mass build

### DIFF
--- a/content_sync/pipelines/definitions/concourse/mass_build_sites.py
+++ b/content_sync/pipelines/definitions/concourse/mass_build_sites.py
@@ -273,7 +273,10 @@ class MassBuildSitesPipelineDefinition(Pipeline):
             if not config.offline:
                 site_build_tasks.extend(
                     SitePipelineOnlineTasks(
-                        pipeline_vars=site_pipeline_vars, fastly_var=config.version
+                        pipeline_vars=site_pipeline_vars,
+                        fastly_var=config.version,
+                        destructive_sync=False,
+                        filter_videos=True,
                     )
                 )
             else:


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1965

# Description (What does it do?)
This PR adds two new optional arguments to the constructor of `SitePipelineOnlineTasks`, `destructive_sync` with a default of `True` and `filter_videos` with a default of `False`. This maintains the existing functionality of `SitePipelineDefinition` by default for single site pipelines, but allows this functionality to be overridden in the case of the online version of `MassBuildSitesPipelineDefinition`. Not handling videos during the online mass build keeps the build time down. Since adding videos to every single site is not a thing that ever really happens, this works out well. The single site pipeline will still pull in the videos for a site and publish them, so when a new video is added to a course and it is published they will go live as usual. 

# How can this be tested?
 - Follow the instructions in https://github.com/mitodl/ocw-studio/pull/1931 to smoke test the individual site pipeline
 - Follow the instructions in https://github.com/mitodl/ocw-studio/pull/1923 to smoke test the mass build pipeline
 - While testing the mass build, inspect the `static-resources-s3` step in any given site in the online mass build and ensure that the sync is run with `--exclude *.mp4`
 - Also ensure that during the `upload-online-build` step, the sync is *not* run with `--delete`
