### PR TITLE
test: improve tests for existing captions

### DIFF
--- a/fixtures/common.py
+++ b/fixtures/common.py
@@ -7,3 +7,26 @@ from rest_framework.test import APIClient
 def drf_client():
     """DRF API anonymous test client"""
     return APIClient()
+
+
+@pytest.fixture()
+def preexisting_captions_filenames():
+    """
+    Filenames for gdrive files and resources as they relate to
+    preexisting captions.
+
+    Do not change unless you update the logic that associates
+    preexisting captions with videos.
+    """
+    return {
+        "gdrive": {
+            "video": "file.mp4",
+            "captions": "file_captions.vtt",
+            "transcript": "file_transcript.pdf",
+        },
+        "website_content": {
+            "video": "file_mp4",
+            "captions": "file_captions_vtt",
+            "transcript": "file_transcript_pdf",
+        },
+    }

--- a/main/utils_test.py
+++ b/main/utils_test.py
@@ -3,6 +3,7 @@ import pytest
 
 from main.utils import (
     are_equivalent_paths,
+    get_base_filename,
     get_dirpath_and_filename,
     get_file_extension,
     is_valid_uuid,
@@ -109,3 +110,16 @@ def test_valid_key(mocker, key, is_valid):
 def test_truncate_words(text, truncated):
     """truncate_words returns expected result"""
     assert truncate_words(text, 9, suffix="___") == truncated
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected_base_filename"),
+    [
+        ("file", "file"),
+        ("file_ext", "file"),
+        ("file_name_ext", "file_name"),
+    ],
+)
+def test_get_base_filename(filename, expected_base_filename):
+    """Test get_base_filename truncates extension"""
+    assert get_base_filename(filename) == expected_base_filename

--- a/videos/models_test.py
+++ b/videos/models_test.py
@@ -3,6 +3,8 @@ import pytest
 
 from videos.constants import DESTINATION_YOUTUBE
 from videos.factories import VideoFactory, VideoFileFactory
+from websites.factories import WebsiteContentFactory, WebsiteFactory
+from websites.site_config_api import SiteConfig
 
 # pylint:disable=unused-argument,redefined-outer-name
 pytestmark = pytest.mark.django_db
@@ -16,3 +18,54 @@ def test_video_youtube_id():
         destination=DESTINATION_YOUTUBE, video=video, destination_id="expected_id"
     )
     assert video.youtube_id() == "expected_id"
+
+
+@pytest.mark.parametrize("has_transcript", [True, False])
+@pytest.mark.parametrize("has_caption", [True, False])
+def test_video_caption_transcript_resources(has_transcript, has_caption):
+    """Test caption_transcript_resources finds appropriate resources for video"""
+    youtube_id = "yt-id"
+
+    video = VideoFactory.create()
+    VideoFileFactory.create(
+        destination=DESTINATION_YOUTUBE, video=video, destination_id=youtube_id
+    )
+    WebsiteContentFactory.create(
+        metadata={"video_metadata": {"youtube_id": youtube_id}},
+        filename="file_mp4",
+        website=video.website,
+    )
+
+    if has_transcript:
+        WebsiteContentFactory.create(
+            filename="file_transcript_pdf",
+            website=video.website,
+        )
+
+    if has_caption:
+        WebsiteContentFactory.create(
+            filename="file_captions_vtt",
+            website=video.website,
+        )
+
+    captions, transcript = video.caption_transcript_resources()
+
+    assert bool(captions) == has_caption
+    assert bool(transcript) == has_transcript
+
+
+def test_video_upload_file_to(course_starter):
+    """Test upload_file_to generates the expected path"""
+    website = WebsiteFactory.create(starter=course_starter, name="website-name")
+
+    video = VideoFactory.create(
+        website=website, source_key="gdrive_uploads/hash/file.ext"
+    )
+
+    filename = "filename.ext"
+    expected_upload_location = f"{SiteConfig(course_starter.config).root_url_path}/website-name/hash_{filename}".lstrip(
+        "/"
+    )
+
+    upload_location = video.upload_file_to(filename)
+    assert upload_location == expected_upload_location

--- a/videos/models_test.py
+++ b/videos/models_test.py
@@ -22,7 +22,9 @@ def test_video_youtube_id():
 
 @pytest.mark.parametrize("has_transcript", [True, False])
 @pytest.mark.parametrize("has_caption", [True, False])
