### PR TITLE
use new mass build pipeline

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,6 +8,9 @@
       "url": "https://github.com/heroku/heroku-buildpack-nodejs"
     },
     {
+      "url": "https://github.com/moneymeets/python-poetry-buildpack"
+    },
+    {
       "url": "https://github.com/heroku/heroku-buildpack-python"
     },
     {

--- a/app.json
+++ b/app.json
@@ -8,9 +8,6 @@
       "url": "https://github.com/heroku/heroku-buildpack-nodejs"
     },
     {
-      "url": "https://github.com/moneymeets/python-poetry-buildpack"
-    },
-    {
       "url": "https://github.com/heroku/heroku-buildpack-python"
     },
     {
@@ -32,6 +29,10 @@
     },
     "AWS_ACCOUNT_ID": {
       "description": "AWS Account ID",
+      "required": false
+    },
+    "AWS_ARTIFACTS_BUCKET_NAME": {
+      "description": "S3 artifacts bucket name.",
       "required": false
     },
     "AWS_OFFLINE_PREVIEW_BUCKET_NAME": {

--- a/content_sync/api.py
+++ b/content_sync/api.py
@@ -65,13 +65,14 @@ def get_theme_assets_pipeline(
 @is_publish_pipeline_enabled
 def get_mass_build_sites_pipeline(  # pylint:disable=too-many-arguments  # noqa: PLR0913
     version: str,
+    *,
     api: Optional[object] = None,
-    prefix: Optional[str] = None,
-    themes_branch: Optional[str] = None,
-    projects_branch: Optional[str] = None,
-    starter: Optional[str] = None,
-    offline: Optional[bool] = None,
-    hugo_args: Optional[str] = None,
+    prefix: Optional[str] = "",
+    themes_branch: Optional[str] = "",
+    projects_branch: Optional[str] = "",
+    starter: Optional[str] = "",
+    offline: Optional[bool] = False,
+    hugo_args: Optional[str] = "",
 ) -> object:
     """Get the mass build sites pipeline if the backend has one"""
     return import_string(

--- a/content_sync/api.py
+++ b/content_sync/api.py
@@ -187,6 +187,7 @@ def publish_website(  # pylint: disable=too-many-arguments
         raise
     finally:
         Website.objects.filter(name=name).update(**update_kwargs)
+        tasks.update_mass_build_pipelines_on_publish(version=version, website=website)
 
 
 def throttle_git_backend_calls(backend: object, min_delay: Optional[int] = None):

--- a/content_sync/conftest.py
+++ b/content_sync/conftest.py
@@ -66,6 +66,7 @@ def required_concourse_settings(settings):  # noqa: PT004
     settings.CONCOURSE_USERNAME = "test"
     settings.CONCOURSE_PASSWORD = "pass"  # pragma: allowlist secret  # noqa: S105
     settings.CONCOURSE_TEAM = "ocwtest"
+    settings.AWS_ARTIFACTS_BUCKET_NAME = "artifacts_bucket"
     settings.AWS_PREVIEW_BUCKET_NAME = "preview_bucket"
     settings.AWS_PUBLISH_BUCKET_NAME = "publish_bucket"
     settings.AWS_OFFLINE_PREVIEW_BUCKET_NAME = "offline_preview_bucket"

--- a/content_sync/conftest.py
+++ b/content_sync/conftest.py
@@ -1,9 +1,12 @@
 """Test config for content_sync app"""
 from base64 import b64encode
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 import pytest
 
+from websites.constants import STARTER_SOURCE_GITHUB
+from websites.factories import WebsiteFactory, WebsiteStarterFactory
 from websites.models import Website, WebsiteStarter
 
 
@@ -77,3 +80,30 @@ def required_concourse_settings(settings):  # noqa: PT004
     settings.API_BEARER_TOKEN = "abc123"  # pragma: allowlist secret  # noqa: S105
     settings.SEARCH_API_URL = "http://test.edu/api/v0/search"
     settings.OCW_GTM_ACCOUNT_ID = "abc123"
+
+
+@pytest.fixture(scope="module")
+def mass_build_websites(django_db_setup, django_db_blocker):  # noqa: ARG001
+    """Generate websites for testing the mass build pipeline"""
+    with django_db_blocker.unblock():
+        now = datetime.now(tz=timezone.utc) - timedelta(hours=48)
+        total_sites = 6
+        ocw_hugo_projects_path = "https://github.com/org/repo"
+        root_starter = WebsiteStarterFactory.create(
+            source=STARTER_SOURCE_GITHUB,
+            path=ocw_hugo_projects_path,
+            slug="root-website-starter",
+        )
+        starter = WebsiteStarterFactory.create(
+            source=STARTER_SOURCE_GITHUB, path=ocw_hugo_projects_path
+        )
+        root_website = WebsiteFactory.create(name="root-website", starter=root_starter)
+        batch_sites = WebsiteFactory.create_batch(
+            total_sites, starter=starter, draft_publish_date=now, publish_date=now
+        )
+        batch_sites.append(root_website)
+        yield batch_sites
+        for site in batch_sites:
+            site.delete()
+        starter.delete()
+        root_starter.delete()

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -20,8 +20,6 @@ from requests import HTTPError
 
 from content_sync.constants import (
     DEV_ENDPOINT_URL,
-    TARGET_OFFLINE,
-    TARGET_ONLINE,
     VERSION_DRAFT,
     VERSION_LIVE,
 )
@@ -34,6 +32,10 @@ from content_sync.pipelines.base import (
     BaseThemeAssetsPipeline,
     BaseUnpublishedSiteRemovalPipeline,
 )
+from content_sync.pipelines.definitions.concourse.mass_build_sites import (
+    MassBuildSitesPipelineDefinition,
+    MassBuildSitesPipelineDefinitionConfig,
+)
 from content_sync.pipelines.definitions.concourse.site_pipeline import (
     SitePipelineDefinition,
     SitePipelineDefinitionConfig,
@@ -44,17 +46,16 @@ from content_sync.pipelines.definitions.concourse.theme_assets_pipeline import (
 from content_sync.utils import (
     check_mandatory_settings,
     get_common_pipeline_vars,
-    get_hugo_arg_string,
     get_ocw_studio_api_url,
+    get_site_content_branch,
     get_theme_branch,
     strip_dev_lines,
     strip_non_dev_lines,
     strip_offline_lines,
     strip_online_lines,
 )
-from main.constants import PRODUCTION_NAMES
 from main.utils import is_dev
-from websites.constants import OCW_HUGO_THEMES_GIT, STARTER_SOURCE_GITHUB
+from websites.constants import STARTER_SOURCE_GITHUB
 from websites.models import Website
 
 log = logging.getLogger(__name__)
@@ -519,10 +520,7 @@ class MassBuildSitesPipeline(
         super().__init__(api=api)
         self.pipeline_name = "mass_build_sites"
         self.VERSION = version
-        if prefix:
-            self.PREFIX = prefix[1:] if prefix.startswith("/") else prefix
-        else:
-            self.PREFIX = ""
+        self.PREFIX = prefix if prefix else ""
         self.THEMES_BRANCH = themes_branch if themes_branch else get_theme_branch()
         self.PROJECTS_BRANCH = (
             projects_branch if projects_branch else self.THEMES_BRANCH
@@ -545,137 +543,19 @@ class MassBuildSitesPipeline(
         """
         Create or update the concourse pipeline
         """
-        template_vars = get_common_pipeline_vars()
-        starter = Website.objects.get(name=settings.ROOT_WEBSITE_NAME).starter
-        starter_path_url = urlparse(starter.path)
-        hugo_projects_url = urljoin(
-            f"{starter_path_url.scheme}://{starter_path_url.netloc}",
-            f"{'/'.join(starter_path_url.path.strip('/').split('/')[:2])}.git",  # /<org>/<repo>.git  # noqa: E501
+        site_content_branch = get_site_content_branch(self.VERSION)
+        pipeline_config = MassBuildSitesPipelineDefinitionConfig(
+            version=self.VERSION,
+            artifacts_bucket=settings.AWS_ARTIFACTS_BUCKET_NAME,
+            site_content_branch=site_content_branch,
+            ocw_hugo_themes_branch=self.THEMES_BRANCH,
+            ocw_hugo_projects_branch=self.PROJECTS_BRANCH,
+            offline=self.OFFLINE,
+            prefix=self.PREFIX,
+            instance_vars=self.instance_vars,
         )
-        if settings.CONCOURSE_IS_PRIVATE_REPO:
-            markdown_uri = f"git@{settings.GIT_DOMAIN}:{settings.GIT_ORGANIZATION}"
-            private_key_var = "((git-private-key))"
-        else:
-            markdown_uri = f"https://{settings.GIT_DOMAIN}/{settings.GIT_ORGANIZATION}"
-            private_key_var = ""
-
-        if self.VERSION == VERSION_DRAFT:
-            template_vars.update(
-                {
-                    "branch": settings.GIT_BRANCH_PREVIEW,
-                    "static_api_url": template_vars["static_api_base_url_draft"],
-                    "web_bucket": template_vars["preview_bucket_name"],
-                    "offline_bucket": template_vars["offline_preview_bucket_name"],
-                    "build_drafts": "--buildDrafts",
-                    "resource_base_url": settings.RESOURCE_BASE_URL_DRAFT,
-                    "noindex": "true",
-                }
-            )
-        elif self.VERSION == VERSION_LIVE:
-            template_vars.update(
-                {
-                    "branch": settings.GIT_BRANCH_RELEASE,
-                    "static_api_url": template_vars["static_api_base_url_live"],
-                    "web_bucket": template_vars["publish_bucket_name"],
-                    "offline_bucket": template_vars["offline_publish_bucket_name"],
-                    "build_drafts": "",
-                    "resource_base_url": settings.RESOURCE_BASE_URL_LIVE,
-                    "noindex": "true"
-                    if settings.ENV_NAME not in PRODUCTION_NAMES
-                    else "false",
-                }
-            )
-        base_hugo_args = {
-            "--themesDir": "../ocw-hugo-themes/",
-            "--quiet": "",
-        }
-        base_online_args = base_hugo_args.copy()
-        base_online_args.update(
-            {
-                "--baseURL": "$PREFIX/$BASE_URL",
-                "--config": "../ocw-hugo-projects/$STARTER_SLUG/config.yaml",
-            }
-        )
-        base_offline_args = base_hugo_args.copy()
-        base_offline_args.update(
-            {
-                "--baseURL": "/",
-                "--config": "../ocw-hugo-projects/$STARTER_SLUG/config-offline.yaml",
-            }
-        )
-        hugo_args_online = get_hugo_arg_string(
-            TARGET_ONLINE,
-            self.VERSION,
-            base_online_args,
-            self.HUGO_ARGS,
-        )
-        hugo_args_offline = get_hugo_arg_string(
-            TARGET_OFFLINE,
-            self.VERSION,
-            base_offline_args,
-            self.HUGO_ARGS,
-        )
-
-        config_str = (
-            self.get_pipeline_definition(
-                "definitions/concourse/mass-build-sites.yml", offline=self.OFFLINE
-            )
-            .replace("((hugo-args-online))", hugo_args_online)
-            .replace("((hugo-args-offline))", hugo_args_offline)
-            .replace("((markdown-uri))", markdown_uri)
-            .replace("((git-private-key-var))", private_key_var)
-            .replace("((gtm-account-id))", settings.OCW_GTM_ACCOUNT_ID)
-            .replace(
-                "((artifacts-bucket))", template_vars["artifacts_bucket_name"] or ""
-            )
-            .replace("((web-bucket))", template_vars["web_bucket"] or "")
-            .replace("((offline-bucket))", template_vars["offline_bucket"] or "")
-            .replace("((ocw-hugo-themes-branch))", self.THEMES_BRANCH)
-            .replace("((ocw-hugo-themes-uri))", OCW_HUGO_THEMES_GIT)
-            .replace(
-                "((ocw-hugo-projects-branch))",
-                (settings.OCW_HUGO_PROJECTS_BRANCH or self.PROJECTS_BRANCH)
-                if is_dev()
-                else self.PROJECTS_BRANCH,
-            )
-            .replace("((ocw-hugo-projects-uri))", hugo_projects_url)
-            .replace("((ocw-import-starter-slug))", settings.OCW_COURSE_STARTER_SLUG)
-            .replace("((ocw-course-starter-slug))", settings.OCW_COURSE_STARTER_SLUG)
-            .replace("((ocw-studio-url))", get_ocw_studio_api_url() or "")
-            .replace("((static-api-base-url))", template_vars["static_api_url"] or "")
-            .replace("((ocw-studio-bucket))", settings.AWS_STORAGE_BUCKET_NAME or "")
-            .replace("((ocw-site-repo-branch))", template_vars["branch"] or "")
-            .replace("((version))", self.VERSION)
-            .replace("((api-token))", settings.API_BEARER_TOKEN or "")
-            .replace("((open-discussions-url))", settings.OPEN_DISCUSSIONS_URL)
-            .replace("((open-webhook-key))", settings.OCW_NEXT_SEARCH_WEBHOOK_KEY)
-            .replace("((build-drafts))", template_vars["build_drafts"] or "")
-            .replace("((sitemap-domain))", settings.SITEMAP_DOMAIN)
-            .replace("((endpoint-url))", DEV_ENDPOINT_URL)
-            .replace(
-                "((cli-endpoint-url))",
-                f" --endpoint-url {DEV_ENDPOINT_URL}" if is_dev() else "",
-            )
-            .replace("((minio-root-user))", settings.AWS_ACCESS_KEY_ID or "")
-            .replace("((minio-root-password))", settings.AWS_SECRET_ACCESS_KEY or "")
-            .replace("((resource-base-url))", template_vars["resource_base_url"])
-            .replace("((prefix))", self.PREFIX)
-            .replace("((search-api-url))", settings.SEARCH_API_URL)
-            .replace("((starter))", f"&starter={self.STARTER}" if self.STARTER else "")
-            .replace(
-                "((trigger))",
-                str(
-                    self.THEMES_BRANCH == settings.GITHUB_WEBHOOK_BRANCH
-                    and self.PROJECTS_BRANCH == settings.GITHUB_WEBHOOK_BRANCH
-                ),
-            )
-            .replace(
-                "((ocw-hugo-themes-sentry-dsn))",
-                settings.OCW_HUGO_THEMES_SENTRY_DSN or "",
-            )
-            .replace("((noindex))", template_vars["noindex"])
-        )
-        self.upsert_config(config_str, self.PIPELINE_NAME)
+        pipeline_definition = MassBuildSitesPipelineDefinition(config=pipeline_config)
+        self.upsert_config(pipeline_definition.json(), self.PIPELINE_NAME)
 
 
 class UnpublishedSiteRemovalPipeline(

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -357,6 +357,9 @@ class ThemeAssetsPipeline(GeneralPipeline, BaseThemeAssetsPipeline):
 
     MANDATORY_SETTINGS = [
         *MANDATORY_CONCOURSE_SETTINGS,
+        "AWS_ARTIFACTS_BUCKET_NAME",
+        "AWS_PREVIEW_BUCKET_NAME",
+        "AWS_PUBLISH_BUCKET_NAME",
         "GITHUB_WEBHOOK_BRANCH",
         "SEARCH_API_URL",
     ]
@@ -389,6 +392,7 @@ class SitePipeline(BaseSitePipeline, GeneralPipeline):
     BRANCH = settings.GITHUB_WEBHOOK_BRANCH
     MANDATORY_SETTINGS = [
         *MANDATORY_CONCOURSE_SETTINGS,
+        "AWS_ARTIFACTS_BUCKET_NAME",
         "AWS_PREVIEW_BUCKET_NAME",
         "AWS_PUBLISH_BUCKET_NAME",
         "AWS_OFFLINE_PREVIEW_BUCKET_NAME",
@@ -504,6 +508,7 @@ class MassBuildSitesPipeline(
         """Initialize the pipeline instance"""
         self.MANDATORY_SETTINGS = [
             *MANDATORY_CONCOURSE_SETTINGS,
+            "AWS_ARTIFACTS_BUCKET_NAME",
             "AWS_PREVIEW_BUCKET_NAME",
             "AWS_PUBLISH_BUCKET_NAME",
             "AWS_OFFLINE_PREVIEW_BUCKET_NAME",

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -115,6 +115,7 @@ def pipeline_settings(settings, request):  # noqa: PT004
     """Default settings for pipelines"""  # noqa: D401
     env = request.param
     settings.ENVIRONMENT = env
+    settings.AWS_ARTIFACTS_BUCKET_NAME = "artifacts_bucket_test"
     settings.AWS_STORAGE_BUCKET_NAME = "storage_bucket_test"
     settings.AWS_PREVIEW_BUCKET_NAME = "draft_bucket_test"
     settings.AWS_PUBLISH_BUCKET_NAME = "live_bucket_test"

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -1,6 +1,5 @@
 """concourse tests"""
 import json
-from datetime import datetime, timedelta, timezone
 from html import unescape
 from urllib.parse import quote, urljoin
 
@@ -621,33 +620,6 @@ def test_upsert_pipeline(
     assert (
         f"s3://{artifacts_bucket_name}/ocw-hugo-themes/{expected_branch}" in config_str
     )
-
-
-@pytest.fixture(scope="module")
-def mass_build_websites(django_db_setup, django_db_blocker):
-    """Generate websites for testing the mass build pipeline"""
-    with django_db_blocker.unblock():
-        now = datetime.now(tz=timezone.utc) - timedelta(hours=48)
-        total_sites = 6
-        ocw_hugo_projects_path = "https://github.com/org/repo"
-        root_starter = WebsiteStarterFactory.create(
-            source=STARTER_SOURCE_GITHUB,
-            path=ocw_hugo_projects_path,
-            slug="root-website-starter",
-        )
-        starter = WebsiteStarterFactory.create(
-            source=STARTER_SOURCE_GITHUB, path=ocw_hugo_projects_path
-        )
-        root_website = WebsiteFactory.create(name="root-website", starter=root_starter)
-        batch_sites = WebsiteFactory.create_batch(
-            total_sites, starter=starter, draft_publish_date=now, publish_date=now
-        )
-        batch_sites.append(root_website)
-        yield batch_sites
-        for site in batch_sites:
-            site.delete()
-        starter.delete()
-        root_starter.delete()
 
 
 @pytest.mark.parametrize("pipeline_exists", [True, False])

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -627,7 +627,6 @@ def test_upsert_pipeline(
 @pytest.mark.parametrize("version", [VERSION_DRAFT, VERSION_LIVE])
 @pytest.mark.parametrize("themes_branch", ["", "main", "test_themes_branch"])
 @pytest.mark.parametrize("projects_branch", ["", "main", "test_projects_branch"])
-@pytest.mark.parametrize("prefix", ["", "/test_prefix", "test_prefix"])
 @pytest.mark.parametrize("starter", ["", "ocw-course"])
 @pytest.mark.parametrize("offline", [True, False])
 def test_upsert_mass_build_pipeline(  # noqa: PLR0913
@@ -640,7 +639,6 @@ def test_upsert_mass_build_pipeline(  # noqa: PLR0913
     version,
     themes_branch,
     projects_branch,
-    prefix,
     starter,
     offline,
 ):  # pylint:disable=too-many-locals,too-many-arguments,too-many-statements,too-many-branches
@@ -658,7 +656,7 @@ def test_upsert_mass_build_pipeline(  # noqa: PLR0913
         "version": version,
         "themes_branch": themes_branch,
         "projects_branch": projects_branch,
-        "prefix": prefix,
+        "prefix": "",
         "starter": starter,
         "offline": offline,
     }
@@ -691,7 +689,7 @@ def test_upsert_mass_build_pipeline(  # noqa: PLR0913
         ocw_hugo_themes_branch=themes_branch,
         ocw_hugo_projects_branch=projects_branch,
         offline=offline,
-        prefix=prefix,
+        prefix="",
         instance_vars=instance_vars_str,
     )
     mock_get.assert_any_call(url_path)

--- a/content_sync/pipelines/definitions/concourse/common/identifiers.py
+++ b/content_sync/pipelines/definitions/concourse/common/identifiers.py
@@ -8,9 +8,15 @@ OCW_STUDIO_WEBHOOK_RESOURCE_TYPE_IDENTIFIER = Identifier("ocw-studio-webhook").r
 SLACK_ALERT_RESOURCE_IDENTIFIER = Identifier("slack-alert").root
 OPEN_DISCUSSIONS_RESOURCE_IDENTIFIER = Identifier("open-discussions-webhook").root
 WEBPACK_MANIFEST_S3_IDENTIFIER = Identifier("webpack-manifest-s3").root
+WEBPACK_MANIFEST_S3_TRIGGER_IDENTIFIER = Identifier(
+    f"{WEBPACK_MANIFEST_S3_IDENTIFIER}-trigger"
+).root
 WEBPACK_ARTIFACTS_IDENTIFIER = Identifier("webpack-artifacts").root
 OCW_HUGO_THEMES_GIT_IDENTIFIER = Identifier("ocw-hugo-themes-git").root
 OCW_HUGO_PROJECTS_GIT_IDENTIFIER = Identifier("ocw-hugo-projects-git").root
+OCW_HUGO_PROJECTS_GIT_TRIGGER_IDENTIFIER = Identifier(
+    f"{OCW_HUGO_PROJECTS_GIT_IDENTIFIER}-trigger"
+).root
 SITE_CONTENT_GIT_IDENTIFIER = Identifier("site-content-git").root
 STATIC_RESOURCES_S3_IDENTIFIER = Identifier("static-resources-s3").root
 MASS_BULID_SITES_PIPELINE_IDENTIFIER = Identifier("mass-build-sites").root

--- a/content_sync/pipelines/definitions/concourse/mass_build_sites.py
+++ b/content_sync/pipelines/definitions/concourse/mass_build_sites.py
@@ -1,4 +1,5 @@
 import json
+from random import shuffle
 from typing import Optional
 from urllib.parse import quote
 
@@ -49,9 +50,9 @@ from content_sync.pipelines.definitions.concourse.site_pipeline import (
     SitePipelineOnlineTasks,
     get_site_pipeline_definition_vars,
 )
-from content_sync.utils import get_common_pipeline_vars
+from content_sync.utils import get_common_pipeline_vars, get_publishable_sites
 from main.utils import is_dev
-from websites.models import Website, WebsiteQuerySet, WebsiteStarter
+from websites.models import Website, WebsiteStarter
 
 
 class MassBuildSitesPipelineDefinitionConfig:
@@ -59,7 +60,6 @@ class MassBuildSitesPipelineDefinitionConfig:
     A class with configuration properties for building a mass build pipeline
 
     Args:
-        sites(WebsiteQuerySet): The sites to build the pipeline for
         version(str): The version of the sites to build in the pipeline (draft / live)
         artifacts_bucket(str): The versioned bucket where the webpack manifest is stored (ol-eng-artifacts)
         site_content_branch(str): The branch to use in the site content repo (preview / release)
@@ -74,7 +74,6 @@ class MassBuildSitesPipelineDefinitionConfig:
 
     def __init__(  # noqa: PLR0913
         self,
-        sites: WebsiteQuerySet,
         version: str,
         artifacts_bucket: str,
         site_content_branch: str,
@@ -87,6 +86,8 @@ class MassBuildSitesPipelineDefinitionConfig:
         hugo_arg_overrides: Optional[str] = None,
     ):
         vars = get_common_pipeline_vars()  # noqa: A001
+        sites = list(get_publishable_sites(version))
+        shuffle(sites)
         self.sites = sites
         self.version = version
         self.prefix = prefix

--- a/content_sync/pipelines/definitions/concourse/mass_build_sites.py
+++ b/content_sync/pipelines/definitions/concourse/mass_build_sites.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from ol_concourse.lib.models.pipeline import (
     AcrossVar,
     DoStep,
+    Duration,
     GetStep,
     Job,
     Pipeline,
@@ -24,8 +25,10 @@ from content_sync.pipelines.definitions.concourse.common.identifiers import (
     MASS_BUILD_SITES_BATCH_GATE_IDENTIFIER,
     MASS_BUILD_SITES_JOB_IDENTIFIER,
     OCW_HUGO_PROJECTS_GIT_IDENTIFIER,
+    OCW_HUGO_PROJECTS_GIT_TRIGGER_IDENTIFIER,
     OCW_HUGO_THEMES_GIT_IDENTIFIER,
     WEBPACK_MANIFEST_S3_IDENTIFIER,
+    WEBPACK_MANIFEST_S3_TRIGGER_IDENTIFIER,
 )
 from content_sync.pipelines.definitions.concourse.common.resource_types import (
     HttpResourceType,
@@ -33,6 +36,7 @@ from content_sync.pipelines.definitions.concourse.common.resource_types import (
     S3IamResourceType,
 )
 from content_sync.pipelines.definitions.concourse.common.resources import (
+    GitResource,
     OcwHugoProjectsGitResource,
     OcwHugoThemesGitResource,
     OcwStudioWebhookResource,
@@ -137,6 +141,12 @@ class MassBuildSitesResources(list[Resource]):
             bucket=config.artifacts_bucket,
             branch=config.ocw_hugo_themes_branch,
         )
+        webpack_manifest_trigger_resource = WebpackManifestResource(
+            name=WEBPACK_MANIFEST_S3_TRIGGER_IDENTIFIER,
+            bucket=config.artifacts_bucket,
+            branch=config.ocw_hugo_themes_branch,
+        )
+        webpack_manifest_trigger_resource.check_every = Duration("1m")
         ocw_hugo_themes_resource = OcwHugoThemesGitResource(
             branch=config.ocw_hugo_themes_branch
         )
@@ -145,9 +155,17 @@ class MassBuildSitesResources(list[Resource]):
             uri=root_starter.ocw_hugo_projects_url,
             branch=config.ocw_hugo_projects_branch,
         )
+        ocw_hugo_projects_trigger_resource = GitResource(
+            name=OCW_HUGO_PROJECTS_GIT_TRIGGER_IDENTIFIER,
+            uri=root_starter.ocw_hugo_projects_url,
+            branch=config.ocw_hugo_projects_branch,
+        )
+        ocw_hugo_projects_trigger_resource.check_every = Duration("1m")
         self.append(webpack_manifest_resource)
+        self.append(webpack_manifest_trigger_resource)
         self.append(ocw_hugo_themes_resource)
         self.append(ocw_hugo_projects_resource)
+        self.append(ocw_hugo_projects_trigger_resource)
         self.append(
             OcwStudioWebhookResource(
                 site_name=site_pipeline_vars["site_name"],
@@ -223,6 +241,25 @@ class MassBuildSitesPipelineDefinition(Pipeline):
         batch_count = len(batches)
         batch_number = 1
         for batch in batches:
+            tasks = []
+            if batch_number == 1:
+                trigger = not config.offline
+                tasks.extend(
+                    [
+                        GetStep(
+                            get=WEBPACK_MANIFEST_S3_TRIGGER_IDENTIFIER,
+                            trigger=trigger,
+                            timeout="5m",
+                            attempts=3,
+                        ),
+                        GetStep(
+                            get=OCW_HUGO_PROJECTS_GIT_TRIGGER_IDENTIFIER,
+                            trigger=trigger,
+                            timeout="5m",
+                            attempts=3,
+                        ),
+                    ]
+                )
             if batch_number < batch_count:
                 batch_gate_resources.append(
                     Resource(
@@ -232,7 +269,6 @@ class MassBuildSitesPipelineDefinition(Pipeline):
                         check_every="never",
                     )
                 )
-            tasks = []
             tasks.extend(base_tasks)
             if config.offline:
                 tasks.append(filter_webpack_artifacts_step)

--- a/content_sync/pipelines/definitions/concourse/mass_build_sites_test.py
+++ b/content_sync/pipelines/definitions/concourse/mass_build_sites_test.py
@@ -101,7 +101,7 @@ def test_generate_mass_build_sites_definition(  # noqa: C901, PLR0913, PLR0912 P
     )
     mock_is_dev.return_value = is_dev
     site_content_branch = get_site_content_branch(version)
-    artifacts_bucket = "ol-eng-artifacts"
+    artifacts_bucket = settings.AWS_ARTIFACTS_BUCKET_NAME
     web_bucket = (
         settings.AWS_PREVIEW_BUCKET_NAME
         if version == VERSION_DRAFT

--- a/content_sync/pipelines/definitions/concourse/mass_build_sites_test.py
+++ b/content_sync/pipelines/definitions/concourse/mass_build_sites_test.py
@@ -30,7 +30,7 @@ from content_sync.pipelines.definitions.concourse.site_pipeline import (
     SitePipelineDefinitionConfig,
     get_site_pipeline_definition_vars,
 )
-from content_sync.utils import get_ocw_studio_api_url
+from content_sync.utils import get_ocw_studio_api_url, get_site_content_branch
 from main.utils import get_dict_list_item_by_field
 from websites.constants import OCW_HUGO_THEMES_GIT, STARTER_SOURCE_GITHUB
 from websites.factories import WebsiteFactory, WebsiteStarterFactory
@@ -100,11 +100,7 @@ def test_generate_mass_build_sites_definition(  # noqa: C901, PLR0913, PLR0912 P
         "content_sync.pipelines.definitions.concourse.site_pipeline.is_dev"
     )
     mock_is_dev.return_value = is_dev
-    site_content_branch = (
-        settings.GIT_BRANCH_PREVIEW
-        if version == VERSION_DRAFT
-        else settings.GIT_BRANCH_RELEASE
-    )
+    site_content_branch = get_site_content_branch(version)
     artifacts_bucket = "ol-eng-artifacts"
     web_bucket = (
         settings.AWS_PREVIEW_BUCKET_NAME
@@ -121,7 +117,6 @@ def test_generate_mass_build_sites_definition(  # noqa: C901, PLR0913, PLR0912 P
     ocw_studio_url = get_ocw_studio_api_url()
     site_pipeline_vars = get_site_pipeline_definition_vars(namespace=".:site.")
     pipeline_config = MassBuildSitesPipelineDefinitionConfig(
-        sites=websites,
         version=version,
         artifacts_bucket=artifacts_bucket,
         site_content_branch=site_content_branch,

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -397,7 +397,7 @@ class StaticResourcesTaskStep(TaskStep):
         video_filter = " --exclude *.mp4" if filter_videos else ""
         super().__init__(
             task=STATIC_RESOURCES_S3_IDENTIFIER,
-            timeout="40m",
+            timeout="120m",
             attempts=3,
             params={},
             config=TaskConfig(
@@ -626,7 +626,7 @@ class SitePipelineOfflineTasks(list[StepModifierMixin]):
         build_offline_site_step = add_error_handling(
             step=TaskStep(
                 task=BUILD_OFFLINE_SITE_IDENTIFIER,
-                timeout="20m",
+                timeout="120m",
                 attempts=3,
                 params={
                     "API_BEARER_TOKEN": settings.API_BEARER_TOKEN,
@@ -690,7 +690,7 @@ class SitePipelineOfflineTasks(list[StepModifierMixin]):
         upload_offline_build_step = add_error_handling(
             step=TaskStep(
                 task=UPLOAD_OFFLINE_BUILD_IDENTIFIER,
-                timeout="40m",
+                timeout="120m",
                 params={"IS_ROOT_WEBSITE": pipeline_vars["is_root_website"]},
                 config=TaskConfig(
                     platform="linux",

--- a/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
@@ -124,7 +124,7 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
     )
     ocw_studio_url = "http://10.1.0.102:8043" if is_dev else settings.SITE_BASE_URL
     storage_bucket = "ol-ocw-studio-app"
-    artifacts_bucket = "ol-eng-artifacts"
+    artifacts_bucket = settings.AWS_ARTIFACTS_BUCKET_NAME
     instance_vars = f"?vars={quote(json.dumps({'site': website.name}))}"
     config = SitePipelineDefinitionConfig(
         site=website,

--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline_test.py
@@ -1,5 +1,7 @@
 import json
 
+from django.conf import settings
+
 from content_sync.constants import DEV_ENDPOINT_URL
 from content_sync.pipelines.definitions.concourse.common.identifiers import (
     OCW_HUGO_THEMES_GIT_IDENTIFIER,
@@ -14,9 +16,9 @@ def test_generate_theme_assets_pipeline_definition(mock_environments):
     """
     The theme assets pipeline definition should contain the expected properties
     """
-    artifacts_bucket = "ol-eng-artifacts"
-    preview_bucket = "ocw-content-preview"
-    publish_bucket = "ocw-content-publish"
+    artifacts_bucket = settings.AWS_ARTIFACTS_BUCKET_NAME
+    preview_bucket = settings.AWS_PREVIEW_BUCKET_NAME
+    publish_bucket = settings.AWS_PUBLISH_BUCKET_NAME
     ocw_hugo_themes_branch = "main"
     pipeline_definition = ThemeAssetsPipelineDefinition(
         artifacts_bucket=artifacts_bucket,

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -240,7 +240,7 @@ def update_mass_build_pipelines_on_publish(version: str, website: Website):
             "publish_date" if version == VERSION_LIVE else "draft_publish_date"
         )
         publish_date = getattr(website, publish_date_field)
-        if not publish_date:
+        if not publish_date or website.unpublish_status:
             pipeline = api.get_mass_build_sites_pipeline(version)
             pipeline.upsert_pipeline()
             offline_pipeline = api.get_mass_build_sites_pipeline(version, offline=True)

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -226,8 +226,15 @@ def sync_website_content(website_name: str):
 
 
 @app.task(acks_late=True)
-def update_mass_build_pipelines(website: Website, version: str):
-    """Update the mass-build-sites pipeline definitions"""
+def update_mass_build_pipelines_on_publish(version: str, website: Website):
+    """
+    Update the mass-build-sites pipeline definitions upon publishing of a new website,
+    but only do so if the site has never been published before
+
+    Args:
+        version(str): The version (draft / live) to update
+        website(Website): The website being published to check publish_date against
+    """
     if settings.CONTENT_SYNC_PIPELINE_BACKEND:
         publish_date_field = (
             "publish_date" if version == VERSION_LIVE else "draft_publish_date"

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -229,7 +229,7 @@ def sync_website_content(website_name: str):
 def update_mass_build_pipelines_on_publish(version: str, website: Website):
     """
     Update the mass-build-sites pipeline definitions upon publishing of a new website,
-    but only do so if the site has never been published before
+    but only do so if the site has never been published before or has been unpublished
 
     Args:
         version(str): The version (draft / live) to update

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -234,13 +234,9 @@ def update_mass_build_pipelines(website: Website, version: str):
         )
         publish_date = getattr(website, publish_date_field)
         if not publish_date:
-            pipeline = api.get_mass_build_sites_pipeline(
-                version, offline=False, prefix="", starter=""
-            )
+            pipeline = api.get_mass_build_sites_pipeline(version)
             pipeline.upsert_pipeline()
-            offline_pipeline = api.get_mass_build_sites_pipeline(
-                version, offline=True, prefix="", starter=""
-            )
+            offline_pipeline = api.get_mass_build_sites_pipeline(version, offline=True)
             offline_pipeline.upsert_pipeline()
 
 

--- a/content_sync/tasks_test.py
+++ b/content_sync/tasks_test.py
@@ -118,19 +118,19 @@ def test_update_mass_build_pipelines(api_mock):
     fake_date = factory.Faker("date_time", tzinfo=pytz.utc)
     website.draft_publish_date = None
     website.publish_date = None
-    tasks.update_mass_build_pipelines(website, VERSION_DRAFT)
+    tasks.update_mass_build_pipelines_on_publish(version=VERSION_DRAFT, website=website)
     api_mock.get_mass_build_sites_pipeline.assert_any_call(VERSION_DRAFT)
     api_mock.get_mass_build_sites_pipeline.assert_any_call(VERSION_DRAFT, offline=True)
     assert api_mock.get_mass_build_sites_pipeline.call_count == 2
     website.draft_publish_date = fake_date
-    tasks.update_mass_build_pipelines(website, VERSION_DRAFT)
+    tasks.update_mass_build_pipelines_on_publish(version=VERSION_DRAFT, website=website)
     assert api_mock.get_mass_build_sites_pipeline.call_count == 2
-    tasks.update_mass_build_pipelines(website, VERSION_LIVE)
+    tasks.update_mass_build_pipelines_on_publish(version=VERSION_LIVE, website=website)
     api_mock.get_mass_build_sites_pipeline.assert_any_call(VERSION_LIVE)
     api_mock.get_mass_build_sites_pipeline.assert_any_call(VERSION_LIVE, offline=True)
     assert api_mock.get_mass_build_sites_pipeline.call_count == 4
     website.publish_date = fake_date
-    tasks.update_mass_build_pipelines(website, VERSION_LIVE)
+    tasks.update_mass_build_pipelines_on_publish(version=VERSION_LIVE, website=website)
     assert api_mock.get_mass_build_sites_pipeline.call_count == 4
 
 

--- a/content_sync/tasks_test.py
+++ b/content_sync/tasks_test.py
@@ -132,6 +132,10 @@ def test_update_mass_build_pipelines(api_mock):
     website.publish_date = fake_date
     tasks.update_mass_build_pipelines_on_publish(version=VERSION_LIVE, website=website)
     assert api_mock.get_mass_build_sites_pipeline.call_count == 4
+    website.unpublish_status = PUBLISH_STATUS_NOT_STARTED
+    tasks.update_mass_build_pipelines_on_publish(version=VERSION_DRAFT, website=website)
+    tasks.update_mass_build_pipelines_on_publish(version=VERSION_LIVE, website=website)
+    assert api_mock.get_mass_build_sites_pipeline.call_count == 8
 
 
 @pytest.mark.parametrize("backend_exists", [True, False])

--- a/content_sync/tasks_test.py
+++ b/content_sync/tasks_test.py
@@ -2,7 +2,9 @@
 import os
 from datetime import timedelta
 
+import factory
 import pytest
+import pytz
 from django.db.models.signals import post_save
 from factory.django import mute_signals
 from github.GithubException import RateLimitExceededException
@@ -108,6 +110,36 @@ def test_sync_website_content_not_exists(api_mock, log_mock):
         "fakesite",
     )
     api_mock.get_sync_backend.assert_not_called()
+
+
+def test_update_mass_build_pipelines(api_mock):
+    """Verify that mass_build_sites pipelines are upserted under the proper conditions"""
+    website = WebsiteFactory.create()
+    fake_date = factory.Faker("date_time", tzinfo=pytz.utc)
+    website.draft_publish_date = None
+    website.publish_date = None
+    tasks.update_mass_build_pipelines(website, VERSION_DRAFT)
+    api_mock.get_mass_build_sites_pipeline.assert_any_call(
+        VERSION_DRAFT, offline=False, prefix="", starter=""
+    )
+    api_mock.get_mass_build_sites_pipeline.assert_any_call(
+        VERSION_DRAFT, offline=True, prefix="", starter=""
+    )
+    assert api_mock.get_mass_build_sites_pipeline.call_count == 2
+    website.draft_publish_date = fake_date
+    tasks.update_mass_build_pipelines(website, VERSION_DRAFT)
+    assert api_mock.get_mass_build_sites_pipeline.call_count == 2
+    tasks.update_mass_build_pipelines(website, VERSION_LIVE)
+    api_mock.get_mass_build_sites_pipeline.assert_any_call(
+        VERSION_LIVE, offline=False, prefix="", starter=""
+    )
+    api_mock.get_mass_build_sites_pipeline.assert_any_call(
+        VERSION_LIVE, offline=True, prefix="", starter=""
+    )
+    assert api_mock.get_mass_build_sites_pipeline.call_count == 4
+    website.publish_date = fake_date
+    tasks.update_mass_build_pipelines(website, VERSION_LIVE)
+    assert api_mock.get_mass_build_sites_pipeline.call_count == 4
 
 
 @pytest.mark.parametrize("backend_exists", [True, False])

--- a/content_sync/tasks_test.py
+++ b/content_sync/tasks_test.py
@@ -119,23 +119,15 @@ def test_update_mass_build_pipelines(api_mock):
     website.draft_publish_date = None
     website.publish_date = None
     tasks.update_mass_build_pipelines(website, VERSION_DRAFT)
-    api_mock.get_mass_build_sites_pipeline.assert_any_call(
-        VERSION_DRAFT, offline=False, prefix="", starter=""
-    )
-    api_mock.get_mass_build_sites_pipeline.assert_any_call(
-        VERSION_DRAFT, offline=True, prefix="", starter=""
-    )
+    api_mock.get_mass_build_sites_pipeline.assert_any_call(VERSION_DRAFT)
+    api_mock.get_mass_build_sites_pipeline.assert_any_call(VERSION_DRAFT, offline=True)
     assert api_mock.get_mass_build_sites_pipeline.call_count == 2
     website.draft_publish_date = fake_date
     tasks.update_mass_build_pipelines(website, VERSION_DRAFT)
     assert api_mock.get_mass_build_sites_pipeline.call_count == 2
     tasks.update_mass_build_pipelines(website, VERSION_LIVE)
-    api_mock.get_mass_build_sites_pipeline.assert_any_call(
-        VERSION_LIVE, offline=False, prefix="", starter=""
-    )
-    api_mock.get_mass_build_sites_pipeline.assert_any_call(
-        VERSION_LIVE, offline=True, prefix="", starter=""
-    )
+    api_mock.get_mass_build_sites_pipeline.assert_any_call(VERSION_LIVE)
+    api_mock.get_mass_build_sites_pipeline.assert_any_call(VERSION_LIVE, offline=True)
     assert api_mock.get_mass_build_sites_pipeline.call_count == 4
     website.publish_date = fake_date
     tasks.update_mass_build_pipelines(website, VERSION_LIVE)

--- a/content_sync/utils.py
+++ b/content_sync/utils.py
@@ -135,14 +135,22 @@ def get_common_pipeline_vars():
 
 
 def get_cli_endpoint_url():
+    """Get the S3 endpoint-url, which points to Minio for local dev"""
     return f" --endpoint-url {DEV_ENDPOINT_URL}" if is_dev() else ""
 
 
 def get_ocw_studio_api_url():
+    """Get the ocw-studio URL, which points to Docker for local dev"""
     return "http://10.1.0.102:8043" if is_dev() else settings.SITE_BASE_URL
 
 
 def get_publishable_sites(version: str):
+    """
+    Get a QuerySet of Website objects that are eligible for publishing
+
+    Args:
+        version(str): The version (draft/live) to check publish eligibility with
+    """
     publish_date_field = (
         "publish_date" if version == VERSION_LIVE else "draft_publish_date"
     )

--- a/content_sync/utils.py
+++ b/content_sync/utils.py
@@ -157,8 +157,7 @@ def get_publishable_sites(version: str):
     # Get all sites, minus any sites that have never been successfully published
     sites = Website.objects.exclude(
         Q(**{f"{publish_date_field}__isnull": True}) | Q(url_path__isnull=True)
-    )
-    sites = sites.exclude(unpublish_status__isnull=False)
+    ).exclude(unpublish_status__isnull=False)
     return sites.prefetch_related("starter")
 
 

--- a/content_sync/utils.py
+++ b/content_sync/utils.py
@@ -150,8 +150,7 @@ def get_publishable_sites(version: str):
     sites = Website.objects.exclude(
         Q(**{f"{publish_date_field}__isnull": True}) | Q(url_path__isnull=True)
     )
-    if version == VERSION_LIVE:
-        sites = sites.exclude(unpublish_status__isnull=False)
+    sites = sites.exclude(unpublish_status__isnull=False)
     return sites.prefetch_related("starter")
 
 

--- a/content_sync/utils.py
+++ b/content_sync/utils.py
@@ -112,7 +112,7 @@ def get_common_pipeline_vars():
         "offline_preview_bucket_name": settings.AWS_OFFLINE_PREVIEW_BUCKET_NAME,
         "offline_publish_bucket_name": settings.AWS_OFFLINE_PUBLISH_BUCKET_NAME,
         "storage_bucket_name": settings.AWS_STORAGE_BUCKET_NAME,
-        "artifacts_bucket_name": "ol-eng-artifacts",
+        "artifacts_bucket_name": settings.AWS_ARTIFACTS_BUCKET_NAME,
         "static_api_base_url_draft": settings.OCW_STUDIO_DRAFT_URL,
         "static_api_base_url_live": settings.OCW_STUDIO_LIVE_URL,
         "resource_base_url_draft": "",

--- a/content_sync/utils_test.py
+++ b/content_sync/utils_test.py
@@ -203,7 +203,7 @@ def test_get_common_pipeline_vars(settings, mocker, is_dev):
         == settings.AWS_OFFLINE_PUBLISH_BUCKET_NAME
     )
     assert pipeline_vars["storage_bucket_name"] == settings.AWS_STORAGE_BUCKET_NAME
-    assert pipeline_vars["artifacts_bucket_name"] == "ol-eng-artifacts"
+    assert pipeline_vars["artifacts_bucket_name"] == settings.AWS_ARTIFACTS_BUCKET_NAME
     if is_dev:
         assert (
             pipeline_vars["static_api_base_url_draft"]

--- a/content_sync/utils_test.py
+++ b/content_sync/utils_test.py
@@ -32,6 +32,8 @@ from content_sync.utils import (
     get_destination_url,
     get_hugo_arg_string,
     get_ocw_studio_api_url,
+    get_publishable_sites,
+    get_site_content_branch,
     move_s3_object,
     strip_lines_between,
 )
@@ -246,6 +248,30 @@ def test_get_ocw_studio_api_url(settings, mocker, is_dev):
         "http://10.1.0.102:8043" if is_dev else settings.SITE_BASE_URL
     )
     assert ocw_studio_api_url == expected_ocw_studio_api_url
+
+
+@pytest.mark.parametrize("version", [VERSION_DRAFT, VERSION_LIVE])
+def test_get_publishable_sites(settings, mocker, mass_build_websites, version):
+    """get_publishable_sites should return a queryset of sites that have been published before"""
+    unpublished_site = mass_build_websites[0]
+    if version == VERSION_DRAFT:
+        unpublished_site.draft_publish_date = None
+    else:
+        unpublished_site.publish_date = None
+    unpublished_site.save()
+    assert len(mass_build_websites) == 7
+    publishable_sites = get_publishable_sites(version)
+    assert publishable_sites.count() == 6
+
+
+@pytest.mark.parametrize("version", [VERSION_DRAFT, VERSION_LIVE])
+def test_get_site_content_branch(settings, mocker, mass_build_websites, version):
+    """get_publishable_sites should return the proper git branch based on version"""
+    site_content_branch = get_site_content_branch(version)
+    if version == VERSION_DRAFT:
+        assert site_content_branch == settings.GIT_BRANCH_PREVIEW
+    else:
+        assert site_content_branch == settings.GIT_BRANCH_RELEASE
 
 
 @pytest.mark.parametrize("build_target", [TARGET_OFFLINE, TARGET_ONLINE])

--- a/main/settings.py
+++ b/main/settings.py
@@ -414,6 +414,11 @@ AWS_SECRET_ACCESS_KEY = get_string(
     default=None,
     description="AWS Secret Key for S3 storage.",
 )
+AWS_ARTIFACTS_BUCKET_NAME = get_string(
+    name="AWS_ARTIFACTS_BUCKET_NAME",
+    default=None,
+    description="S3 artifacts bucket name.",
+)
 AWS_STORAGE_BUCKET_NAME = get_string(
     name="AWS_STORAGE_BUCKET_NAME", default=None, description="S3 Bucket name."
 )

--- a/websites/management/commands/unpublish_sites.py
+++ b/websites/management/commands/unpublish_sites.py
@@ -6,7 +6,10 @@ from django.db.models import Q
 
 from content_sync import api
 from content_sync.constants import VERSION_LIVE
-from content_sync.tasks import remove_website_in_root_website
+from content_sync.tasks import (
+    remove_website_in_root_website,
+    update_mass_build_pipelines,
+)
 from main.management.commands.filter import WebsiteFilterCommand
 from users.models import User
 from websites.constants import (
@@ -119,6 +122,7 @@ class Command(WebsiteFilterCommand):
                 site_pipeline = api.get_site_pipeline(website)
                 site_pipeline.pause_pipeline(VERSION_LIVE)
                 remove_website_in_root_website(website)
+                update_mass_build_pipelines(VERSION_LIVE)
         removal_pipeline = api.get_unpublished_removal_pipeline()
         removal_pipeline.unpause()
         removal_pipeline.trigger()

--- a/websites/management/commands/unpublish_sites.py
+++ b/websites/management/commands/unpublish_sites.py
@@ -8,7 +8,7 @@ from content_sync import api
 from content_sync.constants import VERSION_LIVE
 from content_sync.tasks import (
     remove_website_in_root_website,
-    update_mass_build_pipelines,
+    update_mass_build_pipelines_on_publish,
 )
 from main.management.commands.filter import WebsiteFilterCommand
 from users.models import User
@@ -122,7 +122,9 @@ class Command(WebsiteFilterCommand):
                 site_pipeline = api.get_site_pipeline(website)
                 site_pipeline.pause_pipeline(VERSION_LIVE)
                 remove_website_in_root_website(website)
-                update_mass_build_pipelines(VERSION_LIVE)
+                update_mass_build_pipelines_on_publish(
+                    version=VERSION_LIVE, website=website
+                )
         removal_pipeline = api.get_unpublished_removal_pipeline()
         removal_pipeline.unpause()
         removal_pipeline.trigger()


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1966

# Description (What does it do?)
This PR sets up `content_sync.pipelines.concourse.MassBuildSitesPipeline` to use `content_sync.pipelines.definitions.mass_build_sites.MassBuildSitesPipelineDefinition` rather than the current strategy of running `mass-build-sites.yml` through `get_pipeline_definition`, stripping lines out based on environment. It also makes a number of adjustments to tests relating to pipeline fixtures and the tests that use them. 


# How can this be tested?
 - Make sure you have a fairly recent database restore, have a Github organization set up and are otherwise set up for publishing sites locally
 - To facilitate easier local testing, you may also want to specifically set the following environment variables:
```
RESOURCE_BASE_URL_DRAFT=https://draft.ocw.mit.edu
RESOURCE_BASE_URL_LIVE=https://ocw.mit.edu
STATIC_API_BASE_URL_DRAFT=https://draft.ocw.mit.edu
STATIC_API_BASE_URL_LIVE=https://ocw.mit.edu
OCW_STUDIO_DRAFT_URL=http://localhost:8044/
OCW_STUDIO_LIVE_URL=http://localhost:8045/
OCW_HUGO_THEMES_BRANCH=main
OCW_HUGO_PROJECTS_BRANCH=main
```
 - You will also want to make sure you add `content_sync.tasks.update_mass_build_pipelines` to your `PREPUBLISH_ACTIONS` env variable, or create it if it doesn't exist
 - Make sure your Github repos in your test org are fully up to date by running the following (This will take a couple of hours depending on your latency to Github and rate limiting, so you may want to start this and then move on to something else for the time being):
```
docker compose exec web ./manage.py reset_sync_states --skip_sync
docker compose exec web ./manage.py mass_publish live
```
 - First we will test that the pipelines are upserted to Concourse when a site is being published for the first time to either draft or live:
   - If you don't have any mass build pipelines already in Concourse, you can skip the next 2 steps:
   - Run `fly -t local pipelines | grep mass-build-sites` and you should see some output listing the mass build pipelines in your local Concourse
   - Destroy the pipelines one at a time by running, for example, `fly -t local destroy-pipeline -p 'mass-build-sites/offline:false,prefix:"",projects_branch:main,starter:"",themes_branch:main,version:draft'`
   - Browse to http://localhost:8043/admin/websites/website/ and find any site you want to use to testing. Open the admin page for the site and blank out all fields relating to draft and live publish status, then click save
   - Ensure the single site pipeline for said website is pushed up to your local Concourse by running `docker-compose exec web ./manage.py backpopulate_pipelines --filter site-id` where `site-id` is the `name` or `short_id` of your site
   - Browse to the site's editor in the `ocw-studio` UI at http://localhost:8043/sites
   - Publish the site to draft
   - Browse to http://localhost:8080/?search=team%3A%22main%22%20group%3A%22mass-build-sites%22 and after a short while, you should see 2 mass build pipelines appear, both with `version: draft`, one with `offline: false` and the other with `offline: true`
   - Back in the `ocw-studio` UI for the site, wait for the status to change to "Succeded" and then publish the site live
   - Open the Concourse link above again, and after a short while you should see 2 more pipelines appear, this time with `version: live`
 - Browse to the Concourse UI at http://localhost:8080
 - Trigger the live online mass builds and wait for it to complete
 - Trigger the live offline mass builds and wait for it to complete
 - After both builds have finished you should have a fully usable OCW site in your local system. Verify the following:
   - Browse to http://localhost:8045 and verify that you see the home page
   - Click on any of the courses under "new courses" and verify that you see a course site and can browse it normally
   - Browse to the download page and verify that you can download the course ZIP archive
   - Extract the archive and verify that the offline version of the site works
   - Browse to the Minio UI at http://localhost:9001, go to the offline bucket and download one of the folders and ensure you can browse the site offline


## Checklist:
- [ ] After this PR is *released*, a `salt-ops` PR should be put up to add `content_sync.tasks.update_mass_build_pipelines` to `PREPUBLISH_ACTIONS`