### PR TITLE
fix: use transcoded video's size in content

### DIFF
--- a/videos/api.py
+++ b/videos/api.py
@@ -8,6 +8,8 @@ from django.conf import settings
 
 from content_sync.utils import move_s3_object
 from gdrive_sync.models import DriveFile
+from gdrive_sync.utils import fetch_content_file_size
+from main.s3_utils import get_boto3_resource
 from videos.apps import VideoApp
 from videos.constants import (
     DESTINATION_ARCHIVE,
@@ -44,6 +46,12 @@ def prepare_video_download_file(video: Video):
         video_file.save()
     content = DriveFile.objects.get(video=video).resource
     content.file = new_s3_key
+
+    # update file size metadata
+    s3 = get_boto3_resource("s3")
+    bucket = s3.Bucket(settings.AWS_STORAGE_BUCKET_NAME)
+    content.metadata["file_size"] = fetch_content_file_size(content, bucket)
+
     content.save()
 
 

--- a/videos/api.py
+++ b/videos/api.py
@@ -4,6 +4,7 @@ import logging
 import os
 
 import boto3
+import botocore
 from django.conf import settings
 
 from content_sync.utils import move_s3_object
@@ -50,7 +51,10 @@ def prepare_video_download_file(video: Video):
     # update file size metadata
     s3 = get_boto3_resource("s3")
     bucket = s3.Bucket(settings.AWS_STORAGE_BUCKET_NAME)
-    content.metadata["file_size"] = fetch_content_file_size(content, bucket)
+    try:
+        content.metadata["file_size"] = fetch_content_file_size(content, bucket)
+    except botocore.exceptions.ClientError as ex:
+        log.exception("Could not read file size for video %s.", video, exc_info=ex)
 
     content.save()
 

--- a/videos/api_test.py
+++ b/videos/api_test.py
@@ -95,6 +95,11 @@ def test_prepare_video_download_file(settings, mocker, files_exist):
     video = VideoFactory.create(website=content.website)
     DriveFileFactory.create(website=video.website, video=video, resource=content)
     mock_move_s3 = mocker.patch("videos.api.move_s3_object")
+
+    NEW_FILE_SIZE = 1234
+    mock_fetch_content_file_size = mocker.patch("videos.api.fetch_content_file_size")
+    mock_fetch_content_file_size.return_value = NEW_FILE_SIZE
+
     dl_video_name = "my_video__360p_16_9.mp4"
     if files_exist:
         for name in ("my_video_youtube.mp4", dl_video_name, "my_video_360p_4_3.mp4"):
@@ -111,6 +116,7 @@ def test_prepare_video_download_file(settings, mocker, files_exist):
             f"{video.website.s3_path}/{dl_video_name}",
         )
         assert content.file.name == f"{video.website.s3_path}/{dl_video_name}"
+        assert content.metadata["file_size"] == NEW_FILE_SIZE
     else:
         mock_move_s3.assert_not_called()
         assert content.file.name == ""


### PR DESCRIPTION
# What are the relevant tickets?
Relates to https://github.com/mitodl/ocw-studio/issues/2007

# Description (What does it do?)

This PR updates the file size of a video resource content when the video transcoding is complete. 

# How can this be tested?

Testing this is not straightforward so we'll do some hacking.

## Prerequisites

- Get an RC dump. You may follow https://github.com/mitodl/hq/discussions/1189

## Steps

1. Navigate to your local `ocw-studio` setup.
2. Checkout `hussaintaj/2007-transcoded-video-size`.
3. Start/Restart Studio.
4. Pick out a video and its associated content object from http://localhost:8043/admin/videos/video/, http://localhost:8043/admin/websites/websitecontent/ respectively. For example, on RC you have [this video](https://ocw-studio-rc.odl.mit.edu/admin/videos/video/398/change/) and [this content](https://ocw-studio-rc.odl.mit.edu/admin/websites/websitecontent/521766/change/).
5. Note the video object's ID.
6. Open the content object and update the "file_size" metadata. Set it to `123` or whatever you like, the goal is to simulate an inaccurate value.
7. Note the location under the `file` field.
8. Upload a video file in your local MinIO `AWS_STORAGE_BUCKET` bucket under the same name and path you noted above. The purpose of this file is to provide a file size. Note this file's size for later.
9. Run the django shell.
    ```bash
    docker-compose exec web ./manage.py shell
    ```
10. Run the following code. Replace IDs where necessary.
    ```py
    from videos.api import prepare_video_download_file
    from videos.models import Video
    video = Video.objects.get(pk=<video-id>)
    prepare_video_download_file(video)
    ```
11. Refresh the content object.
12. Expect to see the correct size in the file_size metadata.


