### PR TITLE
feat: add link to external resource rules

### DIFF
--- a/websites/constants.py
+++ b/websites/constants.py
@@ -10,6 +10,7 @@ CONTENT_TYPE_INSTRUCTOR = "instructor"
 CONTENT_TYPE_METADATA = "sitemetadata"
 CONTENT_TYPE_NAVMENU = "navmenu"
 CONTENT_TYPE_COURSE_LIST = "course-lists"
+CONTENT_TYPE_EXTERNAL_RESOURCE = "external-resource"
 
 
 COURSE_PAGE_LAYOUTS = ["instructor_insights"]

--- a/websites/management/commands/markdown_cleaning/cleanup_rule.py
+++ b/websites/management/commands/markdown_cleaning/cleanup_rule.py
@@ -18,6 +18,10 @@ class MarkdownCleanupRule(abc.ABC):
     rules, inherit from RegexpCleanupRule.
     """
 
+    def set_options(self, options: dict | None = None):
+        """Arbitrary options for any particular rule instance."""
+        self.options = options
+
     @property
     @abc.abstractclassmethod
     def alias(cls) -> str:

--- a/websites/management/commands/markdown_cleaning/rules/link_to_external_resource.py
+++ b/websites/management/commands/markdown_cleaning/rules/link_to_external_resource.py
@@ -29,6 +29,12 @@ class LinkToExternalResourceRule(PyparsingRule):
 
     fields = [
         "markdown",
+        "metadata.related_resources_text",
+        "metadata.image_metadata.caption",
+        "metadata.image_metadata.credit",
+        "metadata.optional_text",
+        "metadata.description",
+        "metadata.course_description",
     ]
 
     @dataclass
@@ -71,7 +77,7 @@ class LinkToExternalResourceRule(PyparsingRule):
         )
         metadata["external_url"] = toks.link.destination
 
-        text_id = uuid_string()  # to avoid collisions
+        text_id = uuid_string()
         link_text = toks.link.text
         config_item = config.find_item_by_name(CONTENT_TYPE_EXTERNAL_RESOURCE)
 
@@ -86,14 +92,13 @@ class LinkToExternalResourceRule(PyparsingRule):
                 "is_page_content": config.is_page_content(config_item),
                 "filename": slugify(
                     get_valid_base_filename(
-                        f"{link_text}_{text_id}", CONTENT_TYPE_EXTERNAL_RESOURCE
+                        f"{link_text}_{text_id}",  # to avoid collisions
+                        CONTENT_TYPE_EXTERNAL_RESOURCE,
                     ),
                     allow_unicode=True,
                 ),
             },
         )
-
-        resource.delete()
 
         shortcode = ShortcodeTag.resource_link(resource.text_id, link_text)
 

--- a/websites/management/commands/markdown_cleaning/rules/link_to_external_resource.py
+++ b/websites/management/commands/markdown_cleaning/rules/link_to_external_resource.py
@@ -107,9 +107,9 @@ class LinkToExternalResourceRule(PyparsingRule):
     Example:
     From:
     ```
-        [OCW](https://ocw.mit.edu)
-        [OCW clone](https://ocw.mit.edu)
-        [OCW same but not so](https://ocw.mit.edu#fragment)
+    [OCW](https://ocw.mit.edu)
+    [OCW clone](https://ocw.mit.edu)
+    [OCW same but not so](https://ocw.mit.edu#fragment)
     ```
 
     To:
@@ -140,7 +140,7 @@ class LinkToExternalResourceRule(PyparsingRule):
         note: str
         url: str = ""
         external_resource: str = ""
-        has_external_license_warning: bool = ""
+        has_external_license_warning: bool = True
 
     def __init__(self) -> None:
         super().__init__()
@@ -227,7 +227,7 @@ class NavItemToExternalResourceRule(MarkdownCleanupRule):
         ```
         [
             {
-                "name": "Nest",
+                "name": "Name",
                 "weight": 10,
                 "identifier": "f3d0ebae-7083-4524-9b93-f688537a0317"
             }
@@ -254,7 +254,7 @@ class NavItemToExternalResourceRule(MarkdownCleanupRule):
 
     def generate_item_replacement(
         self, website_content: WebsiteContent, item: dict
-    ) -> dict:
+    ) -> tuple[dict, WebsiteContent]:
         """
         Generate a new item linked to an external resource using
         the values from `item`.

