### PR TITLE
Multiple open catalog webhook endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,3 +104,8 @@ FEATURE_SELECT_FIELD_INFINITE_SCROLL=false
 FEATURE_SORTABLE_SELECT_HIDE_SELECTED=false
 FEATURE_SORTABLE_SELECT_QUICK_ADD=false
 FEATURE_SORTABLE_SELECT_PRESERVE_SEARCH_TEXT=false
+
+
+# Open catalog webhook endpoints
+OPEN_CATALOG_URLS=https://changeme1.mit.edu/api/v0/ocw_next_webhook/,https://changeme2.mit.edu/api/v1/ocw_next_webhook/
+OPEN_CATALOG_WEBHOOK_KEY=changeme

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -113,9 +113,9 @@
         "filename": "README.md",
         "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
         "is_verified": false,
-        "line_number": 243
+        "line_number": 244
       }
     ]
   },
-  "generated_at": "2023-12-15T21:56:45Z"
+  "generated_at": "2024-01-18T19:14:12Z"
 }

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ OCW Studio manages deployments for OCW courses.
 - [Enabling Google Drive integration](#enabling-google-drive-integration)
 - [Enabling AWS MediaConvert transcoding](#enabling-aws-mediaconvert-transcoding)
 - [Enabling 3Play integration](#enabling-3play-integration)
+- [Enabling Open Catalog Search Webhooks](#enabling-open-catalog-search-webhooks)
 
 # Initial Setup
 
@@ -488,4 +489,13 @@ The following environment variables need to be defined in your .env file (for a 
 THREEPLAY_API_KEY
 THREEPLAY_CALLBACK_KEY
 THREEPLAY_PROJECT_ID
+```
+
+# Enabling Open Catalog Search Webhooks
+
+The following environment variables need to be defined in your .env file in order to notify external course catalogs like MIT Open when OCW sites are created/updated.
+
+```
+OPEN_CATALOG_URLS=delimited list of api endpoint urls that webhooks should be sent to
+OPEN_CATALOG_WEBHOOK_KEY=secret key that will be used to confirm that webhook requests are legitimate
 ```

--- a/app.json
+++ b/app.json
@@ -333,8 +333,8 @@
       "description": "The amount of sites to build simultaneously in each job created by MassBuildSitesPipelineDefinition",
       "required": false
     },
-    "OCW_NEXT_SEARCH_WEBHOOK_KEY": {
-      "description": "Open discussions webhook key",
+    "OPEN_CATALOG_WEBHOOK_KEY": {
+      "description": "Open catalog webhook key",
       "required": false
     },
     "OCW_STUDIO_ADMIN_EMAIL": {

--- a/app.json
+++ b/app.json
@@ -437,8 +437,8 @@
       "description": "The slug of the root Website used to run end to end tests",
       "required": false
     },
-    "OPEN_DISCUSSIONS_URL": {
-      "description": "Open discussions url",
+    "OPEN_CATALOG_URLS": {
+      "description": "List of open catalog urls",
       "required": false
     },
     "PGBOUNCER_DEFAULT_POOL_SIZE": {

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -132,7 +132,7 @@ def pipeline_settings(settings, request):  # noqa: PT004
     settings.OCW_IMPORT_STARTER_SLUG = "custom_slug"
     settings.OCW_COURSE_STARTER_SLUG = "another_custom_slug"
     settings.OCW_NEXT_SEARCH_WEBHOOK_KEY = "abc123"
-    settings.OPEN_DISCUSSIONS_URL = "https://open.mit.edu"
+    settings.OPEN_CATALOG_URLS = "https://open.mit.edu,http://mitopen.odl.mit.edu"
     if env == "dev":
         settings.AWS_ACCESS_KEY_ID = "minio_root_user"
         settings.AWS_SECRET_ACCESS_KEY = "minio_root_password"  # noqa: S105

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -131,7 +131,7 @@ def pipeline_settings(settings, request):  # noqa: PT004
     settings.OCW_STUDIO_LIVE_URL = "https://live.ocw.mit.edu"
     settings.OCW_IMPORT_STARTER_SLUG = "custom_slug"
     settings.OCW_COURSE_STARTER_SLUG = "another_custom_slug"
-    settings.OCW_NEXT_SEARCH_WEBHOOK_KEY = "abc123"
+    settings.OPEN_CATALOG_WEBHOOK_KEY = "abc123"
     settings.OPEN_CATALOG_URLS = "https://open.mit.edu,http://mitopen.odl.mit.edu"
     if env == "dev":
         settings.AWS_ACCESS_KEY_ID = "minio_root_user"

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -132,7 +132,7 @@ def pipeline_settings(settings, request):  # noqa: PT004
     settings.OCW_IMPORT_STARTER_SLUG = "custom_slug"
     settings.OCW_COURSE_STARTER_SLUG = "another_custom_slug"
     settings.OPEN_CATALOG_WEBHOOK_KEY = "abc123"
-    settings.OPEN_CATALOG_URLS = "https://open.mit.edu,http://mitopen.odl.mit.edu"
+    settings.OPEN_CATALOG_URLS = "https://open.mit.edu/api/v0/ocw_next_webhook/,http://mitopen.odl.mit.edu/api/v1/ocw_next_webhook/"
     if env == "dev":
         settings.AWS_ACCESS_KEY_ID = "minio_root_user"
         settings.AWS_SECRET_ACCESS_KEY = "minio_root_password"  # noqa: S105

--- a/content_sync/pipelines/definitions/concourse/common/identifiers.py
+++ b/content_sync/pipelines/definitions/concourse/common/identifiers.py
@@ -1,3 +1,6 @@
+from urllib.parse import urlparse
+
+from django.utils.text import slugify
 from ol_concourse.lib.models.pipeline import Identifier
 
 # Commonly used identifiers
@@ -7,7 +10,6 @@ S3_IAM_RESOURCE_TYPE_IDENTIFIER = Identifier("s3-resource-iam").root
 OCW_STUDIO_WEBHOOK_RESOURCE_TYPE_IDENTIFIER = Identifier("ocw-studio-webhook").root
 OCW_STUDIO_WEBHOOK_CURL_STEP_IDENTIFIER = Identifier("ocw-studio-webhook-curl").root
 SLACK_ALERT_RESOURCE_IDENTIFIER = Identifier("slack-alert").root
-OPEN_DISCUSSIONS_RESOURCE_IDENTIFIER = Identifier("open-discussions-webhook").root
 WEBPACK_MANIFEST_S3_IDENTIFIER = Identifier("webpack-manifest-s3").root
 WEBPACK_MANIFEST_S3_TRIGGER_IDENTIFIER = Identifier(
     f"{WEBPACK_MANIFEST_S3_IDENTIFIER}-trigger"
@@ -23,3 +25,16 @@ STATIC_RESOURCES_S3_IDENTIFIER = Identifier("static-resources-s3").root
 MASS_BULID_SITES_PIPELINE_IDENTIFIER = Identifier("mass-build-sites").root
 MASS_BUILD_SITES_JOB_IDENTIFIER = Identifier("mass-build-sites-job").root
 MASS_BUILD_SITES_BATCH_GATE_IDENTIFIER = Identifier("batch-gate").root
+
+
+def get_ocw_catalog_identifier(url: str):
+    """
+    Get the identifier for a given OCW Catalog URL
+
+    Args:
+        url(str): The URL of the OCW Catalog
+
+    Returns:
+        Identifier
+    """
+    return Identifier(f"open-catalog-webhook-{slugify(urlparse(url).netloc)}").root

--- a/content_sync/pipelines/definitions/concourse/common/identifiers.py
+++ b/content_sync/pipelines/definitions/concourse/common/identifiers.py
@@ -27,7 +27,7 @@ MASS_BUILD_SITES_JOB_IDENTIFIER = Identifier("mass-build-sites-job").root
 MASS_BUILD_SITES_BATCH_GATE_IDENTIFIER = Identifier("batch-gate").root
 
 
-def get_ocw_catalog_identifier(url: str):
+def get_ocw_catalog_identifier(url: str, prefix="open-catalog-webhook"):
     """
     Get the identifier for a given OCW Catalog URL
 
@@ -37,4 +37,4 @@ def get_ocw_catalog_identifier(url: str):
     Returns:
         Identifier
     """
-    return Identifier(f"open-catalog-webhook-{slugify(urlparse(url).netloc)}").root
+    return Identifier(f"{prefix}-{slugify(urlparse(url).netloc)}").root

--- a/content_sync/pipelines/definitions/concourse/common/resources.py
+++ b/content_sync/pipelines/definitions/concourse/common/resources.py
@@ -51,7 +51,7 @@ class OpenCatalogResource(Resource):
             type=HTTP_RESOURCE_TYPE_IDENTIFIER,
             check_every="never",
             source={
-                "url": f"{open_url.rstrip('/')}/api/v0/ocw_next_webhook/",
+                "url": f"{open_url}",
                 "method": "POST",
                 "out_only": True,
                 "headers": {

--- a/content_sync/pipelines/definitions/concourse/common/resources.py
+++ b/content_sync/pipelines/definitions/concourse/common/resources.py
@@ -12,9 +12,9 @@ from content_sync.pipelines.definitions.concourse.common.identifiers import (
     OCW_HUGO_PROJECTS_GIT_IDENTIFIER,
     OCW_HUGO_THEMES_GIT_IDENTIFIER,
     OCW_STUDIO_WEBHOOK_RESOURCE_TYPE_IDENTIFIER,
-    OPEN_DISCUSSIONS_RESOURCE_IDENTIFIER,
     S3_IAM_RESOURCE_TYPE_IDENTIFIER,
     SLACK_ALERT_RESOURCE_IDENTIFIER,
+    get_ocw_catalog_identifier,
 )
 from content_sync.utils import get_ocw_studio_api_url
 from main.utils import is_dev
@@ -39,19 +39,19 @@ class SlackAlertResource(Resource):
         )
 
 
-class OpenDiscussionsResource(Resource):
+class OpenCatalogResource(Resource):
     """
-    A Resource that uses the http-resource ResourceType to trigger API calls to open-discussions
+    A Resource that uses the http-resource ResourceType to trigger API calls to open catalog sites
     """  # noqa: E501
 
-    def __init__(self, **kwargs):
+    def __init__(self, open_url, **kwargs):
         super().__init__(
-            name=OPEN_DISCUSSIONS_RESOURCE_IDENTIFIER,
+            name=get_ocw_catalog_identifier(open_url),
             icon="cloud-search",
             type=HTTP_RESOURCE_TYPE_IDENTIFIER,
             check_every="never",
             source={
-                "url": f"{settings.OPEN_DISCUSSIONS_URL}/api/v0/ocw_next_webhook/",
+                "url": f"{open_url.rstrip('/')}/api/v0/ocw_next_webhook/",
                 "method": "POST",
                 "out_only": True,
                 "headers": {

--- a/content_sync/pipelines/definitions/concourse/common/steps.py
+++ b/content_sync/pipelines/definitions/concourse/common/steps.py
@@ -246,7 +246,7 @@ class OcwStudioWebhookCurlStep(TryStep):
 
 class OpenCatalogWebhookStep(TryStep):
     """
-    A PutStep to the open-discussions api resource that refreshes the search index for a given site_url and version
+    A PutStep to an open catalog api resource that refreshes the search index for a given site_url and version
 
     Args:
         site_url(str): The url path of the site

--- a/content_sync/pipelines/definitions/concourse/common/steps.py
+++ b/content_sync/pipelines/definitions/concourse/common/steps.py
@@ -264,7 +264,7 @@ class OpenCatalogWebhookStep(TryStep):
                 params={
                     "text": json.dumps(
                         {
-                            "webhook_key": settings.OCW_NEXT_SEARCH_WEBHOOK_KEY,
+                            "webhook_key": settings.OPEN_CATALOG_WEBHOOK_KEY,
                             "prefix": f"{site_url}/",
                             "version": pipeline_name,
                         }

--- a/content_sync/pipelines/definitions/concourse/common/steps.py
+++ b/content_sync/pipelines/definitions/concourse/common/steps.py
@@ -20,9 +20,9 @@ from ol_concourse.lib.models.pipeline import (
 from content_sync.pipelines.definitions.concourse.common.identifiers import (
     OCW_STUDIO_WEBHOOK_CURL_STEP_IDENTIFIER,
     OCW_STUDIO_WEBHOOK_RESOURCE_TYPE_IDENTIFIER,
-    OPEN_DISCUSSIONS_RESOURCE_IDENTIFIER,
     SITE_CONTENT_GIT_IDENTIFIER,
     SLACK_ALERT_RESOURCE_IDENTIFIER,
+    get_ocw_catalog_identifier,
 )
 from content_sync.pipelines.definitions.concourse.common.image_resources import (
     CURL_REGISTRY_IMAGE,
@@ -244,7 +244,7 @@ class OcwStudioWebhookCurlStep(TryStep):
         )
 
 
-class OpenDiscussionsWebhookStep(TryStep):
+class OpenCatalogWebhookStep(TryStep):
     """
     A PutStep to the open-discussions api resource that refreshes the search index for a given site_url and version
 
@@ -253,10 +253,12 @@ class OpenDiscussionsWebhookStep(TryStep):
         pipeline_name(str): The pipeline name to use as the version (draft / live)
     """  # noqa: E501
 
-    def __init__(self, site_url: str, pipeline_name: str, **kwargs):
+    def __init__(
+        self, site_url: str, pipeline_name: str, open_catalog_url: str, **kwargs
+    ):
         super().__init__(
             try_=PutStep(
-                put=OPEN_DISCUSSIONS_RESOURCE_IDENTIFIER,
+                put=get_ocw_catalog_identifier(open_catalog_url),
                 timeout="1m",
                 attempts=3,
                 params={

--- a/content_sync/pipelines/definitions/concourse/common/steps_test.py
+++ b/content_sync/pipelines/definitions/concourse/common/steps_test.py
@@ -93,7 +93,7 @@ def test_put_steps_empty_inputs():
             OpenCatalogWebhookStep(
                 pipeline_name="test_pipeline",
                 site_url="http://ocw.mit.edu/courses/test_course",
-                open_catalog_url="http://test_open_catalog",
+                open_catalog_url="http://test_open_catalog/api/v0/ocw_next_webhook/",
             ).model_dump_json(by_alias=True)
         )["try"]["inputs"]
         == []

--- a/content_sync/pipelines/definitions/concourse/common/steps_test.py
+++ b/content_sync/pipelines/definitions/concourse/common/steps_test.py
@@ -18,7 +18,7 @@ from content_sync.pipelines.definitions.concourse.common.steps import (
     ClearCdnCacheStep,
     ErrorHandlingStep,
     OcwStudioWebhookStep,
-    OpenDiscussionsWebhookStep,
+    OpenCatalogWebhookStep,
     SiteContentGitTaskStep,
     SlackAlertStep,
     add_error_handling,
@@ -90,9 +90,10 @@ def test_put_steps_empty_inputs():
     )
     assert (
         json.loads(
-            OpenDiscussionsWebhookStep(
+            OpenCatalogWebhookStep(
                 pipeline_name="test_pipeline",
                 site_url="http://ocw.mit.edu/courses/test_course",
+                open_catalog_url="http://test_open_catalog",
             ).model_dump_json(by_alias=True)
         )["try"]["inputs"]
         == []

--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline_test.py
@@ -66,7 +66,7 @@ def test_generate_e2e_test_site_pipeline_definition(  # noqa: PLR0913 PLR0915
     open_webhook_key = "abc123"
     open_catalog_urls = ["https://example.com", "http://other_example.com"]
     settings.OPEN_CATALOG_URLS = open_catalog_urls
-    settings.OCW_NEXT_SEARCH_WEBHOOK_KEY = open_webhook_key
+    settings.OPEN_CATALOG_WEBHOOK_KEY = open_webhook_key
     settings.AWS_ACCESS_KEY_ID = "test_access_key_id"
     settings.AWS_SECRET_ACCESS_KEY = "test_secret_access_key"  # noqa: S105
     settings.OCW_HUGO_THEMES_SENTRY_DSN = "test_sentry_dsn"

--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline_test.py
@@ -64,7 +64,10 @@ def test_generate_e2e_test_site_pipeline_definition(  # noqa: PLR0913 PLR0915
     www_site = test_sites["www"]
     course_site = test_sites["course"]
     open_webhook_key = "abc123"
-    open_catalog_urls = ["https://example.com", "http://other_example.com"]
+    open_catalog_urls = [
+        "https://example.com/api/v0/ocw_next_webhook/",
+        "http://other_example.com/api/v1/ocw_next_webhook/",
+    ]
     settings.OPEN_CATALOG_URLS = open_catalog_urls
     settings.OPEN_CATALOG_WEBHOOK_KEY = open_webhook_key
     settings.AWS_ACCESS_KEY_ID = "test_access_key_id"

--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline_test.py
@@ -64,7 +64,7 @@ def test_generate_e2e_test_site_pipeline_definition(  # noqa: PLR0913 PLR0915
     www_site = test_sites["www"]
     course_site = test_sites["course"]
     open_webhook_key = "abc123"
-    open_catalog_urls = "https://example.com,http://other_example.com"
+    open_catalog_urls = ["https://example.com", "http://other_example.com"]
     settings.OPEN_CATALOG_URLS = open_catalog_urls
     settings.OCW_NEXT_SEARCH_WEBHOOK_KEY = open_webhook_key
     settings.AWS_ACCESS_KEY_ID = "test_access_key_id"

--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline_test.py
@@ -64,8 +64,8 @@ def test_generate_e2e_test_site_pipeline_definition(  # noqa: PLR0913 PLR0915
     www_site = test_sites["www"]
     course_site = test_sites["course"]
     open_webhook_key = "abc123"
-    open_discussions_url = "https://example.com"
-    settings.OPEN_DISCUSSIONS_URL = open_discussions_url
+    open_catalog_urls = "https://example.com,http://other_example.com"
+    settings.OPEN_CATALOG_URLS = open_catalog_urls
     settings.OCW_NEXT_SEARCH_WEBHOOK_KEY = open_webhook_key
     settings.AWS_ACCESS_KEY_ID = "test_access_key_id"
     settings.AWS_SECRET_ACCESS_KEY = "test_secret_access_key"  # noqa: S105

--- a/content_sync/pipelines/definitions/concourse/mass_build_sites.py
+++ b/content_sync/pipelines/definitions/concourse/mass_build_sites.py
@@ -40,7 +40,7 @@ from content_sync.pipelines.definitions.concourse.common.resources import (
     OcwHugoProjectsGitResource,
     OcwHugoThemesGitResource,
     OcwStudioWebhookResource,
-    OpenDiscussionsResource,
+    OpenCatalogResource,
     SlackAlertResource,
     WebpackManifestResource,
 )
@@ -174,7 +174,8 @@ class MassBuildSitesResources(list[Resource]):
         )
         self.append(SlackAlertResource())
         if not is_dev():
-            self.append(OpenDiscussionsResource())
+            for url in settings.OPEN_CATALOG_URLS:
+                self.append(OpenCatalogResource(url))
 
 
 class MassBuildSitesPipelineBaseTasks(list[StepModifierMixin]):

--- a/content_sync/pipelines/definitions/concourse/mass_build_sites.py
+++ b/content_sync/pipelines/definitions/concourse/mass_build_sites.py
@@ -174,8 +174,9 @@ class MassBuildSitesResources(list[Resource]):
         )
         self.append(SlackAlertResource())
         if not is_dev():
-            for url in settings.OPEN_CATALOG_URLS:
-                self.append(OpenCatalogResource(url))
+            self.extend(
+                [OpenCatalogResource(url) for url in settings.OPEN_CATALOG_URLS]
+            )
 
 
 class MassBuildSitesPipelineBaseTasks(list[StepModifierMixin]):

--- a/content_sync/pipelines/definitions/concourse/remove_unpublished_sites.py
+++ b/content_sync/pipelines/definitions/concourse/remove_unpublished_sites.py
@@ -15,6 +15,9 @@ from ol_concourse.lib.models.pipeline import (
 )
 
 from content_sync.constants import DEV_ENDPOINT_URL, VERSION_LIVE
+from content_sync.pipelines.definitions.concourse.common.identifiers import (
+    get_ocw_catalog_identifier,
+)
 from content_sync.pipelines.definitions.concourse.common.image_resources import (
     AWS_CLI_REGISTRY_IMAGE,
     BASH_REGISTRY_IMAGE,
@@ -61,7 +64,7 @@ class UnpublishedSiteRemovalPipelineDefinition(Pipeline):
     ).root
     _unpublished_sites_output_identifier = Identifier("unpublished-sites-output").root
     _unpublished_sites_var_identifier = Identifier("unpublished-sites-var").root
-    _search_index_removal_task_identifier = Identifier("search-index-removal-task").root
+    _search_index_removal_task_prefix = "search-index-removal-task"
     _empty_s3_bucket_task_identifier = Identifier("empty-s3-bucket-task").root
     _clear_cdn_cache_task_identifier = Identifier("clear-cdn-cache-task").root
     _ocw_studio_webhook_task_identifier = Identifier("ocw-studio-webhook-task").root
@@ -105,7 +108,9 @@ class UnpublishedSiteRemovalPipelineDefinition(Pipeline):
         )
         search_index_removal_across_tasks = [
             TaskStep(
-                task=self._search_index_removal_task_identifier,
+                task=get_ocw_catalog_identifier(
+                    catalog_url, prefix=self._search_index_removal_task_prefix
+                ),
                 timeout="1m",
                 attempts=3,
                 config=TaskConfig(

--- a/content_sync/pipelines/definitions/concourse/remove_unpublished_sites.py
+++ b/content_sync/pipelines/definitions/concourse/remove_unpublished_sites.py
@@ -86,7 +86,7 @@ class UnpublishedSiteRemovalPipelineDefinition(Pipeline):
         open_catalog_urls = [
             catalog_url.rstrip("/") for catalog_url in settings.OPEN_CATALOG_URLS
         ]
-        open_webhook_key = settings.OCW_NEXT_SEARCH_WEBHOOK_KEY
+        open_webhook_key = settings.OPEN_CATALOG_WEBHOOK_KEY
         minio_root_user = settings.AWS_ACCESS_KEY_ID
         minio_root_password = settings.AWS_SECRET_ACCESS_KEY
 

--- a/content_sync/pipelines/definitions/concourse/remove_unpublished_sites.py
+++ b/content_sync/pipelines/definitions/concourse/remove_unpublished_sites.py
@@ -78,9 +78,7 @@ class UnpublishedSiteRemovalPipelineDefinition(Pipeline):
         ocw_studio_url = get_ocw_studio_api_url().rstrip("/")
         cli_endpoint_url = get_cli_endpoint_url()
         api_token = settings.API_BEARER_TOKEN
-        open_catalog_urls = [
-            catalog_url.rstrip("/") for catalog_url in settings.OPEN_CATALOG_URLS
-        ]
+        open_catalog_urls = settings.OPEN_CATALOG_URLS
         open_webhook_key = settings.OPEN_CATALOG_WEBHOOK_KEY
         minio_root_user = settings.AWS_ACCESS_KEY_ID
         minio_root_password = settings.AWS_SECRET_ACCESS_KEY
@@ -128,13 +126,14 @@ class UnpublishedSiteRemovalPipelineDefinition(Pipeline):
                                     "unpublished": True,
                                 }
                             ),
-                            f"{catalog_url}/api/v0/ocw_next_webhook/",
+                            catalog_url,
                         ],
                     ),
                 ),
                 on_failure=unpublish_failed_webhook_across_step,
             )
             for catalog_url in open_catalog_urls
+            if catalog_url
         ]
         empty_s3_bucket_across_task = TaskStep(
             task=self._empty_s3_bucket_task_identifier,

--- a/content_sync/pipelines/definitions/concourse/remove_unpublished_sites.py
+++ b/content_sync/pipelines/definitions/concourse/remove_unpublished_sites.py
@@ -28,7 +28,6 @@ from content_sync.pipelines.definitions.concourse.common.resource_types import (
     S3IamResourceType,
 )
 from content_sync.pipelines.definitions.concourse.common.resources import (
-    OpenCatalogResource,
     SlackAlertResource,
 )
 from content_sync.pipelines.definitions.concourse.common.steps import (
@@ -68,10 +67,6 @@ class UnpublishedSiteRemovalPipelineDefinition(Pipeline):
     _empty_s3_bucket_task_identifier = Identifier("empty-s3-bucket-task").root
     _clear_cdn_cache_task_identifier = Identifier("clear-cdn-cache-task").root
     _ocw_studio_webhook_task_identifier = Identifier("ocw-studio-webhook-task").root
-
-    _open_catalog_resources = [
-        OpenCatalogResource(catalog_url) for catalog_url in settings.OPEN_CATALOG_URLS
-    ]
     _slack_resource = SlackAlertResource()
 
     def __init__(self, **kwargs):

--- a/content_sync/pipelines/definitions/concourse/remove_unpublished_sites_test.py
+++ b/content_sync/pipelines/definitions/concourse/remove_unpublished_sites_test.py
@@ -21,7 +21,7 @@ def test_generate_unpublished_site_removal_pipeline_definition(  # noqa: PLR0915
     web_bucket = common_pipeline_vars["publish_bucket_name"]
     offline_bucket = common_pipeline_vars["offline_publish_bucket_name"]
     settings.OPEN_CATALOG_URLS = open_catalog_urls
-    settings.OCW_NEXT_SEARCH_WEBHOOK_KEY = open_webhook_key
+    settings.OPEN_CATALOG_WEBHOOK_KEY = open_webhook_key
 
     pipeline_definition = UnpublishedSiteRemovalPipelineDefinition()
     rendered_definition = json.loads(pipeline_definition.json(indent=2))

--- a/content_sync/pipelines/definitions/concourse/remove_unpublished_sites_test.py
+++ b/content_sync/pipelines/definitions/concourse/remove_unpublished_sites_test.py
@@ -15,12 +15,12 @@ def test_generate_unpublished_site_removal_pipeline_definition(  # noqa: PLR0915
     The unpublished site removal pipeline definition should contain the expected properties
     """
     open_webhook_key = "abc123"
-    open_discussions_url = "https://example.com"
+    open_catalog_urls = "https://example.com,http://other_example.com"
     common_pipeline_vars = get_common_pipeline_vars()
     cli_endpoint_url = get_cli_endpoint_url()
     web_bucket = common_pipeline_vars["publish_bucket_name"]
     offline_bucket = common_pipeline_vars["offline_publish_bucket_name"]
-    settings.OPEN_DISCUSSIONS_URL = open_discussions_url
+    settings.OPEN_CATALOG_URLS = open_catalog_urls
     settings.OCW_NEXT_SEARCH_WEBHOOK_KEY = open_webhook_key
 
     pipeline_definition = UnpublishedSiteRemovalPipelineDefinition()
@@ -86,10 +86,11 @@ def test_generate_unpublished_site_removal_pipeline_definition(  # noqa: PLR0915
         )
         assert f'"webhook_key": "{open_webhook_key}"' in search_index_removal_command
         assert f'"version": "{VERSION_LIVE}"' in search_index_removal_command
-        assert (
-            f"{open_discussions_url}/api/v0/ocw_next_webhook/"
-            in search_index_removal_command
-        )
+        for catalog_url in open_catalog_urls.split(","):
+            assert (
+                f"{catalog_url}/api/v0/ocw_next_webhook/"
+                in search_index_removal_command
+            )
         clear_cdn_cache_tasks = [
             task
             for task in across_tasks

--- a/content_sync/pipelines/definitions/concourse/remove_unpublished_sites_test.py
+++ b/content_sync/pipelines/definitions/concourse/remove_unpublished_sites_test.py
@@ -15,7 +15,10 @@ def test_generate_unpublished_site_removal_pipeline_definition(  # noqa: PLR0915
     The unpublished site removal pipeline definition should contain the expected properties
     """
     open_webhook_key = "abc123"
-    open_catalog_urls = ["https://example.com", "http://other_example.com"]
+    open_catalog_urls = [
+        "https://example.com/api/v0/ocw_next_webhook/",
+        "http://other_example.com/api/v1/ocw_next_webhook/",
+    ]
     common_pipeline_vars = get_common_pipeline_vars()
     cli_endpoint_url = get_cli_endpoint_url()
     web_bucket = common_pipeline_vars["publish_bucket_name"]
@@ -86,10 +89,7 @@ def test_generate_unpublished_site_removal_pipeline_definition(  # noqa: PLR0915
                 f'"webhook_key": "{open_webhook_key}"' in search_index_removal_command
             )
             assert f'"version": "{VERSION_LIVE}"' in search_index_removal_command
-            assert (
-                f"{open_catalog_urls[idx]}/api/v0/ocw_next_webhook/"
-                in search_index_removal_command
-            )
+            assert f"{open_catalog_urls[idx]}" in search_index_removal_command
         clear_cdn_cache_tasks = [
             task
             for task in across_tasks

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -296,10 +296,7 @@ class SitePipelineResources(list[Resource]):
         )
         if not is_dev():
             self.extend(
-                [
-                    OpenCatalogResource(url.rstrip("/"))
-                    for url in settings.OPEN_CATALOG_URLS
-                ]
+                [OpenCatalogResource(url) for url in settings.OPEN_CATALOG_URLS]
             )
 
 

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -45,7 +45,7 @@ from content_sync.pipelines.definitions.concourse.common.resources import (
     OcwHugoProjectsGitResource,
     OcwHugoThemesGitResource,
     OcwStudioWebhookResource,
-    OpenDiscussionsResource,
+    OpenCatalogResource,
     SiteContentGitResource,
     SlackAlertResource,
     WebpackManifestResource,
@@ -53,7 +53,7 @@ from content_sync.pipelines.definitions.concourse.common.resources import (
 from content_sync.pipelines.definitions.concourse.common.steps import (
     ClearCdnCacheStep,
     OcwStudioWebhookStep,
-    OpenDiscussionsWebhookStep,
+    OpenCatalogWebhookStep,
     add_error_handling,
 )
 from content_sync.utils import (
@@ -295,7 +295,8 @@ class SitePipelineResources(list[Resource]):
             ]
         )
         if not is_dev():
-            self.append(OpenDiscussionsResource())
+            for url in settings.OPEN_CATALOG_URLS:
+                self.append(OpenCatalogResource(url.rstrip("/")))
 
 
 class SitePipelineBaseTasks(list[StepModifierMixin]):
@@ -567,10 +568,14 @@ class SitePipelineOnlineTasks(list[StepModifierMixin]):
         clear_cdn_cache_online_step.on_success = TryStep(
             try_=DoStep(
                 do=[
-                    OpenDiscussionsWebhookStep(
-                        site_url=pipeline_vars["url_path"],
-                        pipeline_name=pipeline_vars["pipeline_name"],
-                    ),
+                    *[
+                        OpenCatalogWebhookStep(
+                            site_url=pipeline_vars["url_path"],
+                            pipeline_name=pipeline_vars["pipeline_name"],
+                            open_catalog_url=open_catalog_url,
+                        )
+                        for open_catalog_url in settings.OPEN_CATALOG_URLS
+                    ],
                     OcwStudioWebhookStep(
                         pipeline_name=pipeline_vars["pipeline_name"],
                         status="succeeded",
@@ -752,10 +757,14 @@ class SitePipelineOfflineTasks(list[StepModifierMixin]):
         clear_cdn_cache_offline_step.on_success = TryStep(
             try_=DoStep(
                 do=[
-                    OpenDiscussionsWebhookStep(
-                        site_url=pipeline_vars["url_path"],
-                        pipeline_name=pipeline_vars["pipeline_name"],
-                    ),
+                    *[
+                        OpenCatalogWebhookStep(
+                            site_url=pipeline_vars["url_path"],
+                            pipeline_name=pipeline_vars["pipeline_name"],
+                            open_catalog_url=open_catalog_url,
+                        )
+                        for open_catalog_url in settings.OPEN_CATALOG_URLS
+                    ],
                     OcwStudioWebhookStep(
                         pipeline_name=pipeline_vars["pipeline_name"],
                         status="succeeded",

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -295,8 +295,12 @@ class SitePipelineResources(list[Resource]):
             ]
         )
         if not is_dev():
-            for url in settings.OPEN_CATALOG_URLS:
-                self.append(OpenCatalogResource(url.rstrip("/")))
+            self.extend(
+                [
+                    OpenCatalogResource(url.rstrip("/"))
+                    for url in settings.OPEN_CATALOG_URLS
+                ]
+            )
 
 
 class SitePipelineBaseTasks(list[StepModifierMixin]):

--- a/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
@@ -410,7 +410,7 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
         )
         assert (
             open_discussions_webhook_step_online_params["webhook_key"]
-            == settings.OCW_NEXT_SEARCH_WEBHOOK_KEY
+            == settings.OPEN_CATALOG_WEBHOOK_KEY
         )
         assert (
             open_discussions_webhook_step_online_params["prefix"]
@@ -579,7 +579,7 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
         )
         assert (
             open_discussions_webhook_step_offline_params["webhook_key"]
-            == settings.OCW_NEXT_SEARCH_WEBHOOK_KEY
+            == settings.OPEN_CATALOG_WEBHOOK_KEY
         )
         assert (
             open_discussions_webhook_step_offline_params["prefix"]

--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
@@ -22,7 +22,6 @@ from content_sync.pipelines.definitions.concourse.common.image_resources import 
 )
 from content_sync.pipelines.definitions.concourse.common.resources import (
     GitResource,
-    OpenCatalogResource,
     SlackAlertResource,
 )
 from content_sync.pipelines.definitions.concourse.common.steps import (
@@ -60,10 +59,6 @@ class ThemeAssetsPipelineDefinition(Pipeline):
         "clear-draft-cdn-cache-task"
     ).root
     _clear_live_cdn_cache_identifier = Identifier("clear-live-cdn-cache-task").root
-
-    _open_catalog_resources = [
-        OpenCatalogResource(catalog_url) for catalog_url in settings.OPEN_CATALOG_URLS
-    ]
     _slack_resource = SlackAlertResource()
 
     def __init__(  # noqa: PLR0913

--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
@@ -22,7 +22,7 @@ from content_sync.pipelines.definitions.concourse.common.image_resources import 
 )
 from content_sync.pipelines.definitions.concourse.common.resources import (
     GitResource,
-    OpenDiscussionsResource,
+    OpenCatalogResource,
     SlackAlertResource,
 )
 from content_sync.pipelines.definitions.concourse.common.steps import (
@@ -61,7 +61,9 @@ class ThemeAssetsPipelineDefinition(Pipeline):
     ).root
     _clear_live_cdn_cache_identifier = Identifier("clear-live-cdn-cache-task").root
 
-    _open_discussions_resource = OpenDiscussionsResource()
+    _open_catalog_resources = [
+        OpenCatalogResource(catalog_url) for catalog_url in settings.OPEN_CATALOG_URLS
+    ]
     _slack_resource = SlackAlertResource()
 
     def __init__(  # noqa: PLR0913

--- a/main/settings.py
+++ b/main/settings.py
@@ -499,8 +499,8 @@ DRIVE_UPLOADS_PARENT_FOLDER_ID = get_string(
     description="Gdrive folder for video uploads",
     required=False,
 )
-OCW_NEXT_SEARCH_WEBHOOK_KEY = get_string(
-    name="OCW_NEXT_SEARCH_WEBHOOK_KEY",
+OPEN_CATALOG_WEBHOOK_KEY = get_string(
+    name="OPEN_CATALOG_WEBHOOK_KEY",
     default="",
     description="Open discussions webhook key",
     required=False,

--- a/main/settings.py
+++ b/main/settings.py
@@ -505,10 +505,10 @@ OCW_NEXT_SEARCH_WEBHOOK_KEY = get_string(
     description="Open discussions webhook key",
     required=False,
 )
-OPEN_DISCUSSIONS_URL = get_string(
-    name="OPEN_DISCUSSIONS_URL",
+OPEN_CATALOG_URLS = get_delimited_list(
+    name="OPEN_CATALOG_URLS",
     default="",
-    description="Open discussions url",
+    description="Open catalog urls",
     required=False,
 )
 VIDEO_S3_TRANSCODE_PREFIX = get_string(


### PR DESCRIPTION
### What are the relevant tickets?
Closes #1994

Related salt-ops PR: https://github.com/mitodl/salt-ops/pull/1609

### Description (What does it do?)
Modifies the pipeline generation code to allow for sending webhook requests to multiple urls.
Renames the following env vars:
  - `OCW_NEXT_SEARCH_WEBHOOK_KEY` to `OPEN_CATALOG_WEBHOOK_KEY`
  -  `OPEN_DISCUSSIONS_URL` to `OPEN_CATALOG_URLS`

### How can this be tested?
- Change the value of `OCW_STUDIO_ENVIRONMENT` to anything except `dev`
- Add this to your .env: 
  ```
  OPEN_CATALOG_URLS=http://discussions-rc.odl.mit.edu,https://mitopen-rc.odl.mit.edu
  OPEN_CATALOG_WEBHOOK_KEY=<former value of OCW_NEXT_SEARCH_WEBHOOK_KEY>
  ```
- Run the following commands:
  ```
  ./manage.py upsert_theme_assets_pipeline --delete
  ./manage.py upsert_mass_build_pipeline --delete
  ./manage.py upsert_site_removal_pipeline --delete
  ./manage.py backpopulate_pipelines --filter <site-name>
  ```
- Using fly, save the pipeline configurations locally and make sure there are sections present to send webhooks to both open catalog urls:
  ```
   fly -t local get-pipeline -p 'mass-build-sites/offline:false,prefix:"",projects_branch:main,starter:"",themes_branch:main,version:live ' > mass_publish.yml
   fly -t local get-pipeline -p remove-unpublished-sites > remove_unpublished.yml
   fly -t local get-pipeline -p live/site:site_name > single_site.yml
  ```

### Additional Context
This assumes that the webhook key is always the same for all endpoints.  In salt-ops they all use the [same source](https://github.com/mitodl/salt-ops/blob/main/pillar/heroku/mitopen.sls#L127).

When deployed to RC/production, all the existing pipelines will need to be updated