-def test_video_caption_transcript_resources(has_transcript, has_caption):
+def test_video_caption_transcript_resources(
+    has_transcript, has_caption, preexisting_captions_filenames
+):
     """Test caption_transcript_resources finds appropriate resources for video"""
     youtube_id = "yt-id"
 
@@ -32,19 +34,19 @@ def test_video_caption_transcript_resources(has_transcript, has_caption):
     )
     WebsiteContentFactory.create(
         metadata={"video_metadata": {"youtube_id": youtube_id}},
-        filename="file_mp4",
+        filename=preexisting_captions_filenames["website_content"]["video"],
         website=video.website,
     )
 
     if has_transcript:
         WebsiteContentFactory.create(
-            filename="file_transcript_pdf",
+            filename=preexisting_captions_filenames["website_content"]["transcript"],
             website=video.website,
         )
 
     if has_caption:
         WebsiteContentFactory.create(
-            filename="file_captions_vtt",
+            filename=preexisting_captions_filenames["website_content"]["captions"],
             website=video.website,
         )
 

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -13,6 +13,7 @@ from moto import mock_s3
 from gdrive_sync.api import create_gdrive_resource_content
 from gdrive_sync.factories import DriveFileFactory
 from main.s3_utils import get_boto3_client
+from main.utils import get_base_filename
 from ocw_import.conftest import MOCK_BUCKET_NAME, setup_s3
 from users.factories import UserFactory
 from videos.conftest import MockHttpErrorResponse