--- a/websites/management/commands/markdown_cleaning/rules/link_to_external_resource.py
+++ b/websites/management/commands/markdown_cleaning/rules/link_to_external_resource.py
@@ -188,8 +188,8 @@ class LinkToExternalResourceRule(PyparsingRule):
 
         return shortcode.to_hugo(), self.ReplacementNotes(
             note="replaced successfully",
-            url=url,
-            external_resource=resource,
+            url=toks.link.destination,
+            external_resource=resource.text_id,
             has_external_license_warning=resource.metadata[
                 "has_external_license_warning"
             ],

--- a/websites/management/commands/markdown_cleaning/rules/link_to_external_resource.py
+++ b/websites/management/commands/markdown_cleaning/rules/link_to_external_resource.py
@@ -1,0 +1,108 @@
+from dataclasses import dataclass
+from functools import partial
+from urllib.parse import urlparse
+
+from django.conf import settings
+from django.utils.text import slugify
+
+from main.utils import uuid_string
+from websites.constants import CONTENT_TYPE_EXTERNAL_RESOURCE
+from websites.management.commands.markdown_cleaning.cleanup_rule import PyparsingRule
+from websites.management.commands.markdown_cleaning.link_parser import (
+    LinkParser,
+    LinkParseResult,
+)
+from websites.management.commands.markdown_cleaning.parsing_utils import ShortcodeTag
+from websites.management.commands.markdown_cleaning.utils import StarterSiteConfigLookup
+from websites.models import WebsiteContent
+from websites.utils import get_valid_base_filename
+
+
+class LinkToExternalResourceRule(PyparsingRule):
+    """
+    Convert links to external resources.
+    """
+
+    alias = "link_to_external_resource"
+
+    Parser = partial(LinkParser, recursive=True)
+
+    fields = [
+        "markdown",
+    ]
+
+    @dataclass
+    class ReplacementNotes:
+        note: str
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.starter_lookup = StarterSiteConfigLookup()
+
+    def replace_match(
+        self,
+        s: str,  # noqa: ARG002
+        l: int,  # noqa: E741, ARG002
+        toks: LinkParseResult,
+        website_content: WebsiteContent,
+    ):
+        link = toks.link
+        try:
+            url = urlparse(link.destination)
+        except ValueError:
+            return toks.original_text, self.ReplacementNotes(note="invalid url")
+
+        if not url.scheme.startswith("http"):
+            return toks.original_text, self.ReplacementNotes(note="not external")
+
+        if toks.link.is_image:
+            return toks.original_text, self.ReplacementNotes(note="is image")
+
+        starter_id = website_content.website.starter_id
+        starter = self.starter_lookup.get_starter(starter_id)
+
+        if starter.slug != settings.OCW_COURSE_STARTER_SLUG:
+            return toks.original_text, self.ReplacementNotes(note="not course content")
+
+        config = self.starter_lookup.get_config(starter_id)
+
+        metadata = config.generate_item_metadata(
+            CONTENT_TYPE_EXTERNAL_RESOURCE, use_defaults=True
+        )
+        metadata["external_url"] = toks.link.destination
+
+        text_id = uuid_string()  # to avoid collisions
+        link_text = toks.link.text
+        config_item = config.find_item_by_name(CONTENT_TYPE_EXTERNAL_RESOURCE)
+
+        resource, _ = WebsiteContent.objects.get_or_create(
+            metadata=metadata,
+            dirpath=config_item.file_target,
+            website=website_content.website,
+            type=CONTENT_TYPE_EXTERNAL_RESOURCE,
+            defaults={
+                "text_id": text_id,
+                "title": link_text,
+                "is_page_content": config.is_page_content(config_item),
+                "filename": slugify(
+                    get_valid_base_filename(
+                        f"{link_text}_{text_id}", CONTENT_TYPE_EXTERNAL_RESOURCE
+                    ),
+                    allow_unicode=True,
+                ),
+            },
+        )
+
+        resource.delete()
+
+        shortcode = ShortcodeTag.resource_link(resource.text_id, link_text)
+
+        return shortcode.to_hugo(), self.ReplacementNotes(note="replaced successfully")
+
+    def should_parse(self, text: str):
+        """Should the text be parsed?
+
+        If the text does not contain '](', then it definitely does not have
+        markdown links.
+        """  # noqa: D401
+        return "](" in text

--- a/websites/management/commands/markdown_cleaning/rules/link_to_external_resource.py
+++ b/websites/management/commands/markdown_cleaning/rules/link_to_external_resource.py
@@ -101,6 +101,24 @@ class LinkToExternalResourceRule(PyparsingRule):
     """
     Converts links to external resources by replacing
     markdown links with resource_link shortcodes.
+
+    Creates new WebsiteContent objects for unqiue links.
+
+    Example:
+    From:
+    ```
+        [OCW](https://ocw.mit.edu)
+        [OCW clone](https://ocw.mit.edu)
+        [OCW same but not so](https://ocw.mit.edu#fragment)
+    ```
+
+    To:
+    ```
+    {{% resource_link "f3d0ebae-7083-4524-9b93-f688537a0317" "OCW" %}}
+    {{% resource_link "f3d0ebae-7083-4524-9b93-f688537a0317" "OCW clone" %}}
+    {{% resource_link "d3d0ebae-7083-3453-7b92-a688537a0276" "OCW same but not so" %}}
+    ```
+    and two new WebsiteContent objects.
     """
 
     alias = "link_to_external_resource"
@@ -189,6 +207,33 @@ class NavItemToExternalResourceRule(MarkdownCleanupRule):
     Convert navigation menu's external links to external resources.
 
     Creates a new external resource for each link.
+
+    Example
+        From:
+
+        ```
+        [
+            {
+                "name": "Name",
+                "url": "https://ocw.mit.edu",
+                "weight": 10,
+                "identifier": "external--760432549-1711617249481"
+            }
+        ]
+        ```
+
+        To:
+
+        ```
+        [
+            {
+                "name": "Nest",
+                "weight": 10,
+                "identifier": "f3d0ebae-7083-4524-9b93-f688537a0317"
+            }
+        ]
+        ```
+        and a new corresponding WebsiteContent object.
     """
 
     alias = "nav_item_to_external_resource"
@@ -242,7 +287,7 @@ class NavItemToExternalResourceRule(MarkdownCleanupRule):
         self, website_content: WebsiteContent, text: list[dict], on_match
     ) -> str:
         """
-        Return new text to relace `text`.
+        Return new text to replace `text`.
         """
         nav_items = text
         transformed_items = []

--- a/websites/management/commands/markdown_cleaning/rules/link_to_external_resource_test.py
+++ b/websites/management/commands/markdown_cleaning/rules/link_to_external_resource_test.py
@@ -20,11 +20,7 @@ from websites.management.commands.markdown_cleaning.rules.link_to_external_resou
 from websites.models import WebsiteContent
 from websites.site_config_api import SiteConfig
 
-EXAMPLE_RESOLVEUID = "89ce47d27edcdd9b8a8cbe641a59b520"
-EXAMPLE_RESOLVEUID_FORMATTED = "89ce47d2-7edc-dd9b-8a8c-be641a59b520"
-
-
-SITE_CONFIG = {
+SAMPLE_SITE_CONFIG = {
     "collections": [
         {
             "category": "Content",
@@ -117,13 +113,16 @@ def test_is_ocw_domain_url(url, expected_result):
 
 def test_build_external_resource():
     """Test build_external_resource."""
-    starter = WebsiteStarterFactory.create(config=SITE_CONFIG)
+    starter = WebsiteStarterFactory.create(config=SAMPLE_SITE_CONFIG)
     website = WebsiteFactory.create(starter=starter)
     title = "title"
     url = "https://google.com"
 
     external_resource = build_external_resource(
-        website=website, site_config=SiteConfig(SITE_CONFIG), title=title, url=url
+        website=website,
+        site_config=SiteConfig(SAMPLE_SITE_CONFIG),
+        title=title,
+        url=url,
     )
 
     assert external_resource.title == title
@@ -136,11 +135,11 @@ def test_build_external_resource():
 @pytest.mark.parametrize("content_exists", [True, False])
 def test_get_or_build_external_resource(content_exists):
     """Test get_or_build_external_resource builds or gets depending on content existence."""
-    starter = WebsiteStarterFactory.create(config=SITE_CONFIG)
+    starter = WebsiteStarterFactory.create(config=SAMPLE_SITE_CONFIG)
     website = WebsiteFactory.create(starter=starter)
     title = "title"
     url = "https://google.com"
-    site_config = SiteConfig(SITE_CONFIG)
+    site_config = SiteConfig(SAMPLE_SITE_CONFIG)
     config_item = site_config.find_item_by_name(CONTENT_TYPE_EXTERNAL_RESOURCE)
 
     if content_exists:
@@ -158,7 +157,10 @@ def test_get_or_build_external_resource(content_exists):
         )
 
     external_resource = get_or_build_external_resource(
-        website=website, site_config=SiteConfig(SITE_CONFIG), title=title, url=url
+        website=website,
+        site_config=SiteConfig(SAMPLE_SITE_CONFIG),
+        title=title,
+        url=url,
     )
 
     assert external_resource.title == title
@@ -199,7 +201,7 @@ def test_link_to_external_resources(settings, content, expected_content_template
     Test link_to_external_resources correctly replaces links
     with resource_link shortcode.
     """
-    starter = WebsiteStarterFactory.create(config=SITE_CONFIG)
+    starter = WebsiteStarterFactory.create(config=SAMPLE_SITE_CONFIG)
     website = WebsiteFactory.create(starter=starter)
     settings.OCW_COURSE_STARTER_SLUG = starter.slug
 
@@ -311,7 +313,7 @@ def test_link_to_external_resources(settings, content, expected_content_template
 )
 def test_nav_item_to_external_resources(content, expected_content_template):
     """Test nav_item_to_external_resource correctly converts external links to external resources."""
-    starter = WebsiteStarterFactory.create(config=SITE_CONFIG)
+    starter = WebsiteStarterFactory.create(config=SAMPLE_SITE_CONFIG)
     website = WebsiteFactory.create(starter=starter)
 
     target_content = WebsiteContentFactory.create(

--- a/websites/management/commands/markdown_cleaning/rules/link_to_external_resource_test.py
+++ b/websites/management/commands/markdown_cleaning/rules/link_to_external_resource_test.py
@@ -1,0 +1,344 @@
+"""Tests for link_resolveuid.py"""
+import pytest
+
+from websites.constants import CONTENT_TYPE_EXTERNAL_RESOURCE
+from websites.factories import (
+    WebsiteContentFactory,
+    WebsiteFactory,
+    WebsiteStarterFactory,
+)
+from websites.management.commands.markdown_cleaning.cleaner import (
+    WebsiteContentMarkdownCleaner as Cleaner,
+)
+from websites.management.commands.markdown_cleaning.rules.link_to_external_resource import (
+    LinkToExternalResourceRule,
+    NavItemToExternalResourceRule,
+    build_external_resource,
+    get_or_build_external_resource,
+    is_ocw_domain_url,
+)
+from websites.models import WebsiteContent
+from websites.site_config_api import SiteConfig
+
+EXAMPLE_RESOLVEUID = "89ce47d27edcdd9b8a8cbe641a59b520"
+EXAMPLE_RESOLVEUID_FORMATTED = "89ce47d2-7edc-dd9b-8a8c-be641a59b520"
+
+
+SITE_CONFIG = {
+    "collections": [
+        {
+            "category": "Content",
+            "fields": [
+                {
+                    "help": "The URL. For example, https://owl.english.purdue.edu/owl/resource/747/01/\n",
+                    "label": "URL",
+                    "name": "external_url",
+                    "required": True,
+                    "widget": "string",
+                },
+                {
+                    "default": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+                    "label": "License",
+                    "name": "license",
+                    "options": [
+                        {
+                            "label": "CC BY-NC-SA",
+                            "value": "https://creativecommons.org/licenses/by-nc-sa/4.0/",
+                        },
+                        {
+                            "label": "CC BY",
+                            "value": "https://creativecommons.org/licenses/by/4.0/",
+                        },
+                    ],
+                    "required": True,
+                    "widget": "select",
+                },
+                {
+                    "default": True,
+                    "help": "If true, user sees warning that external content is not covered by OCW licensing.\n",
+                    "label": "Include non-OCW licensing warning",
+                    "name": "has_external_license_warning",
+                    "required": True,
+                    "widget": "boolean",
+                },
+                {
+                    "default": None,
+                    "help": "Whether or not this link is broken.",
+                    "label": "Is Broken",
+                    "name": "is_broken",
+                    "required": True,
+                    "widget": "hidden",
+                },
+                {
+                    "default": None,
+                    "help": "URL to use when is_broken is true.",
+                    "label": "Internet Archive Backup URL",
+                    "name": "backup_url",
+                    "required": True,
+                    "widget": "hidden",
+                },
+            ],
+            "folder": "content/external-resources",
+            "label": "External Resources",
+            "name": "external-resource",
+        },
+    ],
+    "root-url-path": "courses",
+    "site-url-format": "[sitemetadata:primary_course_number]-[sitemetadata:course_title]-[sitemetadata:term]-[sitemetadata:year]",
+}
+
+pytestmark = pytest.mark.django_db
+
+
+def get_cleaner(rule_type):
+    """Get cleaner for this test module."""
+    if rule_type == "markdown":
+        rule = LinkToExternalResourceRule()
+    else:
+        rule = NavItemToExternalResourceRule()
+
+    rule.set_options({"commit": True})
+
+    return Cleaner(rule)
+
+
+@pytest.mark.parametrize(
+    ("url", "expected_result"),
+    [
+        ("https://ocw.mit.edu", True),
+        ("https://google.com", False),
+    ],
+)
+def test_is_ocw_domain_url(url, expected_result):
+    """Test is_ocw_domain_url."""
+    result = is_ocw_domain_url(url)
+    assert result == expected_result
+
+
+def test_build_external_resource():
+    """Test build_external_resource."""
+    starter = WebsiteStarterFactory.create(config=SITE_CONFIG)
+    website = WebsiteFactory.create(starter=starter)
+    title = "title"
+    url = "https://google.com"
+
+    external_resource = build_external_resource(
+        website=website, site_config=SiteConfig(SITE_CONFIG), title=title, url=url
+    )
+
+    assert external_resource.title == title
+    assert external_resource.metadata["external_url"] == url
+    assert external_resource.metadata["has_external_license_warning"] is True
+    assert not bool(external_resource.metadata["is_broken"])
+    assert not bool(external_resource.metadata["backup_url"])
+
+
+@pytest.mark.parametrize("content_exists", [True, False])
+def test_get_or_build_external_resource(content_exists):
+    """Test get_or_build_external_resource builds or gets depending on content existence."""
+    starter = WebsiteStarterFactory.create(config=SITE_CONFIG)
+    website = WebsiteFactory.create(starter=starter)
+    title = "title"
+    url = "https://google.com"
+    site_config = SiteConfig(SITE_CONFIG)
+    config_item = site_config.find_item_by_name(CONTENT_TYPE_EXTERNAL_RESOURCE)
+
+    if content_exists:
+        existing_content = WebsiteContentFactory.create(
+            metadata={
+                "external_url": url,
+                "has_external_license_warning": True,
+                "is_broken": False,
+                "backup_url": None,
+            },
+            dirpath=config_item.file_target,
+            website=website,
+            type=CONTENT_TYPE_EXTERNAL_RESOURCE,
+            title=title,
+        )
+
+    external_resource = get_or_build_external_resource(
+        website=website, site_config=SiteConfig(SITE_CONFIG), title=title, url=url
+    )
+
+    assert external_resource.title == title
+    assert external_resource.metadata["external_url"] == url
+    assert external_resource.metadata["has_external_license_warning"] is True
+    assert not bool(external_resource.metadata["is_broken"])
+    assert not bool(external_resource.metadata["backup_url"])
+
+    if content_exists:
+        assert existing_content.id == external_resource.id
+
+
+@pytest.mark.parametrize(
+    ("content", "expected_content_template"),
+    [
+        (
+            R"""
+            ![image](https://example.com/image.jpg)
+            [invalid url](https://www.example website.com)
+            [internal url](/pages/page)
+            [OCW](https://ocw.mit.edu)
+            [OCW clone](https://ocw.mit.edu)
+            [OCW same but not so](https://ocw.mit.edu#fragment)
+            """,
+            R"""
+            ![image](https://example.com/image.jpg)
+            [invalid url](https://www.example website.com)
+            [internal url](/pages/page)
+            {{{{% resource_link "{text_id_1}" "OCW" %}}}}
+            {{{{% resource_link "{text_id_1}" "OCW clone" %}}}}
+            {{{{% resource_link "{text_id_2}" "OCW same but not so" %}}}}
+            """,
+        ),
+    ],
+)
+def test_link_to_external_resources(settings, content, expected_content_template):
+    """
+    Test link_to_external_resources correctly replaces links
+    with resource_link shortcode.
+    """
+    starter = WebsiteStarterFactory.create(config=SITE_CONFIG)
+    website = WebsiteFactory.create(starter=starter)
+    settings.OCW_COURSE_STARTER_SLUG = starter.slug
+
+    target_content = WebsiteContentFactory.create(
+        markdown=content,
+        website=website,
+        metadata={
+            "description": content,
+            "related_resources_text": content,
+            "optional_text": content,
+            "course_description": content,
+            "image_metadata": {
+                "caption": content,
+                "credit": content,
+            },
+        },
+    )
+
+    cleaner = get_cleaner("markdown")
+    cleaner.update_website_content(target_content)
+
+    wc_ocw = WebsiteContent.objects.get(title="OCW").text_id
+    wc_ocw_2 = WebsiteContent.objects.get(title="OCW same but not so")
+
+    expected_content = expected_content_template.format(
+        text_id_1=wc_ocw.text_id, text_id_2=wc_ocw_2.text_id
+    )
+
+    assert target_content.markdown == expected_content
+
+    for field in [
+        "description",
+        "related_resources_text",
+        "optional_text",
+        "course_description",
+    ]:
+        assert target_content.metadata[field] == expected_content
+
+    for field in ["credit", "caption"]:
+        assert target_content.metadata["image_metadata"][field] == expected_content
+
+
+@pytest.mark.parametrize(
+    ("content", "expected_content_template"),
+    [
+        (
+            [
+                {
+                    "name": "Nest",
+                    "url": "https://ocw.mit.edu",
+                    "weight": 10,
+                    "identifier": "external--760432549-1711617249481",
+                },
+                {
+                    "name": "Bird 1",
+                    "url": "https://ocw.mit.edu",
+                    "weight": 10,
+                    "identifier": "external--760432549-1711617249482",
+                    "parent": "external--760432549-1711617249481",
+                },
+                {
+                    "name": "Bird 2",
+                    "url": "https://ocw.mit.edu",
+                    "weight": 20,
+                    "identifier": "external--760432549-1711617249483",
+                    "parent": "external--760432549-1711617249481",
+                },
+                {
+                    "name": "Egg",
+                    "url": "https://ocw.mit.edu",
+                    "weight": 10,
+                    "identifier": "external--760432549-1711617249484",
+                    "parent": "external--760432549-1711617249483",
+                },
+                {
+                    "name": "Control",
+                    "weight": 20,
+                    "identifier": "f3d0ebae-7083-4524-9b93-f688537a0317",
+                },
+            ],
+            [
+                {"name": "Nest", "weight": 10, "identifier": "nest-id"},
+                {
+                    "name": "Bird 1",
+                    "weight": 10,
+                    "identifier": "bird-1-id",
+                    "parent": "nest-id",
+                },
+                {
+                    "name": "Bird 2",
+                    "weight": 20,
+                    "identifier": "bird-2-id",
+                    "parent": "nest-id",
+                },
+                {
+                    "name": "Egg",
+                    "weight": 10,
+                    "identifier": "egg-id",
+                    "parent": "bird-2-id",
+                },
+                {
+                    "name": "Control",
+                    "weight": 20,
+                    "identifier": "f3d0ebae-7083-4524-9b93-f688537a0317",
+                },
+            ],
+        ),
+    ],
+)
+def test_nav_item_to_external_resources(content, expected_content_template):
+    """Test nav_item_to_external_resource correctly converts external links to external resources."""
+    starter = WebsiteStarterFactory.create(config=SITE_CONFIG)
+    website = WebsiteFactory.create(starter=starter)
+
+    target_content = WebsiteContentFactory.create(
+        website=website,
+        metadata={
+            "leftnav": content,
+        },
+    )
+
+    cleaner = get_cleaner("nav_item")
+    cleaner.update_website_content(target_content)
+
+    content_ids = {
+        "nest-id": WebsiteContent.objects.get(title="Nest").text_id,
+        "bird-1-id": WebsiteContent.objects.get(title="Bird 1").text_id,
+        "bird-2-id": WebsiteContent.objects.get(title="Bird 2").text_id,
+        "egg-id": WebsiteContent.objects.get(title="Egg").text_id,
+    }
+
+    # replace placeholders in the templates with new ids.
+    expected_content = expected_content_template
+    for item in expected_content:
+        if item["name"] == "Control":
+            continue
+
+        item["identifier"] = content_ids[item["identifier"]]
+        if item.get("parent"):
+            item["parent"] = content_ids[item["parent"]]
+
+    assert target_content.metadata["leftnav"] == expected_content

--- a/websites/management/commands/markdown_cleaning/rules/link_to_external_resource_test.py
+++ b/websites/management/commands/markdown_cleaning/rules/link_to_external_resource_test.py
@@ -221,7 +221,7 @@ def test_link_to_external_resources(settings, content, expected_content_template
     cleaner = get_cleaner("markdown")
     cleaner.update_website_content(target_content)
 
-    wc_ocw = WebsiteContent.objects.get(title="OCW").text_id
+    wc_ocw = WebsiteContent.objects.get(title="OCW")
     wc_ocw_2 = WebsiteContent.objects.get(title="OCW same but not so")
 
     expected_content = expected_content_template.format(

--- a/websites/management/commands/markdown_cleaning/utils.py
+++ b/websites/management/commands/markdown_cleaning/utils.py
@@ -43,10 +43,15 @@ class StarterSiteConfigLookup:
             starter_id: list(config.iter_items())
             for starter_id, config in self._configs.items()
         }
+        self._starters = {starter.id: starter for starter in starters}
 
-    def get_config(self, starter_id):
+    def get_config(self, starter_id) -> SiteConfig:
         """Return SiteConfig for `starter_id`."""
         return self._configs[starter_id]
+
+    def get_starter(self, starter_id) -> WebsiteStarter:
+        """Return Starter for `starter_id`."""
+        return self._starters[starter_id]
 
     def config_items(self, starter_id):
         """Return a list ConfigItem for `starter_id`."""

--- a/websites/management/commands/markdown_cleanup.py
+++ b/websites/management/commands/markdown_cleanup.py
@@ -48,6 +48,7 @@ class Command(WebsiteFilterCommand):
         rules.BrokenMarkdownLinkFixRule,
         rules.BrokenMetadataLinkFixRule,
         rules.CourseAbsoluteLinkRule,
+        rules.LinkToExternalResourceRule,
     ]
 
     def add_arguments(self, parser: CommandParser) -> None:

--- a/websites/management/commands/markdown_cleanup.py
+++ b/websites/management/commands/markdown_cleanup.py
@@ -153,6 +153,7 @@ class Command(WebsiteFilterCommand):
 
         Rule = next(R for R in cls.Rules if R.alias == alias)
         rule = Rule()
+        rule.set_options({"commit": commit})
 
         cleaner = WebsiteContentMarkdownCleaner(rule)
 

--- a/websites/management/commands/markdown_cleanup.py
+++ b/websites/management/commands/markdown_cleanup.py
@@ -49,6 +49,7 @@ class Command(WebsiteFilterCommand):
         rules.BrokenMetadataLinkFixRule,
         rules.CourseAbsoluteLinkRule,
         rules.LinkToExternalResourceRule,
+        rules.NavItemToExternalResourceRule,
     ]
 
     def add_arguments(self, parser: CommandParser) -> None:


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/3678

### Description (What does it do?)

This PR creates two new markdown cleanup rules.

- `link_to_external_resource`: Converts markdown links present in the content body and metadata into external resources and `resource_link` shortcodes.
- `nav_item_external_resource`: Converts external menu links to external resources and updates menu accordingly.

Additionally, this PR introduces a new method on the `MarkdownCleanupRule` class. `set_options` allows a client to set dynamic options for a rule. This was introduced so that we could forward options like `commit` down to the rule's implementation.

Example outputs:

- [link_to_external_resource](https://docs.google.com/spreadsheets/d/1kl6jdFsOBNC-4PjhIfTgRgWiE2FPPKuL9pfXWr8u9hc/edit?usp=sharing)
- [nav_item_to_external_resource](https://docs.google.com/spreadsheets/d/1DhoHxK05V7Ur-vZs3nsEAgbYBbDnf3aOWw3g8AaWMAw/edit?usp=sharing)

### How can this be tested?

#### Prerequisites 

- A production or RC DB clone, or create a course with markdown links and external menu links.

#### Steps


1. Navigate to your local `ocw-studio` setup.
2. Checkout branch `hussaintaj/3678-migrate-link-2-external-resource`.
3. Start/Restart Studio.
4. Run the following set of commands.
    ```sh
    docker compose exec web ./manage.py markdown_cleanup link_to_external_resource --skip-sync --out link_to_external_resource.csv
    docker compose exec web ./manage.py markdown_cleanup nav_item_to_external_resource --skip-sync --out nav_item_to_external_resource.csv
    ```
5. Analyze the output files.
6. *Expect* changes to be predictable and valid.
7. Choose specific courses to apply the changes to and test builds with. For example, [this test course](https://ocw-studio-rc.odl.mit.edu/sites/ht-test-2024/).
8. Run the following set of commands for specific courses. These will run a rule for a specific course, reset the courses sync states, populate the course's pipelines, and sync the course markdown to the backend. So please make sure your GitHub backend is set up.
    ```sh
    COURSE_ID=<course-id>
    docker compose exec web ./manage.py markdown_cleanup <rule> --skip-sync --commit --filter $COURSE_ID
    docker compose exec web ./manage.py reset_sync_states --skip_sync --filter $COURSE_ID && docker compose exec web ./manage.py backpopulate_pipelines --filter $COURSE_ID && docker compose exec web ./manage.py sync_website_to_backend --filter $COURSE_ID --delete
    ```
9. Publish your changes from the Studio UI.
10. *Expect* the build to succeed.
11. *Expect* the external resources to be functioning properly i.e. they open external links, have the correct icon, and open a warning modal if applicable.
