### PR TITLE
added encoding/decoding for URL in markdown editor

### DIFF
--- a/static/js/lib/ckeditor/plugins/Markdown.test.ts
+++ b/static/js/lib/ckeditor/plugins/Markdown.test.ts
@@ -183,11 +183,11 @@ describe("Handling of raw HTML", () => {
 
     const html = `
     <p>
-    <a href="http://host.com/with_(parenthese)/uri">Hello World</a>
+    <a href="http://host.com/with_(parentheses)/uri">Hello World</a>
     </p>
     `
     expect(encodeParentheses(html2md(html))).toBe(
-      `[Hello World](http://host.com/with_%28parenthese%29/uri)`,
+      `[Hello World](http://host.com/with_%28parentheses%29/uri)`,
     )
   })
 
@@ -199,10 +199,10 @@ describe("Handling of raw HTML", () => {
 
     expect(
       decodeParentheses(
-        md2html(`[Hello World](http://host.com/with_%28parenthese%29/uri)`),
+        md2html(`[Hello World](http://host.com/with_%28parentheses%29/uri)`),
       ),
     ).toBe(
-      `<p><a href="http://host.com/with_(parenthese)/uri">Hello World</a></p>`,
+      `<p><a href="http://host.com/with_(parentheses)/uri">Hello World</a></p>`,
     )
   })
 })

--- a/static/js/lib/ckeditor/plugins/Markdown.test.ts
+++ b/static/js/lib/ckeditor/plugins/Markdown.test.ts
@@ -6,6 +6,7 @@ import { TEST_MARKDOWN, TEST_HTML } from "../../../test_constants"
 import MarkdownSyntaxPlugin from "./MarkdownSyntaxPlugin"
 import { ShowdownExtension } from "showdown"
 import { TurndownRule } from "../../../types/ckeditor_markdown"
+import { decodeParentheses, encodeParentheses } from "./util"
 
 describe("Markdown CKEditor plugin", () => {
   const getEditor = createTestEditor([Markdown])
@@ -171,6 +172,37 @@ describe("Handling of raw HTML", () => {
     `
     expect(html2md(html)).toBe(
       'hello <sup><span>meow</span>alert("maliciousness")</sup> world',
+    )
+  })
+
+  test("URLs with parentheses are encoded", async () => {
+    const editor = await getEditor("", {
+      "markdown-config": { allowedHtml: ["sup", "span"] },
+    })
+    const { html2md } = getConverters(editor)
+
+    const html = `
+    <p>
+    <a href="http://host.com/with_(parenthese)/uri">Hello World</a>
+    </p>
+    `
+    expect(encodeParentheses(html2md(html))).toBe(
+      `[Hello World](http://host.com/with_%28parenthese%29/uri)`,
+    )
+  })
+
+  test("URLs with encoded parentheses are decoded", async () => {
+    const editor = await getEditor("", {
+      "markdown-config": { allowedHtml: ["sup", "span"] },
+    })
+    const { md2html } = getConverters(editor)
+
+    expect(
+      decodeParentheses(
+        md2html(`[Hello World](http://host.com/with_%28parenthese%29/uri)`),
+      ),
+    ).toBe(
+      `<p><a href="http://host.com/with_(parenthese)/uri">Hello World</a></p>`,
     )
   })
 })

--- a/static/js/lib/ckeditor/plugins/Markdown.ts
+++ b/static/js/lib/ckeditor/plugins/Markdown.ts
@@ -57,7 +57,8 @@ export class MarkdownDataProcessor extends GFMDataProcessor {
    * Convert markdown string to CKEditor View
    */
   toView(md: string): DocumentFragment {
-    const html = this.md2html(md)
+    // Decode HTML URLs to Markdown Syntax
+    const html = this.md2html(md).replace(/%28/g, "(").replace(/%29/g, ")")
     return this._htmlDP.toView(html)
   }
 
@@ -66,7 +67,9 @@ export class MarkdownDataProcessor extends GFMDataProcessor {
    */
   toData(viewFragment: DocumentFragment): string {
     const html = this._htmlDP.toData(viewFragment)
-    return this.html2md(html)
+
+    // Encode parentheses in URL to HTML encoding for URLs
+    return this.html2md(html).replace(/\\\(/g, "%28").replace(/\\\)/g, "%29")
   }
 }
 

--- a/static/js/lib/ckeditor/plugins/Markdown.ts
+++ b/static/js/lib/ckeditor/plugins/Markdown.ts
@@ -12,7 +12,7 @@ import {
   turndownHtmlHelpers,
 } from "../turndown"
 import Turndown from "turndown"
-import { buildAttrsString } from "./util"
+import { buildAttrsString, encodeParentheses, decodeParentheses } from "./util"
 import { validateHtml2md } from "./validateMdConversion"
 
 /**
@@ -58,7 +58,7 @@ export class MarkdownDataProcessor extends GFMDataProcessor {
    */
   toView(md: string): DocumentFragment {
     // Decode HTML URLs to Markdown Syntax
-    const html = this.md2html(md).replace(/%28/g, "(").replace(/%29/g, ")")
+    const html = decodeParentheses(this.md2html(md))
     return this._htmlDP.toView(html)
   }
 
@@ -69,7 +69,7 @@ export class MarkdownDataProcessor extends GFMDataProcessor {
     const html = this._htmlDP.toData(viewFragment)
 
     // Encode parentheses in URL to HTML encoding for URLs
-    return this.html2md(html).replace(/\\\(/g, "%28").replace(/\\\)/g, "%29")
+    return encodeParentheses(this.html2md(html))
   }
 }
 

