### PR TITLE
Fix S3 path for Google Drive backfill

### DIFF
--- a/gdrive_sync/management/commands/backfill_gdrive_folder.py
+++ b/gdrive_sync/management/commands/backfill_gdrive_folder.py
@@ -155,8 +155,11 @@ class Command(WebsiteFilterCommand):
         )
         try:
             self.s3.download_fileobj(
-                settings.AWS_STORAGE_BUCKET_NAME, str(resource.file), file_obj
+                settings.AWS_STORAGE_BUCKET_NAME,
+                f"{resource.file}".lstrip("/"),
+                file_obj,
             )
+
         except BotoCoreError as e:
             self.stdout.write(f"Error downloading {resource.file}: {e}")
             return

--- a/gdrive_sync/management/commands/backfill_gdrive_folder_test.py
+++ b/gdrive_sync/management/commands/backfill_gdrive_folder_test.py
@@ -91,7 +91,7 @@ def test_backfill_gdrive_folder(
         website=website,
         title="test.txt",
         type="resource",
-        file="test_file",
+        file="/test_path/test_file",
         metadata={
             "file_type": "text/plain",
             "title": "test.txt",
@@ -101,7 +101,7 @@ def test_backfill_gdrive_folder(
     call_command("backfill_gdrive_folder", filter="test-site")
     if return_empty_files:
         mock_s3.download_fileobj.assert_called_with(
-            settings.AWS_STORAGE_BUCKET_NAME, str(resource.file), mocker.ANY
+            settings.AWS_STORAGE_BUCKET_NAME, str(resource.file).lstrip("/"), mocker.ANY
         )
         mock_gdrive_service.files().create.assert_called_with(
             body=mocker.ANY, media_body=mocker.ANY, fields="id", supportsAllDrives=True


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/2088.

### Description (What does it do?)
This PR updates the call to download a file from S3 to strip a leading forward slash, if it exists. While MinIO properly handles a path with an extra leading forward slash, S3 does not.

### How can this be tested?
Note: Testing is similar to testing for https://github.com/mitodl/ocw-studio/pull/2081, except that the AWS storage is used instead of MinIO. This can be done by setting the following variables in the OCW Studio `.env` file:
```
ENVIRONMENT=<anything except `dev`>
AWS_ACCESS_KEY_ID=<use value from RC>
AWS_SECRET_ACCESS_KEY=<use value from RC>
AWS_STORAGE_BUCKET_NAME=<use value from RC>
```
1. Pick a legacy course that has no Google Drive content but does contain non-video resources for testing. An example is `24-915-linguistic-phonetics-fall-2015`. 
2. Spin up OCW Studio with `docker compose up`. 
3. Run `docker compose exec web ./manage.py backfill_gdrive_folder --filter <course name or short-id>`. 
4.  Check the Google Drive folder for the website to ensure that the resources have been uploaded correctly. Also, check the Django admin to ensure that DriveFile objects have been created for each resource.