### PR TITLE
Fix italics font size issue in CKEditor

### DIFF
--- a/static/js/components/widgets/ObjectField.tsx
+++ b/static/js/components/widgets/ObjectField.tsx
@@ -45,9 +45,9 @@ export default function ObjectField(props: Props): JSX.Element {
         >
           {field.label}
         </label>
-        <i className="material-icons">
+        <span className="material-icons">
           {collapsed ? "expand_more" : "expand_less"}
-        </i>
+        </span>
       </div>
       {collapsed ? null : (
         <div className="object-sub-fields">

--- a/static/scss/ckeditor.scss
+++ b/static/scss/ckeditor.scss
@@ -9,12 +9,6 @@
   }
 
   .ck-content {
-    p {
-      i {
-        font-size: initial;
-      }
-    }
-
     blockquote {
       font-style: initial;
     }

--- a/static/scss/forms.scss
+++ b/static/scss/forms.scss
@@ -43,7 +43,7 @@ form input[type="file"] {
     border-left: 5px solid $studio-gray;
   }
 
-  i {
+  .material-icons {
     font-size: 30px;
   }
 }


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/2215.

# Description (What does it do?)

Previously, there was an issue where making text italic in the `Caption` or `Credit` fields in `Image Metadata` for an Image Resource would increase the font size in CKEditor. While this did not affect published output, it was not intended. This PR resolves that issue. 

# How can this be tested?

For an Image resource in OCW Studio, verify that text in the `Caption` and `Credit` fields under `Image Metadata` can now be made italic using the Markdown editor without changing the font size.

Verify that the font sizes in the full Markdown editor (such as in `Pages`) are not affected when changing to and from italics for any of the Heading types. 

# Additional Context
This PR does something similar for block quotes: https://github.com/mitodl/ocw-studio/pull/974.
