### PR TITLE
set RESOURCE_BASE_URL regardless of environment

### DIFF
--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -468,6 +468,7 @@ class SitePipelineOnlineTasks(list[StepModifierMixin]):
                     "STATIC_API_BASE_URL": pipeline_vars["static_api_url"],
                     "OCW_IMPORT_STARTER_SLUG": settings.OCW_COURSE_STARTER_SLUG,
                     "OCW_COURSE_STARTER_SLUG": settings.OCW_COURSE_STARTER_SLUG,
+                    "RESOURCE_BASE_URL": pipeline_vars["resource_base_url"],
                     "SITEMAP_DOMAIN": pipeline_vars["sitemap_domain"],
                     "SENTRY_DSN": settings.OCW_HUGO_THEMES_SENTRY_DSN,
                     "NOINDEX": pipeline_vars["noindex"],
@@ -506,9 +507,6 @@ class SitePipelineOnlineTasks(list[StepModifierMixin]):
             instance_vars=pipeline_vars["instance_vars"],
         )
         if is_dev():
-            build_online_site_step.params["RESOURCE_BASE_URL"] = pipeline_vars[
-                "resource_base_url"
-            ]
             build_online_site_step.params[
                 "AWS_ACCESS_KEY_ID"
             ] = settings.AWS_ACCESS_KEY_ID
@@ -648,6 +646,7 @@ class SitePipelineOfflineTasks(list[StepModifierMixin]):
                     "STATIC_API_BASE_URL": pipeline_vars["static_api_url"],
                     "OCW_IMPORT_STARTER_SLUG": settings.OCW_COURSE_STARTER_SLUG,
                     "OCW_COURSE_STARTER_SLUG": settings.OCW_COURSE_STARTER_SLUG,
+                    "RESOURCE_BASE_URL": pipeline_vars["resource_base_url"] or "",
                     "SITEMAP_DOMAIN": pipeline_vars["sitemap_domain"],
                     "SENTRY_DSN": settings.OCW_HUGO_THEMES_SENTRY_DSN,
                     "NOINDEX": pipeline_vars["noindex"],
@@ -685,9 +684,6 @@ class SitePipelineOfflineTasks(list[StepModifierMixin]):
             instance_vars=pipeline_vars["instance_vars"],
         )
         if is_dev():
-            build_offline_site_step.params["RESOURCE_BASE_URL"] = (
-                pipeline_vars["resource_base_url"] or ""
-            )
             build_offline_site_step.params["AWS_ACCESS_KEY_ID"] = (
                 settings.AWS_ACCESS_KEY_ID or ""
             )


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/2072

### Description (What does it do?)
This PR corrects an issue with `site_pipeline.py` causing the end to end testing pipeline to fail outside of dev. The `RESOURCE_BASE_URL` env variable is only set within the Hugo build steps of the pipeline if the environment is `dev`. The end to end testing pipeline sets this to `STATIC_API_BASE_URL_TEST`. This setting is not applied when the pipeline is run outside of dev, and the pipeline fails. This PR simply sets `RESOURCE_BASE_URL` to the appropriate value regardless of environment. Other existing code that initializes `SitePipelineDefinitionConfig` passes in the value it gets from `get_common_pipeline_vars`, which for non-dev environments defaults to a blank string. The OCW themes will ignore blank values for this variable.

### How can this be tested?
 - Make sure you have the basic prerequisites for `ocw-studio` set up and can run it locally & publish websites, also have a somewhat recent database restore from production
 - In your `.env`, make sure `RESOURCE_BASE_URL_DRAFT` and `RESOURCE_BASE_URL_LIVE` are not set
 - Pick an actual website pipeline to test with (I'll use `2-830j-control-of-manufacturing-processes-sma-6303-spring-2008` as an example here)
 - Update the site's pipeline with `backpopulate_pipelines` (`docker compose exec web ./manage.py backpopulate_pipelines --filter 2-830j-control-of-manufacturing-processes-sma-6303-spring-2008` for me)
 - Browse to your example site in production and go to the download page
 - Click the Download Course button
 - Extract the downloaded course
 - Browse to the Minio web UI at http://localhost:9001 and login with your Minio root credentials
 - Browse to the `ol-ocw-studio-app` bucket, then go to the `courses` folder
 - Create a folder with your course's `name` property if it doesn't exist (`2-830j-control-of-manufacturing-processes-sma-6303-spring-2008`) in my case
 - Drag and drop the contents of the `static_resources` folder from our extracted ZIP from earlier into the folder we just created in Minio
 - In the `ocw-studio` UI for your site (http://localhost:8043/sites/2-830j-control-of-manufacturing-processes-sma-6303-spring-2008/ for me) click Publish and publish the site live
 - Wait for the pipeline to complete, then open the publish drawer again and click the link to visit the site
 - Assert that:
   - The course image loads correctly
   - If you go to the download page and download the course, the offline build should also have the course image load properly when you extract the ZIP and open `index.html`
 - Upsert the end to end test pipeline with `docker compose exec web ./manage.py upsert_e2e_test_pipeline`
 - Open the Concourse web interface at http://localhost:8080/ and find the end to end test pipeline, unpause it if necessary and run it
 - The pipeline should pass
