### PR TITLE
update FilterWebpackArtifactsStep to support webpack-manifest-plugin

### DIFF
--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -375,7 +375,7 @@ class FilterWebpackArtifactsStep(TaskStep):
                     path="sh",
                     args=[
                         "-exc",
-                        f"jq 'recurse | select(type==\"string\")' ./{WEBPACK_MANIFEST_S3_IDENTIFIER}/webpack.json | tr -d '\"' | xargs -I {{}} aws s3{get_cli_endpoint_url()} cp s3://{web_bucket}{{}} ./{WEBPACK_ARTIFACTS_IDENTIFIER}/{{}} --exclude *.js.map",  # noqa: E501
+                        f"jq -r 'values[]' ./{WEBPACK_MANIFEST_S3_IDENTIFIER}/webpack.json | xargs -I {{}} aws s3{get_cli_endpoint_url()} cp s3://{web_bucket}{{}} ./{WEBPACK_ARTIFACTS_IDENTIFIER}/{{}} --exclude *.js.map",  # noqa: E501
                     ],
                 ),
             ),

--- a/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
@@ -457,7 +457,7 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
         filter_webpack_artifacts_task["config"]["run"]["args"]
     )
     assert (
-        f"jq 'recurse | select(type==\"string\")' ./{WEBPACK_MANIFEST_S3_IDENTIFIER}/webpack.json | tr -d '\"' | xargs -I {{}} aws s3{cli_endpoint_url} cp s3://{config.vars['web_bucket']}{{}} ./{WEBPACK_ARTIFACTS_IDENTIFIER}/{{}} --exclude *.js.map"
+        f"jq -r 'values[]' ./{WEBPACK_MANIFEST_S3_IDENTIFIER}/webpack.json | xargs -I {{}} aws s3{cli_endpoint_url} cp s3://{config.vars['web_bucket']}{{}} ./{WEBPACK_ARTIFACTS_IDENTIFIER}/{{}} --exclude *.js.map"
         in filter_webpack_artifacts_command
     )
     if is_dev:


### PR DESCRIPTION
# What are the relevant tickets?
Closes #2012

# Description (What does it do?)
Updates FilterWebpackArtifactsStep according to the structure of newly generated `webpack.json` in https://github.com/mitodl/ocw-hugo-themes/pull/1272
Previously we had a nested structure, so we were using `recurse` option with `jq`. But we don't have to use that anymore because our new `webpack.json` is not nested.

# Additional Context
To compare the difference in structure of `webpack.json`, simply do the following:
For ocw-hugo-themes: 
You should already have the prior `webpack.json` file, but if you don't:
1. `git checkout main`
2. `yarn start course`
3. Webpack will generate `webpack.json` file in `base-theme/data/` after all the processing is done.
4. You can stop the server now.

For the new` webpack.json`, simply follow the above steps but in branch `ibrahim/1212/hash-static-assets-using-webpack`. You might need to save/rename the previous copy of `webpack.json` though otherwise it would be replaced by the current file.

# How can this be tested?
Testing will be done in ocw-studio. Checkout to this branch.
1. Use `OCW_HUGO_THEMES_BRANCH=ibrahim/1212/hash-static-assets-using-webpack` in `.env`
2. Spin up `ocw-studio`.
3. Update pipelines:
  i. `docker-compose exec web ./manage.py upsert_theme_assets_pipeline`
  ii. `docker-compose exec web ./manage.py backpopulate_pipelines`
4. Open concourse interface: http://concourse:8080
5. Unpause `ocw-themes-assets` pipeline and trigger a build for it.
6. After the above step is completed, go to draft (or live) single pipeline for a specific course and trigger an `online-site-job` build. Make sure the pipeline is unpaused as well.
7. After the `online-site-job` finishes, it will trigger a build for `offline-site-build`. And this is what we're looking to test.
8. Make sure the `filter-webpack-artifacts` task in the `offline-site-build` works as before. We're making sure:
  i. It does not break
  ii. Structure works same as before
  iii. `.js.map` files are filtered out. You could do `cmd+f` (or `ctrl+f` for windows) and try to find if there are any `js source map` files. There should not be.
9. Open `minio` interface: http://localhost:9001/
10. Go to `Object Browser`
11. Open the bucket for which you triggered a build: eg. `ocw-content-offline-draft-local`
12. Go to courses
13. Open your specific course for which you triggered a build in step 6.
14. Go to `static_shared/js/` and make sure you don't see any `.js.map` files.
15. Download the full course from `ocw-content-draft[or live]-local` bucket, under courses, your specific course, [name].zip file from there. Extract the zip file and run the `index.html`. Make sure everything (.js, .css, images, fonts) work correctly.
  
