### PR TITLE
fix static api base url dev override

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,13 +244,14 @@ can run pipelines and have them push their output to your Minio S3 buckets. The 
 control the branch of each of these repos that are pulled down in pipelines that build sites. If you are debugging an issue with a specific branch,
 This is where you want to change them before you run a command that pushes up a pipeline like `docker-compose exec web ./manage.py backpopulate_pipelines --filter etc...`
 
-Note that you may also want to set `OCW_STUDIO_LIVE_URL=https://localhost:8045/`and `OCW_STUDIO_DRAFT_URL=http://localhost:8045/` in your `.env` file so that the URLs
-in the publish drawer will point to your Minio published content. If you do this, you will likely need to also set `STATIC_API_BASE_URL` to https://ocw.mit.edu like above.
-Usually the best way to get started getting content into your local instance of `ocw-studio` is to dump and restore the production database to your local instance.
-One side effect of doing this is that the `ocw-www` site in production has a bunch of different sites linked to it via various course lists. When building `ocw-www`,
-Hugo will attempt to fetch static JSON data related to these linked courses and will encounter errors if it cannot fetch them. To avoid this, make sure `STATIC_API_BASE_URL`
-is set as detailed above. If `STATIC_API_BASE_URL` is not set, it will fall back to `OCW_STUDIO_DRAFT_URL` or `OCW_STUDIO_LIVE_URL` depending on the context of the pipeline.
-So, if you have this set to a URL where the courses referenced in your `ocw-www` site's course lists haven't been published, you will have issues.
+Note that you may also want to set `OCW_STUDIO_DRAFT_URL=https://localhost:8044`and `OCW_STUDIO_LIVE_URL=http://localhost:8045` in your `.env` file
+so that the URLs in the publish drawer will point to your Minio published content. If you do this, you will likely need to also set `STATIC_API_BASE_URL_DRAFT=https://draft.ocw.mit.edu`
+and `STATIC_API_BASE_URL_LIVE=https://ocw.mit.edu`. Usually the best way to get started getting content into your local instance of `ocw-studio` is to dump
+and restore the production database to your local instance. One side effect of doing this is that the `ocw-www` site in production has a bunch of different sites linked
+to it via various course lists. When building `ocw-www`, Hugo will attempt to fetch static JSON data related to these linked courses and will encounter errors if it cannot
+fetch them. To avoid this, make sure `STATIC_API_BASE_URL_DRAFT` and `STATIC_API_BASE_URL_LIVE` are set as detailed above. If `STATIC_API_BASE_URL` is not set,
+it will fall back to `OCW_STUDIO_DRAFT_URL` or `OCW_STUDIO_LIVE_URL` depending on the context of the pipeline. So, if you have this set to a URL where the courses
+referenced in your `ocw-www` site's course lists haven't been published, you will have issues.
 
 # Enabling Concourse-CI integration
 

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -436,45 +436,38 @@ class SitePipeline(BaseSitePipeline, GeneralPipeline):
             # Invalid github url, so skip
             return
 
+        pipeline_vars = get_common_pipeline_vars()
         for branch_vars in [
             {
                 "branch": settings.GIT_BRANCH_PREVIEW,
                 "pipeline_name": VERSION_DRAFT,
-                "static_api_url": settings.STATIC_API_BASE_URL
-                or settings.OCW_STUDIO_DRAFT_URL
-                if is_dev()
-                else settings.OCW_STUDIO_DRAFT_URL,
             },
             {
                 "branch": settings.GIT_BRANCH_RELEASE,
                 "pipeline_name": VERSION_LIVE,
-                "static_api_url": settings.STATIC_API_BASE_URL
-                or settings.OCW_STUDIO_LIVE_URL
-                if is_dev()
-                else settings.OCW_STUDIO_LIVE_URL,
             },
         ]:
