### PR TITLE
Update actions: checkout, setup-python, setup-node, node-version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,8 @@ jobs:
         - 9200:9200
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+
 
     - name: update
       run: sudo apt-get update -y
@@ -60,7 +61,7 @@ jobs:
         virtualenvs-in-project: true
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
       with:
         python-version: "3.10.12"
         cache: "poetry"
@@ -120,10 +121,10 @@ jobs:
   frontend-tests:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
 
     - name: Setup NodeJS
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
       with:
         node-version: 20
         cache: yarn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         - 9200:9200
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: update
       run: sudo apt-get update -y
@@ -60,7 +60,7 @@ jobs:
         virtualenvs-in-project: true
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10.12"
         cache: "poetry"
@@ -120,12 +120,12 @@ jobs:
   frontend-tests:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Setup NodeJS
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: "16.15.0"
+        node-version: 20
         cache: yarn
 
     - name: Install dependencies

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -16,7 +16,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       with:
         ref: release
     - uses: akhileshns/heroku-deploy@9fd0f9faae4aa93a38d6f5e25b9128589f1371b0

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -16,7 +16,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: release
     - uses: akhileshns/heroku-deploy@9fd0f9faae4aa93a38d6f5e25b9128589f1371b0

--- a/.github/workflows/release-candiate.yml
+++ b/.github/workflows/release-candiate.yml
@@ -16,7 +16,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         ref: release-candidate
     - uses: akhileshns/heroku-deploy@9fd0f9faae4aa93a38d6f5e25b9128589f1371b0

--- a/.github/workflows/release-candiate.yml
+++ b/.github/workflows/release-candiate.yml
@@ -16,7 +16,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.workflow_run.conclusion == 'success'
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       with:
         ref: release-candidate
     - uses: akhileshns/heroku-deploy@9fd0f9faae4aa93a38d6f5e25b9128589f1371b0


### PR DESCRIPTION
### What are the relevant tickets?
None, but there are Renovate PRs:
https://github.com/mitodl/ocw-studio/pull/2143
https://github.com/mitodl/ocw-studio/pull/2144
https://github.com/mitodl/ocw-studio/pull/2145

### Description (What does it do?)
This PR updates versions of actions `checkout`, `setup-node`, `setup-python` and also updates `node-version`.
I have added them all in one place for easier testing via runner logs of workflow runs.
I upgraded `node-version` from `16.15.0` to `20`. The reason for this is `yarn v4` uses `>=18.12.0`. So we would be able to update `yarn` later .

### How can this be tested?
Check out the runner logs of PR's workflow runs, and you can compare it with any other PR's workflow runs to make sure everything is good.

Here are two runs of this PR:
https://github.com/mitodl/ocw-studio/actions/runs/8750466425
https://github.com/mitodl/ocw-studio/actions/runs/8751107510
