### PR TITLE
fix api mocking in e2e test pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,7 @@ SEARCH_API_URL=https://discussions-rc.odl.mit.edu/api/v0/search/
 RESOURCE_BASE_URL_DRAFT=http://localhost:8044/
 RESOURCE_BASE_URL_LIVE=http://localhost:8045/
 STATIC_API_BASE_URL=https://live-qa.odl.mit.edu/
+STATIC_API_BASE_URL_TEST=http://10.1.0.102:8046/
 OCW_HUGO_THEMES_BRANCH=main
 OCW_HUGO_PROJECTS_BRANCH=main
 OCW_GTM_ACCOUNT_ID=changeme

--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ OCW_WWW_TEST_SLUG=ocw-ci-test-www
 OCW_COURSE_TEST_SLUG=ocw-ci-test-course
 AWS_TEST_BUCKET_NAME=ocw-content-test
 AWS_OFFLINE_TEST_BUCKET_NAME=ocw-content-offline-test
+STATIC_API_BASE_URL_TEST=http://10.1.0.102:8046
 ```
 
 There are fixtures for two test websites in the `test_site_fixtures` folder. These contain two sites; `ocw-ci-test-www` and `ocw-ci-test-course` along with test content. In `test_websites.json`, the ID's of the `ocw-www` and `ocw-course` starters are referenced. If these ID's are not correct on your system, you can get the ID's of your starters in Django admin and modify the fixture. They can be loaded into the database with the following commands:

--- a/config/nginx.conf
+++ b/config/nginx.conf
@@ -58,7 +58,7 @@ server {
         # If our URI doesn't contain a period and also doesn't have a slash at the end, add one
         rewrite ^([^.]*[^/])$ $1/ permanent;
         # If our URI ends with a slash, add index.html to the end
-        rewrite /$ ${request_uri}index.html last;
+        rewrite /$ ${uri}index.html?${args} last;
         # Pass to the Minio preview bucket
         proxy_pass http://s3:9000/${AWS_PREVIEW_BUCKET_NAME}/;
     }
@@ -96,7 +96,7 @@ server {
         # If our URI doesn't contain a period and also doesn't have a slash at the end, add one
         rewrite ^([^.]*[^/])$ $1/ permanent;
         # If our URI ends with a slash, add index.html to the end
-        rewrite /$ ${request_uri}index.html last;
+        rewrite /$ ${uri}index.html?${args} last;
         # Pass to the Minio publish bucket
         proxy_pass http://s3:9000/${AWS_PUBLISH_BUCKET_NAME}/;
     }
@@ -131,14 +131,10 @@ server {
             rewrite ^/courses/.*/static_shared/(.*)$ /static_shared/$1 last;
         }
 
-        # Rewrite requests to the websites API
-        rewrite ^/api/websites/.*$ /api/websites.json last;
-        # Rewrite requests to the publish API
-        rewrite ^/api/publish/.*$ /api/publish.json last;
         # If our URI doesn't contain a period and also doesn't have a slash at the end, add one
         rewrite ^([^.]*[^/])$ $1/ permanent;
         # If our URI ends with a slash, add index.html to the end
-        rewrite /$ ${request_uri}index.html last;
+        rewrite /$ ${uri}index.html?${args} last;
         # Pass to the Minio test bucket
         proxy_pass http://s3:9000/${AWS_TEST_BUCKET_NAME}/;
     }

--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
@@ -303,7 +303,7 @@ class EndToEndTestPipelineDefinition(Pipeline):
                 }
             )
         tasks.append(fetch_built_content_step)
-        playwright_commands = "yarn install\nnpx playwright install firefox --with-deps\nnpx playwright install chrome --with-deps\nnpx playwright test"  # noqa: E501
+        playwright_commands = "corepack enable\nyarn install\nnpx playwright install firefox --with-deps\nnpx playwright install chrome --with-deps\nnpx playwright test"  # noqa: E501
         tasks.append(
             TaskStep(
                 task=playwright_task_identifier,

--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
@@ -109,7 +109,6 @@ class TestPipelineBaseTasks(list[StepModifierMixin]):
                         "-exc",
                         "\n".join(
                             [
-                                "|-",
                                 f"aws s3{get_cli_endpoint_url()} sync {OCW_HUGO_THEMES_GIT_IDENTIFIER}/test-sites/__fixtures__/ s3://{common_pipeline_vars['test_bucket_name']}/",  # noqa: E501
                                 f"aws s3{get_cli_endpoint_url()} cp {OCW_HUGO_THEMES_GIT_IDENTIFIER}/test-sites/__fixtures__/api/websites.json s3://{common_pipeline_vars['test_bucket_name']}/api/websites/index.html",  # noqa: E501
                                 f"aws s3{get_cli_endpoint_url()} cp {OCW_HUGO_THEMES_GIT_IDENTIFIER}/test-sites/__fixtures__/api/publish.json s3://{common_pipeline_vars['test_bucket_name']}/api/publish/index.html",  # noqa: E501

--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
@@ -109,7 +109,10 @@ class TestPipelineBaseTasks(list[StepModifierMixin]):
                         "-exc",
                         "\n".join(
                             [
-                                f"aws s3{get_cli_endpoint_url()} sync {OCW_HUGO_THEMES_GIT_IDENTIFIER}/test-sites/__fixtures__/ s3://{common_pipeline_vars['test_bucket_name']}/"  # noqa: E501
+                                "|-",
+                                f"aws s3{get_cli_endpoint_url()} sync {OCW_HUGO_THEMES_GIT_IDENTIFIER}/test-sites/__fixtures__/ s3://{common_pipeline_vars['test_bucket_name']}/",  # noqa: E501
+                                f"aws s3{get_cli_endpoint_url()} cp {OCW_HUGO_THEMES_GIT_IDENTIFIER}/test-sites/__fixtures__/api/websites.json s3://{common_pipeline_vars['test_bucket_name']}/api/websites/index.html",  # noqa: E501
+                                f"aws s3{get_cli_endpoint_url()} cp {OCW_HUGO_THEMES_GIT_IDENTIFIER}/test-sites/__fixtures__/api/publish.json s3://{common_pipeline_vars['test_bucket_name']}/api/publish/index.html",  # noqa: E501
                             ]
                         ),
                     ],

--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline_test.py
@@ -124,9 +124,20 @@ def test_generate_e2e_test_site_pipeline_definition(  # noqa: PLR0913 PLR0915
     ]
     assert len(upload_fixtures_task_steps) == 1
     upload_fixtures_task_step = upload_fixtures_task_steps[0]
+    upload_fixtures_commands = upload_fixtures_task_step["config"]["run"]["args"][
+        1
+    ].split("\n")
     assert (
         f"aws s3{get_cli_endpoint_url()} sync {OCW_HUGO_THEMES_GIT_IDENTIFIER}/test-sites/__fixtures__/ s3://{common_pipeline_vars['test_bucket_name']}/"
-        in upload_fixtures_task_step["config"]["run"]["args"]
+        in upload_fixtures_commands
+    )
+    assert (
+        f"aws s3{get_cli_endpoint_url()} cp {OCW_HUGO_THEMES_GIT_IDENTIFIER}/test-sites/__fixtures__/api/websites.json s3://{common_pipeline_vars['test_bucket_name']}/api/websites/index.html"
+        in upload_fixtures_commands
+    )
+    assert (
+        f"aws s3{get_cli_endpoint_url()} cp {OCW_HUGO_THEMES_GIT_IDENTIFIER}/test-sites/__fixtures__/api/publish.json s3://{common_pipeline_vars['test_bucket_name']}/api/publish/index.html"
+        in upload_fixtures_commands
     )
     if is_dev:
         assert (


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/2065

### Description (What does it do?)
This PR alters `upload-fixtures-step` in the end to end test pipeline definition to upload the API fixtures as HTML files in the correct place. Since AWS S3 treats every URL path as a string rather than an actual path, a request to something like `https://live-qa.ocw.mit.edu/api/websites/` will result in a 404. In this PR, we upload `__fixtures__/api/websites.json` and `publish__fixtures__/api/publish.json` as `/api/websites/index.html` and `/api/publish/index.html` respectively into the target bucket. This means that web CDN's fronting an S3 bucket that are set up to automatically deliver `index.html` for URL paths that do not include an extension will deliver the JSON content at the expected URLs.

### How can this be tested?
 - If you don't have the end to end testing sites in your local database, follow the steps in this PR to get those: https://github.com/mitodl/ocw-studio/pull/2018
 - Upsert the test pipeline definition with `docker compose exec web ./manage.py upsert_e2e_test_pipeline`
 - Go to http://localhost:8080/, log in and find `e2e-test-pipeline` and run it
 - Ensure that the pipeline passes
