### PR TITLE
overhaul unpublish sites pipeline

### DIFF
--- a/content_sync/conftest.py
+++ b/content_sync/conftest.py
@@ -22,6 +22,7 @@ def mock_environments(settings, request):  # noqa: PT004
     """Fixture that tests with dev vs non-dev environment"""
     settings.OCW_STUDIO_ENVIRONMENT = request.param
     settings.ENV_NAME = request.param
+    settings.ENVIRONMENT = request.param
 
 
 @pytest.fixture(params=[True, False])

--- a/content_sync/pipelines/definitions/concourse/common/identifiers.py
+++ b/content_sync/pipelines/definitions/concourse/common/identifiers.py
@@ -5,6 +5,7 @@ HTTP_RESOURCE_TYPE_IDENTIFIER = Identifier("http-resource").root
 KEYVAL_RESOURCE_TYPE_IDENTIFIER = Identifier("keyval").root
 S3_IAM_RESOURCE_TYPE_IDENTIFIER = Identifier("s3-resource-iam").root
 OCW_STUDIO_WEBHOOK_RESOURCE_TYPE_IDENTIFIER = Identifier("ocw-studio-webhook").root
+OCW_STUDIO_WEBHOOK_CURL_STEP_IDENTIFIER = Identifier("ocw-studio-webhook-curl").root
 SLACK_ALERT_RESOURCE_IDENTIFIER = Identifier("slack-alert").root
 OPEN_DISCUSSIONS_RESOURCE_IDENTIFIER = Identifier("open-discussions-webhook").root
 WEBPACK_MANIFEST_S3_IDENTIFIER = Identifier("webpack-manifest-s3").root

--- a/content_sync/pipelines/definitions/concourse/common/image_resources.py
+++ b/content_sync/pipelines/definitions/concourse/common/image_resources.py
@@ -15,6 +15,10 @@ AWS_CLI_REGISTRY_IMAGE = AnonymousResource(
     type=REGISTRY_IMAGE, source=RegistryImage(repository="amazon/aws-cli", tag="latest")
 )
 
+BASH_REGISTRY_IMAGE = AnonymousResource(
+    type=REGISTRY_IMAGE, source=RegistryImage(repository="bash", tag="latest")
+)
+
 CURL_REGISTRY_IMAGE = AnonymousResource(
     type=REGISTRY_IMAGE, source=RegistryImage(repository="curlimages/curl")
 )

