### PR TITLE
Allow editing and publishing of test sites

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,8 +24,8 @@ OCW_STUDIO_LIVE_URL=http://localhost:8045/
 SOCIAL_AUTH_SAML_LOGIN_URL=http://localhost
 API_BEARER_TOKEN=changeme
 USE_LOCAL_STARTERS=false
-OCW_WWW_TEST_SLUG=ocw-ci-test-www
-OCW_COURSE_TEST_SLUG=ocw-ci-test-course
+TEST_ROOT_WEBSITE_NAME="ocw-ci-test-www"
+OCW_TEST_SITE_SLUGS=["ocw-ci-test-www","ocw-ci-test-course"]
 
 # Classes to use for Git backend and publishing pipelines
 CONTENT_SYNC_BACKEND=content_sync.backends.github.GithubBackend

--- a/README.md
+++ b/README.md
@@ -360,8 +360,7 @@ There is a pipeline definition for end to end testing of sites using the `ocw-ww
 Firstly, there are some environment variables you will want to set:
 
 ```
-OCW_WWW_TEST_SLUG=ocw-ci-test-www
-OCW_COURSE_TEST_SLUG=ocw-ci-test-course
+OCW_TEST_SITE_SLUGS=["ocw-ci-test-www", "ocw-ci-test-course"]
 AWS_TEST_BUCKET_NAME=ocw-content-test
 AWS_OFFLINE_TEST_BUCKET_NAME=ocw-content-offline-test
 STATIC_API_BASE_URL_TEST=http://10.1.0.102:8046

--- a/content_sync/conftest.py
+++ b/content_sync/conftest.py
@@ -88,6 +88,7 @@ def required_concourse_settings(settings):
     settings.OCW_GTM_ACCOUNT_ID = "abc123"
     settings.TEST_ROOT_WEBSITE_NAME = "ocw-ci-test-www"
     settings.OCW_TEST_SITE_SLUGS = ["ocw-ci-test-www", "ocw-ci-test-course"]
+    settings.ROOT_WEBSITE_NAME = "root-website"
     return settings
 
 

--- a/content_sync/conftest.py
+++ b/content_sync/conftest.py
@@ -88,7 +88,6 @@ def required_concourse_settings(settings):
     settings.OCW_GTM_ACCOUNT_ID = "abc123"
     settings.TEST_ROOT_WEBSITE_NAME = "ocw-ci-test-www"
     settings.OCW_TEST_SITE_SLUGS = ["ocw-ci-test-www", "ocw-ci-test-course"]
-    settings.ROOT_WEBSITE_NAME = "root-website"
     return settings
 
 

--- a/content_sync/conftest.py
+++ b/content_sync/conftest.py
@@ -81,6 +81,7 @@ def required_concourse_settings(settings):
     settings.GIT_ORGANIZATION = "test_org"
     settings.GITHUB_WEBHOOK_BRANCH = "release"
     settings.SITE_BASE_URL = "http://test.edu"
+    settings.STATIC_API_BASE_URL_TEST = "http://test.ocw.mit.edu"
     settings.API_BEARER_TOKEN = "abc123"  # pragma: allowlist secret  # noqa: S105
     settings.SEARCH_API_URL = "http://test.edu/api/v0/search"
     settings.COURSE_SEARCH_API_URL = "http://test.edu/api/v1/learning_resources_search"

--- a/content_sync/conftest.py
+++ b/content_sync/conftest.py
@@ -86,6 +86,7 @@ def required_concourse_settings(settings):
     settings.COURSE_SEARCH_API_URL = "http://test.edu/api/v1/learning_resources_search"
     settings.CONTENT_FILE_SEARCH_API_URL = "http://test.edu/api/v1/content_file_search"
     settings.OCW_GTM_ACCOUNT_ID = "abc123"
+    settings.TEST_ROOT_WEBSITE_NAME = "ocw-ci-test-www"
     settings.OCW_TEST_SITE_SLUGS = ["ocw-ci-test-www", "ocw-ci-test-course"]
     return settings
 

--- a/content_sync/conftest.py
+++ b/content_sync/conftest.py
@@ -86,8 +86,7 @@ def required_concourse_settings(settings):
     settings.COURSE_SEARCH_API_URL = "http://test.edu/api/v1/learning_resources_search"
     settings.CONTENT_FILE_SEARCH_API_URL = "http://test.edu/api/v1/content_file_search"
     settings.OCW_GTM_ACCOUNT_ID = "abc123"
-    settings.OCW_WWW_TEST_SLUG = "ocw-ci-test-www"
-    settings.OCW_COURSE_TEST_SLUG = "ocw-ci-test-course"
+    settings.OCW_TEST_SITE_SLUGS = ["ocw-ci-test-www", "ocw-ci-test-course"]
     return settings
 
 

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -615,6 +615,7 @@ class TestPipeline(BaseTestPipeline, GeneralPipeline):
             *MANDATORY_CONCOURSE_SETTINGS,
             "AWS_TEST_BUCKET_NAME",
             "AWS_OFFLINE_TEST_BUCKET_NAME",
+            "TEST_ROOT_WEBSITE_NAME",
             "OCW_TEST_SITE_SLUGS",
             "STATIC_API_BASE_URL_TEST",
         ]

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -615,8 +615,7 @@ class TestPipeline(BaseTestPipeline, GeneralPipeline):
             *MANDATORY_CONCOURSE_SETTINGS,
             "AWS_TEST_BUCKET_NAME",
             "AWS_OFFLINE_TEST_BUCKET_NAME",
-            "OCW_WWW_TEST_SLUG",
-            "OCW_COURSE_TEST_SLUG",
+            "OCW_TEST_SITE_SLUGS",
             "STATIC_API_BASE_URL_TEST",
         ]
         super().__init__(api=api)

--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
@@ -160,7 +160,7 @@ class EndToEndTestPipelineDefinition(Pipeline):
         sitemap_domain = urlparse(static_api_base_url).netloc
         version = VERSION_LIVE
 
-        test_sites = Website.objects.filter(name__in=settings.TEST_SITE_SLUGS)
+        test_sites = Website.objects.filter(name__in=settings.OCW_TEST_SITE_SLUGS)
         www_test_site = Website.objects.get(name=settings.TEST_ROOT_WEBSITE_NAME)
         ocw_hugo_projects_url = www_test_site.starter.ocw_hugo_projects_url
         site_content_branch = get_site_content_branch(version)

