### PR TITLE
fix: metadata fields for migration rules

### DIFF
--- a/websites/management/commands/markdown_cleaning/rules/link_to_external_resource.py
+++ b/websites/management/commands/markdown_cleaning/rules/link_to_external_resource.py
@@ -43,7 +43,14 @@ def build_external_resource(
         CONTENT_TYPE_EXTERNAL_RESOURCE, use_defaults=True
     )
     metadata["external_url"] = url
-    metadata["has_external_licence_warning"] = not is_ocw_domain_url(url)
+    metadata["has_external_license_warning"] = not is_ocw_domain_url(url)
+
+    # title is a special field. By default the value of title
+    # is stored in `website_content.title` field. Having both,
+    # `website_content.title` and `website_content.metadata['title']`,
+    # not only confuses the developer but also some UI components like
+    # navmenu.
+    metadata.pop("title", None)
 
     config_item = site_config.find_item_by_name(CONTENT_TYPE_EXTERNAL_RESOURCE)
     text_id = uuid_string()


### PR DESCRIPTION
### What are the relevant tickets?

Relates to https://github.com/mitodl/ocw-hugo-projects/pull/292

### Description (What does it do?)

With https://github.com/mitodl/ocw-hugo-projects/pull/292 merged, the default metadata will have a `title` field. When migration is run on older data to create new external resource objects, those objects will have a `title` in their metadata field. This will cause the menu item selection UI to misbehave on Studio. This is because it prefers `website_content.metadata.title` over `website_content.title` (which is the default location of the title).

This PR prevents `title` from being added to the metadata and keeps the structure consistent with what normal flow gets us.

This PR also fixes a spelling error in a field name `has_external_licence_warning` -> `has_external_license_warning`.

### How can this be tested?
1. Navigate to your local `ocw-studio` setup.
2. Checkout branch `external-resource-add-title-field`.
3. Start/Restart Studio.
4. Follow the instructions in https://github.com/mitodl/ocw-hugo-projects/pull/292 to load the starter config.
5. Create a course.
6. Create a page in that course.
7. Create a markdown link on that page.
8. Save the page.
9. Run the following set of commands.
    ```sh
    docker compose exec web ./manage.py markdown_cleanup link_to_external_resource --skip-sync --commit --filter your-course-id
    ```
10. Open [Django admin](http://localhost:8043/admin/websites/websitecontent/).
11. Expect to see new content created for the markdown link.
12. Open that new content object.
13. Observe the metadata field.
14. Expect to NOT find any `title` field.
15. Expect to find a `has_external_license_warning` field with these exact spellings.

