### PR TITLE
management command for importing website starters from GitHub

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -113,9 +113,9 @@
         "filename": "README.md",
         "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
         "is_verified": false,
-        "line_number": 237
+        "line_number": 242
       }
     ]
   },
-  "generated_at": "2023-12-13T00:57:24Z"
+  "generated_at": "2023-12-14T22:35:57Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -113,9 +113,9 @@
         "filename": "README.md",
         "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
         "is_verified": false,
-        "line_number": 212
+        "line_number": 237
       }
     ]
   },
-  "generated_at": "2023-10-25T01:10:31Z"
+  "generated_at": "2023-12-13T00:57:24Z"
 }

--- a/README.md
+++ b/README.md
@@ -4,18 +4,28 @@ OCW Studio manages deployments for OCW courses.
 
 **SECTIONS**
 
-1. [Initial Setup](#initial-setup)
-1. [Testing and Formatting](#testing-and-formatting)
-1. [Defining local starter projects and site configs](#defining-local-starter-projects-and-site-configs)
-1. [Enabling GitHub integration](#enabling-github-integration)
-1. [Local S3 emulation with Minio](#local-s3-emulation-with-minio)
-1. [Enabling Concourse-CI integration](#enabling-concourse-ci-integration)
-1. [Running OCW Studio on Apple Silicon](#running-ocw-studio-on-apple-silicon)
-1. [Video Workflow](#video-workflow)
-1. [Enabling YouTube integration](#enabling-youtube-integration)
-1. [Enabling Google Drive integration](#enabling-google-drive-integration)
-1. [Enabling AWS MediaConvert transcoding](#enabling-aws-mediaconvert-transcoding)
-1. [Enabling 3Play integration](#enabling-3play-integration)
+- [ocw_studio](#ocw_studio)
+- [Initial Setup](#initial-setup)
+  - [Testing Touchstone login with SAML via SSOCircle](#testing-touchstone-login-with-saml-via-ssocircle)
+  - [Commits](#commits)
+- [Testing and Formatting](#testing-and-formatting)
+  - [JS/CSS Tests and Linting](#jscss-tests-and-linting)
+    - [JS tests](#js-tests)
+    - [JS formatting, linting, and typechecking](#js-formatting-linting-and-typechecking)
+- [Defining local starter projects and site configs](#defining-local-starter-projects-and-site-configs)
+  - [The `localdev` folder](#the-localdev-folder)
+  - [Importing starter projects from Github](#importing-starter-projects-from-github)
+  - [Automatically updating starters from Github](#automatically-updating-starters-from-github)
+- [Enabling GitHub integration](#enabling-github-integration)
+- [Local S3 emulation with Minio](#local-s3-emulation-with-minio)
+- [Enabling Concourse-CI integration](#enabling-concourse-ci-integration)
+  - [Running a Local Concourse Docker Container](#running-a-local-concourse-docker-container)
+- [Running OCW Studio on Apple Silicon](#running-ocw-studio-on-apple-silicon)
+- [Video Workflow](#video-workflow)
+- [Enabling YouTube integration](#enabling-youtube-integration)
+- [Enabling Google Drive integration](#enabling-google-drive-integration)
+- [Enabling AWS MediaConvert transcoding](#enabling-aws-mediaconvert-transcoding)
+- [Enabling 3Play integration](#enabling-3play-integration)
 
 # Initial Setup
 
@@ -167,10 +177,25 @@ You can also try `npm run fmt:check` to see if any files need to be reformatted.
 
 # Defining local starter projects and site configs
 
-This project includes some tools that simplify development with starter projects and site configs. These tools allow you to do the following:
+The `ocw-studio` software allows you to create websites based on a configuration called a "starter." These configuration files are named `ocw-studio.yaml` by default but that name can be overridden by setting `OCW_STUDIO_SITE_CONFIG_FILE` in your environment. These starters can be imported into `ocw-studio` in a couple different ways.
 
-- Define entire starter projects within this repo and load them into your database
-- Override the site config for starters with a particular `slug` value
+### The `localdev` folder
+
+More details on this are in [this readme file](localdev/README.md)
+
+### Importing starter projects from Github
+
+MIT OCW has a set of starter configs that are used in building the official OCW site. They are stored in a repo called [`ocw-hugo-projects`](https://github.com/mitodl/ocw-hugo-projects). This repo can be used as a reference for setting up your own repo. When you make your own repo, make sure that your config files in the repo are in their own folder and the filenames match what is set to `OCW_STUDIO_SITE_CONFIG_FILE`, which is `ocw-studio.yaml` by default. The folder name is used to determine the `slug` property of the resulting starter object, and the config file is read from that folder and applied to the `config` property. When your repo is ready, make sure it is publically accessible and then you can import the starter configs from it by running:
+
+```sh
+docker-compose exec web ./manage.py import_website_starters https://github.com/mitodl/ocw-hugo-projects
+```
+
+If you wish to use your own Github repo containing starters use that URL instead. If any starters already exist with the same slug as one being imported, their configuration will be updated.
+
+### Automatically updating starters from Github
+
+If you are hosting `ocw-studio` on the internet and wish to have your starter updated automatically when you make changes to the starter configurations in your Github repo, this is possible by configuring a webhook. In order to accomplish this, you will need to first set `GITHUB_WEBHOOK_BRANCH` in your environment to the branch that you wish to watch for changes on (i.e. `release`). Then, you will need to configure a webhook in the settings of your Github repo targeting `/api/starters/site_configs` on your instance of `ocw-studio`. After this is set up, on pushes to the configured branch, a webhook will be fired to your `ocw-studio` instance which will trigger automatic updating of your starter configurations.
 
 # Enabling GitHub integration
 

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ You can also try `npm run fmt:check` to see if any files need to be reformatted.
 
 # Defining local starter projects and site configs
 
-The `ocw-studio` software allows you to create websites based on a configuration called a "starter." These configuration files are named `ocw-studio.yaml` by default but that name can be overridden by setting `OCW_STUDIO_SITE_CONFIG_FILE` in your environment. These starters can be imported into `ocw-studio` in a couple different ways.
+The `ocw-studio` software allows you to create websites based on a configuration called a "starter." These configuration files are named `ocw-studio.yaml` by default but that name can be overridden by setting `OCW_STUDIO_SITE_CONFIG_FILE` in your environment. These starters can be imported into `ocw-studio` in a couple of different ways.
 
 ### The `localdev` folder
 

--- a/README.md
+++ b/README.md
@@ -29,17 +29,22 @@ OCW Studio manages deployments for OCW courses.
 
 # Initial Setup
 
-ocw_studio follows the same [initial setup steps outlined in the common ODL web app guide](https://mitodl.github.io/handbook/how-to/common-web-app-guide.html).
+`ocw_studio` follows the same [initial setup steps outlined in the common ODL web app guide](https://mitodl.github.io/handbook/how-to/common-web-app-guide.html).
 Run through those steps **including the addition of `/etc/hosts` aliases and the optional step for running the
 `createsuperuser` command**.
 
-In addition, you should create a starter with `slug=ocw-www` through the admin interface with config data taken from the `ocw-www` starter on RC or production. Then, you should go to the `/sites` UI and create a new site with `name=ocw-www` using the `ocw-www` starter.
+Websites are created using a template called a "starter." You can import a standard set of starters by running:
 
-Finally, create/update additional starters with the following command:
+```sh
+docker-compose exec web ./manage.py import_website_starters https://github.com/mitodl/ocw-hugo-projects
+```
 
-```
-docker-compose run web python manage.py override_site_config
-```
+The `ocw-www` starter is meant for creating a home page, aka the "root website." This is called `ocw-www` by default, but the name of the site can be set on `ROOT_WEBSITE_NAME` in your environment if you wish to change it. The other starters are different types of websites that can be built within `ocw-studio`. After you have imported some starters, you are ready to start creating websites. To publish those websites, follow the guides in the table of contents above for setting up:
+
+- A Github organization
+- Google Drive integration for resources
+- AWS S3 credentials (Minio S3 emulation should work out of the box for local development)
+- Youtube / AWS MediaConvert / 3Play if you need to work with videos
 
 ### Testing Touchstone login with SAML via SSOCircle
 

--- a/content_sync/apis/github.py
+++ b/content_sync/apis/github.py
@@ -516,3 +516,21 @@ class GithubApiWrapper:
         ]
         if tree_elements:
             self.commit_tree(tree_elements, user)
+
+
+def find_files_recursive(
+    repo: Repository, path: str, file_name: str, commit: Optional[str] = None
+) -> Iterable[str]:
+    """Find files recursively in a Repository"""
+    file_paths = []
+    contents = repo.get_contents(path, commit) if commit else repo.get_contents(path)
+    for content in contents:
+        if content.type == "dir":
+            file_paths.extend(
+                find_files_recursive(
+                    repo=repo, path=content.path, file_name=file_name, commit=commit
+                )
+            )
+        elif file_name in content.name:
+            file_paths.append(content.path)
+    return file_paths

--- a/content_sync/apis/github.py
+++ b/content_sync/apis/github.py
@@ -526,7 +526,11 @@ def find_files_recursive(
 ) -> Iterable[str]:
     """Find files recursively in a Repository"""
     file_paths = []
-    contents = repo.get_contents(path, commit) if commit else repo.get_contents(path)
+    contents = (
+        repo.get_contents(path=path, ref=commit)
+        if commit
+        else repo.get_contents(path=path)
+    )
     for content in contents:
         if content.type == "dir":
             file_paths.extend(
@@ -534,6 +538,6 @@ def find_files_recursive(
                     repo=repo, path=content.path, file_name=file_name, commit=commit
                 )
             )
-        elif file_name in content.name:
+        elif file_name in str(content.name):
             file_paths.append(content.path)
     return file_paths

--- a/content_sync/apis/github.py
+++ b/content_sync/apis/github.py
@@ -92,7 +92,10 @@ def sync_starter_configs(  # pylint:disable=too-many-locals
 
     for config_file in config_files:
         try:
-            git_file = repo.get_contents(config_file, commit)
+            if commit:
+                git_file = repo.get_contents(config_file, commit)
+            else:
+                git_file = repo.get_contents(config_file)
             slug = (
                 git_file.path.split("/")[0]
                 if git_file.path != settings.OCW_STUDIO_SITE_CONFIG_FILE

--- a/content_sync/apis/github_test.py
+++ b/content_sync/apis/github_test.py
@@ -996,7 +996,7 @@ def test_find_files_recursive(mocker, mock_github):
         if kwargs["path"] == "":
             return [
                 mocker.Mock(path="site-1", name="site-1", type="dir"),
-                mocker.Mock(path="site-1", name="site-2", type="dir"),
+                mocker.Mock(path="site-2", name="site-2", type="dir"),
             ]
         elif kwargs["path"] == "site-1":
             return [
@@ -1027,4 +1027,4 @@ def test_find_files_recursive(mocker, mock_github):
     repo = mock_github.return_value.get_organization.return_value.get_repo.return_value
     repo.get_contents.side_effect = get_content_side_effect
     files = find_files_recursive(repo=repo, path="", file_name="ocw-studio.yaml")
-    assert files == ["site-1/ocw-studio.yaml", "site-1/ocw-studio.yaml"]
+    assert files == ["site-1/ocw-studio.yaml", "site-2/ocw-studio.yaml"]

--- a/websites/management/commands/import_website_starters.py
+++ b/websites/management/commands/import_website_starters.py
@@ -50,6 +50,6 @@ class Command(BaseCommand):
             sync_starter_configs(
                 repo_url=git_url, config_files=config_files, commit=commit
             )
+            self.stdout.write("Successfully updated WebsiteStarter objects")
         else:
             self.stdout.write("No ocw-studio.yaml files found in the given repository")
-        self.stdout.write("Successfully updated WebsiteStarter objects")

--- a/websites/management/commands/import_website_starters.py
+++ b/websites/management/commands/import_website_starters.py
@@ -1,0 +1,55 @@
+"""Import WebsiteStarter objects from ocw-studio.yaml files in a Github repo"""  # noqa: E501 INP001
+from urllib.parse import urlparse
+
+from django.conf import settings
+from django.core.management import BaseCommand
+from github import Github
+
+from content_sync.apis.github import find_files_recursive, sync_starter_configs
+
+
+class Command(BaseCommand):
+    """Import WebsiteStarter objects from ocw-studio.yaml files in a Github repo"""
+
+    help = __doc__  # noqa: A003
+
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+        parser.add_argument(
+            "git_url",
+            help="The URL to the Github repo",
+        )
+        parser.add_argument(
+            "-c",
+            "--commit",
+            dest="commit",
+            default=None,
+            help="If specified, use a specific commit hash",
+        )
+
+    def handle(self, *args, **options):  # noqa: ARG002
+        git_url = options["git_url"]
+        commit = options["commit"]
+
+        repo_path = urlparse(git_url).path.lstrip("/")
+        org_name, repo_name = repo_path.split("/", 1)
+        git = Github()
+        org = git.get_organization(org_name)
+        repo = org.get_repo(repo_name)
+        config_files = find_files_recursive(
+            repo=repo,
+            path="",
+            file_name=settings.OCW_STUDIO_SITE_CONFIG_FILE,
+            commit=commit,
+        )
+        num_config_files = len(config_files)
+        if num_config_files > 0:
+            self.stdout.write(
+                f"Creating or updating WebsiteStarter objects for {num_config_files} config files: {config_files}"  # noqa: E501
+            )
+            sync_starter_configs(
+                repo_url=git_url, config_files=config_files, commit=commit
+            )
+        else:
+            self.stdout.write("No ocw-studio.yaml files found in the given repository")
+        self.stdout.write("Successfully updated WebsiteStarter objects")


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/2048

# Description (What does it do?)
This PR adds a new management command, `import_website_starters`. This command takes 2 arguments, a Github URL to clone a repository from and optionally a commit hash. The command uses a new utility function, `find_files_recursive`, to recursively search for starter config files in the repo based on the value of `settings.OCW_STUDIO_SITE_CONFIG_FILE` and returns a list of paths pointing to any files found. If files are found, they are passed into the existing `sync_starter_configs` function, which is the same function that the `/api/starters/site_configs` API endpoint calls. `WebsiteStarter` objects are then created or updated based on the config files found.

# How can this be tested?
 - Start up `ocw-studio` and ensure that you have superuser access
 - Browse to the `WebsiteStarter` section of Django admin: http://localhost:8043/admin/websites/websitestarter/
 - Delete the `mit-fields` starter from your local database (this is a mostly unused starter, so unless you have created some fields sites then there will likely be no dependencies
 - Browse to the `ocw-course` starter and change something about the config that you will be able to recognize (help text is an easy one) and save it
 - Run `docker-compose exec web ./manage.py import_website_starters https://github.com/mitodl/ocw-hugo-projects`
 - Back in Django admin, verify that:
   - The `mit-fields` starter has been recreated
   - The manual change you made to the `ocw-course` starter has been restored to its original value