### PR TITLE
root website pipeline improvements

### DIFF
--- a/app.json
+++ b/app.json
@@ -38,6 +38,10 @@
       "description": "S3 artifacts bucket name.",
       "required": false
     },
+    "AWS_MAX_CONCURRENT_CONNECTIONS": {
+      "description": "The max concurrent connections used by cp and sync AWS CLI commands",
+      "required": false
+    },
     "AWS_OFFLINE_PREVIEW_BUCKET_NAME": {
       "description": "S3 offline preview bucket name.",
       "required": false

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -452,6 +452,9 @@ class SitePipelineOnlineTasks(list[StepModifierMixin]):
                 timeout="20m",
                 attempts=3,
                 params={
+                    "AWS_MAX_CONCURRENT_CONNECTIONS": str(
+                        settings.AWS_MAX_CONCURRENT_CONNECTIONS
+                    ),
                     "API_BEARER_TOKEN": settings.API_BEARER_TOKEN,
                     "GTM_ACCOUNT_ID": settings.OCW_GTM_ACCOUNT_ID,
                     "OCW_STUDIO_BASE_URL": get_ocw_studio_api_url(),
@@ -508,8 +511,9 @@ class SitePipelineOnlineTasks(list[StepModifierMixin]):
             ] = settings.AWS_SECRET_ACCESS_KEY
 
         online_sync_command = f"""
+        aws configure set default.s3.max_concurrent_requests $AWS_MAX_CONCURRENT_CONNECTIONS
         if [ $IS_ROOT_WEBSITE = 1 ] ; then
-            aws s3{get_cli_endpoint_url()} sync {SITE_CONTENT_GIT_IDENTIFIER}/output-online s3://{pipeline_vars['web_bucket']}/{pipeline_vars['prefix']}{pipeline_vars['base_url']} --metadata site-id={pipeline_vars['site_name']}{pipeline_vars['delete_flag']}
+            aws s3{get_cli_endpoint_url()} cp {SITE_CONTENT_GIT_IDENTIFIER}/output-online s3://{pipeline_vars['web_bucket']}/{pipeline_vars['prefix']}{pipeline_vars['base_url']} --recursive --metadata site-id={pipeline_vars['site_name']}{pipeline_vars['delete_flag']}
         else
             aws s3{get_cli_endpoint_url()} sync {SITE_CONTENT_GIT_IDENTIFIER}/output-online s3://{pipeline_vars['web_bucket']}/{pipeline_vars['prefix']}{pipeline_vars['base_url']} --exclude='{pipeline_vars['short_id']}.zip' --exclude='{pipeline_vars['short_id']}-video.zip' --metadata site-id={pipeline_vars['site_name']}{delete_flag}
         fi
@@ -629,6 +633,9 @@ class SitePipelineOfflineTasks(list[StepModifierMixin]):
                 timeout="120m",
                 attempts=3,
                 params={
+                    "AWS_MAX_CONCURRENT_CONNECTIONS": str(
+                        settings.AWS_MAX_CONCURRENT_CONNECTIONS
+                    ),
                     "API_BEARER_TOKEN": settings.API_BEARER_TOKEN,
                     "GTM_ACCOUNT_ID": settings.OCW_GTM_ACCOUNT_ID,
                     "OCW_STUDIO_BASE_URL": get_ocw_studio_api_url(),
@@ -682,7 +689,12 @@ class SitePipelineOfflineTasks(list[StepModifierMixin]):
                 settings.AWS_SECRET_ACCESS_KEY or ""
             )
         offline_sync_command = f"""
-        aws s3{get_cli_endpoint_url()} sync {SITE_CONTENT_GIT_IDENTIFIER}/output-offline/ s3://{pipeline_vars['offline_bucket']}/{pipeline_vars['prefix']}{pipeline_vars['base_url']} --metadata site-id={pipeline_vars['site_name']}{pipeline_vars['delete_flag']}
+        aws configure set default.s3.max_concurrent_requests $AWS_MAX_CONCURRENT_CONNECTIONS
+        if [ $IS_ROOT_WEBSITE = 1 ] ; then
+            aws s3{get_cli_endpoint_url()} cp {SITE_CONTENT_GIT_IDENTIFIER}/output-offline/ s3://{pipeline_vars['offline_bucket']}/{pipeline_vars['prefix']}{pipeline_vars['base_url']} --recursive --metadata site-id={pipeline_vars['site_name']}{pipeline_vars['delete_flag']}
+        else
+            aws s3{get_cli_endpoint_url()} sync {SITE_CONTENT_GIT_IDENTIFIER}/output-offline/ s3://{pipeline_vars['offline_bucket']}/{pipeline_vars['prefix']}{pipeline_vars['base_url']} --metadata site-id={pipeline_vars['site_name']}{pipeline_vars['delete_flag']}
+        fi
         if [ $IS_ROOT_WEBSITE = 0 ] ; then
             aws s3{get_cli_endpoint_url()} sync {BUILD_OFFLINE_SITE_IDENTIFIER}/ s3://{pipeline_vars['web_bucket']}/{pipeline_vars['prefix']}{pipeline_vars['base_url']} --exclude='*' --include='{pipeline_vars['short_id']}.zip' --include='{pipeline_vars['short_id']}-video.zip' --metadata site-id={pipeline_vars['site_name']}
         fi

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -452,9 +452,6 @@ class SitePipelineOnlineTasks(list[StepModifierMixin]):
                 timeout="20m",
                 attempts=3,
                 params={
-                    "AWS_MAX_CONCURRENT_CONNECTIONS": str(
-                        settings.AWS_MAX_CONCURRENT_CONNECTIONS
-                    ),
                     "API_BEARER_TOKEN": settings.API_BEARER_TOKEN,
                     "GTM_ACCOUNT_ID": settings.OCW_GTM_ACCOUNT_ID,
                     "OCW_STUDIO_BASE_URL": get_ocw_studio_api_url(),
@@ -523,6 +520,9 @@ class SitePipelineOnlineTasks(list[StepModifierMixin]):
                 task=UPLOAD_ONLINE_BUILD_IDENTIFIER,
                 timeout="40m",
                 params={
+                    "AWS_MAX_CONCURRENT_CONNECTIONS": str(
+                        settings.AWS_MAX_CONCURRENT_CONNECTIONS
+                    ),
                     "IS_ROOT_WEBSITE": pipeline_vars["is_root_website"],
                 },
                 config=TaskConfig(
@@ -633,9 +633,6 @@ class SitePipelineOfflineTasks(list[StepModifierMixin]):
                 timeout="120m",
                 attempts=3,
                 params={
-                    "AWS_MAX_CONCURRENT_CONNECTIONS": str(
-                        settings.AWS_MAX_CONCURRENT_CONNECTIONS
-                    ),
                     "API_BEARER_TOKEN": settings.API_BEARER_TOKEN,
                     "GTM_ACCOUNT_ID": settings.OCW_GTM_ACCOUNT_ID,
                     "OCW_STUDIO_BASE_URL": get_ocw_studio_api_url(),
@@ -703,7 +700,12 @@ class SitePipelineOfflineTasks(list[StepModifierMixin]):
             step=TaskStep(
                 task=UPLOAD_OFFLINE_BUILD_IDENTIFIER,
                 timeout="120m",
-                params={"IS_ROOT_WEBSITE": pipeline_vars["is_root_website"]},
+                params={
+                    "AWS_MAX_CONCURRENT_CONNECTIONS": str(
+                        settings.AWS_MAX_CONCURRENT_CONNECTIONS
+                    ),
+                    "IS_ROOT_WEBSITE": pipeline_vars["is_root_website"],
+                },
                 config=TaskConfig(
                     platform="linux",
                     image_resource=AWS_CLI_REGISTRY_IMAGE,

--- a/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
@@ -377,7 +377,7 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
         upload_online_build_task["config"]["run"]["args"]
     )
     assert (
-        f"if [ $IS_ROOT_WEBSITE = 1 ] ; then\n            aws s3{cli_endpoint_url} sync {SITE_CONTENT_GIT_IDENTIFIER}/output-online s3://{config.vars['web_bucket']}/{config.vars['prefix']}{config.vars['base_url']} --metadata site-id={config.vars['site_name']}{config.vars['delete_flag']}"
+        f"if [ $IS_ROOT_WEBSITE = 1 ] ; then\n            aws s3{cli_endpoint_url} cp {SITE_CONTENT_GIT_IDENTIFIER}/output-online s3://{config.vars['web_bucket']}/{config.vars['prefix']}{config.vars['base_url']} --recursive --metadata site-id={config.vars['site_name']}{config.vars['delete_flag']}"
         in upload_online_build_command
     )
     assert (
@@ -546,7 +546,11 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
         upload_offline_build_task["config"]["run"]["args"]
     )
     assert (
-        f"aws s3{cli_endpoint_url} sync {SITE_CONTENT_GIT_IDENTIFIER}/output-offline/ s3://{config.vars['offline_bucket']}/{config.vars['prefix']}{config.vars['base_url']} --metadata site-id={config.vars['site_name']}{config.vars['delete_flag']}"
+        f"if [ $IS_ROOT_WEBSITE = 1 ] ; then\n            aws s3{cli_endpoint_url} cp {SITE_CONTENT_GIT_IDENTIFIER}/output-offline/ s3://{config.vars['offline_bucket']}/{config.vars['prefix']}{config.vars['base_url']} --recursive --metadata site-id={config.vars['site_name']}{config.vars['delete_flag']}"
+        in upload_offline_build_command
+    )
+    assert (
+        f"else\n            aws s3{cli_endpoint_url} sync {SITE_CONTENT_GIT_IDENTIFIER}/output-offline/ s3://{config.vars['offline_bucket']}/{config.vars['prefix']}{config.vars['base_url']} --metadata site-id={config.vars['site_name']}{config.vars['delete_flag']}"
         in upload_offline_build_command
     )
     assert (

--- a/main/settings.py
+++ b/main/settings.py
@@ -406,6 +406,11 @@ MAX_S3_GET_ITERATIONS = get_int(
     default=3,
     description="Max retry attempts to get an S3 object",
 )
+AWS_MAX_CONCURRENT_CONNECTIONS = get_int(
+    name="AWS_MAX_CONCURRENT_CONNECTIONS",
+    default=10,
+    description="The max concurrent connections used by cp and sync AWS CLI commands",
+)
 AWS_ACCESS_KEY_ID = get_string(
     name="AWS_ACCESS_KEY_ID", default=None, description="AWS Access Key for S3 storage."
 )


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/1998

# Description (What does it do?)
This PR makes some optimizations to the AWS CLI commands used when syncing build output to S3:

 - The `aws s3 sync` commands for the root website have been changed to `aws s3 cp --recursive`. This reduces the amount of time it takes to copy large amounts of small files into S3 because a comparison doesn't need to be made with all of those files against everything that already exists in the bucket.
 - The `AWS_MAX_CONCURRENT_CONNECTIONS` setting was added with a default of 10 (the same as the CLI default) and this value is set on `max_concurrent_connections` in the AWS CLI configuration before sync steps are run. This allows us to experiment with setting the value higher to see how it improves performance, or if it causes issues with things like the mass build.

# How can this be tested?
 - Check out the `master` branch and make sure you have a recent database restore as well as all the prerequisites outlined in the README for publishing courses locally set up. In your `.env` file, also set `AWS_MAX_CONCURRENT_CONNECTIONS=100`, then spin up `ocw-studio` with `docker-compose up`
 - Upsert the `ocw-www` pipeline to your local Concourse with `docker-compose exec web ./manage.py backpopulate_pipelines --filter ocw-www`
 - Open the `ocw-studio` UI (http://localhost:8043/sites/) as well as the Concourse UI (http://localhost:8080) in two tabs
 - Publish `ocw-www` from the `ocw-studio` UI, then find the running pipeline in the Concourse UI by typing `status: running` into the search bar
 - Run the build 2 more times by clicking the plus sign in the upper right of the Concourse UI in `online-site-job`
 - Take the average runtime of the 3 runs
 - Check out this PR branch and repeat the above steps from the backpopulate step and get an average runtime against this branch
 - The average runtime on this branch should be a bit shorter
 - If you're comparing against QA / production, keep in mind that your local build time should be much shorter because copying to Minio locally takes a lot less time than syncing to S3 proper
