### PR TITLE
Fix legacy closing shortcodes in CKEditor

### DIFF
--- a/static/js/lib/ckeditor/plugins/LegacyShortcodes.ts
+++ b/static/js/lib/ckeditor/plugins/LegacyShortcodes.ts
@@ -188,7 +188,7 @@ class LegacyShortcodeEditing extends CKPlugin {
               el.innerHTML =
                 isSelfClosing.trim() === "true"
                   ? `${shortcode} [self-closing tag]`
-                  : `${shortcode}`
+                  : el.innerHTML
             },
           )
 


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1967.

# Description (What does it do?)
After the update in https://github.com/mitodl/ocw-studio/pull/1961, legacy closing shortcodes were being rendered as `shortcode` instead of `/shortcode`. This PR fixes that issue.

# How can this be tested?
Same testing instructions as for https://github.com/mitodl/ocw-studio/pull/1961; verify that closing shortcodes look correct in CKEditor.