--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
@@ -19,7 +19,7 @@ from ol_concourse.lib.models.pipeline import (
 )
 from ol_concourse.lib.resource_types import slack_notification_resource
 
-from content_sync.constants import DEV_ENDPOINT_URL, VERSION_LIVE
+from content_sync.constants import DEV_ENDPOINT_URL, DEV_TEST_URL, VERSION_LIVE
 from content_sync.pipelines.definitions.concourse.common.identifiers import (
     OCW_HUGO_PROJECTS_GIT_IDENTIFIER,
     OCW_HUGO_THEMES_GIT_IDENTIFIER,
@@ -156,13 +156,13 @@ class EndToEndTestPipelineDefinition(Pipeline):
         common_pipeline_vars = get_common_pipeline_vars()
         namespace = ".:site."
         site_pipeline_vars = get_site_pipeline_definition_vars(namespace=namespace)
-        static_api_base_url = common_pipeline_vars["static_api_base_url_test"]
-        site_pipeline_vars["sitemap_domain"] = urlparse(static_api_base_url).netloc
+        static_api_base_url = settings.STATIC_API_BASE_URL_TEST or DEV_TEST_URL
+        sitemap_domain = urlparse(static_api_base_url).netloc
         version = VERSION_LIVE
 
-        www_site = Website.objects.get(name=settings.OCW_WWW_TEST_SLUG)
-        course_site = Website.objects.get(name=settings.OCW_COURSE_TEST_SLUG)
-        ocw_hugo_projects_url = www_site.starter.ocw_hugo_projects_url
+        test_sites = Website.objects.filter(name__in=settings.TEST_SITE_SLUGS)
+        www_test_site = Website.objects.get(name=settings.TEST_ROOT_WEBSITE_NAME)
+        ocw_hugo_projects_url = www_test_site.starter.ocw_hugo_projects_url
         site_content_branch = get_site_content_branch(version)
 
         resource_types = [
@@ -184,7 +184,7 @@ class EndToEndTestPipelineDefinition(Pipeline):
         )
         ocw_hugo_projects_resource.check_every = Duration(root="1m")
         ocw_studio_webhook_resource = OcwStudioWebhookResource(
-            site_name=course_site.name,
+            site_name=www_test_site.name,
             api_token=settings.API_BEARER_TOKEN or "",
         )
 
@@ -196,46 +196,24 @@ class EndToEndTestPipelineDefinition(Pipeline):
             SlackAlertResource(),
         ]
 
