### PR TITLE
fix links in prefixed sites built with the mass-build-sites pipeline

### DIFF
--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -161,6 +161,7 @@ class SitePipelineDefinitionConfig:
         self.offline_bucket = offline_bucket
         self.static_api_url = static_api_url
         self.sitemap_domain = sitemap_domain
+        self.prefix = f"{prefix.strip('/')}/" if prefix != "" else prefix
         self.url_path = site.get_url_path()
         self.resource_base_url = resource_base_url
         self.ocw_studio_url = get_ocw_studio_api_url()
@@ -198,7 +199,7 @@ class SitePipelineDefinitionConfig:
         base_online_args.update(
             {
                 "--config": f"../{OCW_HUGO_PROJECTS_GIT_IDENTIFIER}/{starter_slug}/config.yaml",  # noqa: E501
-                "--baseURL": f"/{self.base_url}",
+                "--baseURL": f"/{self.prefix}{self.base_url}",
                 "--destination": "output-online",
             }
         )
@@ -253,7 +254,7 @@ class SitePipelineDefinitionConfig:
             "ocw_studio_url": self.ocw_studio_url,
             "hugo_args_online": hugo_args_online,
             "hugo_args_offline": hugo_args_offline,
-            "prefix": f"{prefix.strip('/')}/" if prefix != "" else prefix,
+            "prefix": self.prefix,
         }
 
 

--- a/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
@@ -618,5 +618,6 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
     assert dummy_vars["ocw_hugo_projects_url"] == website.starter.ocw_hugo_projects_url
     assert dummy_vars["ocw_hugo_projects_branch"] == ocw_hugo_projects_branch
     assert dummy_vars["hugo_args_online"] == config.hugo_args_online
+    assert f"--baseURL /{prefix.lstrip('/')}" in dummy_vars["hugo_args_online"]
     assert dummy_vars["hugo_args_offline"] == config.hugo_args_offline
     assert dummy_vars["prefix"] == expected_prefix


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/2113

### Description (What does it do?)
This PR takes the `prefix` argument being sent to `SitePipelineDefinition` and in addition to prefixing the S3 path with it, the Hugo `baseURL` argument is now also prefixed. This means that links rendered inside of sites deployed at a prefix URL will correctly link you to the prefixed page, at least for content generated by Hugo.

### How can this be tested?
 - Make sure you have run through the basic requirements for setting up `ocw-studio` and can publish sites locally
 - Run `docker compose exec web ./manage.py upsert_mass_build_pipeline --prefix test-prefix`
 - Browse to http://localhost:8080 and log into the Concourse web UI
 - Find the prefixed mass build pipeline, unpause it and trigger the first batch. You can pause it after, as you only need to run through one batch to test this.
 - In the batch's `across` step, find of of the sites it published and copy the `url_path`. Browse to the site by appending the `url_path` and the prefix to http://localhost:8045/. It should be something like `http://localhost:8045/test-prefix/courses/site-name`
 - Click the links in the sidebar to browse the different parts of the site and verify that you stay under the `test-prefix`