--- a/content_sync/pipelines/definitions/concourse/remove_unpublished_sites.py
+++ b/content_sync/pipelines/definitions/concourse/remove_unpublished_sites.py
@@ -1,0 +1,213 @@
+import json
+
+from django.conf import settings
+from ol_concourse.lib.models.pipeline import (
+    AcrossVar,
+    Command,
+    DoStep,
+    Identifier,
+    Job,
+    LoadVarStep,
+    Output,
+    Pipeline,
+    TaskConfig,
+    TaskStep,
+)
+
+from content_sync.constants import DEV_ENDPOINT_URL, VERSION_LIVE
+from content_sync.pipelines.definitions.concourse.common.image_resources import (
+    AWS_CLI_REGISTRY_IMAGE,
+    BASH_REGISTRY_IMAGE,
+    CURL_REGISTRY_IMAGE,
+)
+from content_sync.pipelines.definitions.concourse.common.resource_types import (
+    HttpResourceType,
+    S3IamResourceType,
+)
+from content_sync.pipelines.definitions.concourse.common.resources import (
+    OpenDiscussionsResource,
+    SlackAlertResource,
+)
+from content_sync.pipelines.definitions.concourse.common.steps import (
+    ClearCdnCacheStep,
+    OcwStudioWebhookCurlStep,
+)
+from content_sync.utils import (
+    get_cli_endpoint_url,
+    get_common_pipeline_vars,
+    get_ocw_studio_api_url,
+)
+from main.utils import is_dev
+
+CLI_ENDPOINT_URL = f" --endpoint-url {DEV_ENDPOINT_URL}" if is_dev() else ""
+
+
+class UnpublishedSiteRemovalPipelineDefinition(Pipeline):
+    """
+    A Pipeline that does the following:
+
+     - Fetch a list of unpublishable sites from the ocw-studio API
+     - For each site:
+       - Remove from Open search index
+       - Remove the site from S3
+       - Clear CDN cache
+    """
+
+    _remove_unpublished_sites_job_identifier = Identifier(
+        "remove-unpublished-sites-job"
+    ).root
+    _get_unpublished_sites_task_identifier = Identifier(
+        "get-unpublished-sites-task"
+    ).root
+    _unpublishable_sites_output_identifier = Identifier(
+        "unpublishable-sites-output"
+    ).root
+    _unpublishable_sites_var_identifier = Identifier("unpublishable-sites-var").root
+    _search_index_removal_task_identifier = Identifier("search-index-removal-task").root
+    _empty_s3_bucket_task_identifier = Identifier("empty-s3-bucket-task").root
+    _clear_cdn_cache_task_identifier = Identifier("clear-cdn-cache-task").root
+    _ocw_studio_webhook_task_identifier = Identifier("ocw-studio-webhook-task").root
+
+    _open_discussions_resource = OpenDiscussionsResource()
+    _slack_resource = SlackAlertResource()
+
+    def __init__(self, **kwargs):
+        base = super()
+        base.__init__(**kwargs)
+        common_pipeline_vars = get_common_pipeline_vars()
+        web_bucket = common_pipeline_vars["publish_bucket_name"]
+        offline_bucket = common_pipeline_vars["offline_publish_bucket_name"]
+        ocw_studio_url = get_ocw_studio_api_url().rstrip("/")
+        cli_endpoint_url = get_cli_endpoint_url()
+        api_token = settings.API_BEARER_TOKEN
+        open_discussions_url = settings.OPEN_DISCUSSIONS_URL.rstrip("/")
+        open_webhook_key = settings.OCW_NEXT_SEARCH_WEBHOOK_KEY
+        minio_root_user = settings.AWS_ACCESS_KEY_ID
+        minio_root_password = settings.AWS_SECRET_ACCESS_KEY
+
+        resource_types = [
+            HttpResourceType(),
+            S3IamResourceType(),
+        ]
+        unpublish_failed_webhook_across_step = OcwStudioWebhookCurlStep(
+            site_name="((.:site.name))",
+            data={"version": VERSION_LIVE, "status": "errored", "unpublished": True},
+        )
+        unpublish_succeeded_webhook_across_step = OcwStudioWebhookCurlStep(
+            site_name="((.:site.name))",
+            data={
+                "version": VERSION_LIVE,
+                "status": "succeeded",
+                "unpublished": True,
+            },
+        )
+        search_index_removal_across_task = TaskStep(
+            task=self._search_index_removal_task_identifier,
+            timeout="1m",
+            attempts=3,
+            config=TaskConfig(
+                platform="linux",
+                image_resource=CURL_REGISTRY_IMAGE,
+                run=Command(
+                    path="curl",
+                    args=[
+                        "-f",
+                        "-X",
+                        "POST",
+                        "-H",
+                        "Content-Type: application/json",
+                        "--data",
+                        json.dumps(
+                            {
+                                "webhook_key": open_webhook_key,
+                                "site_uid": "((.:site.site_uid))",
+                                "version": VERSION_LIVE,
+                                "unpublished": "true",
+                            }
+                        ),
+                        f"{open_discussions_url}/api/v0/ocw_next_webhook/",
+                    ],
+                ),
+            ),
+            on_failure=unpublish_failed_webhook_across_step,
+        )
+        empty_s3_bucket_across_task = TaskStep(
+            task=self._empty_s3_bucket_task_identifier,
+            timeout="10m",
+            attempts=3,
+            params={},
+            config=TaskConfig(
+                platform="linux",
+                image_resource=AWS_CLI_REGISTRY_IMAGE,
+                run=Command(
+                    path="sh",
+                    args=[
+                        "-exc",
+                        f"""
+                        aws s3{cli_endpoint_url} rm s3://{web_bucket}/((.:site.site_url))/ --recursive
+                        aws s3{cli_endpoint_url} rm s3://{offline_bucket}/((.:site.site_url))/ --recursive
+                        """,  # noqa: E501
+                    ],
+                ),
+            ),
+            on_failure=unpublish_failed_webhook_across_step,
+        )
+        if is_dev():
+            empty_s3_bucket_across_task.params.update(
+                {
+                    "AWS_ACCESS_KEY_ID": minio_root_user,
+                    "AWS_SECRET_ACCESS_KEY": minio_root_password,
+                }
+            )
+        clear_cdn_cache_step = ClearCdnCacheStep(
+            name=self._clear_cdn_cache_task_identifier,
+            fastly_var=f"fastly_{VERSION_LIVE}",
+            site_name="((.:site.name))",
+            on_success=unpublish_succeeded_webhook_across_step,
+            on_failure=unpublish_failed_webhook_across_step,
+        )
+        across_tasks = [
+            empty_s3_bucket_across_task,
+        ]
+        if not is_dev():
+            across_tasks.append(search_index_removal_across_task)
+            across_tasks.append(clear_cdn_cache_step)
+        tasks = [
+            TaskStep(
+                task=self._get_unpublished_sites_task_identifier,
+                timeout="2m",
+                attempts=3,
+                config=TaskConfig(
+                    platform="linux",
+                    image_resource=BASH_REGISTRY_IMAGE,
+                    outputs=[Output(name=self._unpublishable_sites_output_identifier)],
+                    run=Command(
+                        path="sh",
+                        args=[
+                            "-exc",
+                            f'wget -O {self._unpublishable_sites_output_identifier}/sites.json --header="Authorization: Bearer {api_token}" "{ocw_studio_url}/api/unpublish/"',  # noqa: E501
+                        ],
+                    ),
+                ),
+            ),
+            LoadVarStep(
+                load_var=self._unpublishable_sites_var_identifier,
+                file=f"{self._unpublishable_sites_output_identifier}/sites.json",
+                format="json",
+                reveal=True,
+            ),
+            DoStep(
+                do=across_tasks,
+                across=[
+                    AcrossVar(
+                        var="site",
+                        values=f"((.:{self._unpublishable_sites_var_identifier}.sites))",
+                        max_in_flight=5,
+                    )
+                ],
+            ),
+        ]
+        job = Job(name=self._remove_unpublished_sites_job_identifier, serial=True)
+
+        job.plan = tasks
+        base.__init__(resource_types=resource_types, jobs=[job], **kwargs)