-            pipeline_vars = get_common_pipeline_vars()
             pipeline_vars.update(branch_vars)
             branch = pipeline_vars["branch"]
             pipeline_name = pipeline_vars["pipeline_name"]
-            static_api_url = pipeline_vars["static_api_url"]
             storage_bucket = pipeline_vars["storage_bucket_name"]
             artifacts_bucket = pipeline_vars["artifacts_bucket_name"]
             if branch == settings.GIT_BRANCH_PREVIEW:
                 web_bucket = pipeline_vars["preview_bucket_name"]
                 offline_bucket = pipeline_vars["offline_preview_bucket_name"]
+                static_api_base_url = pipeline_vars["static_api_base_url_draft"]
                 resource_base_url = pipeline_vars["resource_base_url_draft"]
             elif branch == settings.GIT_BRANCH_RELEASE:
                 web_bucket = pipeline_vars["publish_bucket_name"]
                 offline_bucket = pipeline_vars["offline_publish_bucket_name"]
+                static_api_base_url = pipeline_vars["static_api_base_url_live"]
                 resource_base_url = pipeline_vars["resource_base_url_live"]
             pipeline_config = SitePipelineDefinitionConfig(
                 site=self.WEBSITE,
                 pipeline_name=pipeline_name,
                 instance_vars=self.instance_vars,
                 site_content_branch=branch,
-                static_api_url=static_api_url,
+                static_api_url=static_api_base_url,
                 storage_bucket=storage_bucket,
                 artifacts_bucket=artifacts_bucket,
                 web_bucket=web_bucket,

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -563,10 +563,7 @@ class MassBuildSitesPipeline(
             template_vars.update(
                 {
                     "branch": settings.GIT_BRANCH_PREVIEW,
-                    "static_api_url": settings.STATIC_API_BASE_URL
-                    or settings.OCW_STUDIO_DRAFT_URL
-                    if is_dev()
-                    else settings.OCW_STUDIO_DRAFT_URL,
+                    "static_api_url": template_vars["static_api_base_url_draft"],
                     "web_bucket": template_vars["preview_bucket_name"],
                     "offline_bucket": template_vars["offline_preview_bucket_name"],
                     "build_drafts": "--buildDrafts",
@@ -578,10 +575,7 @@ class MassBuildSitesPipeline(
             template_vars.update(
                 {
                     "branch": settings.GIT_BRANCH_RELEASE,
-                    "static_api_url": settings.STATIC_API_BASE_URL
-                    or settings.OCW_STUDIO_LIVE_URL
-                    if is_dev()
-                    else settings.OCW_STUDIO_LIVE_URL,
+                    "static_api_url": template_vars["static_api_base_url_live"],
                     "web_bucket": template_vars["publish_bucket_name"],
                     "offline_bucket": template_vars["offline_publish_bucket_name"],
                     "build_drafts": "",

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -705,11 +705,11 @@ def test_upsert_mass_build_pipeline(  # noqa: C901, PLR0912, PLR0913, PLR0915
     if version == VERSION_DRAFT:
         bucket = expected_template_vars["preview_bucket_name"]
         offline_bucket = expected_template_vars["offline_preview_bucket_name"]
-        static_api_url = settings.OCW_STUDIO_DRAFT_URL
+        static_api_base_url = expected_template_vars["static_api_base_url_draft"]
     elif version == VERSION_LIVE:
         bucket = expected_template_vars["publish_bucket_name"]
         offline_bucket = expected_template_vars["offline_publish_bucket_name"]
-        static_api_url = settings.OCW_STUDIO_LIVE_URL
+        static_api_base_url = expected_template_vars["static_api_base_url_live"]
     config_str = json.dumps(kwargs)
     assert settings.OCW_GTM_ACCOUNT_ID in config_str
     assert bucket in config_str
@@ -721,7 +721,7 @@ def test_upsert_mass_build_pipeline(  # noqa: C901, PLR0912, PLR0913, PLR0915
     assert f'\\"branch\\": \\"{themes_branch}\\"' in config_str
     assert f'\\"branch\\": \\"{projects_branch}\\"' in config_str
     assert f"{hugo_projects_path}.git" in config_str
-    assert static_api_url in config_str
+    assert static_api_base_url in config_str
     if (
         version == VERSION_DRAFT in config_str
         or settings.ENV_NAME not in PRODUCTION_NAMES

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -142,6 +142,10 @@ def pipeline_settings(settings, request):  # noqa: PT004
         settings.AWS_ARTIFACTS_BUCKET_NAME = "artifact_buckets_dev"
         settings.OCW_HUGO_THEMES_BRANCH = "themes_dev"
         settings.OCW_HUGO_PROJECTS_BRANCH = "projects_dev"
+        settings.OCW_STUDIO_DRAFT_URL = "http://localhost:8044"
+        settings.OCW_STUDIO_LIVE_URL = "http://localhost:8045"
+        settings.STATIC_API_BASE_URL_DRAFT = "https://draft.ocw.mit.edu"
+        settings.STATIC_API_BASE_URL_LIVE = "https://live.ocw.mit.edu"
         settings.RESOURCE_BASE_URL_DRAFT = "https://draft.ocw.mit.edu"
         settings.RESOURCE_BASE_URL_LIVE = "https://live.ocw.mit.edu"
 
@@ -351,22 +355,18 @@ def test_upsert_website_pipelines(  # noqa: PLR0913, PLR0915
         expected_web_bucket = expected_template_vars["preview_bucket_name"]
         expected_offline_bucket = expected_template_vars["offline_preview_bucket_name"]
         expected_resource_base_url = expected_template_vars["resource_base_url_draft"]
-        expected_static_api_url = (
-            settings.STATIC_API_BASE_URL or settings.OCW_STUDIO_DRAFT_URL
-            if is_dev()
-            else settings.OCW_STUDIO_DRAFT_URL
-        )
+        expected_static_api_base_url = expected_template_vars[
+            "static_api_base_url_draft"
+        ]
     else:
         _, kwargs = mock_put_headers.call_args_list[1]
         expected_site_content_branch = settings.GIT_BRANCH_RELEASE
         expected_web_bucket = expected_template_vars["publish_bucket_name"]
         expected_offline_bucket = expected_template_vars["offline_publish_bucket_name"]
         expected_resource_base_url = expected_template_vars["resource_base_url_live"]
-        expected_static_api_url = (
-            settings.STATIC_API_BASE_URL or settings.OCW_STUDIO_LIVE_URL
-            if is_dev()
-            else settings.OCW_STUDIO_LIVE_URL
-        )
+        expected_static_api_base_url = expected_template_vars[
+            "static_api_base_url_live"
+        ]
 
     expected_is_root_website = 1 if home_page else 0
     expected_base_url = "" if home_page else website.get_url_path()
@@ -434,7 +434,7 @@ def test_upsert_website_pipelines(  # noqa: PLR0913, PLR0915
     assert f'\\"noindex\\": \\"{expected_noindex}\\"' in config_str
     assert f'\\"pipeline_name\\": \\"{version}\\"' in config_str
     assert f'\\"instance_vars\\": \\"{expected_instance_vars}\\"' in config_str
-    assert f'\\"static_api_url\\": \\"{expected_static_api_url}\\"' in config_str
+    assert f'\\"static_api_url\\": \\"{expected_static_api_base_url}\\"' in config_str
     assert (
         f'\\"storage_bucket\\": \\"{expected_template_vars["storage_bucket_name"]}\\"'
         in config_str

--- a/content_sync/utils.py
+++ b/content_sync/utils.py
@@ -117,6 +117,12 @@ def get_common_pipeline_vars():
         "resource_base_url_live": "",
     }
     if is_dev():
+        pipeline_vars["static_api_base_url_draft"] = (
+            settings.STATIC_API_BASE_URL_DRAFT or settings.OCW_STUDIO_DRAFT_URL
+        )
+        pipeline_vars["static_api_base_url_live"] = (
+            settings.STATIC_API_BASE_URL_LIVE or settings.OCW_STUDIO_LIVE_URL
+        )
         pipeline_vars.update(
             {
                 "resource_base_url_draft": settings.RESOURCE_BASE_URL_DRAFT,

--- a/content_sync/utils_test.py
+++ b/content_sync/utils_test.py
@@ -183,8 +183,8 @@ def test_get_common_pipeline_vars(settings, mocker, is_dev):
     """get_common_pipeline_vars should return the correct values based on environment"""
     if is_dev:
         settings.ENVIRONMENT = "dev"
-        settings.OCW_STUDIO_DRAFT_URL = "http://localhost:8044/"
-        settings.OCW_STUDIO_LIVE_URL = "http://localhost:8045/"
+        settings.OCW_STUDIO_DRAFT_URL = "http://localhost:8044"
+        settings.OCW_STUDIO_LIVE_URL = "http://localhost:8045"
         settings.STATIC_API_BASE_URL_DRAFT = "http://draft.ocw.mit.edu"
         settings.STATIC_API_BASE_URL_LIVE = "http://ocw.mit.edu"
     else:

--- a/content_sync/utils_test.py
+++ b/content_sync/utils_test.py
@@ -181,8 +181,14 @@ def test_move_s3_object(settings):
 @pytest.mark.parametrize("is_dev", [True, False])
 def test_get_common_pipeline_vars(settings, mocker, is_dev):
     """get_common_pipeline_vars should return the correct values based on environment"""
-    mock_is_dev = mocker.patch("content_sync.utils.is_dev")
-    mock_is_dev.return_value = is_dev
+    if is_dev:
+        settings.ENVIRONMENT = "dev"
+        settings.OCW_STUDIO_DRAFT_URL = "http://localhost:8044/"
+        settings.OCW_STUDIO_LIVE_URL = "http://localhost:8045/"
+        settings.STATIC_API_BASE_URL_DRAFT = "http://draft.ocw.mit.edu"
+        settings.STATIC_API_BASE_URL_LIVE = "http://ocw.mit.edu"
+    else:
+        settings.ENVIRONMENT = "not_dev"
     pipeline_vars = get_common_pipeline_vars()
     assert pipeline_vars["preview_bucket_name"] == settings.AWS_PREVIEW_BUCKET_NAME
     assert pipeline_vars["publish_bucket_name"] == settings.AWS_PUBLISH_BUCKET_NAME
@@ -196,9 +202,15 @@ def test_get_common_pipeline_vars(settings, mocker, is_dev):
     )
     assert pipeline_vars["storage_bucket_name"] == settings.AWS_STORAGE_BUCKET_NAME
     assert pipeline_vars["artifacts_bucket_name"] == "ol-eng-artifacts"
-    assert pipeline_vars["static_api_base_url_draft"] == settings.OCW_STUDIO_DRAFT_URL
-    assert pipeline_vars["static_api_base_url_live"] == settings.OCW_STUDIO_LIVE_URL
     if is_dev:
+        assert (
+            pipeline_vars["static_api_base_url_draft"]
+            == settings.STATIC_API_BASE_URL_DRAFT
+        )
+        assert (
+            pipeline_vars["static_api_base_url_live"]
+            == settings.STATIC_API_BASE_URL_LIVE
+        )
         assert (
             pipeline_vars["resource_base_url_draft"] == settings.RESOURCE_BASE_URL_DRAFT
         )
@@ -206,6 +218,10 @@ def test_get_common_pipeline_vars(settings, mocker, is_dev):
             pipeline_vars["resource_base_url_live"] == settings.RESOURCE_BASE_URL_LIVE
         )
     else:
+        assert (
+            pipeline_vars["static_api_base_url_draft"] == settings.OCW_STUDIO_DRAFT_URL
+        )
+        assert pipeline_vars["static_api_base_url_live"] == settings.OCW_STUDIO_LIVE_URL
         assert pipeline_vars["resource_base_url_draft"] == ""
         assert pipeline_vars["resource_base_url_live"] == ""
 

--- a/main/settings.py
+++ b/main/settings.py
@@ -1102,13 +1102,6 @@ SEARCH_API_URL = get_string(
     default=None,
     description="The URL to open discussions search to inject into the theme assets build",  # noqa: E501
 )
-STATIC_API_BASE_URL = get_string(
-    name="STATIC_API_BASE_URL",
-    description="The static api base url to use when building and deploying sites locally to minio",  # noqa: E501
-    default="",
-    required=False,
-    dev_only=True,
-)
 STATIC_API_BASE_URL_DRAFT = get_string(
     name="STATIC_API_BASE_URL_DRAFT",
     description="The static api base url to use when building and deploying draft sites locally to minio",  # noqa: E501

--- a/main/settings.py
+++ b/main/settings.py
@@ -1109,6 +1109,20 @@ STATIC_API_BASE_URL = get_string(
     required=False,
     dev_only=True,
 )
+STATIC_API_BASE_URL_DRAFT = get_string(
+    name="STATIC_API_BASE_URL_DRAFT",
+    description="The static api base url to use when building and deploying draft sites locally to minio",  # noqa: E501
+    default="",
+    required=False,
+    dev_only=True,
+)
+STATIC_API_BASE_URL_LIVE = get_string(
+    name="STATIC_API_BASE_URL_LIVE",
+    description="The static api base url to use when building and deploying live sites locally to minio",  # noqa: E501
+    default="",
+    required=False,
+    dev_only=True,
+)
 RESOURCE_BASE_URL_DRAFT = get_string(
     name="RESOURCE_BASE_URL_DRAFT",
     description="The draft resource base url to use when building and deploying sites locally to minio",  # noqa: E501


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1974

# Description (What does it do?)
This PR fixes some issues with the assignment of `STATIC_API_BASE_URL` in pipelines based on environment and publishing target. The value is derived from `settings.OCW_STUDIO_DRAFT_URL` and `settings.OCW_STUDIO_LIVE_URL`, but in development it is handy to override this value so if `settings.STATIC_API_BASE_URL` is set, then that is used instead. In order for this to make sense, there should instead be two settings, thus `settings.STATIC_API_BASE_URL` was replaced with `settings.STATIC_API_BASE_URL_DRAFT` and `settings.STATIC_API_BASE_URL_LIVE`.

# How can this be tested?
 - Make sure you have a recent database restore from production and have the `fly` CLI set up locally, as well as the other prerequisites for publishing sites locally such as a Github org
 - In your `.env` file, set the following:
```
STATIC_API_BASE_URL_DRAFT=https://draft.ocw.mit.edu
STATIC_API_BASE_URL_LIVE=https://ocw.mit.edu
OCW_STUDIO_DRAFT_URL=http://localhost:8044
OCW_STUDIO_LIVE_URL=http://localhost:8045
```
 - Spin up `ocw-studio` with `docker-compose up`
 - Browse to any site through the `ocw-studio` UI at http://localhost:8043/sites
 - Open the publish drawer for a site that has already been published and verify that you see the `localhost` based URL's there as links to the draft and live sites
 - In your terminal, run `docker-compose exec web ./manage.py backpopulate_pipelines --filter site-id`, replacing `site-id` with a site of your choice
 - Publish the draft version of this site and ensure it succeeds
 - In a terminal run `fly -t local get-pipeline -p draft/site:site-id | grep "static_api_url":` (you may need to run it without the `grep` first to log in) and ensure that you see `static_api_url: https://draft.ocw.mit.edu`
 - If you repeat the above command and replace `draft` with `live`, you should see `static_api_url: https://ocw.mit.edu`
