### PR TITLE
add support for specifying prefix to SitePipelineDefinition and MassBuildSitesPipelineDefinition

### DIFF
--- a/content_sync/pipelines/definitions/concourse/mass_build_sites.py
+++ b/content_sync/pipelines/definitions/concourse/mass_build_sites.py
@@ -51,7 +51,7 @@ from content_sync.pipelines.definitions.concourse.site_pipeline import (
 )
 from content_sync.utils import get_common_pipeline_vars
 from main.utils import is_dev
-from websites.models import WebsiteQuerySet, WebsiteStarter
+from websites.models import Website, WebsiteQuerySet, WebsiteStarter
 
 
 class MassBuildSitesPipelineDefinitionConfig:
@@ -83,7 +83,7 @@ class MassBuildSitesPipelineDefinitionConfig:
         offline: bool,  # noqa: FBT001
         instance_vars: str,
         starter: Optional[WebsiteStarter] = None,
-        prefix: Optional[str] = None,
+        prefix: Optional[str] = "",
         hugo_arg_overrides: Optional[str] = None,
     ):
         vars = get_common_pipeline_vars()  # noqa: A001
@@ -139,7 +139,7 @@ class MassBuildSitesResources(list[Resource]):
         ocw_hugo_themes_resource = OcwHugoThemesGitResource(
             branch=config.ocw_hugo_themes_branch
         )
-        root_starter = WebsiteStarter.objects.get(slug=settings.ROOT_WEBSITE_NAME)
+        root_starter = Website.objects.get(name=settings.ROOT_WEBSITE_NAME).starter
         ocw_hugo_projects_resource = OcwHugoProjectsGitResource(
             uri=root_starter.ocw_hugo_projects_url,
             branch=config.ocw_hugo_projects_branch,
@@ -261,6 +261,7 @@ class MassBuildSitesPipelineDefinition(Pipeline):
                     ocw_hugo_themes_branch=config.ocw_hugo_themes_branch,
                     ocw_hugo_projects_branch=config.ocw_hugo_projects_branch,
                     namespace=namespace,
+                    prefix=config.prefix,
                 )
                 across_var_values.append(site_config.values)
 


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1987

# Description (What does it do?)
This PR implements support for the `prefix` argument to `MassBuildSitesPipelineDefinition` and subsequently `SitePipelineDefinition`. In https://github.com/mitodl/ocw-studio/pull/1429, we added support for this to the static `mass-build-sites.yml` pipeline definition to enable developers to deploy a whole other copy of the OCW site to an alternate prefixed URL to support development of new themes. Support for this was neglected in the initial PR's to add the new pipeline definitions, and is being added now.


# How can this be tested?
 - Make sure you have a fairly recent database restore, have a Github organization set up and are otherwise set up for publishing sites locally
 - Open a Django shell with `docker compose exec web ./manage.py shell` and execute the following:
```
import json
from django.conf import settings
from urllib.parse import quote
from content_sync.constants import VERSION_DRAFT, VERSION_LIVE
from websites.models import *
from content_sync.pipelines.definitions.concourse.mass_build_sites import (
    MassBuildSitesPipelineDefinitionConfig,
    MassBuildSitesPipelineDefinition
)

version = VERSION_DRAFT
offline = False
prefix = "test_prefix"
settings.OCW_MASS_BUILD_BATCH_SIZE=40
settings.OCW_MASS_BUILD_MAX_IN_FLIGHT=20

publish_date_field = (
    "publish_date" if version == VERSION_LIVE else "draft_publish_date"
)

# Get all sites, minus any sites that have never been successfully published
sites = Website.objects.exclude(
    Q(**{f"{publish_date_field}__isnull": True}) | Q(url_path__isnull=True)
)
sites = sites.prefetch_related("starter").order_by("name")
pipeline_config = MassBuildSitesPipelineDefinitionConfig(
    sites=sites,
    version=version,
    artifacts_bucket="ol-eng-artifacts",
    site_content_branch="preview",
    ocw_hugo_themes_branch="main",
    ocw_hugo_projects_branch="main",
    offline=offline,
    prefix=prefix,
    instance_vars=f"?vars={quote(json.dumps({'offline': offline, 'prefix': '', 'projects_branch': 'main', 'themes_branch': 'main', 'starter': '', 'version': 'draft'}))}"
)
pipeline_definition = MassBuildSitesPipelineDefinition(config=pipeline_config)
f = open(f"mass-build-pipeline-test-{version}-{'offline' if offline else 'online'}.json", "w")
f.write(pipeline_definition.json(indent=2, by_alias=True))
f.close()
```
 - Inspect the JSON file output by the above script. It should:
   - contain the `"prefix": "test_prefix/" var in each `across`
   - prefix each s3 sync destination with the across var `((.:site.prefix))` before `((.:site.base_url))`
 - Look at the first batch of sites in the first `across` section and make sure you have those sites published to your test Github org
 - Run `fly -t local set-pipeline -p mass-build-sites-test-online -c mass-build-pipeline-test-draft-online.json` to push the pipeline up to your local Concourse instance
 - Start the first batch of the pipeline and watch the output of the `upload-online-build` step and you should see the destination path prefixed with the prefix that we specified
 - Visit one of the sites by copying and pasting the path to the end of http://localhost:8044, like http://localhost:8044/test_prefix/courses/10-01-ethics-for-engineers-artificial-intelligence-spring-2020/