--- a/static/js/lib/ckeditor/plugins/util.test.ts
+++ b/static/js/lib/ckeditor/plugins/util.test.ts
@@ -510,14 +510,14 @@ describe("Shortcode", () => {
 
 describe("urlWithParentheses", () => {
   it("decode URL with Parentheses", () => {
-    expect(decodeParentheses(`http://host.com/with_%28parenthese%29/uri`)).toBe(
-      `http://host.com/with_(parenthese)/uri`,
-    )
+    expect(
+      decodeParentheses(`http://host.com/with_%28parentheses%29/uri`),
+    ).toBe(`http://host.com/with_(parentheses)/uri`)
   })
 
   it("encode URL with Parentheses", () => {
     expect(
-      encodeParentheses(`http://host.com/with_\\\(parenthese\\\)/uri`), //eslint-disable-line
-    ).toBe(`http://host.com/with_%28parenthese%29/uri`)
+      encodeParentheses(`http://host.com/with_\\\(parentheses\\\)/uri`), //eslint-disable-line
+    ).toBe(`http://host.com/with_%28parentheses%29/uri`)
   })
 })

--- a/static/js/lib/ckeditor/plugins/util.test.ts
+++ b/static/js/lib/ckeditor/plugins/util.test.ts
@@ -1,4 +1,10 @@
-import { unescapeStringQuotedWith, Shortcode, ShortcodeParam } from "./util"
+import {
+  unescapeStringQuotedWith,
+  Shortcode,
+  ShortcodeParam,
+  encodeParentheses,
+  decodeParentheses,
+} from "./util"
 
 const makeParams = ({
   value,
@@ -499,5 +505,19 @@ describe("Shortcode", () => {
       const match = text.match(regex)
       expect(match).toStrictEqual(["{{< cat meow >}}", "{{< dog woof >}}"])
     })
+  })
+})
+
+describe("urlWithParentheses", () => {
+  it("decode URL with Parentheses", () => {
+    expect(decodeParentheses(`http://host.com/with_%28parenthese%29/uri`)).toBe(
+      `http://host.com/with_(parenthese)/uri`,
+    )
+  })
+
+  it("encode URL with Parentheses", () => {
+    expect(
+      encodeParentheses(`http://host.com/with_\\\(parenthese\\\)/uri`), //eslint-disable-line
+    ).toBe(`http://host.com/with_%28parenthese%29/uri`)
   })
 })

--- a/static/js/lib/ckeditor/plugins/util.ts
+++ b/static/js/lib/ckeditor/plugins/util.ts
@@ -380,3 +380,21 @@ export const makeHtmlString = (
 export const escapeShortcodes = (text: string) => {
   return text.replace(/{{</g, "{{\\<").replace("{{%", "{\\{%")
 }
+
+/**
+ *
+ * Encode parentheses in URL which are escaped in markdown string,
+ * `"\("` --> `"%28"` and `"\)"` --> `"%29"`
+ */
+export const encodeParentheses = (text: string) => {
+  return text.replace(/\\\(/g, "%28").replace(/\\\)/g, "%29")
+}
+
+/**
+ *
+ * Decode parentheses in URL to view original in Edit dialogue,
+ * `"%28"` --> `"("` and `"%29"` --> `")"`
+ */
+export const decodeParentheses = (text: string) => {
+  return text.replace(/%28/g, "(").replace(/%29/g, ")")
+}


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/4590

### Description (What does it do?)
This PR aims to encode/decode URLs in text editor in `ocw-studio` for correct browser readable URLs.
The opening and closing brackets will be saved as `%28` and `%29` respectively for being later used in course compilation.

### How can this be tested?
1. Switch to branch `umar/4590-links-to-urls-that-have-parentheses`
2. Create any resource and link a URL with parentheses, e.g `https://commons.wikimedia.org/wiki/File:Saint_Joseph_charpentier_(La_Tour).jpg` in the text editor.
<img width="978" alt="Screenshot 2024-07-02 at 5 47 47 PM" src="https://github.com/mitodl/ocw-studio/assets/71461724/e7283398-86f0-4802-a908-081424335ce0">

3. Save and publish changes.
4. Visit the published site. and Click on the URL it follow proper URL.

### Additional Testing
1. The content data in markdown should be save in encoded format.
<img width="978" alt="Screenshot 2024-07-02 at 5 54 42 PM" src="https://github.com/mitodl/ocw-studio/assets/71461724/bc8fb4ca-bcb1-4796-a64f-9943ce0e1efb">
