### PR TITLE
compose file updates

### DIFF
--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -2,7 +2,5 @@
 version: "3.7"
 
 services:
-  concourse:
-    image: rdclda/concourse:7.9.1
   concourse-worker:
-    image: rdclda/concourse:7.9.1
+    image: concourse/dev:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -257,10 +257,11 @@ services:
       MINIO_ROOT_PASSWORD: $MINIO_ROOT_PASSWORD
     command: server --address 0.0.0.0:9000 --console-address 0.0.0.0:9001 /data
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 30s
-      timeout: 20s
-      retries: 3
+      test: timeout 5s bash -c ':> /dev/tcp/127.0.0.1/9000' || exit 1
+      interval: 5s
+      retries: 1
+      start_period: 5s
+      timeout: 5s
     networks:
       default-network:
       concourse-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -166,7 +166,7 @@ services:
     - concourse-keys:/concourse-keys
 
   concourse:
-    image: concourse/concourse:7.10
+    image: concourse/concourse:7.11
     command: web
     privileged: true
     depends_on:
@@ -215,7 +215,7 @@ services:
         ipv4_address: 10.1.0.101
 
   concourse-worker:
-    image: concourse/concourse:7.10
+    image: concourse/concourse:7.11
     command: worker
     privileged: true
     depends_on:


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/2021
Closes https://github.com/mitodl/ocw-studio/issues/2022

# Description (What does it do?)
This PR updates the configuration of some dependencies in our `docker-compose.yml` file. 

In the MIT OCW production environment, Concourse 7.11 is being used now. In order to use the `fly` CLI locally against Concourse as well as production, the versions need to be in sync. So, this PR updates `docker-compose.yml` to specify 7.11.

I also noticed that when pulling the latest version of Minio with `docker compose pull`, the health check was failing. I looked at the container health check log and saw `OCI runtime exec failed: exec failed: unable to start container process: exec: "curl": executable file not found in $PATH: unknown`. Stepping into the container, `curl` was indeed not available. A but of further research revealed this issue: https://github.com/minio/minio/issues/18373, saying they moved the base image to UBI micro, which does not contain curl. The health check command was updated with the example in the link above, which fixed the issue.

# How can this be tested?
 - Run `docker-compose pull` to pull the latest versions of all images
 - Run `docker-compose up` to spin up `ocw-studio`
 - If you don't already have `fly` configured, follow the steps in the documentation to configure targets for both your local Concourse and RC
 - Run `sudo fly -t rc sync` to ensure you're running the same version of `fly` locally as RC
 - Run `fly -t local pipelines` and you should see a list of pipelines with no errors
 - Run `docker inspect --format "{{json .State.Health }}" ocw-studio-s3-1 | jq` to inspect the health check status of the Minio container. You should see something like this:

```
{
  "Status": "healthy",
  "FailingStreak": 0,
  "Log": [
    {
      "Start": "2023-11-09T14:16:10.464735864-05:00",
      "End": "2023-11-09T14:16:10.546746741-05:00",
      "ExitCode": 0,
      "Output": ""
    },
    {
      "Start": "2023-11-09T14:16:15.551730915-05:00",
      "End": "2023-11-09T14:16:15.626124758-05:00",
      "ExitCode": 0,
      "Output": ""
    },
    {
      "Start": "2023-11-09T14:16:20.631522235-05:00",
      "End": "2023-11-09T14:16:20.701347031-05:00",
      "ExitCode": 0,
      "Output": ""
    },
    {
      "Start": "2023-11-09T14:16:25.705457338-05:00",
      "End": "2023-11-09T14:16:25.792339102-05:00",
      "ExitCode": 0,
      "Output": ""
    },
    {
      "Start": "2023-11-09T14:50:27.313074754-05:00",
      "End": "2023-11-09T14:50:27.48553119-05:00",
      "ExitCode": 0,
      "Output": ""
    }
  ]
}
```