--- a/content_sync/pipelines/definitions/concourse/remove_unpublished_sites_test.py
+++ b/content_sync/pipelines/definitions/concourse/remove_unpublished_sites_test.py
@@ -1,0 +1,128 @@
+import json
+
+from content_sync.constants import VERSION_LIVE
+from content_sync.pipelines.definitions.concourse.remove_unpublished_sites import (
+    UnpublishedSiteRemovalPipelineDefinition,
+)
+from content_sync.utils import get_cli_endpoint_url, get_common_pipeline_vars
+from main.utils import is_dev
+
+
+def test_generate_unpublished_site_removal_pipeline_definition(  # noqa: PLR0915
+    mock_environments, settings
+):
+    """
+    The unpublished site removal pipeline definition should contain the expected properties
+    """
+    open_webhook_key = "abc123"
+    open_discussions_url = "https://example.com"
+    common_pipeline_vars = get_common_pipeline_vars()
+    cli_endpoint_url = get_cli_endpoint_url()
+    web_bucket = common_pipeline_vars["publish_bucket_name"]
+    offline_bucket = common_pipeline_vars["offline_publish_bucket_name"]
+    settings.OPEN_DISCUSSIONS_URL = open_discussions_url
+    settings.OCW_NEXT_SEARCH_WEBHOOK_KEY = open_webhook_key
+
+    pipeline_definition = UnpublishedSiteRemovalPipelineDefinition()
+    rendered_definition = json.loads(pipeline_definition.json(indent=2))
+
+    jobs = [
+        job
+        for job in rendered_definition["jobs"]
+        if job["name"]
+        == pipeline_definition._remove_unpublished_sites_job_identifier  # noqa: SLF001
+    ]
+    assert len(jobs) == 1
+    remove_unpublished_sites_job = jobs[0]
+    get_unpublished_sites_tasks = [
+        task
+        for task in remove_unpublished_sites_job["plan"]
+        if task.get("task")
+        == pipeline_definition._get_unpublished_sites_task_identifier  # noqa: SLF001
+    ]
+    assert len(get_unpublished_sites_tasks) == 1
+    get_unpublished_sites_task = get_unpublished_sites_tasks[0]
+    get_unpublished_sites_command = " ".join(
+        get_unpublished_sites_task["config"]["run"]["args"]
+    )
+    assert (
+        pipeline_definition._unpublishable_sites_output_identifier  # noqa: SLF001
+        in get_unpublished_sites_command
+    )
+    search_index_removal_tasks = [
+        task
+        for task in remove_unpublished_sites_job["plan"]
+        if task.get("load_var")
+        == pipeline_definition._unpublishable_sites_var_identifier  # noqa: SLF001
+    ]
+    assert len(search_index_removal_tasks) == 1
+    load_unpublishable_sites_task = search_index_removal_tasks[0]
+    assert (
+        load_unpublishable_sites_task["file"]
+        == f"{pipeline_definition._unpublishable_sites_output_identifier}/sites.json"  # noqa: SLF001
+    )
+    assert load_unpublishable_sites_task["format"] == "json"
+    assert load_unpublishable_sites_task["reveal"] is True
+    across_step = remove_unpublished_sites_job["plan"][-1]
+    across_var = across_step["across"][0]
+    assert across_var["var"] == "site"
+    assert (
+        across_var["values"]
+        == f"((.:{pipeline_definition._unpublishable_sites_var_identifier}.sites))"  # noqa: SLF001
+    )
+    assert across_var["max_in_flight"] == 5
+    across_tasks = across_step["do"]
+    if not is_dev():
+        search_index_removal_tasks = [
+            task
+            for task in across_tasks
+            if task.get("task")
+            == pipeline_definition._search_index_removal_task_identifier  # noqa: SLF001
+        ]
+        assert len(search_index_removal_tasks) == 1
+        search_index_removal_task = search_index_removal_tasks[0]
+        search_index_removal_command = " ".join(
+            search_index_removal_task["config"]["run"]["args"]
+        )
+        assert f'"webhook_key": "{open_webhook_key}"' in search_index_removal_command
+        assert f'"version": "{VERSION_LIVE}"' in search_index_removal_command
+        assert (
+            f"{open_discussions_url}/api/v0/ocw_next_webhook/"
+            in search_index_removal_command
+        )
+        clear_cdn_cache_tasks = [
+            task
+            for task in across_tasks
+            if task.get("task")
+            == pipeline_definition._clear_cdn_cache_task_identifier  # noqa: SLF001
+        ]
+        assert len(clear_cdn_cache_tasks) == 1
+        clear_cdn_cache_task = clear_cdn_cache_tasks[0]
+        assert clear_cdn_cache_task["on_success"] is not None
+        assert clear_cdn_cache_task["on_failure"] is not None
+    empty_s3_buckets_tasks = [
+        task
+        for task in across_tasks
+        if task.get("task")
+        == pipeline_definition._empty_s3_bucket_task_identifier  # noqa: SLF001
+    ]
+    assert len(empty_s3_buckets_tasks) == 1
+    empty_s3_buckets_task = empty_s3_buckets_tasks[0]
+    empty_s3_buckets_command = " ".join(empty_s3_buckets_task["config"]["run"]["args"])
+    assert (
+        f"aws s3{cli_endpoint_url} rm s3://{web_bucket}/((.:site.site_url))/ --recursive"
+        in empty_s3_buckets_command
+    )
+    assert (
+        f"aws s3{cli_endpoint_url} rm s3://{offline_bucket}/((.:site.site_url))/ --recursive"
+        in empty_s3_buckets_command
+    )
+    if is_dev():
+        assert (
+            empty_s3_buckets_task["params"]["AWS_ACCESS_KEY_ID"]
+            == settings.AWS_ACCESS_KEY_ID
+        )
+        assert (
+            empty_s3_buckets_task["params"]["AWS_SECRET_ACCESS_KEY"]
+            == settings.AWS_SECRET_ACCESS_KEY
+        )

