### PR TITLE
unpublished should be a boolean in open webhook call

### DIFF
--- a/content_sync/pipelines/definitions/concourse/remove_unpublished_sites.py
+++ b/content_sync/pipelines/definitions/concourse/remove_unpublished_sites.py
@@ -120,7 +120,7 @@ class UnpublishedSiteRemovalPipelineDefinition(Pipeline):
                                 "webhook_key": open_webhook_key,
                                 "site_uid": "((.:site.site_uid))",
                                 "version": VERSION_LIVE,
-                                "unpublished": "true",
+                                "unpublished": True,
                             }
                         ),
                         f"{open_discussions_url}/api/v0/ocw_next_webhook/",


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/2045

# Description (What does it do?)
In https://github.com/mitodl/ocw-studio/pull/1993, we rewrote the `remove_unpublished_sites.yml` pipeline using the `ol-concourse` library in Python. Part of this pipeline sends a webhook request to `open-discussions` to remove the unpublished sites from the search index. This was not functioning properly because the `published` argument in the webhook call had a value of `"true"` being sent across as a string. This PR changes the value to be a boolean.

# How can this be tested?
 - Make sure you have the `fly` CLI installed locally and make sure you set `OCW_STUDIO_ENVIRONMENT` in your `.env` file to anything except "dev"
 - Run `docker-compose exec web ./manage.py upsert_site_removal_pipeline`
 - Run `fly -t local get-pipeline -p remove-unpublished-sites`
 - Inspect the output and make sure that the `open-discussions` webhook code has `- '{"version": "live", "status": "errored", "unpublished": true}'` and not `- '{"version": "live", "status": "errored", "unpublished": "true"}'`
 - The actual functionality of removing courses from the index is best tested in RC, after this PR is merged
