### PR TITLE
don't remove videos during single site online pipeline

### DIFF
--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -485,7 +485,6 @@ class SitePipelineOnlineTasks(list[StepModifierMixin]):
                             cp ../{WEBPACK_MANIFEST_S3_IDENTIFIER}/webpack.json ../{OCW_HUGO_THEMES_GIT_IDENTIFIER}/base-theme/data
                             hugo {pipeline_vars['hugo_args_online']}
                             cp -r -n ../{STATIC_RESOURCES_S3_IDENTIFIER}/. ./output-online{pipeline_vars['static_resources_subdirectory']}
-                            rm -rf ./output-online{pipeline_vars['static_resources_subdirectory']}*.mp4
                             """,  # noqa: E501
                         ],
                     ),

--- a/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
@@ -340,10 +340,6 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
         f"cp -r -n ../{STATIC_RESOURCES_S3_IDENTIFIER}/. ./output-online{config.vars['static_resources_subdirectory']}"
         in build_online_site_command
     )
-    assert (
-        f"rm -rf ./output-online{config.vars['static_resources_subdirectory']}*.mp4"
-        in build_online_site_command
-    )
     build_online_site_expected_params = {
         "API_BEARER_TOKEN": settings.API_BEARER_TOKEN,
         "GTM_ACCOUNT_ID": settings.OCW_GTM_ACCOUNT_ID,


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/2001

# Description (What does it do?)
In https://github.com/mitodl/ocw-studio/pull/1963, we added the `filter_videos` and `destructive_sync` optional boolean arguments to `SitePipelineOnlineTasks`. This allows the online mass build to get tasks which filter out mp4 files when pulling in static resources as well as running the final sync without the `--delete` flag. The single site pipelines do not filter out videos by default, because their final sync to S3 is run with `--delete`, as long as they are not the root website. A line at the end of the online site build that removes videos after the build was missed, a hangover from the old pipeline definition that did this. This causes a destructive sync to be run without the videos being present, removing them from the destination S3 bucket. This PR removes that line, so that during single site builds videos are not removed, but the mass build still avoids handling them.

# How can this be tested?
 - Make sure you are set up for publishing courses locally
 - Create a site or pull up an existing site in the `ocw-studio` UI with the minimum metadata needed to publish a site and publish it at least once
 - Log into the Minio console at http://localhost:9001
 - Browse to the `ol-ocw-studio-app` bucket, then under the `courses` folder find the folder with the name matching your site
 - Drop in an example mp4 file into the folder
 - From the `ocw-studio` UI, publish the course again
 - Back in Minio, browse to the draft / live bucket (whichever you published to)
 - Browse to the folder matching your course and ensure that your example video is in the folder

# Additional Context
We are not testing this locally using the traditional video workflow because spoofing YouTube / AWS MediaConvert is difficult and the test above verifies that videos present in the `ocw-studio` bucket are not removed from the publish bucket. The full video flow will be tested in RC.