@@ -227,7 +228,7 @@ def test_start_transcript_job(
     video = create_video(youtube_id, title)
     video_content = create_content(video.website, youtube_id, title)
 
-    base_filename = video_content.filename.rsplit("_", 1)[0]
+    base_filename = get_base_filename(video_content.filename)
 
     base_path = f"/some/path/to/{base_filename}"
 
@@ -690,7 +691,7 @@ def test_update_transcripts_for_video_no_3play(
     video = videofile.video
     resource = WebsiteContentFactory.create(website=video.website, metadata={})
     metadata = resource.metadata
-    base_resource_filename = resource.filename.rsplit("_", 1)[0]
+    base_resource_filename = get_base_filename(resource.filename)
     base_path = f"{resource.website.s3_path}/{base_resource_filename}"
 
     if caption_exists:

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -227,26 +227,28 @@ def test_start_transcript_job(
     video = create_video(youtube_id, title)
     video_content = create_content(video.website, youtube_id, title)
 
-    base_path = f"/some/path/to/{video_content.filename}"
+    base_filename = video_content.filename.rsplit("_", 1)[0]
+
+    base_path = f"/some/path/to/{base_filename}"
 
     if wrong_caption_type:
         WebsiteContentFactory.create(
             website=video.website,
-            filename=f"{video_content.filename}_captions_srt",
+            filename=f"{base_filename}_captions_srt",
             file=f"{base_path}_captions.srt",
         )
 
     if caption_exists:
         WebsiteContentFactory.create(
             website=video.website,
-            filename=f"{video_content.filename}_captions_vtt",
+            filename=f"{base_filename}_captions_vtt",
             file=f"{base_path}_captions.vtt",
         )
 
     if transcript_exists:
         WebsiteContentFactory.create(
             website=video.website,
-            filename=f"{video_content.filename}_transcript_pdf",
+            filename=f"{base_filename}_transcript_pdf",
             file=f"{base_path}_transcript.pdf",
         )
 
@@ -688,19 +690,20 @@ def test_update_transcripts_for_video_no_3play(
     video = videofile.video
     resource = WebsiteContentFactory.create(website=video.website, metadata={})
     metadata = resource.metadata
-    base_path = f"{resource.website.s3_path}/{resource.filename}"
+    base_resource_filename = resource.filename.rsplit("_", 1)[0]
+    base_path = f"{resource.website.s3_path}/{base_resource_filename}"
 
     if caption_exists:
         WebsiteContentFactory.create(
             website=video.website,
-            filename=f"{resource.filename}_captions_vtt",
+            filename=f"{base_resource_filename}_captions_vtt",
             file=f"{base_path}_captions.vtt",
         )
 
     if transcript_exists:
         WebsiteContentFactory.create(
             website=video.website,
-            filename=f"{resource.filename}_transcript_pdf",
+            filename=f"{base_resource_filename}_transcript_pdf",
             file=f"{base_path}_transcript.pdf",
         )
 
@@ -731,12 +734,12 @@ def test_update_transcripts_for_video_no_3play(
     mock_3play.assert_not_called()
 
     assert get_dict_field(resource.metadata, settings.YT_FIELD_CAPTIONS) == (
-        f"/{video.website.url_path}/{resource.filename}_captions.vtt"
+        f"/{video.website.url_path}/{base_resource_filename}_captions.vtt"
         if caption_exists
         else None
     )
     assert get_dict_field(resource.metadata, settings.YT_FIELD_TRANSCRIPT) == (
-        f"/{video.website.url_path}/{resource.filename}_transcript.pdf"
+        f"/{video.website.url_path}/{base_resource_filename}_transcript.pdf"
         if transcript_exists
         else None
     )

--- a/videos/utils_test.py
+++ b/videos/utils_test.py
@@ -1,0 +1,61 @@
+"""Tests for videos.utils"""
+from uuid import uuid4
+
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+from videos.utils import clean_uuid_filename, generate_s3_path, get_content_dirpath
+from websites.factories import (
+    WebsiteContentFactory,
+    WebsiteFactory,
+    WebsiteStarterFactory,
+)
+
+# pylint:disable=redefined-outer-name
+pytestmark = pytest.mark.django_db
+
+
+@pytest.mark.parametrize("use_content", [True, False])
+@pytest.mark.parametrize(
+    ("file_extension", "expected_postfix"),
+    [("vtt", "_captions"), ("webvtt", "_captions"), ("pdf", "_transcript")],
+)
+def test_generate_s3_path(use_content, file_extension, expected_postfix):
+    """Test generate_s3_path generates appropriate paths for captions."""
+
+    website = WebsiteFactory.create()
+    filename = str(uuid4())
+    file = SimpleUploadedFile(
+        f"/courses/{website.name}/{filename}-file.{file_extension}", b"Nothing here."
+    )
+    expected_new_path = f'{website.s3_path.strip("/")}/{filename}-file{expected_postfix}.{file_extension}'
+
+    if use_content:
+        file_or_content = WebsiteContentFactory.create(website=website, file=file)
+    else:
+        file_or_content = file
+
+    new_path = generate_s3_path(file_or_content, website)
+
+    assert new_path == expected_new_path
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected_result"),
+    [
+        (f"{uuid4()}_file.ext", "file.ext"),
+        ("file.ext", "file.ext"),
+    ],
+)
+def test_clean_uuid_filename(filename, expected_result):
+    """Test clean_uuid_filename strips uuid from filename"""
+    assert clean_uuid_filename(filename) == expected_result
+
+
+def test_get_content_dirpath():
+    """Test get_content_dirpath returns the folder of the collection_type"""
+    starter = WebsiteStarterFactory.create()
+
+    dirpath = get_content_dirpath(starter.slug, "resource")
+
+    assert dirpath == "content/resource"

--- a/websites/factories.py
+++ b/websites/factories.py
@@ -100,7 +100,7 @@ class WebsiteContentFactory(DjangoModelFactory):
     )  # noqa: A003, RUF100
     markdown = factory.Faker("text")
     metadata = factory.LazyAttribute(lambda _: {})
-    filename = factory.Sequence(lambda n: f"my-file-{n}")
+    filename = factory.Sequence(lambda n: f"my-file-{n}_ext")
     dirpath = factory.Faker("uri_path", deep=2)
     website = factory.SubFactory(WebsiteFactory)
 


### PR DESCRIPTION
# What are the relevant tickets?

part of https://github.com/mitodl/ocw-studio/issues/1983

# Description (What does it do?)

This PR improves tests surrounding existing captions synced via GDrive.

The objective of this change is to ensure that existing captions are associated correctly. The new tests introduced in this PR will test these associations (file names).

Along with that, I have added a few missing tests, just to improve the general coverage of the code surrounding this feature.


# How can this be tested?

1. Navigate to your local ocw-studio setup.
2. Checkout the branch `hussaintaj/1983-test-improvements`
3. Start/Restart Studio.
4. Run
    ```
    docker-compose exec web pytest
    ```
5. Expect all of the tests to pass.