--- a/content_sync/pipelines/definitions/concourse/remove_unpublished_sites_test.py
+++ b/content_sync/pipelines/definitions/concourse/remove_unpublished_sites_test.py
@@ -46,29 +46,29 @@ def test_generate_unpublished_site_removal_pipeline_definition(  # noqa: PLR0915
         get_unpublished_sites_task["config"]["run"]["args"]
     )
     assert (
-        pipeline_definition._unpublishable_sites_output_identifier  # noqa: SLF001
+        pipeline_definition._unpublished_sites_output_identifier  # noqa: SLF001
         in get_unpublished_sites_command
     )
     search_index_removal_tasks = [
         task
         for task in remove_unpublished_sites_job["plan"]
         if task.get("load_var")
-        == pipeline_definition._unpublishable_sites_var_identifier  # noqa: SLF001
+        == pipeline_definition._unpublished_sites_var_identifier  # noqa: SLF001
     ]
     assert len(search_index_removal_tasks) == 1
-    load_unpublishable_sites_task = search_index_removal_tasks[0]
+    load_unpublished_sites_task = search_index_removal_tasks[0]
     assert (
-        load_unpublishable_sites_task["file"]
-        == f"{pipeline_definition._unpublishable_sites_output_identifier}/sites.json"  # noqa: SLF001
+        load_unpublished_sites_task["file"]
+        == f"{pipeline_definition._unpublished_sites_output_identifier}/sites.json"  # noqa: SLF001
     )
