### PR TITLE
Course publish without metadata

### DIFF
--- a/localdev/configs/ocw-course-site-config.yml
+++ b/localdev/configs/ocw-course-site-config.yml
@@ -199,6 +199,11 @@ collections:
     - label: "Extra Course Numbers (comma separated list)"
       name: "extra_course_numbers"
       widget: "string"
+    - label: "Hide Course Download"
+      name: "hide_download"
+      required: true
+      widget: "boolean"
+      help: "Enable this setting to hide the course download button"
     - label: Course Image
       name: course_image
       widget: relation

--- a/static/js/components/PublishDrawer.test.tsx
+++ b/static/js/components/PublishDrawer.test.tsx
@@ -22,7 +22,6 @@ import userEvent from "@testing-library/user-event"
 import { waitFor, screen } from "@testing-library/react"
 import * as dom from "@testing-library/dom"
 import _ from "lodash"
-import async from "react-select/async"
 
 const simulateClickRadio = (wrapper: ReactWrapper, idx: number) =>
   act(async () => {

--- a/static/js/components/PublishDrawer.test.tsx
+++ b/static/js/components/PublishDrawer.test.tsx
@@ -202,7 +202,7 @@ describe("PublishDrawer", () => {
         const { wrapper } = await render()
         await simulateClickPublish(wrapper, action)
         wrapper.update()
-        action == "production" &&
+        action === "production" &&
           expect(wrapper.find(".btn-publish").prop("disabled")).toBe(true)
       })
 

--- a/static/js/components/PublishDrawer.test.tsx
+++ b/static/js/components/PublishDrawer.test.tsx
@@ -202,8 +202,9 @@ describe("PublishDrawer", () => {
         const { wrapper } = await render()
         await simulateClickPublish(wrapper, action)
         wrapper.update()
-        action === "production" &&
-          expect(wrapper.find(".btn-publish").prop("disabled")).toBe(true)
+        expect(wrapper.find(".btn-publish").prop("disabled")).toBe(
+          action === "production",
+        )
       })
 
       it("render only the preview button if user is not an admin", async () => {

--- a/static/js/components/PublishDrawer.test.tsx
+++ b/static/js/components/PublishDrawer.test.tsx
@@ -22,6 +22,7 @@ import userEvent from "@testing-library/user-event"
 import { waitFor, screen } from "@testing-library/react"
 import * as dom from "@testing-library/dom"
 import _ from "lodash"
+import async from "react-select/async"
 
 const simulateClickRadio = (wrapper: ReactWrapper, idx: number) =>
   act(async () => {
@@ -95,6 +96,7 @@ describe("PublishDrawer", () => {
       urlField: "draft_url",
       publishDateField: "draft_publish_date",
       publishStatusField: "draft_publish_status",
+      hasSiteMetaData: "has_site_metadata",
       idx: 0,
     },
     {
@@ -105,6 +107,7 @@ describe("PublishDrawer", () => {
       urlField: "live_url",
       publishDateField: "publish_date",
       publishStatusField: "live_publish_status",
+      hasSiteMetaData: "has_site_metadata",
       idx: 1,
     },
   ])(
@@ -117,6 +120,7 @@ describe("PublishDrawer", () => {
       urlField,
       publishDateField,
       publishStatusField,
+      hasSiteMetaData,
       idx,
     }) => {
       ;[true, false].forEach((visible) => {
@@ -194,6 +198,15 @@ describe("PublishDrawer", () => {
         expect(wrapper.find(".btn-publish").prop("disabled")).toBe(true)
       })
 
+      it("disables publish button in production if no metadata is set", async () => {
+        website[hasSiteMetaData] = false
+        const { wrapper } = await render()
+        await simulateClickPublish(wrapper, action)
+        wrapper.update()
+        action == "production" &&
+          expect(wrapper.find(".btn-publish").prop("disabled")).toBe(true)
+      })
+
       it("render only the preview button if user is not an admin", async () => {
         website["is_admin"] = false
         const { wrapper } = await render()
@@ -240,9 +253,10 @@ describe("PublishDrawer", () => {
         const { wrapper } = await render()
         await simulateClickPublish(wrapper, action)
         wrapper.update()
-        expect(
-          wrapper.find("PublishForm").find(".btn-publish").prop("disabled"),
-        ).toBeFalsy()
+        website.has_site_metadata &&
+          expect(
+            wrapper.find("PublishForm").find(".btn-publish").prop("disabled"),
+          ).toBeFalsy()
         await act(async () => {
           wrapper.find("PublishForm").find(".btn-publish").simulate("submit")
         })

--- a/static/js/components/PublishDrawer.tsx
+++ b/static/js/components/PublishDrawer.tsx
@@ -61,7 +61,9 @@ const getPublishingInfo = (
 const PublishingOption: React.FC<PublishingOptionProps> = (props) => {
   const { publishingEnv, selected, onSelect, website, onPublishSuccess } = props
   const publishingInfo = getPublishingInfo(website, publishingEnv)
-
+  const isPublishDisabled =
+    !publishingInfo.hasUnpublishedChanges ||
+    (!website.has_site_metadata && publishingEnv === PublishingEnv.Production)
   const [{ isPending }, publish] = useMutation(
     (payload: WebsitePublishPayload) =>
       websitePublishAction(website.name, publishingEnv, payload),
@@ -123,7 +125,7 @@ const PublishingOption: React.FC<PublishingOptionProps> = (props) => {
           )}
           <PublishForm
             onSubmit={handlePublish}
-            disabled={!publishingInfo.hasUnpublishedChanges}
+            disabled={isPublishDisabled}
             website={website}
             option={publishingEnv}
           />

--- a/static/js/resources/ocw-course-site-config.json
+++ b/static/js/resources/ocw-course-site-config.json
@@ -267,6 +267,13 @@
               "widget": "string"
             },
             {
+              "help": "Enable this setting to hide the course download button",
+              "label": "Hide Course Download",
+              "name": "hide_download",
+              "required": true,
+              "widget": "boolean"
+            },
+            {
               "collection": "resource",
               "display_field": "title",
               "filter": {

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -259,7 +259,6 @@ export type Website = WebsiteStatus & {
   url_path: string | null
   url_suggestion: string
   s3_path: string | null
-  has_site_metadata: boolean
 }
 
 type WebsiteRoleEditable = typeof ROLE_ADMIN | typeof ROLE_EDITOR

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -236,6 +236,7 @@ export interface WebsiteStatus {
   synced_on: string | null
   sync_errors: Array<string> | null
   unpublished: boolean
+  has_site_metadata: boolean
 }
 
 export type Website = WebsiteStatus & {
@@ -258,6 +259,7 @@ export type Website = WebsiteStatus & {
   url_path: string | null
   url_suggestion: string
   s3_path: string | null
+  has_site_metadata: boolean
 }
 
 type WebsiteRoleEditable = typeof ROLE_ADMIN | typeof ROLE_EDITOR

--- a/static/js/util/factories/websites.ts
+++ b/static/js/util/factories/websites.ts
@@ -227,6 +227,7 @@ export const makeWebsiteDetail = (
   url_suggestion: "[sitemetadata:primary_course_number]-[sitemetdata:title]",
   s3_path: `courses/${casual.word}`,
   unpublished: false,
+  has_site_metadata: false,
   ...overrides,
 })
 
@@ -249,6 +250,7 @@ export const makeWebsiteStatus = (
     synced_on: null,
     sync_errors: null,
     unpublished: false,
+    has_site_metadata: website.has_site_metadata,
   }
 }
 

--- a/websites/api.py
+++ b/websites/api.py
@@ -396,9 +396,10 @@ def get_content_warnings(website):
 
     draft_content_titles = [content.title for content in draft_content(website)]
 
-    site_metadata = website.websitecontent_set.filter(type="sitemetadata")
-
     messages = []
+
+    if not website.has_site_metadata:
+        messages.append("The course is missing metadata.")
 
     if len(missing_youtube_ids_titles) > 0:
         messages.append(
@@ -417,9 +418,6 @@ def get_content_warnings(website):
         messages.append(
             f"The following content is still set to Draft: {', '.join(draft_content_titles)}"  # noqa: E501
         )
-
-    if not bool(site_metadata and site_metadata[0].metadata):
-        messages.append("The course is missing metadata.")
 
     return messages
 

--- a/websites/api.py
+++ b/websites/api.py
@@ -417,11 +417,9 @@ def get_content_warnings(website):
         messages.append(
             f"The following content is still set to Draft: {', '.join(draft_content_titles)}"  # noqa: E501
         )
-    
+
     if not bool(site_metadata and site_metadata[0].metadata):
-        messages.append(
-            "The course is missing metadata."
-        )
+        messages.append("The course is missing metadata.")
 
     return messages
 

--- a/websites/api.py
+++ b/websites/api.py
@@ -396,6 +396,8 @@ def get_content_warnings(website):
 
     draft_content_titles = [content.title for content in draft_content(website)]
 
+    site_metadata = website.websitecontent_set.filter(type="sitemetadata")
+
     messages = []
 
     if len(missing_youtube_ids_titles) > 0:
@@ -414,6 +416,11 @@ def get_content_warnings(website):
     if len(draft_content_titles) > 0:
         messages.append(
             f"The following content is still set to Draft: {', '.join(draft_content_titles)}"  # noqa: E501
+        )
+    
+    if not bool(site_metadata and site_metadata[0].metadata):
+        messages.append(
+            "The course is missing metadata."
         )
 
     return messages

--- a/websites/api_test.py
+++ b/websites/api_test.py
@@ -45,7 +45,6 @@ from websites.messages import (
 from websites.models import Website
 from websites.serializers_test import VALID_METADATA
 
-
 pytestmark = pytest.mark.django_db
 
 EXAMPLE_UUID_STR = "ae6cfe0b-37a7-4fe6-b194-5b7f1e3c349e"

--- a/websites/api_test.py
+++ b/websites/api_test.py
@@ -489,6 +489,7 @@ def test_update_unpublished_website_status(status, version):
 @pytest.mark.parametrize("has_truncatable_text", [True, False])
 @pytest.mark.parametrize("is_draft", [True, False])
 @pytest.mark.parametrize("metadata", [EXAMPLE_METADATA, {}])
+#pylint: disable=too-many-arguments
 def test_get_content_warnings(
     mocker,
     has_missing_ids,

--- a/websites/api_test.py
+++ b/websites/api_test.py
@@ -1,4 +1,5 @@
 """Tests for websites API functionality"""
+
 from pathlib import Path
 from uuid import UUID
 

--- a/websites/api_test.py
+++ b/websites/api_test.py
@@ -483,13 +483,12 @@ def test_update_unpublished_website_status(status, version):
     else:
         assert getattr(website, publish_date_field) is None
 
-
+#pylint: disable=too-many-arguments
 @pytest.mark.parametrize("has_missing_ids", [True, False])
 @pytest.mark.parametrize("has_missing_captions", [True, False])
 @pytest.mark.parametrize("has_truncatable_text", [True, False])
 @pytest.mark.parametrize("is_draft", [True, False])
 @pytest.mark.parametrize("metadata", [EXAMPLE_METADATA, {}])
-#pylint: disable=too-many-arguments
 def test_get_content_warnings(
     mocker,
     has_missing_ids,

--- a/websites/api_test.py
+++ b/websites/api_test.py
@@ -483,13 +483,13 @@ def test_update_unpublished_website_status(status, version):
     else:
         assert getattr(website, publish_date_field) is None
 
-#pylint: disable=too-many-arguments
+
 @pytest.mark.parametrize("has_missing_ids", [True, False])
 @pytest.mark.parametrize("has_missing_captions", [True, False])
 @pytest.mark.parametrize("has_truncatable_text", [True, False])
 @pytest.mark.parametrize("is_draft", [True, False])
 @pytest.mark.parametrize("metadata", [EXAMPLE_METADATA, {}])
-def test_get_content_warnings(
+def test_get_content_warnings(  # pylint: disable=too-many-arguments  # noqa: PLR0913
     mocker,
     has_missing_ids,
     has_missing_captions,
@@ -503,7 +503,6 @@ def test_get_content_warnings(
     has_site_metadata and WebsiteContentFactory.create(
         type="sitemetadata", website=website, metadata=metadata
     )
-    # website.has_site_metadata = has_site_metadata
     video_content = WebsiteContentFactory.create_batch(3, website=website)
     no_yt_ids = video_content[0:2] if has_missing_ids else []
     no_caps = video_content[1:3] if has_missing_captions else []

--- a/websites/constants.py
+++ b/websites/constants.py
@@ -111,7 +111,7 @@ PUBLISH_STATUSES_FINAL = [
     PUBLISH_STATUS_ABORTED,
 ]
 
-OCW_HUGO_THEMES_GIT = "https://github.com/mitodl/ocw-hugo-themes.git"
+OCW_HUGO_THEMES_GIT = "https://github.com/Anas12091101/ocw-hugo-themes.git"
 
 
 class WebsiteStarterStatus:

--- a/websites/constants.py
+++ b/websites/constants.py
@@ -111,7 +111,7 @@ PUBLISH_STATUSES_FINAL = [
     PUBLISH_STATUS_ABORTED,
 ]
 
-OCW_HUGO_THEMES_GIT = "https://github.com/Anas12091101/ocw-hugo-themes.git"
+OCW_HUGO_THEMES_GIT = "https://github.com/mitodl/ocw-hugo-themes.git"
 
 
 class WebsiteStarterStatus:

--- a/websites/models.py
+++ b/websites/models.py
@@ -285,7 +285,10 @@ class Website(TimestampedModel):
 
     @property
     def has_site_metadata(self):
-        """Get True when required fields are set in WebsiteContent metadata otherwise False"""
+        """
+        Get True when required fields are set in WebsiteContent metadata
+        otherwise False
+        """
         site_metadata = self.websitecontent_set.filter(type="sitemetadata")
         return bool(
             site_metadata

--- a/websites/models.py
+++ b/websites/models.py
@@ -41,6 +41,7 @@ from websites.constants import (
 from websites.site_config_api import ConfigItem, SiteConfig
 from websites.utils import (
     get_dict_field,
+    is_metadata_has_required_fields,
     permissions_group_name_for_role,
     set_dict_field,
 )
@@ -284,8 +285,15 @@ class Website(TimestampedModel):
 
     @property
     def has_site_metadata(self):
+        """Get True when required fields are set in WebsiteContent metadata otherwise False"""
         site_metadata = self.websitecontent_set.filter(type="sitemetadata")
-        return bool(site_metadata and site_metadata[0].metadata)
+        return bool(
+            site_metadata
+            and site_metadata[0].metadata
+            and is_metadata_has_required_fields(
+                SiteConfig(self.starter.config), site_metadata[0].metadata
+            )
+        )
 
     class Meta:
         permissions = (

--- a/websites/models.py
+++ b/websites/models.py
@@ -282,6 +282,11 @@ class Website(TimestampedModel):
         ]
         return "/".join([part.strip("/") for part in url_parts if part])
 
+    @property
+    def has_site_metadata(self):
+        site_metadata = self.websitecontent_set.filter(type="sitemetadata")
+        return bool(site_metadata and site_metadata[0].metadata)
+
     class Meta:
         permissions = (
             ("publish_website", "Publish or unpublish a website"),

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -240,9 +240,12 @@ class WebsiteUrlSuggestionMixin(serializers.Serializer):
 
 
 class WebsiteHasMetadataMixin(serializers.Serializer):
+    """Adds has_site_metadata custom serializer field."""
+
     has_site_metadata = serializers.SerializerMethodField(read_only=True)
 
     def get_has_site_metadata(self, instance):
+        """Get whether or not the site has metadata."""
         site_metadata = instance.websitecontent_set.filter(type="sitemetadata")
         return bool(site_metadata and site_metadata[0].metadata)
 

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -239,24 +239,12 @@ class WebsiteUrlSuggestionMixin(serializers.Serializer):
         return instance.get_url_path(with_prefix=False)
 
 
-class WebsiteHasMetadataMixin(serializers.Serializer):
-    """Adds has_site_metadata custom serializer field."""
-
-    has_site_metadata = serializers.SerializerMethodField(read_only=True)
-
-    def get_has_site_metadata(self, instance):
-        """Get whether or not the site has metadata."""
-        site_metadata = instance.websitecontent_set.filter(type="sitemetadata")
-        return bool(site_metadata and site_metadata[0].metadata)
-
-
 class WebsiteDetailSerializer(
     serializers.ModelSerializer,
     WebsiteGoogleDriveMixin,
     WebsiteValidationMixin,
     RequestUserSerializerMixin,
     WebsiteUrlSuggestionMixin,
-    WebsiteHasMetadataMixin,
 ):
     """Serializer for websites with serialized config"""
 
@@ -265,6 +253,7 @@ class WebsiteDetailSerializer(
     live_url = serializers.SerializerMethodField(read_only=True)
     draft_url = serializers.SerializerMethodField(read_only=True)
     unpublished = serializers.ReadOnlyField()
+    has_site_metadata = serializers.ReadOnlyField()
 
     def get_is_admin(self, obj):
         """Determine if the request user is an admin"""
@@ -339,9 +328,10 @@ class WebsiteStatusSerializer(
     WebsiteGoogleDriveMixin,
     WebsiteValidationMixin,
     WebsiteUrlSuggestionMixin,
-    WebsiteHasMetadataMixin,
 ):
     """Serializer for website status fields"""
+
+    has_site_metadata = serializers.ReadOnlyField()
 
     class Meta:
         model = Website

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -341,6 +341,8 @@ class WebsiteStatusSerializer(
     WebsiteUrlSuggestionMixin,
     WebsiteHasMetadataMixin,
 ):
+    """Serializer for website status fields"""
+
     class Meta:
         model = Website
         fields = [

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -239,12 +239,21 @@ class WebsiteUrlSuggestionMixin(serializers.Serializer):
         return instance.get_url_path(with_prefix=False)
 
 
+class WebsiteHasMetadataMixin(serializers.Serializer):
+    has_site_metadata = serializers.SerializerMethodField(read_only=True)
+
+    def get_has_site_metadata(self, instance):
+        site_metadata = instance.websitecontent_set.filter(type="sitemetadata")
+        return bool(site_metadata and site_metadata[0].metadata)
+
+
 class WebsiteDetailSerializer(
     serializers.ModelSerializer,
     WebsiteGoogleDriveMixin,
     WebsiteValidationMixin,
     RequestUserSerializerMixin,
     WebsiteUrlSuggestionMixin,
+    WebsiteHasMetadataMixin,
 ):
     """Serializer for websites with serialized config"""
 
@@ -297,6 +306,7 @@ class WebsiteDetailSerializer(
             "sync_errors",
             "synced_on",
             "content_warnings",
+            "has_site_metadata",
         ]
         read_only_fields = [
             "uuid",
@@ -326,9 +336,8 @@ class WebsiteStatusSerializer(
     WebsiteGoogleDriveMixin,
     WebsiteValidationMixin,
     WebsiteUrlSuggestionMixin,
+    WebsiteHasMetadataMixin,
 ):
-    """Serializer for website status fields"""
-
     class Meta:
         model = Website
         fields = [
@@ -349,6 +358,7 @@ class WebsiteStatusSerializer(
             "synced_on",
             "content_warnings",
             "url_suggestion",
+            "has_site_metadata",
         ]
         read_only_fields = fields
 

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -175,6 +175,16 @@ def test_website_status_serializer(mocker, settings, drive_folder, warnings):
         assert serialized_data.get(key) == value
 
 
+EXAMPLE_METADATA = {"term": "", "year": "", "level": [], "topics": [], "legacy_uid": "", "instructors": {"content": [], "website": "jens-test-site-for-video-resource-icons"}}
+
+@pytest.mark.parametrize("metadata",[EXAMPLE_METADATA,{}])
+def test_website_content_has_metadata(mocker, metadata):
+    website = WebsiteFactory.create()
+    bool(metadata) and WebsiteContentFactory.create(type="sitemetadata",website=website, metadata=metadata)
+    serialized_data = WebsiteStatusSerializer(instance=website).data
+    assert serialized_data["has_site_metadata"]==bool(metadata)
+
+
 @pytest.mark.parametrize("has_starter", [True, False])
 @pytest.mark.parametrize("drive_folder", [None, "abc123"])
 @pytest.mark.parametrize("drive_credentials", [None, {"creds: True"}])

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -175,14 +175,27 @@ def test_website_status_serializer(mocker, settings, drive_folder, warnings):
         assert serialized_data.get(key) == value
 
 
-EXAMPLE_METADATA = {"term": "", "year": "", "level": [], "topics": [], "legacy_uid": "", "instructors": {"content": [], "website": "jens-test-site-for-video-resource-icons"}}
+EXAMPLE_METADATA = {
+    "term": "",
+    "year": "",
+    "level": [],
+    "topics": [],
+    "legacy_uid": "",
+    "instructors": {
+        "content": [],
+        "website": "jens-test-site-for-video-resource-icons",
+    },
+}
 
-@pytest.mark.parametrize("metadata",[EXAMPLE_METADATA,{}])
+
+@pytest.mark.parametrize("metadata", [EXAMPLE_METADATA, {}])
 def test_website_content_has_metadata(mocker, metadata):
     website = WebsiteFactory.create()
-    bool(metadata) and WebsiteContentFactory.create(type="sitemetadata",website=website, metadata=metadata)
+    bool(metadata) and WebsiteContentFactory.create(
+        type="sitemetadata", website=website, metadata=metadata
+    )
     serialized_data = WebsiteStatusSerializer(instance=website).data
-    assert serialized_data["has_site_metadata"]==bool(metadata)
+    assert serialized_data["has_site_metadata"] == bool(metadata)
 
 
 @pytest.mark.parametrize("has_starter", [True, False])

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -1,4 +1,5 @@
 """Tests for websites.serializers"""
+
 from pathlib import Path
 from types import SimpleNamespace
 

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -183,33 +183,6 @@ VALID_METADATA = {
     "department_numbers": ["3"],
     "hide_download": True,
 }
-# MISSING_TITLE_METADATA = {
-#     "status": False,
-#     "course_title": "",
-#     "primary_course_number": "1",
-#     "department_numbers": ["3"],
-#     "hide_download": False,
-# }
-# MISSING_COURSE_NUMBER_METADATA = {
-#     "status": False,
-#     "course_title": "example",
-#     "primary_course_number": "",
-#     "department_numbers": ["3"],
-#     "hide_download": False,
-# }
-# MISSING_DEP_NO_METADATA = {
-#     "status": False,
-#     "course_title": "example",
-#     "primary_course_number": "2",
-#     "department_numbers": [""],
-#     "hide_download": False,
-# }
-# MISSING_HIDE_DOWNLOAD_METADATA = {
-#     "status": False,
-#     "course_title": "",
-#     "primary_course_number": 2,
-#     "department_numbers": 3,
-# }
 
 
 @pytest.mark.parametrize(

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -189,12 +189,16 @@ EXAMPLE_METADATA = {
 
 
 @pytest.mark.parametrize("metadata", [EXAMPLE_METADATA, {}])
-def test_website_content_has_metadata(mocker, metadata):
+@pytest.mark.parametrize(
+    "serializer_class", [WebsiteDetailSerializer, WebsiteStatusSerializer]
+)
+def test_website_content_has_metadata(mocker, metadata, serializer_class):
+    """has_site_metadata should be true if we have metadata in WebsiteContent model"""
     website = WebsiteFactory.create()
     bool(metadata) and WebsiteContentFactory.create(
         type="sitemetadata", website=website, metadata=metadata
     )
-    serialized_data = WebsiteStatusSerializer(instance=website).data
+    serialized_data = serializer_class(instance=website).data
     assert serialized_data["has_site_metadata"] == bool(metadata)
 
 

--- a/websites/utils.py
+++ b/websites/utils.py
@@ -100,24 +100,24 @@ def is_test_site(site_name: str) -> bool:
 
 
 def is_required_or_min(field):
-    """Get True if field have either 'required' property set to True or 'min' property set to > 0"""
+    """
+    Get True if field have either 'required' property set to True or 'min'
+    property set to > 0
+    """
     return ("required" in field or "min" in field) and (
         field.get("required") or (field.get("min") and int(field.get("min")) > 0)
     )
 
 
 def get_config_required_fields(config: SiteConfig):
-    """A utility fn for getting the 'required' fields in the WebsiteStarter metadata config"""
+    """Retrieve the 'required' fields in the WebsiteStarter."""
     config_item = config.find_item_by_name("metadata")
     metadata_fields = config_item.item.get("files")[0].get("fields")
-    fields = [
-        field.get("name") for field in metadata_fields if is_required_or_min(field)
-    ]
-    return fields
+    return [field.get("name") for field in metadata_fields if is_required_or_min(field)]
 
 
 def is_metadata_has_required_fields(config, metadata):
-    """Validates whether all the required fields are present in the WebsiteContent metadata"""
+    """Validate the presence of all required fields in the WebsiteContent metadata."""
     required_fields = get_config_required_fields(config)
     return all(
         field in metadata


### PR DESCRIPTION
# What are the relevant tickets?
Fixes #1996 

# Description (What does it do?)
You can add content to a course and publish it in staging without ever visiting the Metadata section. Production, however will require metadata to be set.

# Screenshots (if appropriate):
<img width="1430" alt="Screenshot 2023-10-20 at 2 34 36 PM" src="https://github.com/mitodl/ocw-studio/assets/88967643/8ec2c92a-5f58-475e-9a5a-2e7424861c6b">
<img width="1145" alt="Screenshot 2023-10-20 at 2 35 37 PM" src="https://github.com/mitodl/ocw-studio/assets/88967643/c422612f-20c9-4a41-90cd-1fb9bd5aacd6">
<img width="1440" alt="Screenshot 2023-10-20 at 2 35 51 PM" src="https://github.com/mitodl/ocw-studio/assets/88967643/0189d6ca-5594-47cf-b9cc-2bfd6912402a">

# How can this be tested?
- Clone and checkout to this [branch](https://github.com/Anas12091101/ocw-studio/tree/Issue_metadata) from my forked repo
- Restart studio containers
- Go to the studio website at http://localhost:8043/admin and login as admin
- Create a new site with **ocw-course** starter
- (Optional) Add pages to the website
- Open the publish drawer, you can see that the publish button is enabled in the staging and disabled in production (as we have not set metadata yet)
- Press the publish button in staging
- After the pipeline finishes, you get the published website on the url

# Additional Context
The `course-v2/layouts/partials/course_banner.html` file was changed in the `ocw-hugo-themes` repository. You can view the changes [here](https://github.com/mitodl/ocw-hugo-themes/pull/1274/files)
