### PR TITLE
fix: increase timeout for e2e tests

### DIFF
--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
@@ -286,8 +286,8 @@ class EndToEndTestPipelineDefinition(Pipeline):
         tasks.append(
             TaskStep(
                 task=playwright_task_identifier,
-                timeout="20m",
-                attempts=3,
+                timeout="2h",
+                attempts=1,
                 config=TaskConfig(
                     platform="linux",
                     image_resource=PLAYWRIGHT_REGISTRY_IMAGE,


### PR DESCRIPTION
### What are the relevant tickets?
Relates to https://github.com/mitodl/ocw-studio/pull/2125

### Description (What does it do?)

I recently updated e2e tests and the RC pipeline keeps timing out on the [`playwright-task` task](https://cicd-qa.odl.mit.edu/teams/ocw/pipelines/e2e-test-pipeline/jobs/e2e-test-job/builds/85). Upon running the pipeline locally, I faced a similar issue a few times, and increasing the timeout fixed it. I believe the issue is related to limited resources/bandwidth.

Each test has a timeout of [60 seconds](https://github.com/mitodl/ocw-hugo-themes/blob/075510444c58e88624c2525457d38fd4a049deb6/playwright.config.ts#L12) and we have 80 test at the moment. I've chosen a 2h timeout based on the rule:

```
task_timeout > max_playwright_timeout_all_tests + buffer (for browser installation and such)
```


### How can this be tested?

1. Navigate to your local `ocw-studio` directory.
2. Checkout the branch `hussaintaj/increase-e2e-test-timeout`.
3. Start/Restart Studio.
4. Run
   ```
   docker compose exec web ./manage.py upsert_e2e_test_pipeline 
   ```
5. Open your concourse and trigger a build.
6. Expect the pipeline to finish without a timeout.
    > We're not looking for the tests to pass. We just want to make sure it doesn't timeout. You will need to have the ci courses in your git backend.

