### PR TITLE
allow sitemap domain override

### DIFF
--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
@@ -207,6 +207,7 @@ class EndToEndTestPipelineDefinition(Pipeline):
             resource_base_url=static_api_base_url,
             ocw_hugo_themes_branch=themes_branch,
             ocw_hugo_projects_branch=projects_branch,
+            sitemap_domain=site_pipeline_vars["sitemap_domain"],
             namespace=namespace,
         )
         www_config.is_root_website = True
@@ -228,6 +229,7 @@ class EndToEndTestPipelineDefinition(Pipeline):
             resource_base_url=static_api_base_url,
             ocw_hugo_themes_branch=themes_branch,
             ocw_hugo_projects_branch=projects_branch,
+            sitemap_domain=site_pipeline_vars["sitemap_domain"],
             namespace=namespace,
         )
         course_config.values["ocw_studio_url"] = ""

--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline_test.py
@@ -81,6 +81,7 @@ def test_generate_e2e_test_site_pipeline_definition(  # noqa: PLR0913 PLR0915
     static_api_base_url = common_pipeline_vars["static_api_base_url_test"]
     test_bucket = common_pipeline_vars["test_bucket_name"]
     offline_test_bucket = common_pipeline_vars["offline_test_bucket_name"]
+    sitemap_domain = urlparse(static_api_base_url).netloc
 
     pipeline_definition = EndToEndTestPipelineDefinition(
         themes_branch=ocw_hugo_themes_branch,
@@ -158,6 +159,7 @@ def test_generate_e2e_test_site_pipeline_definition(  # noqa: PLR0913 PLR0915
     assert www_values["resource_base_url"] == static_api_base_url
     assert www_values["ocw_hugo_themes_branch"] == ocw_hugo_themes_branch
     assert www_values["ocw_hugo_projects_branch"] == ocw_hugo_projects_branch
+    assert www_values["sitemap_domain"] == sitemap_domain
     course_values = next(
         values
         for values in across_values
@@ -170,6 +172,7 @@ def test_generate_e2e_test_site_pipeline_definition(  # noqa: PLR0913 PLR0915
     assert course_values["resource_base_url"] == static_api_base_url
     assert course_values["ocw_hugo_themes_branch"] == ocw_hugo_themes_branch
     assert course_values["ocw_hugo_projects_branch"] == ocw_hugo_projects_branch
+    assert course_values["sitemap_domain"] == sitemap_domain
     across_step_build_steps = across_steps[0]["do"]
     cdn_cache_clear_steps = [
         step

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -142,6 +142,7 @@ class SitePipelineDefinitionConfig:
         ocw_hugo_themes_branch: str,
         ocw_hugo_projects_branch: str,
         hugo_override_args: Optional[str] = "",
+        sitemap_domain: Optional[str] = settings.SITEMAP_DOMAIN,
         prefix: str = "",
         namespace: str = "site:",
     ):
@@ -220,7 +221,7 @@ class SitePipelineDefinitionConfig:
             "noindex": self.noindex,
             "pipeline_name": pipeline_name,
             "instance_vars": instance_vars,
-            "sitemap_domain": settings.SITEMAP_DOMAIN,
+            "sitemap_domain": sitemap_domain,
             "static_api_url": static_api_url,
             "storage_bucket": storage_bucket,
             "artifacts_bucket": artifacts_bucket,


### PR DESCRIPTION
# What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/2060

# Description (What does it do?)
This PR alters `SitePipelineDefinitionConfig`, adding the optional `sitemap_domain` argument. If this is set, this value is used as the `SITEMAP_DOMAIN` env variable when running Hugo builds. Otherwise, the default of `settings.SITEMAP_DOMAIN` is used from `ocw-studio`. `EndToEndTestPipelineDefinition` was then modified to pass the domain of the test site here so that it is properly used in the Hugo builds for the test sites before running Playwright.


# How can this be tested?
 - In your `.env` file, set `SITEMAP_DOMAIN=live-qa.ocw.mit.edu`
 - Run `docker compose exec web ./manage.py upsert_e2e_test_pipeline` to update your test pipeline definition
 - Use the `fly` CLI to inspect the pipeline definition:
   - If you don't have `fly` installed, you will need to do so. Follow the steps in the docs to install `fly` and add a target for your locally running Concourse called `local`
   - Run `fly -t local get-pipeline -p e2e-test-pipeline | grep SITEMAP_DOMAIN`
   - Ensure that `SITEMAP_DOMAIN` is set to `10.1.0.102:8046`
 - Run the pipeline and it should pass
