### PR TITLE
explicitly check value of IS_ROOT_WEBSITE as an integer

### DIFF
--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -495,7 +495,7 @@ class SitePipelineOnlineTasks(list[StepModifierMixin]):
             ] = settings.AWS_SECRET_ACCESS_KEY
 
         online_sync_command = f"""
-        if [ $IS_ROOT_WEBSITE ] ; then
+        if [ $IS_ROOT_WEBSITE = 1 ] ; then
             aws s3{get_cli_endpoint_url()} sync {SITE_CONTENT_GIT_IDENTIFIER}/output-online s3://{pipeline_vars['web_bucket']}/{pipeline_vars['base_url']} --metadata site-id={pipeline_vars['site_name']}{pipeline_vars['delete_flag']}
         else
             aws s3{get_cli_endpoint_url()} sync {SITE_CONTENT_GIT_IDENTIFIER}/output-online s3://{pipeline_vars['web_bucket']}/{pipeline_vars['base_url']} --exclude='{pipeline_vars['short_id']}.zip' --exclude='{pipeline_vars['short_id']}-video.zip' --metadata site-id={pipeline_vars['site_name']}{pipeline_vars['delete_flag']}
@@ -596,7 +596,7 @@ class SitePipelineOfflineTasks(list[StepModifierMixin]):
         touch ./content/static_resources/_index.md
         cp -r ../{WEBPACK_ARTIFACTS_IDENTIFIER}/static_shared/. ./static/static_shared/
         hugo {pipeline_vars['hugo_args_offline']}
-        if [ $IS_ROOT_WEBSITE ] ; then
+        if [ $IS_ROOT_WEBSITE = 0 ] ; then
             cd output-offline
             zip -r ../../{BUILD_OFFLINE_SITE_IDENTIFIER}/{pipeline_vars['short_id']}.zip ./
             rm -rf ./*
@@ -670,7 +670,7 @@ class SitePipelineOfflineTasks(list[StepModifierMixin]):
             )
         offline_sync_command = f"""
         aws s3{get_cli_endpoint_url()} sync {SITE_CONTENT_GIT_IDENTIFIER}/output-offline/ s3://{pipeline_vars['offline_bucket']}/{pipeline_vars['base_url']} --metadata site-id={pipeline_vars['site_name']}{pipeline_vars['delete_flag']}
