### PR TITLE
remove useless POETRY_VIRTUALENVS_CREATE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ RUN mkdir /var/media && chown -R mitodl:mitodl /var/media
 ## Set some poetry config
 ENV  \
   POETRY_VERSION=1.5.1 \
-  POETRY_VIRTUALENVS_CREATE=false \
   POETRY_CACHE_DIR='/tmp/cache/poetry' \
   POETRY_HOME='/home/mitodl/.local' \
   VIRTUAL_ENV="/opt/venv"


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
This change removes a useless and confusing configuration from the dockerfile

### How can this be tested?
`docker compose up --build`; Studio should work.
