### PR TITLE
upgraded PostgreSQL version from 12.8 to 16.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
 # Add package files, install updated node and pip
 WORKDIR /tmp
 
-# Install packages and add repo needed for postgres 9.6
+# Install packages and add repo needed for postgres 16.3
 COPY apt.txt /tmp/apt.txt
 RUN apt-get update
 RUN apt-get install -y $(grep -vE "^\s*#" apt.txt  | tr "\n" " ")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ networks:
       - subnet: "10.1.0.0/24"
 services:
   db:
-    image: postgres:12.8
+    image: postgres:16.3
     ports:
     - "5431:5432"
     environment:


### PR DESCRIPTION
### What are the relevant tickets?
This closes https://github.com/mitodl/hq/issues/4323

### Description (What does it do?)
PostgreSQL version upgrade from 12.8 to 16.3. Follow instructions in https://github.com/mitodl/hq/issues/4323 to migrate data locally (if required)

### How can this be tested?
1. Restart Containers with the following commands, and check if ocw-studio is running:
    - `docker-compose down`
    - `docker-compose up -d`