### PR TITLE
e2e test pipeline cache clearing

### DIFF
--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
@@ -37,7 +37,6 @@ from content_sync.pipelines.definitions.concourse.common.resources import (
     OcwHugoProjectsGitResource,
     OcwHugoThemesGitResource,
     OcwStudioWebhookResource,
-    OpenCatalogResource,
     SlackAlertResource,
     WebpackManifestResource,
 )
@@ -188,9 +187,6 @@ class EndToEndTestPipelineDefinition(Pipeline):
             site_name=course_site.name,
             api_token=settings.API_BEARER_TOKEN or "",
         )
-        open_catalog_resources = [
-            OpenCatalogResource(url) for url in settings.OPEN_CATALOG_URLS
-        ]
 
         resources = [
             webpack_manifest_resource,
@@ -199,8 +195,6 @@ class EndToEndTestPipelineDefinition(Pipeline):
             ocw_studio_webhook_resource,
             SlackAlertResource(),
         ]
-        if not is_dev():
-            resources.extend(open_catalog_resources)
 
         www_config = SitePipelineDefinitionConfig(
             site=www_site,
@@ -257,6 +251,7 @@ class EndToEndTestPipelineDefinition(Pipeline):
                 pipeline_vars=site_pipeline_vars,
                 fastly_var="test",
                 skip_cache_clear=is_dev(),
+                skip_search_index_update=True,
             )
         )
 

--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
@@ -37,6 +37,7 @@ from content_sync.pipelines.definitions.concourse.common.resources import (
     OcwHugoProjectsGitResource,
     OcwHugoThemesGitResource,
     OcwStudioWebhookResource,
+    OpenCatalogResource,
     SlackAlertResource,
     WebpackManifestResource,
 )
@@ -187,6 +188,9 @@ class EndToEndTestPipelineDefinition(Pipeline):
             site_name=course_site.name,
             api_token=settings.API_BEARER_TOKEN or "",
         )
+        open_catalog_resources = [
+            OpenCatalogResource(url) for url in settings.OPEN_CATALOG_URLS
+        ]
 
         resources = [
             webpack_manifest_resource,
@@ -195,6 +199,8 @@ class EndToEndTestPipelineDefinition(Pipeline):
             ocw_studio_webhook_resource,
             SlackAlertResource(),
         ]
+        if not is_dev():
+            resources.extend(open_catalog_resources)
 
         www_config = SitePipelineDefinitionConfig(
             site=www_site,
@@ -249,8 +255,8 @@ class EndToEndTestPipelineDefinition(Pipeline):
         site_tasks.extend(
             SitePipelineOnlineTasks(
                 pipeline_vars=site_pipeline_vars,
-                fastly_var=version,
-                skip_cache_clear=True,
+                fastly_var="test",
+                skip_cache_clear=is_dev(),
             )
         )
 

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -443,6 +443,7 @@ class SitePipelineOnlineTasks(list[StepModifierMixin]):
         destructive_sync(bool): (Optional) A boolean override for the delete flag used in AWS syncs
         filter_videos(bool): (Optional) A boolean override for filtering videos out of AWS syncs
         skip_cache_clear(bool): (Optional) A boolean override for skipping the CDN cache clear step
+        skip_search_index_update(bool): (Optional) A boolean override for skipping the search index update
     """  # noqa: E501
 
     def __init__(  # noqa: PLR0913
@@ -453,6 +454,7 @@ class SitePipelineOnlineTasks(list[StepModifierMixin]):
         destructive_sync: bool = True,
         filter_videos: bool = False,
         skip_cache_clear: bool = False,
+        skip_search_index_update: bool = False,
     ):
         delete_flag = pipeline_vars["delete_flag"] if destructive_sync else ""
         static_resources_task_step = StaticResourcesTaskStep(
@@ -564,23 +566,26 @@ class SitePipelineOnlineTasks(list[StepModifierMixin]):
             short_id=pipeline_vars["short_id"],
             instance_vars=pipeline_vars["instance_vars"],
         )
-        clear_cdn_cache_online_step.on_success = TryStep(
-            try_=DoStep(
-                do=[
-                    *[
-                        OpenCatalogWebhookStep(
-                            site_url=pipeline_vars["url_path"],
-                            pipeline_name=pipeline_vars["pipeline_name"],
-                            open_catalog_url=open_catalog_url,
-                        )
-                        for open_catalog_url in settings.OPEN_CATALOG_URLS
-                    ],
-                    OcwStudioWebhookStep(
+        clear_cdn_cache_online_on_success_steps = []
+        if not skip_search_index_update:
+            clear_cdn_cache_online_on_success_steps.extend(
+                *[
+                    OpenCatalogWebhookStep(
+                        site_url=pipeline_vars["url_path"],
                         pipeline_name=pipeline_vars["pipeline_name"],
-                        status="succeeded",
-                    ),
+                        open_catalog_url=open_catalog_url,
+                    )
+                    for open_catalog_url in settings.OPEN_CATALOG_URLS
                 ]
             )
+        clear_cdn_cache_online_on_success_steps.append(
+            OcwStudioWebhookStep(
+                pipeline_name=pipeline_vars["pipeline_name"],
+                status="succeeded",
+            )
+        )
+        clear_cdn_cache_online_step.on_success = TryStep(
+            try_=DoStep(do=clear_cdn_cache_online_on_success_steps)
         )
         self.extend(
             [


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/2076

### Description (What does it do?)
This PR adds a cache clearing step to the end to end testing pipeline that is added outside of dev. An optional argument was also added to `SitePipelineOnlineTasks`: `skip_search_index_update`. This boolean defaults to false. The end to end test pipeline will set it to true, which will prevent the test pipeline from calling the catalog sites to update the search index, as the test sites should definitely not show up in the search index.

### How can this be tested?
 - On line 587 of `content_sync/pipelines/definitions/site_pipeline.py`, you will see:
```python
        if not is_dev() and not skip_cache_clear:
            self.append(clear_cdn_cache_online_step)
```
 - Change this to:
```python
        # if not is_dev() and not skip_cache_clear:
        self.append(clear_cdn_cache_online_step)
```
 - This will ensure that even though we are running the site in local dev mode, the cache clearing step will be inserted into the pipeline definition
 - Spin up `ocw-studio` and make sure that you are all set up for publishing sites
 - Run `docker compose exec web ./manage.py upsert_e2e_test_pipeline`
 - Browse to http://localhost:8080 and find the test pipeline, then trigger a build
 - Eventually the pipeline should error out
 - In the site across step, you should see a `clear-cdn-cache` step with the error `failed to interpolate task config: undefined vars: fastly_test.api_token, fastly_test.service_id`
 - Further testing will need to be done on RC, but this indicates that the proper values were inserted into the pipeline definition and it was pushed up to Concourse without error
 - Revert the changes we made above and repeat this process and the end to end pipeline should skip the cache clear and run normally
