### PR TITLE
Fix: Add nubbins for celery monitoring

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -690,6 +690,9 @@ CELERY_RESULT_SERIALIZER = "json"
 CELERY_ACCEPT_CONTENT = ["json"]
 CELERY_TIMEZONE = "UTC"
 
+CELERY_TASK_TRACK_STARTED = True
+CELERY_TASK_SEND_SENT_EVENT = True
+
 CELERY_BEAT_SCHEDULE = {
     "update-youtube-statuses": {
         "task": "videos.tasks.update_youtube_statuses",


### PR DESCRIPTION
This commit adds two Celery client configurables necessary for celery monitoring.

    CELERY_TASK_TRACK_STARTED
    CELERY_TASK_SEND_SENT_EVENT

For: mitodl/ol-infrastructure#2290

### What are the relevant tickets?
mitodl/ol-infrastructure#2290

### Description (What does it do?)
This commit adds two Celery client configurables necessary for [celery monitoring](https://celery-monitoring.odl.mit.edu).

    CELERY_TASK_TRACK_STARTED
    CELERY_TASK_SEND_SENT_EVENT


### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
Browse to
[celery monitoring](https://celery-monitoring.odl.mit.edu). Check task status for ocw studio.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
