### PR TITLE
fix ocw-studio-webhook URL in MassBuildSitesPipelineDefinition

### DIFF
--- a/content_sync/pipelines/definitions/concourse/mass_build_sites.py
+++ b/content_sync/pipelines/definitions/concourse/mass_build_sites.py
@@ -22,7 +22,6 @@ from content_sync.pipelines.definitions.concourse.common.identifiers import (
     KEYVAL_RESOURCE_TYPE_IDENTIFIER,
     MASS_BUILD_SITES_BATCH_GATE_IDENTIFIER,
     MASS_BUILD_SITES_JOB_IDENTIFIER,
-    MASS_BULID_SITES_PIPELINE_IDENTIFIER,
     OCW_HUGO_PROJECTS_GIT_IDENTIFIER,
     OCW_HUGO_THEMES_GIT_IDENTIFIER,
     WEBPACK_MANIFEST_S3_IDENTIFIER,
@@ -131,6 +130,7 @@ class MassBuildSitesResources(list[Resource]):
     """
 
     def __init__(self, config: MassBuildSitesPipelineDefinitionConfig):
+        site_pipeline_vars = get_site_pipeline_definition_vars("site")
         webpack_manifest_resource = WebpackManifestResource(
             name=WEBPACK_MANIFEST_S3_IDENTIFIER,
             bucket=config.artifacts_bucket,
@@ -149,7 +149,7 @@ class MassBuildSitesResources(list[Resource]):
         self.append(ocw_hugo_projects_resource)
         self.append(
             OcwStudioWebhookResource(
-                site_name=MASS_BULID_SITES_PIPELINE_IDENTIFIER,
+                site_name=site_pipeline_vars["site_name"],
                 api_token=settings.API_BEARER_TOKEN or "",
             )
         )

--- a/content_sync/pipelines/definitions/concourse/mass_build_sites.py
+++ b/content_sync/pipelines/definitions/concourse/mass_build_sites.py
@@ -130,7 +130,7 @@ class MassBuildSitesResources(list[Resource]):
     """
 
     def __init__(self, config: MassBuildSitesPipelineDefinitionConfig):
-        site_pipeline_vars = get_site_pipeline_definition_vars("site")
+        site_pipeline_vars = get_site_pipeline_definition_vars(namespace=".:site.")
         webpack_manifest_resource = WebpackManifestResource(
             name=WEBPACK_MANIFEST_S3_IDENTIFIER,
             bucket=config.artifacts_bucket,
@@ -207,6 +207,7 @@ class MassBuildSitesPipelineDefinition(Pipeline):
         base = super()
         pipeline_vars = get_common_pipeline_vars()
         namespace = ".:site."
+        site_pipeline_vars = get_site_pipeline_definition_vars(namespace)
         resource_types = MassBuildSitesPipelineResourceTypes()
         resources = MassBuildSitesResources(config=config)
         base_tasks = MassBuildSitesPipelineBaseTasks()
@@ -235,7 +236,6 @@ class MassBuildSitesPipelineDefinition(Pipeline):
             if config.offline:
                 tasks.append(filter_webpack_artifacts_step)
             across_var_values = []
-            site_pipeline_vars = get_site_pipeline_definition_vars(namespace)
             if config.version == VERSION_DRAFT:
                 static_api_url = pipeline_vars["static_api_base_url_draft"]
                 web_bucket = pipeline_vars["preview_bucket_name"]

--- a/content_sync/pipelines/definitions/concourse/mass_build_sites_test.py
+++ b/content_sync/pipelines/definitions/concourse/mass_build_sites_test.py
@@ -11,7 +11,6 @@ from content_sync.pipelines.definitions.concourse.common.identifiers import (
     KEYVAL_RESOURCE_TYPE_IDENTIFIER,
     MASS_BUILD_SITES_BATCH_GATE_IDENTIFIER,
     MASS_BUILD_SITES_JOB_IDENTIFIER,
-    MASS_BULID_SITES_PIPELINE_IDENTIFIER,
     OCW_HUGO_PROJECTS_GIT_IDENTIFIER,
     OCW_HUGO_THEMES_GIT_IDENTIFIER,
     OCW_STUDIO_WEBHOOK_RESOURCE_TYPE_IDENTIFIER,
@@ -29,6 +28,7 @@ from content_sync.pipelines.definitions.concourse.site_pipeline import (
     FILTER_WEBPACK_ARTIFACTS_IDENTIFIER,
     UPLOAD_ONLINE_BUILD_IDENTIFIER,
     SitePipelineDefinitionConfig,
+    get_site_pipeline_definition_vars,
 )
 from content_sync.utils import get_ocw_studio_api_url
 from main.utils import get_dict_list_item_by_field
@@ -115,6 +115,7 @@ def test_generate_mass_build_sites_definition(  # noqa: C901, PLR0913, PLR0912 P
     instance_vars = f"?vars={quote(json.dumps({'offline': False, 'prefix': '', 'projects_branch': 'main', 'themes_branch': 'main', 'starter': '', 'version': 'draft'}))}"
     ocw_hugo_projects_url = f"{ocw_hugo_projects_path}.git"
     ocw_studio_url = get_ocw_studio_api_url()
+    site_pipeline_vars = get_site_pipeline_definition_vars("site")
     pipeline_config = MassBuildSitesPipelineDefinitionConfig(
         sites=websites,
         version=version,
@@ -178,7 +179,7 @@ def test_generate_mass_build_sites_definition(  # noqa: C901, PLR0913, PLR0912 P
         items=resources, field="name", value=OCW_STUDIO_WEBHOOK_RESOURCE_TYPE_IDENTIFIER
     )
     expected_api_path = os.path.join(  # noqa: PTH118
-        "api", "websites", MASS_BULID_SITES_PIPELINE_IDENTIFIER, "pipeline_status"
+        "api", "websites", site_pipeline_vars["site_name"], "pipeline_status"
     )
     expected_api_url = urljoin(ocw_studio_url, expected_api_path)
     assert ocw_studio_webhook_resource["source"]["url"] == f"{expected_api_url}/"

--- a/content_sync/pipelines/definitions/concourse/mass_build_sites_test.py
+++ b/content_sync/pipelines/definitions/concourse/mass_build_sites_test.py
@@ -115,7 +115,7 @@ def test_generate_mass_build_sites_definition(  # noqa: C901, PLR0913, PLR0912 P
     instance_vars = f"?vars={quote(json.dumps({'offline': False, 'prefix': '', 'projects_branch': 'main', 'themes_branch': 'main', 'starter': '', 'version': 'draft'}))}"
     ocw_hugo_projects_url = f"{ocw_hugo_projects_path}.git"
     ocw_studio_url = get_ocw_studio_api_url()
-    site_pipeline_vars = get_site_pipeline_definition_vars("site")
+    site_pipeline_vars = get_site_pipeline_definition_vars(namespace=".:site.")
     pipeline_config = MassBuildSitesPipelineDefinitionConfig(
         sites=websites,
         version=version,
@@ -264,7 +264,6 @@ def test_generate_mass_build_sites_definition(  # noqa: C901, PLR0913, PLR0912 P
                         ocw_hugo_themes_branch=ocw_hugo_themes_branch,
                         ocw_hugo_projects_branch=ocw_hugo_projects_branch,
                         hugo_override_args="",
-                        namespace="site",
                     )
                     assert across_values["site_name"] == site.name
                     assert across_values["s3_path"] == site.s3_path


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1972

# Description (What does it do?)
This PR makes a change to `mass_build_sites.py` so that the `site_name` Concourse var is used in the `ocw-studio-webhook` resource's `url` property, rather than hard coding the value. This allows the mass build to update the status on individual sites it is building while maintaining the functionality on the individual site pipeline.

# How can this be tested?
 - Follow the instructions in https://github.com/mitodl/ocw-studio/pull/1923 to smoke test the mass build pipeline
 - When running the first batch of the pipeline, instead of just letting it run, abort the build when any site gets to the `static-resources-s3` step
 - The `ocw-studio-webhook` step should fire to set the status on each site that is aborted and the URL should reflect the site being aborted, i.e. something like `http://10.1.0.102:8043/api/websites/10-01-ethics-for-engineers-artificial-intelligence-spring-2020/pipeline_status/`
 - If you visit the `ocw-studio` UI for any given site (i.e. http://localhost:8043/sites/10-01-ethics-for-engineers-artificial-intelligence-spring-2020/ in the example above) the status should show "aborted"

# Additional Context
This was discovered while testing the pipeline in RC at the CDN cache clearing step, which does not get run in dev. Therefore, we are testing it here with the abort hook. This issue was not discovered previously because while testing in RC previous to https://github.com/mitodl/ocw-studio/pull/1960 being merged, the `ocw_studio_url` property had been edited from the dev version which uses `http` instead of `https`. Calling the RC or production servers with `http` redirects to `https` and returns a 300, which does not cause the step to fail.
