### PR TITLE
Fix theme assets pipeline on Apple Silicon

### DIFF
--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
@@ -105,6 +105,7 @@ class ThemeAssetsPipelineDefinition(Pipeline):
                             "-exc",
                             f"""
                             cd {OCW_HUGO_THEMES_GIT_IDENTIFIER}
+                            corepack enable
                             yarn install --immutable
                             npm run build:webpack
                             npm run build:githash


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/2068.

### Description (What does it do?)
Adds `corepack enable` to the theme assets pipeline, which fixes a bug that occurs on Apple Silicon running macOS Sonoma, preventing the theme assets build from working.

### How can this be tested?
Run `docker compose exec web ./manage.py upsert_theme_assets_pipeline` and run the pipeline in concourse (`http://concourse:8080`). Verify that the theme assets build completes as expected.