### PR TITLE
add exclude filter to management commands

### DIFF
--- a/content_sync/management/commands/backpopulate_archive_videos.py
+++ b/content_sync/management/commands/backpopulate_archive_videos.py
@@ -1,6 +1,5 @@
 """Backpopulate legacy videos"""  # noqa: INP001
 from django.core.management import CommandError
-from django.db.models import Q
 from mitol.common.utils.datetime import now_in_utc
 
 from content_sync.tasks import backpopulate_archive_videos
@@ -46,14 +45,8 @@ class Command(WebsiteFilterCommand):
         chunk_size = int(options["chunk_size"])
         is_verbose = options["verbosity"] > 1
 
-        if self.filter_list:
-            website_qset = Website.objects.filter(
-                Q(name__in=self.filter_list) | Q(short_id__in=self.filter_list)
-            )
-        else:
-            website_qset = Website.objects.all()
-
-        website_qset = website_qset.filter(source=WEBSITE_SOURCE_OCW_IMPORT)
+        website_qset = Website.objects.filter(source=WEBSITE_SOURCE_OCW_IMPORT)
+        website_qset = self.filter_websites(websites=website_qset)
 
         website_names = list(website_qset.values_list("name", flat=True))
 

--- a/content_sync/management/commands/backpopulate_pipelines.py
+++ b/content_sync/management/commands/backpopulate_pipelines.py
@@ -1,7 +1,6 @@
 """Backpopulate website pipelines"""  # noqa: INP001
 from django.conf import settings
 from django.core.management import CommandError
-from django.db.models import Q
 from mitol.common.utils.datetime import now_in_utc
 
 from content_sync.api import get_pipeline_api
@@ -94,12 +93,7 @@ class Command(WebsiteFilterCommand):
             else:
                 self.stdout.error("No pipeline api configured")
 
-        if self.filter_list:
-            website_qset = Website.objects.filter(
-                Q(name__in=self.filter_list) | Q(short_id__in=self.filter_list)
-            )
-        else:
-            website_qset = Website.objects.all()
+        website_qset = self.filter_websites(websites=Website.objects.all())
 
         if starter_str:
             website_qset = website_qset.filter(starter__slug=starter_str)

--- a/content_sync/management/commands/mass_publish.py
+++ b/content_sync/management/commands/mass_publish.py
@@ -72,7 +72,7 @@ class Command(WebsiteFilterCommand):
 
         website_qset = Website.objects.filter(starter__source=STARTER_SOURCE_GITHUB)
         website_qset = self.filter_websites(websites=website_qset)
