### PR TITLE
Make return type of is_gdrive_enabled Boolean

### DIFF
--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -385,9 +385,9 @@ def get_resource_type(drive_file: DriveFile) -> str:
 
 def is_gdrive_enabled():
     """Determine if Gdrive integration is enabled via required settings"""
-    return (settings.DRIVE_SHARED_ID is not None) and (
-        settings.DRIVE_SERVICE_ACCOUNT_CREDS is not None
-    )
+    return (
+        settings.DRIVE_SHARED_ID is not None and len(settings.DRIVE_SHARED_ID) > 0
+    ) and (settings.DRIVE_SERVICE_ACCOUNT_CREDS is not None)
 
 
 def gdrive_root_url():


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/2459.

# Description (What does it do?)
Changes the return type of the `is_gdrive_enabled()` function into a Boolean value, which is what it was intended to be.

# How can this be tested?
Start up OCW Studio on this branch using `docker compose up` and verify that the page source reads `"gdrive_enabled": true`, assuming that Google Drive integration is set up. Verify that Google Drive works as expected, including syncing.