-        if ! [ $IS_ROOT_WEBSITE ] ; then
+        if [ $IS_ROOT_WEBSITE = 0 ] ; then
             aws s3{get_cli_endpoint_url()} sync {BUILD_OFFLINE_SITE_IDENTIFIER}/ s3://{pipeline_vars['web_bucket']}/{pipeline_vars['base_url']} --exclude='*' --include='{pipeline_vars['short_id']}.zip' --include='{pipeline_vars['short_id']}-video.zip' --metadata site-id={pipeline_vars['site_name']}
         fi
         """  # noqa: E501

--- a/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
@@ -372,7 +372,7 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
         upload_online_build_task["config"]["run"]["args"]
     )
     assert (
-        f"aws s3{cli_endpoint_url} sync {SITE_CONTENT_GIT_IDENTIFIER}/output-online s3://{config.vars['web_bucket']}/{config.vars['base_url']} --metadata site-id={config.vars['site_name']}{config.vars['delete_flag']}"
+        f"if [ $IS_ROOT_WEBSITE = 1 ] ; then\n            aws s3{cli_endpoint_url} sync {SITE_CONTENT_GIT_IDENTIFIER}/output-online s3://{config.vars['web_bucket']}/{config.vars['base_url']} --metadata site-id={config.vars['site_name']}{config.vars['delete_flag']}"
         in upload_online_build_command
     )
     assert (
@@ -500,6 +500,10 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
     assert STATIC_RESOURCES_S3_IDENTIFIER in build_offline_site_command
     assert WEBPACK_ARTIFACTS_IDENTIFIER in build_offline_site_command
     assert (
+        "if [ $IS_ROOT_WEBSITE = 0 ] ; then\n            cd output-offline"
+        in build_offline_site_command
+    )
+    assert (
         build_offline_site_command.count(f"hugo {config.vars['hugo_args_offline']}")
         == 2
     )
@@ -541,7 +545,7 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
         in upload_offline_build_command
     )
     assert (
-        f"aws s3{cli_endpoint_url} sync {BUILD_OFFLINE_SITE_IDENTIFIER}/ s3://{config.vars['web_bucket']}/{config.vars['base_url']} --exclude='*' --include='{config.vars['short_id']}.zip' --include='{config.vars['short_id']}-video.zip' --metadata site-id={config.vars['site_name']}"
+        f"if [ $IS_ROOT_WEBSITE = 0 ] ; then\n            aws s3{cli_endpoint_url} sync {BUILD_OFFLINE_SITE_IDENTIFIER}/ s3://{config.vars['web_bucket']}/{config.vars['base_url']} --exclude='*' --include='{config.vars['short_id']}.zip' --include='{config.vars['short_id']}-video.zip' --metadata site-id={config.vars['site_name']}"
         in upload_offline_build_command
     )
     upload_offline_build_expected_inputs = [


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1978

# Description (What does it do?)
This PR corrects the logic surrounding how the `IS_ROOT_WEBSITE` environment variable is evaluated in pipelines. In https://github.com/mitodl/ocw-studio/pull/1900 we replaced the static `site-pipeline.yml` with the pydantic model `SitePipelineDefinition`. In https://github.com/mitodl/ocw-studio/pull/1931, we moved from injecting values into the pipeline directly to using the Concourse vars system, so that the steps can be reused in other pipelines and used with the `across` step. As part of this, `IS_ROOT_WEBSITE` was injected as an environment variable to be evaluated at runtime. This was necessary to maintain compatibility with the way the `across` step works. If we were to evaluate `is_root_website` in Python and then not include blocks of code based on that, then the pipeline definition would be run that way for each of the sites in the `across`. The main issue here is that the `IS_ROOT_WEBSITE` env variable had to be added as an integer, rather than a boolean. Concourse threw errors setting a boolean value in the var source. The logic performed a falsy check on these values, which did not function correctly. Instead, these checks have been set up to explicitly check for the numerical 0 or 1 value. Tests have been added to make sure the proper checks show up at the right place in the pipeline, but there's no good way to truly unit test this functionality, as it would require running the pipeline.

# How can this be tested?
 - Make sure you have an up to date database restore and are set up for publishing courses locally
 - Run the following for a test site (noted here by `test-site` that is *not* the root website and also the root website, noted by `ocw-www`: 
```
docker compose exec web ./manage.py backpopulate_pipelines --filter test-site
docker compose exec web ./manage.py backpopulate_pipelines --filter ocw-www
```
 - Publish both the sites and inspect the output in Concourse
 - For `test-site`, in `upload-online-build` under `online-site-job`, you should see `+ '[' 0 = 1 ']'`. The `aws s3 sync` command should have a `--delete` flag and `--exclude` flags for the zip archives, which prevent them from being removed in the destructive sync.
 - For `test-site`, in `build-offline-site` under `offline-site-job`, you should see `[ 0 = 0 ]` which indicates that this is not the root website and a zip archive should be built. You should see the archive being created. In the `upload-offline-build` step, you should see `'[' 0 = 0 ']'`, indicating that this is not the root website and zip archives should be uploaded.
 - For `ocw-www`, in `upload-online-build` under `online-site-job`, you should see `+ '[' 1 = 1 ']'`. The `aws s3 sync` command should have no `--exclude` flags and no `--delete` flag.
 - For `ocw-www`, in `build-offline-site` under `offline-site-job`, you should see `[ 1 = 0 ]` which indicates that this is the root website and a zip archive should not be built. You should see no output below this line. In the `upload-offline-build` step, you should see `'[' 1 = 0 ']'` with nothing below it, indicating that this is the root website and zip archives should not be uploaded.
