### PR TITLE
Fix self-closing shortcodes

### DIFF
--- a/static/js/lib/ckeditor/plugins/util.test.ts
+++ b/static/js/lib/ckeditor/plugins/util.test.ts
@@ -197,7 +197,37 @@ describe("Shortcode", () => {
       expected: new Shortcode("some_shortcode", [], true, false, true),
     },
     {
-      text: "{{< some_shortcode / >}}", //not valid self-closing
+      text: "{{< some_shortcode / >}}", //valid self-closing
+      expected: new Shortcode("some_shortcode", [], false, false, true),
+    },
+    {
+      text: "{{% some_shortcode / %}}", //valid self-closing
+      expected: new Shortcode("some_shortcode", [], true, false, true),
+    },
+    {
+      //respects params before self-closing tag
+      text: "{{% some_shortcode some_param / %}}",
+      expected: new Shortcode(
+        "some_shortcode",
+        [new ShortcodeParam("some_param")],
+        true,
+        false,
+        true,
+      ),
+    },
+    {
+      //ignores params after self-closing tag
+      text: "{{% some_shortcode some_param / another_param %}}",
+      expected: new Shortcode(
+        "some_shortcode",
+        [new ShortcodeParam("some_param")],
+        true,
+        false,
+        true,
+      ),
+    },
+    {
+      text: '{{< some_shortcode "/" >}}', //not valid self-closing
       expected: new Shortcode(
         "some_shortcode",
         [new ShortcodeParam("/")],


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/2005.

# Description (What does it do?)
In https://github.com/mitodl/ocw-to-hugo/pull/418, self-closing shortcodes are written as `{{< quiz_solution / >}}`. However, Studio was not properly treating these as self-closing, and converting them to `{{< quiz_solution "/" >}}` on any page edit, which is no longer self-closing, and breaks publishing.

This PR resolves that issue, and now `{{< quiz_solution / >}}` is an acceptable self-closing shortcode.

Also, this PR makes the update that unquoted shortcode parameters can no longer contain forward slashes: any forward slash in an unquoted shortcode parameter is treated as a self-closing shortcode.

# How can this be tested?
1. Create a page with a self-closing shortcode with a space between the`/` and `>` in markdown, such as `{{< quiz_solution / >}}`.
2. Make an edit to the page using the CKEditor UI in Studio and save the page.
3. Verify that the markdown is now `{{< quiz_solution />}}`, and the shortcode is still identified as self-closing.
4. (Optional) Check that shortcode parameters are properly handled for these self-closing shortcodes. For example, an edit to a page containing `{{< quiz_solution some_param / >}}` using the CKEditor UI in Studio will cause the shortcode to be converted to `{{< quiz_solution "some_param" />}}`. Parameters after the `/` will be ignored.