-        website_qset = self.filter_unpublished_websites(
+        website_qset = self.exclude_unpublished_websites(
             version=version, websites=website_qset
         )
         if starter_str:

--- a/content_sync/management/commands/mass_publish.py
+++ b/content_sync/management/commands/mass_publish.py
@@ -1,10 +1,8 @@
 """Publish live or draft versions of multiple sites"""  # noqa: INP001
 from django.conf import settings
 from django.core.management import CommandError
-from django.db.models import Q
 from mitol.common.utils.datetime import now_in_utc
 
-from content_sync.constants import VERSION_DRAFT
 from content_sync.tasks import publish_websites
 from main.management.commands.filter import WebsiteFilterCommand
 from websites.constants import STARTER_SOURCE_GITHUB
@@ -73,20 +71,14 @@ class Command(WebsiteFilterCommand):
         is_verbose = options["verbosity"] > 1
 
         website_qset = Website.objects.filter(starter__source=STARTER_SOURCE_GITHUB)
-        if self.filter_list:
-            website_qset = website_qset.filter(
-                Q(name__in=self.filter_list) | Q(short_id__in=self.filter_list)
-            )
+        website_qset = self.filter_websites(websites=website_qset)
+        website_qset = self.filter_unpublished_websites(
+            version=version, websites=website_qset
+        )
         if starter_str:
             website_qset = website_qset.filter(starter__slug=starter_str)
         if source_str:
             website_qset = website_qset.filter(source=source_str)
-        # do not publish any sites that have been unpublished or never been published before  # noqa: E501
-        website_qset = website_qset.filter(unpublish_status__isnull=True)
-        if version == VERSION_DRAFT:
-            website_qset = website_qset.exclude(draft_publish_date__isnull=True)
-        else:
-            website_qset = website_qset.exclude(publish_date__isnull=True)
 
         website_names = list(website_qset.values_list("name", flat=True))
 

--- a/content_sync/management/commands/reset_sync_states.py
+++ b/content_sync/management/commands/reset_sync_states.py
@@ -62,22 +62,26 @@ class Command(WebsiteFilterCommand):
         source_str = options["source"].lower()
         skip_sync = options["skip_sync"]
 
-        content_qset = ContentSyncState.objects.exclude(synced_checksum__isnull=True)
+        content_sync_state_qset = ContentSyncState.objects.exclude(
+            synced_checksum__isnull=True
+        )
+        content_sync_state_qset = self.filter_content_sync_states(
+            content_sync_states=content_sync_state_qset
+        )
         if type_str:
-            content_qset = content_qset.filter(Q(content__type=type_str))
-        if self.filter_list:
-            content_qset = content_qset.filter(
-                Q(content__website__name__in=self.filter_list)
-                | Q(content__website__short_id__in=self.filter_list)
+            content_sync_state_qset = content_sync_state_qset.filter(
+                Q(content__type=type_str)
             )
         if starter_str:
-            content_qset = content_qset.filter(
+            content_sync_state_qset = content_sync_state_qset.filter(
                 content__website__starter__slug=starter_str
             )
         if source_str:
-            content_qset = content_qset.filter(content__website__source=source_str)
+            content_sync_state_qset = content_sync_state_qset.filter(
+                content__website__source=source_str
+            )
 
-        content_qset.update(synced_checksum=None, data=None)
+        content_sync_state_qset.update(synced_checksum=None, data=None)
 
         total_seconds = (now_in_utc() - start).total_seconds()
         self.stdout.write(

--- a/content_sync/management/commands/update_checksums.py
+++ b/content_sync/management/commands/update_checksums.py
@@ -2,7 +2,6 @@
 import logging
 
 from django.core.paginator import Paginator
-from django.db.models import Q
 from tqdm import tqdm
 
 from content_sync.models import ContentSyncState
@@ -27,12 +26,7 @@ class Command(WebsiteFilterCommand):
         sync_states = (
             ContentSyncState.objects.all().prefetch_related("content").order_by("id")
         )
-
-        if self.filter_list:
-            sync_states = sync_states.filter(
-                Q(content__website__name__in=self.filter_list)
-                | Q(content__website__short_id__in=self.filter_list)
-            )
+        sync_states = self.filter_content_sync_states(sync_states)
 
         page_size = 100
         pages = Paginator(sync_states, page_size)

--- a/content_sync/models.py
+++ b/content_sync/models.py
@@ -1,9 +1,13 @@
 """Content sync models"""
 from bulk_update_or_create import BulkUpdateOrCreateQuerySet
 from django.db import models
-from mitol.common.models import TimestampedModel
+from mitol.common.models import TimestampedModel, TimestampedModelQuerySet
 
 from websites.models import WebsiteContent
+
+
+class ContentSyncStateQuerySet(TimestampedModelQuerySet):
+    """Queryset for ContentSyncState"""
 
 
 class ContentSyncState(TimestampedModel):

--- a/gdrive_sync/management/commands/populate_file_sizes.py
+++ b/gdrive_sync/management/commands/populate_file_sizes.py
@@ -1,5 +1,4 @@
 """Populate file_size meta field for resources."""  # noqa: INP001
-from django.db.models import Q
 
 from gdrive_sync.tasks import populate_file_sizes_bulk
 from main.management.commands.filter import WebsiteFilterCommand
@@ -32,12 +31,7 @@ class Command(WebsiteFilterCommand):
     def handle(self, *args, **options):
         super().handle(*args, **options)
 
-        if self.filter_list:
-            website_queryset = Website.objects.filter(
-                Q(name__in=self.filter_list) | Q(short_id__in=self.filter_list)
-            )
-        else:
-            website_queryset = Website.objects.all()
+        website_queryset = self.filter_websites(websites=Website.objects.all())
 
         website_names = list(website_queryset.values_list("name", flat=True))
 

--- a/main/management/commands/filter.py
+++ b/main/management/commands/filter.py
@@ -4,7 +4,7 @@ import json
 from django.core.management import BaseCommand
 from django.db.models import Q
 
-from websites.models import WebsiteContentQuerySet
+from websites.models import WebsiteContentQuerySet, WebsiteQuerySet
 
 
 class WebsiteFilterCommand(BaseCommand):
@@ -54,6 +54,19 @@ class WebsiteFilterCommand(BaseCommand):
             self.stdout.write(f"Filtering by website: {self.filter_list}")
         if self.exclude_list and options["verbosity"] > 1:
             self.stdout.write(f"Excluding websites: {self.exclude_list}")
+
+    def filter_websites(self, websites: WebsiteQuerySet) -> WebsiteQuerySet:
+        """Filter websites based on CLI arguments"""
+        filtered_list = websites
+        if self.filter_list:
+            filtered_list = filtered_list.filter(
+                Q(name__in=self.filter_list) | Q(name__in=self.filter_list)
+            )
+        if self.exclude_list:
+            filtered_list = filtered_list.exclude(
+                Q(name__in=self.exclude_list) | Q(name__in=self.exclude_list)
+            )
+        return filtered_list
 
     def filter_website_contents(
         self, website_contents: WebsiteContentQuerySet

--- a/main/management/commands/filter.py
+++ b/main/management/commands/filter.py
@@ -58,41 +58,43 @@ class WebsiteFilterCommand(BaseCommand):
 
     def filter_websites(self, websites: WebsiteQuerySet) -> WebsiteQuerySet:
         """Filter websites based on CLI arguments"""
-        filtered_list = websites
+        filtered_websites = websites
         if self.filter_list:
-            filtered_list = filtered_list.filter(
+            filtered_websites = filtered_websites.filter(
                 Q(name__in=self.filter_list) | Q(name__in=self.filter_list)
             )
         if self.exclude_list:
-            filtered_list = filtered_list.exclude(
+            filtered_websites = filtered_websites.exclude(
                 Q(name__in=self.exclude_list) | Q(name__in=self.exclude_list)
             )
-        return filtered_list
+        return filtered_websites
 
     def filter_unpublished_websites(
         self, version: str, websites: WebsiteQuerySet
     ) -> WebsiteQuerySet:
         """Filter websites that are unpublished or have never been published"""
-        filtered_list = websites.filter(unpublish_status__isnull=True)
+        filtered_websites = websites.filter(unpublish_status__isnull=True)
         if version == VERSION_DRAFT:
-            filtered_list = filtered_list.exclude(draft_publish_date__isnull=True)
+            filtered_websites = filtered_websites.exclude(
+                draft_publish_date__isnull=True
+            )
         else:
-            filtered_list = filtered_list.exclude(publish_date__isnull=True)
-        return filtered_list
+            filtered_websites = filtered_websites.exclude(publish_date__isnull=True)
+        return filtered_websites
 
     def filter_website_contents(
         self, website_contents: WebsiteContentQuerySet
     ) -> WebsiteContentQuerySet:
         """Filter website_contents based on CLI arguments."""
-        filtered_list = website_contents
+        filtered_website_contents = website_contents
         if self.filter_list:
-            filtered_list = filtered_list.filter(
+            filtered_website_contents = filtered_website_contents.filter(
                 Q(website__name__in=self.filter_list)
                 | Q(website__short_id__in=self.filter_list)
             )
         if self.exclude_list:
-            filtered_list = filtered_list.exclude(
+            filtered_website_contents = filtered_website_contents.exclude(
                 Q(website__name__in=self.exclude_list)
                 | Q(website__short_id__in=self.exclude_list)
             )
-        return filtered_list
+        return filtered_website_contents

--- a/main/management/commands/filter.py
+++ b/main/management/commands/filter.py
@@ -40,6 +40,7 @@ class WebsiteFilterCommand(BaseCommand):
 
     def handle(self, *args, **options):  # noqa: ARG002
         self.filter_list = []
+        self.exclude_list = []
         filter_sites = options["filter"]
         filter_json = options["filter_json"]
         exclude_sites = options["exclude"]

--- a/main/management/commands/filter.py
+++ b/main/management/commands/filter.py
@@ -61,11 +61,11 @@ class WebsiteFilterCommand(BaseCommand):
         filtered_websites = websites
         if self.filter_list:
             filtered_websites = filtered_websites.filter(
-                Q(name__in=self.filter_list) | Q(name__in=self.filter_list)
+                Q(name__in=self.filter_list) | Q(short_id__in=self.filter_list)
             )
         if self.exclude_list:
             filtered_websites = filtered_websites.exclude(
-                Q(name__in=self.exclude_list) | Q(name__in=self.exclude_list)
+                Q(name__in=self.exclude_list) | Q(short_id__in=self.exclude_list)
             )
         return filtered_websites
 

--- a/main/management/commands/filter.py
+++ b/main/management/commands/filter.py
@@ -13,6 +13,7 @@ class WebsiteFilterCommand(BaseCommand):
     """Common options for filtering by Website"""
 
     filter_list = None
+    exclude_list = None
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/main/management/commands/filter.py
+++ b/main/management/commands/filter.py
@@ -4,6 +4,7 @@ import json
 from django.core.management import BaseCommand
 from django.db.models import Q
 
+from content_sync.constants import VERSION_DRAFT
 from websites.models import WebsiteContentQuerySet, WebsiteQuerySet
 
 
@@ -66,6 +67,17 @@ class WebsiteFilterCommand(BaseCommand):
             filtered_list = filtered_list.exclude(
                 Q(name__in=self.exclude_list) | Q(name__in=self.exclude_list)
             )
+        return filtered_list
+
+    def filter_unpublished_websites(
+        self, version: str, websites: WebsiteQuerySet
+    ) -> WebsiteQuerySet:
+        """Filter websites that are unpublished or have never been published"""
+        filtered_list = websites.filter(unpublish_status__isnull=True)
+        if version == VERSION_DRAFT:
+            filtered_list = filtered_list.exclude(draft_publish_date__isnull=True)
+        else:
+            filtered_list = filtered_list.exclude(publish_date__isnull=True)
         return filtered_list
 
     def filter_website_contents(

--- a/main/management/commands/filter.py
+++ b/main/management/commands/filter.py
@@ -6,6 +6,7 @@ from django.db.models import Q
 
 from content_sync.constants import VERSION_DRAFT
 from content_sync.models import ContentSyncStateQuerySet
+from videos.models import VideoQuerySet
 from websites.models import WebsiteContentQuerySet, WebsiteQuerySet
 
 
@@ -117,3 +118,18 @@ class WebsiteFilterCommand(BaseCommand):
                 | Q(content__website__short_id__in=self.exclude_list)
             )
         return filtered_content_sync_states
+
+    def filter_videos(self, videos: VideoQuerySet) -> VideoQuerySet:
+        """Filter content_sync_states based on CLI arguments."""
+        filtered_videos = videos
+        if self.filter_list:
+            filtered_videos = filtered_videos.filter(
+                Q(website__name__in=self.filter_list)
+                | Q(website__short_id__in=self.filter_list)
+            )
+        if self.exclude_list:
+            filtered_videos = filtered_videos.exclude(
+                Q(website__name__in=self.exclude_list)
+                | Q(website__short_id__in=self.exclude_list)
+            )
+        return filtered_videos

--- a/main/management/commands/filter.py
+++ b/main/management/commands/filter.py
@@ -69,7 +69,7 @@ class WebsiteFilterCommand(BaseCommand):
             )
         return filtered_websites
 
-    def filter_unpublished_websites(
+    def exclude_unpublished_websites(
         self, version: str, websites: WebsiteQuerySet
     ) -> WebsiteQuerySet:
         """Filter websites that are unpublished or have never been published"""

--- a/main/management/commands/filter.py
+++ b/main/management/commands/filter.py
@@ -5,6 +5,7 @@ from django.core.management import BaseCommand
 from django.db.models import Q
 
 from content_sync.constants import VERSION_DRAFT
+from content_sync.models import ContentSyncStateQuerySet
 from websites.models import WebsiteContentQuerySet, WebsiteQuerySet
 
 
@@ -98,3 +99,20 @@ class WebsiteFilterCommand(BaseCommand):
                 | Q(website__short_id__in=self.exclude_list)
             )
         return filtered_website_contents
+
+    def filter_content_sync_states(
+        self, content_sync_states: ContentSyncStateQuerySet
+    ) -> ContentSyncStateQuerySet:
+        """Filter content_sync_states based on CLI arguments."""
+        filtered_content_sync_states = content_sync_states
+        if self.filter_list:
+            filtered_content_sync_states = filtered_content_sync_states.filter(
+                Q(content__website__name__in=self.filter_list)
+                | Q(content__website__short_id__in=self.filter_list)
+            )
+        if self.exclude_list:
+            filtered_content_sync_states = filtered_content_sync_states.exclude(
+                Q(content__website__name__in=self.exclude_list)
+                | Q(content__website__short_id__in=self.exclude_list)
+            )
+        return filtered_content_sync_states

--- a/ocw_import/management/commands/repair_dupe_repos.py
+++ b/ocw_import/management/commands/repair_dupe_repos.py
@@ -1,6 +1,5 @@
 """Fix sites that have been assigned a new repo on every import"""
 from django.db import transaction
-from django.db.models import Q
 from github import GithubException
 from mitol.common.utils.datetime import now_in_utc
 
@@ -25,10 +24,7 @@ class Command(WebsiteFilterCommand):
             .filter(source="ocw-import", short_id__regex=r".+\-\d{1,2}$")
             .order_by("name")
         )
-        if self.filter_list:
-            websites = websites.filter(
-                Q(name__in=self.filter_list) | Q(short_id__in=self.filter_list)
-            )
+        websites = self.filter_websites(websites=websites)
         self.stdout.write(f"Repairing repos for {websites.count()} sites")
         for website in websites:
             try:

--- a/videos/management/commands/backpopulate_video_downloads.py
+++ b/videos/management/commands/backpopulate_video_downloads.py
@@ -7,7 +7,6 @@ import os
 
 from django.conf import settings
 from django.core.management import CommandParser
-from django.db.models import Q
 from mitol.common.utils import now_in_utc
 
 from content_sync.tasks import sync_unsynced_websites
@@ -45,11 +44,7 @@ class Command(WebsiteFilterCommand):
         is_verbose = options["verbosity"] > 1
 
         videos = Video.objects.all()
-        if self.filter_list:
-            videos = videos.filter(
-                Q(website__name__in=self.filter_list)
-                | Q(website__short_id__in=self.filter_list)
-            )
+        self.filter_videos(videos=videos)
 
         self.stdout.write(
             f"Updating downloadable video files for {videos.count()} videos."

--- a/videos/management/commands/sync_missing_captions.py
+++ b/videos/management/commands/sync_missing_captions.py
@@ -66,8 +66,7 @@ class Command(WebsiteFilterCommand):
                 | Q(metadata__video_files__video_transcript_file=None)
             )
         )
-        if self.filter_list:
-            content_videos = self.filter_website_contents(content_videos)
+        content_videos = self.filter_website_contents(content_videos)
 
         if not content_videos:
             self.stdout.write("No courses found")

--- a/videos/models.py
+++ b/videos/models.py
@@ -2,7 +2,7 @@
 
 from django.db import models
 from django.db.models import CASCADE
-from mitol.common.models import TimestampedModel
+from mitol.common.models import TimestampedModel, TimestampedModelQuerySet
 
 from main import settings
 from main.utils import get_base_filename
@@ -15,6 +15,10 @@ from videos.constants import (
 from websites.models import Website, WebsiteContent
 from websites.site_config_api import SiteConfig
 from websites.utils import get_dict_query_field
+
+
+class VideoQuerySet(TimestampedModelQuerySet):
+    """Queryset for Video"""
 
 
 class Video(TimestampedModel):

--- a/websites/management/commands/backpopulate_groups.py
+++ b/websites/management/commands/backpopulate_groups.py
@@ -1,5 +1,4 @@
 """Backpopulate website groups and permissions"""  # noqa: INP001
-from django.db.models import Q
 from mitol.common.utils.datetime import now_in_utc
 
 from main.management.commands.filter import WebsiteFilterCommand
@@ -42,13 +41,7 @@ class Command(WebsiteFilterCommand):
             )
 
         if not options["only-global"]:
-            if self.filter_list:
-                website_qset = Website.objects.filter(
-                    Q(name__in=self.filter_list)
-                    | Q(short_id__icontains=self.filter_list)
-                )
-            else:
-                website_qset = Website.objects.all()
+            website_qset = self.filter_websites(websites=Website.objects.all())
             for website in website_qset.iterator():
                 created, updated, owner_updated = setup_website_groups_permissions(
                     website

--- a/websites/management/commands/fix_file_urls.py
+++ b/websites/management/commands/fix_file_urls.py
@@ -3,7 +3,6 @@ import csv
 import re
 
 from django.conf import settings
-from django.db.models import Q
 from mitol.common.utils import now_in_utc
 
 from content_sync.tasks import sync_unsynced_websites
@@ -63,11 +62,7 @@ class Command(WebsiteFilterCommand):
             type=CONTENT_TYPE_RESOURCE,
             file__regex=rf"^/?{prefix}/[A-Za-z0-9\-\.\_]+(\.).*",
         )
-        if self.filter_list:
-            bad_paths = bad_paths.filter(
-                Q(website__name__in=self.filter_list)
-                | Q(website__short_id__in=self.filter_list)
-            )
+        bad_paths = self.filter_website_contents(website_contents=bad_paths)
 
         self.stdout.write(
             f"Found {bad_paths.count()} resources with '{prefix}/' file paths missing website names"  # noqa: E501

--- a/websites/management/commands/sync_content_state.py
+++ b/websites/management/commands/sync_content_state.py
@@ -1,5 +1,4 @@
 """Updates/creates content sync records for website contents"""  # noqa: INP001
-from django.db.models import Q
 
 from content_sync.api import upsert_content_sync_state
 from main.management.commands.filter import WebsiteFilterCommand
@@ -32,11 +31,7 @@ class Command(WebsiteFilterCommand):
         if options["text_id"]:
             filter_qset["text_id"] = options["text_id"]
         content_qset = WebsiteContent.objects.filter(**filter_qset)
-        if self.filter_list:
-            content_qset = content_qset.filter(
-                Q(website__name__in=self.filter_list)
-                | Q(website__short_id__in=self.filter_list)
-            )
+        content_qset = self.filter_website_contents(website_contents=content_qset)
         num_records = content_qset.count()
         self.stdout.write(
             self.style.WARNING(

--- a/websites/management/commands/sync_contents_with_config.py
+++ b/websites/management/commands/sync_contents_with_config.py
@@ -1,8 +1,6 @@
 """Updates derived values in WebsiteContent records to match the site config"""  # noqa: E501, INP001
 import sys
 
-from django.db.models import Q
-
 from main.management.commands.filter import WebsiteFilterCommand
 from websites.models import Website, WebsiteContent, WebsiteStarter
 from websites.site_config_api import SiteConfig
@@ -51,11 +49,9 @@ class Command(WebsiteFilterCommand):
                     page_content_config_item_names.append(config_item.name)
                 else:
                     other_config_item_names.append(config_item.name)
-            websites = Website.objects.filter(starter=starter)
-            if self.filter_list:
-                websites = websites.filter(
-                    Q(name__in=self.filter_list) | Q(short_id__in=self.filter_list)
-                )
+            websites = self.filter_websites(
+                websites=Website.objects.filter(starter=starter)
+            )
             for website in websites:
                 _contents_updated = WebsiteContent.objects.filter(
                     website=website,

--- a/websites/management/commands/unpublish_sites.py
+++ b/websites/management/commands/unpublish_sites.py
@@ -48,9 +48,7 @@ class Command(WebsiteFilterCommand):
                 "Please provide a valid email address for an existing user to unpublish courses."  # noqa: E501
             )
             return
-        websites = Website.objects.filter(
-            Q(name__in=self.filter_list) | Q(short_id__in=self.filter_list)
-        )
+        websites = self.filter_websites(websites=Website.objects.all())
         unpublished_count = 0
         unpublished_names = []
         for website in websites:

--- a/websites/management/commands/update_content_fields.py
+++ b/websites/management/commands/update_content_fields.py
@@ -5,7 +5,6 @@ from argparse import ArgumentTypeError
 from django.core.exceptions import FieldDoesNotExist
 from django.core.management import CommandError
 from django.db import transaction
-from django.db.models import Q
 
 from main.management.commands.filter import WebsiteFilterCommand
 from websites.models import WebsiteContent
@@ -70,11 +69,7 @@ class Command(WebsiteFilterCommand):
                 contents = WebsiteContent.objects.filter(
                     website__starter__slug=starter, type=page_type
                 )
-                if self.filter_list:
-                    contents = contents.filter(
-                        Q(website__name__in=self.filter_list)
-                        | Q(website__short_id__in=self.filter_list)
-                    )
+                contents = self.filter_website_contents(website_contents=contents)
                 contents.update(**updated_data)
             except FieldDoesNotExist as e:
                 raise CommandError(e)  # noqa: B904, TRY200

--- a/websites/management/commands/update_content_metadata.py
+++ b/websites/management/commands/update_content_metadata.py
@@ -1,6 +1,5 @@
 """Update content metadata for websites based on a specific starter"""  # noqa: INP001
 from django.db import transaction
-from django.db.models import Q
 
 from main.management.commands.filter import WebsiteFilterCommand
 from websites.models import WebsiteContent, WebsiteStarter
@@ -50,11 +49,7 @@ class Command(WebsiteFilterCommand):
         content_qset = WebsiteContent.objects.filter(
             website__starter__slug=starter_str, type=type_str
         )
-        if self.filter_list:
-            content_qset = content_qset.filter(
-                Q(website__name__in=self.filter_list)
-                | Q(website__short_id__in=self.filter_list)
-            )
+        content_qset = self.filter_website_contents(website_contents=content_qset)
         if source_str:
             content_qset = content_qset.filter(website__source=source_str)
 

--- a/websites/management/commands/update_departments.py
+++ b/websites/management/commands/update_departments.py
@@ -51,11 +51,7 @@ class Command(WebsiteFilterCommand):
                 ],
             ),
         )
-        if self.filter_list:
-            query_set = query_set.filter(
-                Q(website__name__in=self.filter_list)
-                | Q(website__short_id__in=self.filter_list)
-            )
+        query_set = self.filter_website_contents(website_contents=query_set)
 
         query_set = query_set.filter(type="sitemetadata")
         self.stdout.write(


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/2044

# Description (What does it do?)
This PR adds an argument to `main.management.commands.WebsiteFilterCommand`; `--exclude`. The argument takes a comma separated list of either `Website` `name` or `short_id` properties, using these values to exclude sites from the action a given management command is performing. A number of helper functions were added to the class with the goal of more consistent filtering across commands. This block of code was duplicated across almost all management commands:

```python
if self.filter_list:
        website_qset = website_qset.filter(
            Q(name__in=self.filter_list) | Q(short_id__in=self.filter_list)
        )
```

This code was replaced with a call to `website_qset = self.filter_websites(websites=website_qset)`. Additional helper functions were added for excluding unpublished sites, filtering `WebsiteContent`, `ContentSyncState` and `Video` based on a list of websites, either in include (`--filter`) or exclude (`--exclude`) mode.

# How can this be tested?
You may notice that `WebsiteFilterCommand` has been set up to include sites from `--filter` and subsequently exclude sites from `--exclude` after that, allowing you to chain the two together. This doesn't really have a practical use, as if you didn't want to include a site in this scenario you could simply leave it out of your `--filter` list. However, we will use this method here in our testing to make things more easy to verify.
 - Pick ~4 courses from your database for testing and note their `name` or `short_id` properties
 - Run a management command with this syntax: `docker-compose exec web ./manage.py mass_publish --filter "<all 4 courses comma separated>" --exclude "<2 of the courses comma separated>"`, inserting course names / short ID's as directed where indicated
 - Ensure that the courses specified by `--exclude` are excluded from the management command action
 - Repeat this with any of the management commands modified by this PR

# Additional Context
This is mostly being done to allow excluding sites from the `mass_publish` command, but as you probably noticed all old management commands have been updated to use the new helper function. Feel free to test these, but it shouldn't be necessary as the exact same filter logic was replaced across many commands with the helper functions that do the same thing.