-    assert load_unpublishable_sites_task["format"] == "json"
-    assert load_unpublishable_sites_task["reveal"] is True
+    assert load_unpublished_sites_task["format"] == "json"
+    assert load_unpublished_sites_task["reveal"] is True
     across_step = remove_unpublished_sites_job["plan"][-1]
     across_var = across_step["across"][0]
     assert across_var["var"] == "site"
     assert (
         across_var["values"]
-        == f"((.:{pipeline_definition._unpublishable_sites_var_identifier}.sites))"  # noqa: SLF001
+        == f"((.:{pipeline_definition._unpublished_sites_var_identifier}.sites))"  # noqa: SLF001
     )
     assert across_var["max_in_flight"] == 5
     across_tasks = across_step["do"]


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1927

# Description (What does it do?)
This PR takes the `remove-unpublished-sites.yml` pipeline definition and rewrites it as an object based pipeline definition using `ol-concourse`. The original functionality has been unchanged

# How can this be tested?
 - Make sure you have a recent database restore and your local `ocw-studio` is up and running on this branch
 - Run `docker compose exec web ./manage.py upsert_site_removal_pipeline`
 - Go to http://localhost:8043/sites, pick any site aside from ocw-www and publish the site live
 - Once the site is published live and you've verified that you can browse the site by clicking the link in the publish drawer, find the site again in the site listing, click the three dots on the right and unpublish it
 - Go to the Concourse UI at http://localhost:8080 and ensure that the pipeline was triggered and ran successfully
 - Try and reload the course site and verify that it is gone

# Additional Context
The non-dev steps; removing the site from the search index and clearing the CDN cache, are best tested in RC. I verified their functionality locally by modifying code which can be done locally by the reviewer as well but is not necessary.