-        www_config = SitePipelineDefinitionConfig(
-            site=www_site,
-            pipeline_name=version,
-            instance_vars=f"?vars={quote(json.dumps({'site': www_site.name}))}",
-            site_content_branch=site_content_branch,
-            static_api_url=common_pipeline_vars["static_api_base_url_test"],
-            storage_bucket=common_pipeline_vars["storage_bucket_name"],
-            artifacts_bucket=common_pipeline_vars["artifacts_bucket_name"],
-            web_bucket=common_pipeline_vars["test_bucket_name"],
-            offline_bucket=common_pipeline_vars["offline_test_bucket_name"],
-            resource_base_url=static_api_base_url,
-            ocw_hugo_themes_branch=themes_branch,
-            ocw_hugo_projects_branch=projects_branch,
-            sitemap_domain=site_pipeline_vars["sitemap_domain"],
-            namespace=namespace,
-        )
-        www_config.is_root_website = True
-        www_config.values["is_root_website"] = 1
-        www_config.values["delete_flag"] = ""
-        www_config.values["url_path"] = ""
-        www_config.values["base_url"] = ""
-        www_config.values["ocw_studio_url"] = static_api_base_url
-        course_config = SitePipelineDefinitionConfig(
-            site=course_site,
-            pipeline_name=version,
-            instance_vars=f"?vars={quote(json.dumps({'site': course_site.name}))}",
-            site_content_branch=site_content_branch,
-            static_api_url=common_pipeline_vars["static_api_base_url_test"],
-            storage_bucket=common_pipeline_vars["storage_bucket_name"],
-            artifacts_bucket=common_pipeline_vars["artifacts_bucket_name"],
-            web_bucket=common_pipeline_vars["test_bucket_name"],
-            offline_bucket=common_pipeline_vars["offline_test_bucket_name"],
-            resource_base_url=static_api_base_url,
-            ocw_hugo_themes_branch=themes_branch,
-            ocw_hugo_projects_branch=projects_branch,
-            sitemap_domain=site_pipeline_vars["sitemap_domain"],
-            namespace=namespace,
-        )
-        course_config.values["ocw_studio_url"] = ""
-        across_var_values = [www_config.values, course_config.values]
+        across_var_values = []
+        for test_site in test_sites:
+            site_config = SitePipelineDefinitionConfig(
+                site=test_site,
+                pipeline_name=version,
+                instance_vars=f"?vars={quote(json.dumps({'site': test_site.name}))}",
+                site_content_branch=site_content_branch,
+                static_api_url=common_pipeline_vars["static_api_base_url_test"],
+                storage_bucket=common_pipeline_vars["storage_bucket_name"],
+                artifacts_bucket=common_pipeline_vars["artifacts_bucket_name"],
+                web_bucket=common_pipeline_vars["test_bucket_name"],
+                offline_bucket=common_pipeline_vars["offline_test_bucket_name"],
+                resource_base_url=static_api_base_url,
+                ocw_hugo_themes_branch=themes_branch,
+                ocw_hugo_projects_branch=projects_branch,
+                namespace=namespace,
+            )
+            across_var_values.append(site_config.values)
 
         site_tasks = []
         site_tasks.extend(
@@ -326,7 +304,7 @@ class EndToEndTestPipelineDefinition(Pipeline):
                         "OCW_IMPORT_STARTER_SLUG": settings.OCW_COURSE_STARTER_SLUG,
                         "OCW_COURSE_STARTER_SLUG": settings.OCW_COURSE_STARTER_SLUG,
                         "SENTRY_DSN": settings.OCW_HUGO_THEMES_SENTRY_DSN,
-                        "NOINDEX": course_config.values["noindex"],
+                        "NOINDEX": "true",
                         "COURSE_CONTENT_PATH": "../",
                         "COURSE_HUGO_CONFIG_PATH": f"../{OCW_HUGO_PROJECTS_GIT_IDENTIFIER}/ocw-course-v2/config.yaml",  # noqa: E501
                         "FIELDS_CONTENT_PATH": "",
@@ -334,7 +312,7 @@ class EndToEndTestPipelineDefinition(Pipeline):
                         "GIT_CONTENT_SOURCE": "git@github.mit.edu:ocw-content-rc",
                         "OCW_TEST_COURSE": course_content_git_identifier,
                         "RESOURCE_BASE_URL": static_api_base_url,
-                        "SITEMAP_DOMAIN": site_pipeline_vars["sitemap_domain"],
+                        "SITEMAP_DOMAIN": sitemap_domain,
                         "SEARCH_API_URL": "https://discussions-rc.odl.mit.edu/api/v0/search/",
                         "COURSE_SEARCH_API_URL": "https://mit-open-rc.odl.mit.edu/api/v1/learning_resources_search/",
                         "CONTENT_FILE_SEARCH_API_URL": "https://mit-open-rc.odl.mit.edu/api/v1/content_file_search/",

--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline_test.py
@@ -3,6 +3,7 @@ from urllib.parse import urlparse
 
 import pytest
 
+from content_sync.constants import DEV_TEST_URL
 from content_sync.pipelines.definitions.concourse.common.identifiers import (
     OCW_HUGO_PROJECTS_GIT_IDENTIFIER,
     OCW_HUGO_THEMES_GIT_IDENTIFIER,
@@ -82,6 +83,7 @@ def test_generate_e2e_test_site_pipeline_definition(  # noqa: PLR0913 PLR0915
     mock_pipeline_is_dev.return_value = is_dev
     common_pipeline_vars = get_common_pipeline_vars()
     static_api_base_url = common_pipeline_vars["static_api_base_url_test"]
+    ocw_studio_url = DEV_TEST_URL if is_dev else static_api_base_url
     test_bucket = common_pipeline_vars["test_bucket_name"]
     offline_test_bucket = common_pipeline_vars["offline_test_bucket_name"]
     sitemap_domain = urlparse(static_api_base_url).netloc
@@ -166,7 +168,7 @@ def test_generate_e2e_test_site_pipeline_definition(  # noqa: PLR0913 PLR0915
     assert www_values["delete_flag"] == ""
     assert www_values["url_path"] == www_site.name
     assert www_values["base_url"] == ""
-    assert www_values["ocw_studio_url"] == static_api_base_url
+    assert www_values["ocw_studio_url"] == ocw_studio_url
     assert www_values["static_api_url"] == static_api_base_url
     assert www_values["web_bucket"] == test_bucket
     assert www_values["offline_bucket"] == offline_test_bucket

--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline_test.py
@@ -3,7 +3,6 @@ from urllib.parse import urlparse
 
 import pytest
 
-from content_sync.constants import DEV_TEST_URL
 from content_sync.pipelines.definitions.concourse.common.identifiers import (
     OCW_HUGO_PROJECTS_GIT_IDENTIFIER,
     OCW_HUGO_THEMES_GIT_IDENTIFIER,
@@ -75,15 +74,18 @@ def test_generate_e2e_test_site_pipeline_definition(  # noqa: PLR0913 PLR0915
     settings.AWS_SECRET_ACCESS_KEY = "test_secret_access_key"  # noqa: S105
     settings.OCW_HUGO_THEMES_SENTRY_DSN = "test_sentry_dsn"
     mock_utils_is_dev = mocker.patch("content_sync.utils.is_dev")
-    mock_pipeline_is_dev = mocker.patch(
+    mock_test_pipeline_is_dev = mocker.patch(
         "content_sync.pipelines.definitions.concourse.e2e_test_site_pipeline.is_dev"
+    )
+    mock_site_pipeline_is_dev = mocker.patch(
+        "content_sync.pipelines.definitions.concourse.site_pipeline.is_dev"
     )
     is_dev = settings.ENV_NAME == "dev"
     mock_utils_is_dev.return_value = is_dev
-    mock_pipeline_is_dev.return_value = is_dev
+    mock_test_pipeline_is_dev.return_value = is_dev
+    mock_site_pipeline_is_dev.return_value = is_dev
     common_pipeline_vars = get_common_pipeline_vars()
     static_api_base_url = common_pipeline_vars["static_api_base_url_test"]
-    ocw_studio_url = DEV_TEST_URL if is_dev else static_api_base_url
     test_bucket = common_pipeline_vars["test_bucket_name"]
     offline_test_bucket = common_pipeline_vars["offline_test_bucket_name"]
     sitemap_domain = urlparse(static_api_base_url).netloc
@@ -168,7 +170,7 @@ def test_generate_e2e_test_site_pipeline_definition(  # noqa: PLR0913 PLR0915
     assert www_values["delete_flag"] == ""
     assert www_values["url_path"] == www_site.name
     assert www_values["base_url"] == ""
-    assert www_values["ocw_studio_url"] == ocw_studio_url
+    assert www_values["ocw_studio_url"] == static_api_base_url
     assert www_values["static_api_url"] == static_api_base_url
     assert www_values["web_bucket"] == test_bucket
     assert www_values["offline_bucket"] == offline_test_bucket

--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline_test.py
@@ -164,7 +164,7 @@ def test_generate_e2e_test_site_pipeline_definition(  # noqa: PLR0913 PLR0915
     )
     assert www_values["is_root_website"] == 1
     assert www_values["delete_flag"] == ""
-    assert www_values["url_path"] == ""
+    assert www_values["url_path"] == www_site.name
     assert www_values["base_url"] == ""
     assert www_values["ocw_studio_url"] == static_api_base_url
     assert www_values["static_api_url"] == static_api_base_url

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -176,7 +176,6 @@ class SitePipelineDefinitionConfig:
         self.ocw_hugo_projects_branch = ocw_hugo_projects_branch
         if self.is_root_website:
             self.base_url = ""
-            self.url_path = ""
             self.delete_flag = ""
             self.static_resources_subdirectory = f"/{site.get_url_path()}/"
         else:

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -188,6 +188,7 @@ class SitePipelineDefinitionConfig:
             self.web_bucket = settings.AWS_TEST_BUCKET_NAME
             self.offline_bucket = settings.AWS_OFFLINE_TEST_BUCKET_NAME
             self.static_api_url = settings.STATIC_API_BASE_URL_TEST or DEV_TEST_URL
+            self.resource_base_url = self.static_api_url
             self.sitemap_domain = urlparse(self.static_api_url).netloc
             self.ocw_studio_url = self.static_api_url if self.is_root_website else ""
         starter_slug = site.starter.slug
@@ -238,12 +239,12 @@ class SitePipelineDefinitionConfig:
             "pipeline_name": pipeline_name,
             "instance_vars": instance_vars,
             "sitemap_domain": self.sitemap_domain,
-            "static_api_url": static_api_url,
+            "static_api_url": self.static_api_url,
             "storage_bucket": storage_bucket,
             "artifacts_bucket": artifacts_bucket,
-            "web_bucket": web_bucket,
-            "offline_bucket": offline_bucket,
-            "resource_base_url": resource_base_url,
+            "web_bucket": self.web_bucket,
+            "offline_bucket": self.offline_bucket,
+            "resource_base_url": self.resource_base_url,
             "site_content_branch": site_content_branch,
             "ocw_hugo_themes_branch": ocw_hugo_themes_branch,
             "ocw_hugo_projects_url": self.ocw_hugo_projects_url,

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -1,5 +1,5 @@
 from typing import Optional
-from urllib import urlparse
+from urllib.parse import urlparse
 
 from django.conf import settings
 from ol_concourse.lib.models.pipeline import (
@@ -128,7 +128,7 @@ class SitePipelineDefinitionConfig:
         namespace(str): The Concourse vars namespace to use
     """  # noqa: E501
 
-    def __init__(  # noqa: PLR0913
+    def __init__(  # noqa: PLR0913 PLR0915
         self,
         site: Website,
         pipeline_name: str,
@@ -163,6 +163,7 @@ class SitePipelineDefinitionConfig:
         self.sitemap_domain = sitemap_domain
         self.url_path = site.get_url_path()
         self.resource_base_url = resource_base_url
+        self.ocw_studio_url = get_ocw_studio_api_url()
         if (
             self.site_content_branch == settings.GIT_BRANCH_PREVIEW
             or settings.ENV_NAME not in PRODUCTION_NAMES
@@ -188,9 +189,7 @@ class SitePipelineDefinitionConfig:
             self.offline_bucket = settings.AWS_OFFLINE_TEST_BUCKET_NAME
             self.static_api_url = settings.STATIC_API_BASE_URL_TEST or DEV_TEST_URL
             self.sitemap_domain = urlparse(self.static_api_url).netloc
-            self.ocw_studio_url = (
-                self.static_api_base_url if self.is_root_website else ""
-            )
+            self.ocw_studio_url = self.static_api_url if self.is_root_website else ""
         starter_slug = site.starter.slug
         base_hugo_args = {"--themesDir": f"../{OCW_HUGO_THEMES_GIT_IDENTIFIER}/"}
         base_online_args = base_hugo_args.copy()
@@ -249,7 +248,7 @@ class SitePipelineDefinitionConfig:
             "ocw_hugo_themes_branch": ocw_hugo_themes_branch,
             "ocw_hugo_projects_url": self.ocw_hugo_projects_url,
             "ocw_hugo_projects_branch": ocw_hugo_projects_branch,
-            "ocw_studio_url": get_ocw_studio_api_url(),
+            "ocw_studio_url": self.ocw_studio_url,
             "hugo_args_online": hugo_args_online,
             "hugo_args_offline": hugo_args_offline,
             "prefix": f"{prefix.strip('/')}/" if prefix != "" else prefix,

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -190,6 +190,8 @@ class SitePipelineDefinitionConfig:
             self.resource_base_url = self.static_api_url
             self.sitemap_domain = urlparse(self.static_api_url).netloc
             self.ocw_studio_url = self.static_api_url if self.is_root_website else ""
+            if self.is_root_website:
+                self.url_path = site.name
         starter_slug = site.starter.slug
         base_hugo_args = {"--themesDir": f"../{OCW_HUGO_THEMES_GIT_IDENTIFIER}/"}
         base_online_args = base_hugo_args.copy()

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -1,4 +1,5 @@
 from typing import Optional
+from urllib import urlparse
 
 from django.conf import settings
 from ol_concourse.lib.models.pipeline import (
@@ -22,7 +23,7 @@ from ol_concourse.lib.models.pipeline import (
 )
 from ol_concourse.lib.resource_types import slack_notification_resource
 
-from content_sync.constants import TARGET_OFFLINE, TARGET_ONLINE
+from content_sync.constants import DEV_TEST_URL, TARGET_OFFLINE, TARGET_ONLINE
 from content_sync.pipelines.definitions.concourse.common.identifiers import (
     KEYVAL_RESOURCE_TYPE_IDENTIFIER,
     OCW_HUGO_PROJECTS_GIT_IDENTIFIER,
@@ -148,21 +149,19 @@ class SitePipelineDefinitionConfig:
     ):
         self.site = site
         self.pipeline_name = pipeline_name
-        self.is_root_website = site.name == settings.ROOT_WEBSITE_NAME
-        if self.is_root_website:
-            self.base_url = ""
-            self.static_resources_subdirectory = f"/{site.get_url_path()}/"
-            self.delete_flag = ""
-        else:
-            self.base_url = site.get_url_path()
-            self.static_resources_subdirectory = "/"
-            self.delete_flag = " --delete"
+        self.is_root_website = site.name in [
+            settings.ROOT_WEBSITE_NAME,
+            settings.TEST_ROOT_WEBSITE_NAME,
+        ]
+        self.is_test_website = site.name in settings.OCW_TEST_SITE_SLUGS
         self.site_content_branch = site_content_branch
-        self.static_api_url = static_api_url
         self.storage_bucket_name = storage_bucket
         self.artifacts_bucket = artifacts_bucket
         self.web_bucket = web_bucket
         self.offline_bucket = offline_bucket
+        self.static_api_url = static_api_url
+        self.sitemap_domain = sitemap_domain
+        self.url_path = site.get_url_path()
         self.resource_base_url = resource_base_url
         if (
             self.site_content_branch == settings.GIT_BRANCH_PREVIEW
@@ -174,6 +173,24 @@ class SitePipelineDefinitionConfig:
         self.ocw_hugo_themes_branch = ocw_hugo_themes_branch
         self.ocw_hugo_projects_url = site.starter.ocw_hugo_projects_url
         self.ocw_hugo_projects_branch = ocw_hugo_projects_branch
+        if self.is_root_website:
+            self.base_url = ""
+            self.url_path = ""
+            self.delete_flag = ""
+            self.static_resources_subdirectory = f"/{site.get_url_path()}/"
+        else:
+            self.base_url = site.get_url_path()
+            self.static_resources_subdirectory = "/"
+            self.delete_flag = " --delete"
+        if self.is_test_website:
+            self.noindex = "true"
+            self.web_bucket = settings.AWS_TEST_BUCKET_NAME
+            self.offline_bucket = settings.AWS_OFFLINE_TEST_BUCKET_NAME
+            self.static_api_url = settings.STATIC_API_BASE_URL_TEST or DEV_TEST_URL
+            self.sitemap_domain = urlparse(self.static_api_url).netloc
+            self.ocw_studio_url = (
+                self.static_api_base_url if self.is_root_website else ""
+            )
         starter_slug = site.starter.slug
         base_hugo_args = {"--themesDir": f"../{OCW_HUGO_THEMES_GIT_IDENTIFIER}/"}
         base_online_args = base_hugo_args.copy()
@@ -214,14 +231,14 @@ class SitePipelineDefinitionConfig:
             "short_id": site.short_id,
             "site_name": site.name,
             "s3_path": site.s3_path,
-            "url_path": site.get_url_path(),
+            "url_path": self.url_path,
             "base_url": self.base_url,
             "static_resources_subdirectory": self.static_resources_subdirectory,
             "delete_flag": self.delete_flag,
             "noindex": self.noindex,
             "pipeline_name": pipeline_name,
             "instance_vars": instance_vars,
-            "sitemap_domain": sitemap_domain,
+            "sitemap_domain": self.sitemap_domain,
             "static_api_url": static_api_url,
             "storage_bucket": storage_bucket,
             "artifacts_bucket": artifacts_bucket,

--- a/content_sync/utils.py
+++ b/content_sync/utils.py
@@ -168,13 +168,9 @@ def get_publishable_sites(version: str):
         "publish_date" if version == VERSION_LIVE else "draft_publish_date"
     )
     # Get all sites, minus any sites that have never been successfully published and test sites  # noqa: E501
-    sites = (
-        Website.objects.exclude(
-            Q(**{f"{publish_date_field}__isnull": True}) | Q(url_path__isnull=True)
-        )
-        .exclude(unpublish_status__isnull=False)
-        .exclude(name__in=[settings.OCW_WWW_TEST_SLUG, settings.OCW_COURSE_TEST_SLUG])
-    )
+    sites = Website.objects.exclude(
+        Q(**{f"{publish_date_field}__isnull": True}) | Q(url_path__isnull=True)
+    ).exclude(unpublish_status__isnull=False)
     return sites.prefetch_related("starter")
 
 

--- a/content_sync/utils.py
+++ b/content_sync/utils.py
@@ -168,9 +168,13 @@ def get_publishable_sites(version: str):
         "publish_date" if version == VERSION_LIVE else "draft_publish_date"
     )
     # Get all sites, minus any sites that have never been successfully published and test sites  # noqa: E501
-    sites = Website.objects.exclude(
-        Q(**{f"{publish_date_field}__isnull": True}) | Q(url_path__isnull=True)
-    ).exclude(unpublish_status__isnull=False)
+    sites = (
+        Website.objects.exclude(
+            Q(**{f"{publish_date_field}__isnull": True}) | Q(url_path__isnull=True)
+        )
+        .exclude(unpublish_status__isnull=False)
+        .exclude(name__in=settings.OCW_TEST_SITE_SLUGS)
+    )
     return sites.prefetch_related("starter")
 
 

--- a/content_sync/utils_test.py
+++ b/content_sync/utils_test.py
@@ -264,12 +264,6 @@ def test_get_publishable_sites(settings, mocker, mass_build_websites, version):
     else:
         unpublished_site.publish_date = None
     unpublished_site.save()
-    test_www_site = mass_build_websites[1]
-    test_www_site.name = settings.OCW_WWW_TEST_SLUG
-    test_www_site.save()
-    test_course_site = mass_build_websites[2]
-    test_course_site.name = settings.OCW_COURSE_TEST_SLUG
-    test_course_site.save()
     assert len(mass_build_websites) == 7
     publishable_sites = get_publishable_sites(version)
     assert publishable_sites.count() == 4

--- a/content_sync/utils_test.py
+++ b/content_sync/utils_test.py
@@ -264,6 +264,10 @@ def test_get_publishable_sites(settings, mocker, mass_build_websites, version):
     else:
         unpublished_site.publish_date = None
     unpublished_site.save()
+    for index, test_site_slug in enumerate(settings.OCW_TEST_SITE_SLUGS):
+        test_site = mass_build_websites[index + 1]
+        test_site.name = test_site_slug
+        test_site.save()
     assert len(mass_build_websites) == 7
     publishable_sites = get_publishable_sites(version)
     assert publishable_sites.count() == 4

--- a/main/envs.py
+++ b/main/envs.py
@@ -1,0 +1,149 @@
+"""Functions reading and parsing environment variables"""
+
+import os
+from ast import literal_eval
+
+from django.core.exceptions import ImproperlyConfigured
+
+
+class EnvironmentVariableParseException(ImproperlyConfigured):
+    """Environment variable was not parsed correctly"""
+
+
+def get_string(name, default):
+    """
+    Get an environment variable as a string.
+
+    Args:
+        name (str): An environment variable name
+        default (str): The default value to use if the environment variable doesn't exist.
+
+    Returns:
+        str:
+            The environment variable value, or the default
+    """  # noqa: E501
+    return os.environ.get(name, default)
+
+
+def get_bool(name, default):
+    """
+    Get an environment variable as a boolean.
+
+    Args:
+        name (str): An environment variable name
+        default (bool): The default value to use if the environment variable doesn't exist.
+
+    Returns:
+        bool:
+            The environment variable value parsed as a bool
+    """  # noqa: E501
+    value = os.environ.get(name)
+    if value is None:
+        return default
+
+    parsed_value = value.lower()
+    if parsed_value == "true":
+        return True
+    elif parsed_value == "false":
+        return False
+
+    msg = f"Expected value in {name}={value} to be a boolean"
+    raise EnvironmentVariableParseException(msg)
+
+
+def get_int(name, default):
+    """
+    Get an environment variable as an int.
+
+    Args:
+        name (str): An environment variable name
+        default (int): The default value to use if the environment variable doesn't exist.
+
+    Returns:
+        int:
+            The environment variable value parsed as an int
+    """  # noqa: E501
+    value = os.environ.get(name)
+    if value is None:
+        return default
+
+    try:
+        parsed_value = int(value)
+    except ValueError as ex:
+        msg = f"Expected value in {name}={value} to be an int"
+        raise EnvironmentVariableParseException(msg) from ex
+
+    return parsed_value
+
+
+def get_any(name, default):
+    """
+    Get an environment variable as a bool, int, or a string.
+
+    Args:
+        name (str): An environment variable name
+        default (any): The default value to use if the environment variable doesn't exist.
+
+    Returns:
+        any:
+            The environment variable value parsed as a bool, int, or a string
+    """  # noqa: E501
+    try:
+        return get_bool(name, default)
+    except EnvironmentVariableParseException:
+        try:
+            return get_int(name, default)
+        except EnvironmentVariableParseException:
+            return get_string(name, default)
+
+
+def get_list_of_str(name, default):
+    """
+    Get an environment variable as a list of strings.
+    Args:
+        name (str): An environment variable name
+        default (list): The default value to use if the environment variable doesn't exist.
+    Returns:
+        list of str:
+            The environment variable value parsed as a list of strings
+    """  # noqa: E501
+    value = os.environ.get(name)
+    if value is None:
+        return default
+
+    parse_exception = EnvironmentVariableParseException(
+        f"Expected value in {name}={value} to be a list of str"
+    )
+
+    try:
+        parsed_value = literal_eval(value)
+    except (ValueError, SyntaxError) as ex:
+        raise parse_exception from ex
+
+    if not isinstance(parsed_value, list):
+        raise parse_exception
+
+    for item in parsed_value:
+        if not isinstance(item, str):
+            raise parse_exception
+
+    return parsed_value
+
+
+def get_key(name, default):
+    """
+    Get an environment variable as a string representing a private or public key.
+    The difference is that keys are automatically escaped and they need to be unescaped and
+    encoded into bytestrings.
+
+     Args:
+        name (str): An environment variable name
+        default (str): The default value to use if the environment variable doesn't exist.
+
+    Returns:
+        bytes: The environment variable value, or the default as bytestring
+    """  # noqa: E501
+    value = get_string(name, default)
+    if not isinstance(value, str):
+        return value
+    return value.encode().decode("unicode_escape").encode()

--- a/main/settings.py
+++ b/main/settings.py
@@ -1118,6 +1118,11 @@ OCW_STUDIO_LIVE_URL = get_string(
     default=None,
     description="The base url of the live site",
 )
+OCW_STUDIO_TEST_URL = get_string(
+    name="OCW_STUDIO_TEST_URL",
+    default=None,
+    description="The base url of the test site",
+)
 PREPUBLISH_ACTIONS = get_delimited_list(
     name="PREPUBLISH_ACTIONS",
     default=[],

--- a/main/settings.py
+++ b/main/settings.py
@@ -20,6 +20,7 @@ from mitol.common.envs import (
 )
 
 from main.constants import PRODUCTION_NAMES
+from main.envs import get_list_of_str
 from main.sentry import init_sentry
 
 # pylint: disable=too-many-lines
@@ -1012,18 +1013,13 @@ OCW_COURSE_STARTER_SLUG = get_string(
     description="The slug of the WebsiteStarter currently used for OCW course sites",
     required=False,
 )
-OCW_WWW_TEST_SLUG = get_string(
-    name="OCW_WWW_TEST_SLUG",
+TEST_ROOT_WEBSITE_NAME = get_string(
+    name="TEST_ROOT_WEBSITE_NAME",
     default="ocw-ci-test-www",
-    description="The slug of the root Website used to run end to end tests",
+    description="The Website name for the site at the root of the test domain",
     required=False,
 )
-OCW_COURSE_TEST_SLUG = get_string(
-    name="OCW_COURSE_TEST_SLUG",
-    default="ocw-ci-test-course",
-    description="The slug of the course Website used to run end to end tests",
-    required=False,
-)
+OCW_TEST_SITE_SLUGS = get_list_of_str(name="OCW_TEST_SITE_SLUGS", default=[])
 OCW_GTM_ACCOUNT_ID = get_string(
     name="OCW_GTM_ACCOUNT_ID",
     default=None,

--- a/websites/conftest.py
+++ b/websites/conftest.py
@@ -33,12 +33,16 @@ def permission_groups():
         site_owner,
         site_admin,
         site_editor,
-    ) = UserFactory.create_batch(5)
+        superuser,
+    ) = UserFactory.create_batch(6)
     websites = WebsiteFactory.create_batch(2, owner=site_owner, with_url_path=True)
+    websites.append(WebsiteFactory.create(name="ocw-ci-test-course"))
     global_admin.groups.add(Group.objects.get(name=constants.GLOBAL_ADMIN))
     global_author.groups.add(Group.objects.get(name=constants.GLOBAL_AUTHOR))
     site_admin.groups.add(websites[0].admin_group)
     site_editor.groups.add(websites[0].editor_group)
+    superuser.is_superuser = True
+    superuser.save()
 
     website = websites[0]
     owner_content = WebsiteContentFactory.create(website=website, owner=website.owner)
@@ -49,6 +53,7 @@ def permission_groups():
         global_author=global_author,
         site_admin=site_admin,
         site_editor=site_editor,
+        superuser=superuser,
         websites=websites,
         owner_content=owner_content,
         editor_content=editor_content,

--- a/websites/management/commands/export_test_sites.py
+++ b/websites/management/commands/export_test_sites.py
@@ -1,4 +1,4 @@
-"""Export the courses denoted in settings.OCW_WWW_TEST_SLUG and settings.OCW_COURSE_TEST_SLUG"""  # noqa: E501, INP001
+"""Export the courses denoted in settings.OCW_TEST_SITE_SLUGS"""  # noqa: INP001
 import json
 from pathlib import Path
 
@@ -11,16 +11,14 @@ from websites.serializers import ExportWebsiteContentSerializer, ExportWebsiteSe
 
 
 class Command(BaseCommand):
-    """Export the courses denoted in settings.OCW_WWW_TEST_SLUG and settings.OCW_COURSE_TEST_SLUG"""  # noqa: E501
+    """Export the courses denoted in settings.OCW_TEST_SITE_SLUGS"""
 
     help = __doc__  # noqa: A003
 
     def handle(self, *args, **options):  # noqa: ARG002
-        www_slug = settings.OCW_WWW_TEST_SLUG
-        course_slug = settings.OCW_COURSE_TEST_SLUG
-        websites = Website.objects.filter(name__in=[www_slug, course_slug]).order_by(
-            "pk"
-        )
+        websites = Website.objects.filter(
+            name__in=settings.OCW_TEST_SITES_SLUGS
+        ).order_by("pk")
         serialized_websites = ExportWebsiteSerializer(instance=websites, many=True).data
         content = WebsiteContent.objects.filter(website__in=websites).order_by("pk")
         serialized_website_content = ExportWebsiteContentSerializer(

--- a/websites/models.py
+++ b/websites/models.py
@@ -207,8 +207,15 @@ class Website(TimestampedModel):
             if version == VERSION_LIVE
             else settings.OCW_STUDIO_DRAFT_URL
         )
+        if self.name in settings.OCW_TEST_SITE_SLUGS:
+            base_url = settings.OCW_STUDIO_TEST_URL
         url_path = self.url_path
-        if url_path and self.name != settings.ROOT_WEBSITE_NAME:
+
+        if (
+            url_path
+            and self.name != settings.ROOT_WEBSITE_NAME
+            and self.name != settings.TEST_ROOT_WEBSITE_NAME
+        ):
             return urljoin(base_url, url_path)
         else:
             return urljoin(base_url, self.get_site_root_path())

--- a/websites/models_test.py
+++ b/websites/models_test.py
@@ -191,6 +191,20 @@ def test_website_content_unpublished():
     [
         ["test-course", "courses", False, "live", "courses/test-course"],  # noqa: PT007
         ["ocw-home-page", "", True, "draft", ""],  # noqa: PT007
+        [  # noqa: PT007
+            "ocw-ci-test-course",
+            "courses",
+            False,
+            "draft",
+            "courses/ocw-ci-test-course",
+        ],
+        [  # noqa: PT007
+            "ocw-ci-test-course",
+            "courses",
+            False,
+            "live",
+            "courses/ocw-ci-test-course",
+        ],
     ],
 )
 def test_website_get_full_url(  # noqa: PLR0913
@@ -199,11 +213,15 @@ def test_website_get_full_url(  # noqa: PLR0913
     """Verify that Website.get_full_url returns the expected value"""
     settings.OCW_STUDIO_LIVE_URL = "http://test-live.edu"
     settings.OCW_STUDIO_DRAFT_URL = "http://test-draft.edu"
+    settings.OCW_STUDIO_TEST_URL = "http://test-test.edu"
+    settings.OCW_TEST_SITE_SLUGS = ["ocw-ci-test-course"]
     expected_domain = (
         settings.OCW_STUDIO_LIVE_URL
         if version == "live"
         else settings.OCW_STUDIO_DRAFT_URL
     )
+    if name in settings.OCW_TEST_SITE_SLUGS:
+        expected_domain = settings.OCW_STUDIO_TEST_URL
     starter = WebsiteStarterFactory.create()
     starter.config["root-url-path"] = root_url
     starter.save()

--- a/websites/utils.py
+++ b/websites/utils.py
@@ -92,4 +92,4 @@ def resource_reference_field_filter(
 
 
 def is_test_site(site_name: str) -> bool:
-    return site_name in [settings.OCW_WWW_TEST_SLUG, settings.OCW_COURSE_TEST_SLUG]
+    return site_name in settings.OCW_TEST_SITE_SLUGS

--- a/websites/views.py
+++ b/websites/views.py
@@ -29,7 +29,7 @@ from gdrive_sync.constants import WebsiteSyncStatus
 from gdrive_sync.tasks import import_website_files
 from main import features
 from main.permissions import ReadonlyPermission
-from main.utils import is_dev, uuid_string, valid_key
+from main.utils import uuid_string, valid_key
 from main.views import DefaultPagination
 from users.models import User
 from websites import constants
@@ -77,10 +77,6 @@ from websites.site_config_api import SiteConfig
 from websites.utils import get_valid_base_filename, permissions_group_name_for_role
 
 log = logging.getLogger(__name__)
-
-test_site_filter = Q(
-    name__in=[settings.OCW_WWW_TEST_SLUG, settings.OCW_COURSE_TEST_SLUG]
-)
 
 
 class WebsiteViewSet(
@@ -158,9 +154,6 @@ class WebsiteViewSet(
                 queryset = queryset.filter(published_filter)
             else:
                 queryset = queryset.exclude(published_filter)
-
-        if not is_dev():
-            queryset = queryset.exclude(test_site_filter)
 
         return queryset.select_related("starter").order_by(ordering)
 
@@ -346,8 +339,6 @@ class WebsiteMassBuildViewSet(viewsets.ViewSet):
         if starter:
             sites = sites.filter(starter=WebsiteStarter.objects.get(slug=starter))
         sites = sites.prefetch_related("starter").order_by("name")
-        if not is_dev():
-            sites = sites.exclude(test_site_filter)
         serializer = WebsiteMassBuildSerializer(instance=sites, many=True)
         return Response({"sites": serializer.data})
 
@@ -369,8 +360,6 @@ class WebsiteUnpublishViewSet(viewsets.ViewSet):
             .prefetch_related("starter")
             .order_by("name")
         )
-        if not is_dev():
-            sites = sites.exclude(test_site_filter)
         serializer = WebsiteUnpublishSerializer(instance=sites, many=True)
         return Response({"sites": serializer.data})
 

--- a/websites/views.py
+++ b/websites/views.py
@@ -125,6 +125,10 @@ class WebsiteViewSet(
             # Other authenticated users should get a list of websites they are editors/admins/owners for.  # noqa: E501
             queryset = get_objects_for_user(user, constants.PERMISSION_VIEW)
 
+        # Only superusers should be able to edit the test sites
+        if not self.request.user.is_superuser:
+            queryset = queryset.exclude(name__in=settings.OCW_TEST_SITE_SLUGS)
+
         if search is not None and search != "":
             # search query param is used in react-select typeahead, and should
             # match on the title, name, and short_id

--- a/websites/views.py
+++ b/websites/views.py
@@ -338,6 +338,8 @@ class WebsiteMassBuildViewSet(viewsets.ViewSet):
         # If a starter has been specified by the query, only return sites made with that starter  # noqa: E501
         if starter:
             sites = sites.filter(starter=WebsiteStarter.objects.get(slug=starter))
+        # Exclude the test sites from the mass build
+        sites = sites.exclude(name__in=settings.OCW_TEST_SITE_SLUGS)
         sites = sites.prefetch_related("starter").order_by("name")
         serializer = WebsiteMassBuildSerializer(instance=sites, many=True)
         return Response({"sites": serializer.data})

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -111,13 +111,15 @@ def test_websites_endpoint_list(drf_client, filter_by_type, websites, settings):
         ] <= now.strftime(ISO_8601_FORMAT)
 
 
-def test_websites_endpoint_list_permissions(drf_client, permission_groups):
+def test_websites_endpoint_list_permissions(drf_client, permission_groups, settings):
     """Authenticated users should only see the websites they have permissions for"""
+    settings.OCW_TEST_SITE_SLUGS = ["ocw-ci-test-course"]
     for [user, count] in [
         [permission_groups.global_admin, 2],
         [permission_groups.global_author, 0],
         [permission_groups.site_admin, 1],
         [permission_groups.websites[0].owner, 2],
+        [permission_groups.superuser, 3],
     ]:
         drf_client.force_login(user)
         resp = drf_client.get(reverse("websites_api-list"))


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/2112

### Description (What does it do?)
This PR makes some changes that allows editing of test sites directly from the `ocw-studio` sites UI and ensures that any publishing action pushes the output up to the test bucket instead of the draft / live buckets. Instead of 2 specific env variables for the test sites (`OCW_WWW_TEST_SLUG` and `OCW_COURSE_TEST_SLUG`) we now have `TEST_ROOT_WEBSITE_NAME` and `OCW_TEST_SITE_SLUGS`. The `OCW_TEST_SITE_SLUGS` variable is intended to be a list of strings, allowing the specification of any number of test sites to be included in the end to end test pipeline. In `e2e_test_site_pipeline.py`, these sites are iterated and pipeline steps are generated based on them and added to the `across`. The logic determining what to override if a site is a test site was moved directly into `site_pipeline.py`. Whether or not a site is a test site is determined simply by seeing if the current site's `name` is in `settings.OCW_TEST_SITE_SLUGS`. If this is true;

 - `noindex` is set to `True`
 - `web_bucket` is set to `settings.AWS_TEST_BUCKET_NAME`
 - `offline_bucket` is set to `settings.AWS_OFFLINE_TEST_BUCKET_NAME`
 - `static_api_url` is set to `settings.STATIC_API_BASE_URL_TEST` (or the `DEV_TEST_URL` constant, if `is_dev` is true)
 - `resource_base_url` is set to `static_api_url`
 - `sitemap_domain` is set to the parsed domain of `static_api_url`
 - `ocw_studio_url` is set to `static_api_url` if the test website is the root test website, otherwise it's a blank string
 - If the site is the root test website, `url_path` is set to the website's `name` property

### How can this be tested?
 - Make sure you have done the basic setup of `ocw-studio` and are configured for publishing courses locally as well as running the end to end test pipeline locally. Read more here: https://github.com/mitodl/ocw-studio/?tab=readme-ov-file#end-to-end-testing-of-site-pipelines
 - Make sure you have the following new env variables set in your `.env` file:
```
TEST_ROOT_WEBSITE_NAME = "ocw-ci-test-www"
OCW_TEST_SITE_SLUGS=["ocw-ci-test-www","ocw-ci-test-course"]
OCW_STUDIO_TEST_URL=http://localhost:8046/
```
 - Go to http://localhost:8043/sites/ocw-ci-test-www and publish the site live, verifying that the publish URL in the drawer shows http://localhost:8046/. When the pipeline succeeds, browse here and verify that the page loads. Images may not load in your browser, because the HTML is pointing to the internal Docker IP of the nginx server. This is done so that when the end to end test pipeline is running within Concourse, it can load the page properly.
 - Do the same at http://localhost:8043/sites/ocw-ci-test-course, but the URL in the publish drawer should be http://localhost:8046/courses/ocw-ci-test-course.
 - Upsert the end to end test pipeline with `docker compose exec web ./manage.py upsert_e2e_test_pipeline`
 - Browse to http://localhost:8080 and locate the end to end test pipeline. Unpause and run it. The pipeline should succeed.
 - Upsert the mass build pipeline with `docker compose exec web ./manage.py upsert_mass_build_pipeline`
 - Make sure you have the [`fly` CLI](https://concourse-ci.org/fly.html) installed locally, and have used `fly login` to add your locally running Concourse instance as a target
 - Run the following commands and ensure that you get nothing back from either of them:
```
fly -t local get-pipeline -p 'mass-build-sites/offline:false,prefix:"",projects_branch:main,starter:"",themes_branch:main,version:draft' | grep ocw-ci-test-www
fly -t local get-pipeline -p 'mass-build-sites/offline:false,prefix:"",projects_branch:main,starter:"",themes_branch:main,version:draft' | grep ocw-ci-test-course
```
 - Pick any non-test website and go to its editor, for example: http://localhost:8043/sites/6-801-machine-vision-fall-2020/
 - Refresh the pipeline for that site i.e. `docker compose exec web ./manage.py backpopulate_pipelines --filter 6-801-machine-vision-fall-2020`
 - Back on the `ocw-studio` page publish the site live, waiting for it to succeed
 - Click the link in the publish drawer to browse the site, which should be like http://localhost:8045/courses/6-801-machine-vision-fall-2020/
