### PR TITLE
Remove the internal external radio buttons

### DIFF
--- a/content_sync/serializers.py
+++ b/content_sync/serializers.py
@@ -206,7 +206,7 @@ def _transform_hugo_menu_data(
     website_content: WebsiteContent, site_config: SiteConfig
 ) -> dict:
     """
-    Adds 'pageRef' property to internal links in menu data.
+    Adds 'pageRef' property to links in menu data.
 
     Returns the dict of all values that will be serialized to the target file, including the transformed
     "menu" fields.
@@ -225,7 +225,7 @@ def _transform_hugo_menu_data(
         result_menu_items = []
         for menu_item in field_data:
             updated_menu_item = menu_item
-            # Add/update the 'pageRef' value if this is an internal link
+            # Add/update the 'pageRef' value if this is a link
             if menu_item["identifier"] in uuid_content_map:
                 menu_item_content = uuid_content_map[menu_item["identifier"]]
                 updated_menu_item["pageRef"] = get_destination_url(

--- a/static/js/components/forms/MenuItemForm.test.tsx
+++ b/static/js/components/forms/MenuItemForm.test.tsx
@@ -53,8 +53,7 @@ describe("MenuItemForm", () => {
     })
     expect(wrapper.prop("initialValues")).toEqual({
       menuItemTitle: "",
-      menuItemType: "internal",
-      internalLink: "",
+      contentLink: "",
     })
   })
 
@@ -62,15 +61,13 @@ describe("MenuItemForm", () => {
     const activeItem = {
       text: "text",
       targetContentId: "content-id",
-      menuItemType: "internal",
     }
     const wrapper = renderForm({
       activeItem,
     })
     expect(wrapper.prop("initialValues")).toEqual({
       menuItemTitle: activeItem.text,
-      internalLink: activeItem.targetContentId,
-      menuItemType: "internal",
+      contentLink: activeItem.targetContentId,
     })
   })
 
@@ -80,11 +77,11 @@ describe("MenuItemForm", () => {
       {
         values: {
           menuItemTitle: "",
-          internalLink: "",
+          contentLink: "",
         },
       },
     )
-    const relationField = wrapper.find('RelationField[name="internalLink"]')
+    const relationField = wrapper.find('RelationField[name="contentLink"]')
     expect(relationField.exists()).toBe(true)
   })
 
@@ -101,12 +98,12 @@ describe("MenuItemForm", () => {
       {
         values: {
           menuItemTitle: "",
-          internalLink: value,
+          contentLink: value,
         },
         setFieldValue: setFieldValueStub,
       },
     )
-    const relationField = wrapper.find('RelationField[name="internalLink"]')
+    const relationField = wrapper.find('RelationField[name="contentLink"]')
     expect(relationField.exists()).toBe(true)
     expect(relationField.prop("value")).toEqual(value)
     expect(relationField.prop("valuesToOmit")).toEqual(existingMenuIds)
@@ -117,6 +114,6 @@ describe("MenuItemForm", () => {
     }
     // @ts-expect-error Not using a full event
     relationField.prop("onChange")(fakeEvent)
-    expect(setFieldValueStub).toHaveBeenCalledWith("internalLink", "abc")
+    expect(setFieldValueStub).toHaveBeenCalledWith("contentLink", "abc")
   })
 })

--- a/static/js/components/forms/MenuItemForm.test.tsx
+++ b/static/js/components/forms/MenuItemForm.test.tsx
@@ -53,7 +53,7 @@ describe("MenuItemForm", () => {
     })
     expect(wrapper.prop("initialValues")).toEqual({
       menuItemTitle: "",
-      menuItemType: "internal", // This line can be removed
+      menuItemType: "internal",
       internalLink: "",
     })
   })

--- a/static/js/components/forms/MenuItemForm.test.tsx
+++ b/static/js/components/forms/MenuItemForm.test.tsx
@@ -86,7 +86,6 @@ describe("MenuItemForm", () => {
     expect(relationField.exists()).toBe(true)
   })
 
-
   it("renders a RelationField and passes down the right props", () => {
     const existingMenuIds = ["abc", "def"]
     const value = "def"

--- a/static/js/components/forms/MenuItemForm.test.tsx
+++ b/static/js/components/forms/MenuItemForm.test.tsx
@@ -70,6 +70,7 @@ describe("MenuItemForm", () => {
     expect(wrapper.prop("initialValues")).toEqual({
       menuItemTitle: activeItem.text,
       internalLink: activeItem.targetContentId,
+      menuItemType: "internal",
     })
   })
 

--- a/static/js/components/forms/MenuItemForm.test.tsx
+++ b/static/js/components/forms/MenuItemForm.test.tsx
@@ -57,7 +57,7 @@ describe("MenuItemForm", () => {
     })
   })
 
-  it("renders with the correct initial values if given an active item with internal link", () => {
+  it("renders with the correct initial values if given an active item with link", () => {
     const activeItem = {
       text: "text",
       targetContentId: "content-id",
@@ -71,7 +71,7 @@ describe("MenuItemForm", () => {
     })
   })
 
-  it("renders an internal link dropdown", () => {
+  it("renders a link dropdown", () => {
     const wrapper = renderInnerForm(
       {},
       {

--- a/static/js/components/forms/MenuItemForm.test.tsx
+++ b/static/js/components/forms/MenuItemForm.test.tsx
@@ -62,6 +62,7 @@ describe("MenuItemForm", () => {
     const activeItem = {
       text: "text",
       targetContentId: "content-id",
+      menuItemType: "internal",
     }
     const wrapper = renderForm({
       activeItem,

--- a/static/js/components/forms/MenuItemForm.test.tsx
+++ b/static/js/components/forms/MenuItemForm.test.tsx
@@ -5,11 +5,11 @@ import { Formik, FormikProps } from "formik"
 import MenuItemForm from "./MenuItemForm"
 import { defaultFormikChildProps } from "../../test_util"
 
-import { LinkType, WebsiteContent } from "../../types/websites"
+import { WebsiteContent } from "../../types/websites"
 import { makeWebsiteContentDetail } from "../../util/factories/websites"
 
 describe("MenuItemForm", () => {
-  let onSubmitStub: any, contentContext: WebsiteContent[]
+  let onSubmitStub, contentContext
 
   beforeEach(() => {
     onSubmitStub = jest.fn()
@@ -27,8 +27,8 @@ describe("MenuItemForm", () => {
     )
 
   const renderInnerForm = (
-    formProps: { [key: string]: any },
-    formikChildProps: Partial<FormikProps<any>>,
+    formProps,
+    formikChildProps,
   ) => {
     const wrapper = renderForm(formProps || {})
     return wrapper.find(Formik).renderProp("children")({
@@ -53,106 +53,41 @@ describe("MenuItemForm", () => {
     })
     expect(wrapper.prop("initialValues")).toEqual({
       menuItemTitle: "",
-      menuItemType: LinkType.Internal,
-      externalLink: "",
+      menuItemType: "internal", // This line can be removed
       internalLink: "",
     })
   })
-  ;[
-    ["http://example.com", LinkType.External],
-    [null, LinkType.Internal],
-  ].forEach(([targetUrl, expLinkType]) => {
-    it(`renders with the correct initial values if given an active item with ${expLinkType} link`, () => {
-      const activeItem = {
-        text: "text",
-        targetContentId: "content-id",
-        targetUrl: targetUrl,
-      }
-      const wrapper = renderForm({
-        activeItem,
-      })
-      expect(wrapper.prop("initialValues")).toEqual({
-        menuItemTitle: activeItem.text,
-        menuItemType: expLinkType,
-        externalLink: activeItem.targetUrl || "",
-        internalLink: activeItem.targetContentId,
-      })
+
+  it("renders with the correct initial values if given an active item with internal link", () => {
+    const activeItem = {
+      text: "text",
+      targetContentId: "content-id",
+    }
+    const wrapper = renderForm({
+      activeItem,
+    })
+    expect(wrapper.prop("initialValues")).toEqual({
+      menuItemTitle: activeItem.text,
+      internalLink: activeItem.targetContentId,
     })
   })
 
-  it("has radio buttons to switch between external and internal links", () => {
-    const setFieldValueStub = jest.fn()
+  it("renders an internal link dropdown", () => {
     const wrapper = renderInnerForm(
       {},
       {
         values: {
           menuItemTitle: "",
-          menuItemType: LinkType.Internal,
-          externalLink: "",
-          internalLink: "",
-        },
-        setFieldValue: setFieldValueStub,
-      },
-    )
-    const itemTypeBtns = wrapper.find('input[name="menuItemType"]')
-    expect(itemTypeBtns).toHaveLength(2)
-    const internalBtn = itemTypeBtns.at(0)
-    const externalBtn = itemTypeBtns.at(1)
-    expect(internalBtn.prop("checked")).toBe(true)
-    expect(internalBtn.prop("value")).toEqual(LinkType.Internal)
-    expect(externalBtn.prop("checked")).toBe(false)
-    expect(externalBtn.prop("value")).toEqual(LinkType.External)
-    // @ts-expect-error Not going to simulate the event
-    externalBtn.prop("onChange")()
-    expect(setFieldValueStub).toHaveBeenCalledWith(
-      "menuItemType",
-      LinkType.External,
-    )
-    // @ts-expect-error Not going to simulate the event
-    internalBtn.prop("onChange")()
-    expect(setFieldValueStub).toHaveBeenCalledWith(
-      "menuItemType",
-      LinkType.Internal,
-    )
-  })
-
-  it("renders an internal link dropdown if the 'internal' radio is selected", () => {
-    const wrapper = renderInnerForm(
-      {},
-      {
-        values: {
-          menuItemTitle: "",
-          menuItemType: LinkType.Internal,
-          externalLink: "",
           internalLink: "",
         },
       },
     )
     const relationField = wrapper.find('RelationField[name="internalLink"]')
     expect(relationField.exists()).toBe(true)
-    expect(wrapper.find('Field[name="externalLink"]').exists()).toBe(false)
   })
 
-  it("renders an external link dropdown if the 'external' radio is selected", () => {
-    const wrapper = renderInnerForm(
-      {},
-      {
-        values: {
-          menuItemTitle: "",
-          menuItemType: LinkType.External,
-          externalLink: "",
-          internalLink: "",
-        },
-      },
-    )
-    const extLinkField = wrapper.find('Field[name="externalLink"]')
-    expect(extLinkField.exists()).toBe(true)
-    expect(wrapper.find('RelationField[name="internalLink"]').exists()).toBe(
-      false,
-    )
-  })
 
-  it("renders a RelationField and passes down the right props if the internal link option is selected", () => {
+  it("renders a RelationField and passes down the right props", () => {
     const existingMenuIds = ["abc", "def"]
     const value = "def"
     const collections = ["page"]
@@ -165,8 +100,6 @@ describe("MenuItemForm", () => {
       {
         values: {
           menuItemTitle: "",
-          menuItemType: LinkType.Internal,
-          externalLink: "",
           internalLink: value,
         },
         setFieldValue: setFieldValueStub,

--- a/static/js/components/forms/MenuItemForm.test.tsx
+++ b/static/js/components/forms/MenuItemForm.test.tsx
@@ -9,7 +9,7 @@ import { WebsiteContent } from "../../types/websites"
 import { makeWebsiteContentDetail } from "../../util/factories/websites"
 
 describe("MenuItemForm", () => {
-  let onSubmitStub, contentContext
+  let onSubmitStub: any, contentContext: WebsiteContent[]
 
   beforeEach(() => {
     onSubmitStub = jest.fn()
@@ -27,8 +27,8 @@ describe("MenuItemForm", () => {
     )
 
   const renderInnerForm = (
-    formProps,
-    formikChildProps,
+    formProps: { [key: string]: any },
+    formikChildProps: Partial<FormikProps<any>>,
   ) => {
     const wrapper = renderForm(formProps || {})
     return wrapper.find(Formik).renderProp("children")({

--- a/static/js/components/forms/MenuItemForm.tsx
+++ b/static/js/components/forms/MenuItemForm.tsx
@@ -2,18 +2,18 @@ import React, { useMemo } from "react"
 import { ErrorMessage, Field, Form, Formik, FormikHelpers } from "formik"
 import * as yup from "yup"
 
-import { InternalSortableMenuItem } from "../widgets/MenuField"
+import { SortableMenuItem } from "../widgets/MenuField"
 import RelationField from "../widgets/RelationField"
 import { FormError } from "./FormError"
 
-import { LinkType, WebsiteContent } from "../../types/websites"
+import { WebsiteContent } from "../../types/websites"
 
 interface Props {
   onSubmit: (
     values: any,
     formikHelpers: FormikHelpers<any>,
   ) => void | Promise<any>
-  activeItem: InternalSortableMenuItem | null
+  activeItem: SortableMenuItem | null
   collections?: string[]
   existingMenuIds?: Set<string>
   contentContext: WebsiteContent[] | null
@@ -21,19 +21,17 @@ interface Props {
 
 export type MenuItemFormValues = {
   menuItemTitle: string
-  menuItemType: LinkType.Internal
-  internalLink: string
+  contentLink: string
 }
 
 const schema = yup.object().shape({
   menuItemTitle: yup.string().required().label("Title"),
-  internalLink: yup.string().required().label("Internal link"),
+  contentLink: yup.string().required().label("Content link"),
 })
 
 const emptyInitialValues: MenuItemFormValues = {
   menuItemTitle: "",
-  menuItemType: LinkType.Internal,
-  internalLink: "",
+  contentLink: "",
 }
 
 export default function MenuItemForm({
@@ -48,8 +46,7 @@ export default function MenuItemForm({
       activeItem
         ? {
             menuItemTitle: activeItem.text,
-            menuItemType: LinkType.Internal,
-            internalLink: activeItem.targetContentId || "",
+            contentLink: activeItem.targetContentId || "",
           }
         : emptyInitialValues,
     [activeItem],
@@ -77,22 +74,22 @@ export default function MenuItemForm({
               <ErrorMessage name="menuItemTitle" component={FormError} />
             </div>
             <div className="form-group w-100">
-              <label className="px-2" htmlFor="internalLink">
+              <label className="px-2" htmlFor="contentLink">
                 Link to:
               </label>
               <RelationField
-                name="internalLink"
+                name="contentLink"
                 collection={collections}
                 display_field="title"
                 multiple={false}
                 onChange={(event) => {
-                  setFieldValue("internalLink", event.target.value.content)
+                  setFieldValue("contentLink", event.target.value.content)
                 }}
-                value={values.internalLink}
+                value={values.contentLink}
                 valuesToOmit={existingMenuIds}
                 contentContext={contentContext}
               />
-              <ErrorMessage name="internalLink" component={FormError} />
+              <ErrorMessage name="contentLink" component={FormError} />
             </div>
             <div className="form-group d-flex w-100 justify-content-end">
               <button

--- a/static/js/components/forms/MenuItemForm.tsx
+++ b/static/js/components/forms/MenuItemForm.tsx
@@ -26,7 +26,7 @@ export type MenuItemFormValues = {
 
 const schema = yup.object().shape({
   menuItemTitle: yup.string().required().label("Title"),
-  contentLink: yup.string().required().label("Content link"),
+  contentLink: yup.string().required().label("Link"),
 })
 
 const emptyInitialValues: MenuItemFormValues = {

--- a/static/js/components/forms/MenuItemForm.tsx
+++ b/static/js/components/forms/MenuItemForm.tsx
@@ -21,28 +21,18 @@ interface Props {
 
 export type MenuItemFormValues = {
   menuItemTitle: string
-  menuItemType: LinkType.Internal | LinkType.External
-  externalLink: string
+  menuItemType: LinkType.Internal
   internalLink: string
 }
 
 const schema = yup.object().shape({
   menuItemTitle: yup.string().required().label("Title"),
-  menuItemType: yup.mixed().oneOf([LinkType.Internal, LinkType.External]),
-  externalLink: yup.string().label("External link").url().when("menuItemType", {
-    is: LinkType.External,
-    then: yup.string().required(),
-  }),
-  internalLink: yup.string().label("Internal link").when("menuItemType", {
-    is: LinkType.Internal,
-    then: yup.string().required(),
-  }),
+  internalLink: yup.string().required().label("Internal link"),
 })
 
 const emptyInitialValues: MenuItemFormValues = {
   menuItemTitle: "",
   menuItemType: LinkType.Internal,
-  externalLink: "",
   internalLink: "",
 }
 
@@ -58,10 +48,7 @@ export default function MenuItemForm({
       activeItem
         ? {
             menuItemTitle: activeItem.text,
-            menuItemType: activeItem.targetUrl
-              ? LinkType.External
-              : LinkType.Internal,
-            externalLink: activeItem.targetUrl || "",
+            menuItemType: LinkType.Internal,
             internalLink: activeItem.targetContentId || "",
           }
         : emptyInitialValues,
@@ -89,26 +76,23 @@ export default function MenuItemForm({
               />
               <ErrorMessage name="menuItemTitle" component={FormError} />
             </div>
-            
             <div className="form-group w-100">
-                <>
-                  <label className="px-2" htmlFor="internalLink">
-                    Link to:
-                  </label>
-                  <RelationField
-                    name="internalLink"
-                    collection={collections}
-                    display_field="title"
-                    multiple={false}
-                    onChange={(event) => {
-                      setFieldValue("internalLink", event.target.value.content)
-                    }}
-                    value={values.internalLink}
-                    valuesToOmit={existingMenuIds}
-                    contentContext={contentContext}
-                  />
-                  <ErrorMessage name="internalLink" component={FormError} />
-                </>
+              <label className="px-2" htmlFor="internalLink">
+                Link to:
+              </label>
+              <RelationField
+                name="internalLink"
+                collection={collections}
+                display_field="title"
+                multiple={false}
+                onChange={(event) => {
+                  setFieldValue("internalLink", event.target.value.content)
+                }}
+                value={values.internalLink}
+                valuesToOmit={existingMenuIds}
+                contentContext={contentContext}
+              />
+              <ErrorMessage name="internalLink" component={FormError} />
             </div>
             <div className="form-group d-flex w-100 justify-content-end">
               <button

--- a/static/js/components/forms/MenuItemForm.tsx
+++ b/static/js/components/forms/MenuItemForm.tsx
@@ -89,36 +89,8 @@ export default function MenuItemForm({
               />
               <ErrorMessage name="menuItemTitle" component={FormError} />
             </div>
+            
             <div className="form-group w-100">
-              <input
-                type="radio"
-                id="menuItemTypeInternal"
-                name="menuItemType"
-                value={LinkType.Internal}
-                checked={values.menuItemType === LinkType.Internal}
-                onChange={() => {
-                  setFieldValue("menuItemType", LinkType.Internal)
-                }}
-              />
-              <label className="px-2" htmlFor="menuItemTypeInternal">
-                Internal
-              </label>
-              <input
-                type="radio"
-                id="menuItemTypeExternal"
-                name="menuItemType"
-                value={LinkType.External}
-                checked={values.menuItemType === LinkType.External}
-                onChange={() => {
-                  setFieldValue("menuItemType", LinkType.External)
-                }}
-              />
-              <label className="px-2" htmlFor="menuItemTypeExternal">
-                External
-              </label>
-            </div>
-            <div className="form-group w-100">
-              {values.menuItemType === LinkType.Internal ? (
                 <>
                   <label className="px-2" htmlFor="internalLink">
                     Link to:
@@ -137,22 +109,6 @@ export default function MenuItemForm({
                   />
                   <ErrorMessage name="internalLink" component={FormError} />
                 </>
-              ) : (
-                <>
-                  <label className="px-2" htmlFor="externalLink">
-                    Link to:
-                  </label>
-                  <Field
-                    id="externalLink"
-                    name="externalLink"
-                    className="form-control"
-                  />
-                  <span className="help-text">
-                    URL, e.g. http://example.com
-                  </span>
-                  <ErrorMessage name="externalLink" component={FormError} />
-                </>
-              )}
             </div>
             <div className="form-group d-flex w-100 justify-content-end">
               <button

--- a/static/js/components/widgets/MenuField.test.tsx
+++ b/static/js/components/widgets/MenuField.test.tsx
@@ -1,17 +1,11 @@
 import React from "react"
 import { shallow } from "enzyme"
-import MenuField, { HugoItem, InternalSortableMenuItem } from "./MenuField"
+import MenuField, { HugoItem, SortableMenuItem } from "./MenuField"
 
-import { LinkType, WebsiteContent } from "../../types/websites"
+import { WebsiteContent } from "../../types/websites"
 import { makeWebsiteContentDetail } from "../../util/factories/websites"
 
 const dummyHugoItems: HugoItem[] = [
-  {
-    identifier: "external-12345",
-    name: "External Link #1",
-    url: "http://example.com",
-    weight: 20,
-  },
   {
     identifier: "32629a02-3dc5-4128-8e43-0392b51e7b61",
     name: "Unit 1",
@@ -31,7 +25,7 @@ const dummyHugoItems: HugoItem[] = [
   },
 ]
 
-const dummyInternalMenuItems: Required<InternalSortableMenuItem>[] = [
+const dummyContentMenuItems: Required<SortableMenuItem>[] = [
   {
     id: "32629a02-3dc5-4128-8e43-0392b51e7b61",
     text: "Unit 1",
@@ -55,13 +49,6 @@ const dummyInternalMenuItems: Required<InternalSortableMenuItem>[] = [
     targetContentId: "32629a02-3dc5-4128-8e43-0392b51e7b61",
     targetUrl: null,
   },
-  {
-    id: "external-12345",
-    text: "External Link #1",
-    children: [],
-    targetContentId: null,
-    targetUrl: "http://example.com",
-  },
 ]
 
 describe("MenuField", () => {
@@ -84,7 +71,7 @@ describe("MenuField", () => {
       )
   })
 
-  const renderMenuItemForm = (menuItem: InternalSortableMenuItem | null) => {
+  const renderMenuItemForm = (menuItem: SortableMenuItem | null) => {
     const wrapper = render()
     expect(wrapper.find("BasicModal").prop("isVisible")).toBe(false)
     const nestable = wrapper.find("Nestable")
@@ -112,13 +99,13 @@ describe("MenuField", () => {
     const wrapper = render()
     const nestable = wrapper.find("Nestable")
     expect(nestable.exists()).toBe(true)
-    expect(nestable.prop("items")).toEqual(dummyInternalMenuItems)
+    expect(nestable.prop("items")).toEqual(dummyContentMenuItems)
   })
 
   it("should render individual items", () => {
     const wrapper = render()
     const nestable = wrapper.find("Nestable")
-    const menuItem = dummyInternalMenuItems[0]
+    const menuItem = dummyContentMenuItems[0]
     const renderedMenuItem = shallow(
       nestable.prop("renderItem")({ item: menuItem }),
     )
@@ -127,7 +114,7 @@ describe("MenuField", () => {
   })
 
   it("should pass the correct reorder function to the nestable component", () => {
-    const updatedMenuItems = [dummyInternalMenuItems[0]]
+    const updatedMenuItems = [dummyContentMenuItems[0]]
     const wrapper = render()
     const nestable = wrapper.find("Nestable")
     nestable.prop("onChange")({ items: updatedMenuItems })
@@ -142,7 +129,7 @@ describe("MenuField", () => {
   })
 
   it("provides a button to remove each individual menu item", () => {
-    const menuItem = dummyInternalMenuItems[0]
+    const menuItem = dummyContentMenuItems[0]
     const wrapper = render()
     const nestable = wrapper.find("Nestable")
     const renderedMenuItem = shallow(
@@ -162,13 +149,13 @@ describe("MenuField", () => {
     removeDialog.prop("onAccept")()
     wrapper.update()
     expect(wrapper.find("Nestable").prop("items")).toEqual(
-      dummyInternalMenuItems.slice(1),
+      dummyContentMenuItems.slice(1),
     )
   })
 
   it("should put an appropriate title on the modal", () => {
     ;["edit", "add"].forEach((action) => {
-      const menuItem = action === "edit" ? dummyInternalMenuItems[0] : null
+      const menuItem = action === "edit" ? dummyContentMenuItems[0] : null
       const wrapper = render()
       expect(wrapper.find("BasicModal").prop("isVisible")).toBe(false)
       const nestable = wrapper.find("Nestable")
@@ -193,13 +180,12 @@ describe("MenuField", () => {
   })
 
   it("should show a form to edit existing menu items", () => {
-    const menuItem = dummyInternalMenuItems[0]
+    const menuItem = dummyContentMenuItems[0]
     const menuItemForm = renderMenuItemForm(menuItem)
     const formProps = menuItemForm.props()
     expect(formProps.activeItem).toEqual(menuItem)
     expect(formProps.existingMenuIds).toEqual(
       new Set([
-        "external-12345",
         "32629a02-3dc5-4128-8e43-0392b51e7b61",
         "32629a02-3dc5-4128-8e43-0392b51e7b62",
         "32629a02-3dc5-4128-8e43-0392b51e7b63",
@@ -207,24 +193,21 @@ describe("MenuField", () => {
     )
   })
   ;[
-    [false, false, "new menu item, external link"],
-    [false, true, "new menu item, internal link"],
-    [true, false, "existing menu item, external link"],
-    [true, true, "existing menu item, internal link"],
+    [false, true, "new menu item link"],
+    [true, true, "existing menu item link"],
   ].forEach(([useExistingItem, desc]) => {
     it(`menu item form should correctly update widget value with ${desc}`, async () => {
       const initialMenuItemCount = dummyHugoItems.length
       const title = "My Title"
-      const internalLinkUuid = "12629a02-3dc5-4128-8e43-0392b51e7b61"
+      const contentLinkUuid = "12629a02-3dc5-4128-8e43-0392b51e7b61"
       const menuItem = useExistingItem
-        ? dummyInternalMenuItems[0].children[0]
+        ? dummyContentMenuItems[0].children[0]
         : null
       const menuItemForm = renderMenuItemForm(menuItem)
       const formProps = menuItemForm.props()
       const submitData = {
         menuItemTitle: title,
-        menuItemType: LinkType.Internal,
-        internalLink: internalLinkUuid,
+        contentLink: contentLinkUuid,
       }
       const expectedMenuItem = {
         name: title,
@@ -249,7 +232,7 @@ describe("MenuField", () => {
         expect.objectContaining(matchingMenuItem),
       )
       expect(updatedHugoMenuItem.identifier).toEqual(
-        expect.stringContaining(internalLinkUuid),
+        expect.stringContaining(contentLinkUuid),
       )
       expect(updatedHugoMenuItems).toHaveLength(
         useExistingItem ? initialMenuItemCount : initialMenuItemCount + 1,

--- a/static/js/components/widgets/MenuField.test.tsx
+++ b/static/js/components/widgets/MenuField.test.tsx
@@ -1,7 +1,6 @@
 import React from "react"
 import { shallow } from "enzyme"
 import MenuField, { HugoItem, InternalSortableMenuItem } from "./MenuField"
-import { EXTERNAL_LINK_PREFIX } from "../../constants"
 
 import { LinkType, WebsiteContent } from "../../types/websites"
 import { makeWebsiteContentDetail } from "../../util/factories/websites"
@@ -212,39 +211,23 @@ describe("MenuField", () => {
     [false, true, "new menu item, internal link"],
     [true, false, "existing menu item, external link"],
     [true, true, "existing menu item, internal link"],
-  ].forEach(([useExistingItem, isInternalLink, desc]) => {
+  ].forEach(([useExistingItem, desc]) => {
     it(`menu item form should correctly update widget value with ${desc}`, async () => {
-      let submitData, expPartialIdentifier, expectedMenuItem
       const initialMenuItemCount = dummyHugoItems.length
       const title = "My Title"
       const internalLinkUuid = "12629a02-3dc5-4128-8e43-0392b51e7b61"
-      const externalLinkUrl = "http://example.com"
       const menuItem = useExistingItem
         ? dummyInternalMenuItems[0].children[0]
         : null
       const menuItemForm = renderMenuItemForm(menuItem)
       const formProps = menuItemForm.props()
-      if (isInternalLink) {
-        submitData = {
-          menuItemTitle: title,
-          menuItemType: LinkType.Internal,
-          internalLink: internalLinkUuid,
-        }
-        expectedMenuItem = {
-          name: title,
-        }
-        expPartialIdentifier = internalLinkUuid
-      } else {
-        submitData = {
-          menuItemTitle: title,
-          menuItemType: LinkType.External,
-          externalLink: externalLinkUrl,
-        }
-        expectedMenuItem = {
-          name: title,
-          url: externalLinkUrl,
-        }
-        expPartialIdentifier = `${EXTERNAL_LINK_PREFIX}-631280213`
+      const submitData = {
+        menuItemTitle: title,
+        menuItemType: LinkType.Internal,
+        internalLink: internalLinkUuid,
+      }
+      const expectedMenuItem = {
+        name: title,
       }
       formProps.onSubmit(submitData)
       expect(onChangeStub.mock.calls.length).toEqual(1)
@@ -266,7 +249,7 @@ describe("MenuField", () => {
         expect.objectContaining(matchingMenuItem),
       )
       expect(updatedHugoMenuItem.identifier).toEqual(
-        expect.stringContaining(expPartialIdentifier),
+        expect.stringContaining(internalLinkUuid),
       )
       expect(updatedHugoMenuItems).toHaveLength(
         useExistingItem ? initialMenuItemCount : initialMenuItemCount + 1,

--- a/static/js/components/widgets/MenuField.test.tsx
+++ b/static/js/components/widgets/MenuField.test.tsx
@@ -222,7 +222,7 @@ describe("MenuField", () => {
           }
         : {
             ...expectedMenuItem,
-            weight: 30,
+            weight: 20,
           }
       const updatedHugoMenuItems = onChangeStub.mock.calls[0][0].target.value
       const updatedHugoMenuItem = updatedHugoMenuItems.find(

--- a/static/js/components/widgets/MenuField.tsx
+++ b/static/js/components/widgets/MenuField.tsx
@@ -4,10 +4,9 @@ import * as R from "ramda"
 import BasicModal from "../BasicModal"
 import MenuItemForm, { MenuItemFormValues } from "../forms/MenuItemForm"
 import Dialog from "../Dialog"
-import { EXTERNAL_LINK_PREFIX } from "../../constants"
-import { generateHashCode, isExternalLinkId } from "../../lib/util"
+import { isExternalLinkId } from "../../lib/util"
 
-import { LinkType, WebsiteContent } from "../../types/websites"
+import { WebsiteContent } from "../../types/websites"
 import { ModalState, createModalState } from "../../types/modal_state"
 
 interface IMenuModalState {
@@ -361,19 +360,11 @@ export default function MenuField(props: MenuFieldProps): JSX.Element {
     let updatedItems: InternalSortableMenuItem[]
     const updatedItem = {
       text: values.menuItemTitle,
-      ...(values.menuItemType === LinkType.External
-        ? {
-            id: `${EXTERNAL_LINK_PREFIX}${generateHashCode(
-              values.externalLink,
-            )}-${Date.now().toString()}`,
-            targetUrl: values.externalLink,
-            targetContentId: null,
-          }
-        : {
-            id: values.internalLink,
-            targetUrl: null,
-            targetContentId: values.internalLink,
-          }),
+      ...{
+        id: values.internalLink,
+        targetUrl: null,
+        targetContentId: values.internalLink,
+      },
     }
     if (modalState.editing()) {
       const activeItemLens = R.lensPath(modalState.wrapped.path)

--- a/static/js/constants.ts
+++ b/static/js/constants.ts
@@ -6,7 +6,7 @@ import {
   WebsiteStarterConfig,
 } from "./types/websites"
 
-import { WidgetVariant, LinkType } from "./types/websites"
+import { WidgetVariant } from "./types/websites"
 
 export const ROLE_ADMIN = "admin"
 export const ROLE_EDITOR = "editor"
@@ -31,8 +31,6 @@ export const WEBSITE_CONTENT_PAGE_SIZE = 10
  */
 export const MAIN_PAGE_CONTENT_FIELD = "body"
 export const MAIN_PAGE_CONTENT_DB_FIELD = "markdown"
-
-export const EXTERNAL_LINK_PREFIX = `${LinkType.External}-`
 
 /* eslint-disable quote-props, key-spacing */
 export const exampleSiteConfig: WebsiteStarterConfig = {

--- a/static/js/lib/util.test.ts
+++ b/static/js/lib/util.test.ts
@@ -8,7 +8,6 @@ import {
   getResponseBodyError,
   isUuid4,
   generateHashCode,
-  isExternalLinkId,
 } from "./util"
 
 describe("util", () => {
@@ -129,10 +128,5 @@ describe("util", () => {
   it("generateHashCode should produce a numeric hash code for some string value", () => {
     expect(generateHashCode("abcdefg")).toEqual("-1206291356")
     expect(generateHashCode("http://example.com")).toEqual("-631280213")
-  })
-
-  it("isExternalLinkId returns true if the string starts with the external link prefix", () => {
-    expect(isExternalLinkId("external-1234")).toBe(true)
-    expect(isExternalLinkId("not-external-link")).toBe(false)
   })
 })

--- a/static/js/lib/util.ts
+++ b/static/js/lib/util.ts
@@ -1,6 +1,5 @@
 import { isEmpty, isNil } from "ramda"
 import { ActionPromiseValue } from "redux-query"
-import { EXTERNAL_LINK_PREFIX } from "../constants"
 import { SiteFormValue } from "../types/forms"
 
 export const isErrorStatusCode = (statusCode: number): boolean =>
@@ -71,9 +70,6 @@ const uuid4regex =
 
 export const isUuid4 = (strToTest: string): boolean =>
   uuid4regex.test(strToTest)
-
-export const isExternalLinkId = (textId: string): boolean =>
-  textId.startsWith(EXTERNAL_LINK_PREFIX)
 
 export const generateHashCode = (strToHash: string): string => {
   let hash = 0,

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -312,11 +312,6 @@ export interface ContentDetailParams {
   textId: string
 }
 
-export enum LinkType {
-  Internal = "internal",
-  External = "external",
-}
-
 /**
  * For the WebsiteContent drawer we need to keep track of a
  * content ID when we're editing existing content.


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4101

### Description (What does it do?)
It removes the Item type radio button in `Menu Item Form`.
<img width="1680" alt="Screenshot 2024-05-27 at 5 52 27 AM" src="https://github.com/mitodl/ocw-studio/assets/71461724/dc9251bd-14fc-4a5a-a353-8ed41625ef52">


### How can this be tested?
1. Login to `cow-studio`
2. Add a new site course or use and existing one
3. In the course setting, visit page for `Menu`
<img width="301" alt="Screenshot 2024-05-27 at 5 55 10 AM" src="https://github.com/mitodl/ocw-studio/assets/71461724/7ee9d9e2-5486-4646-87b3-b9c84fce8dae">

4. Add a new menu item or open an existing one
5. The item form should not have radio button as shown in the above picture in description
