### PR TITLE
Chore: Course Image Thumbnail Cleanup

### DIFF
--- a/localdev/configs/ocw-course-site-config.yml
+++ b/localdev/configs/ocw-course-site-config.yml
@@ -209,16 +209,6 @@ collections:
         field: "resourcetype"
         filter_type: "equals"
         value: "Image"
-    - label: Course Image Thumbnail
-      name: course_image_thumbnail
-      widget: relation
-      collection: resource
-      display_field: title
-      multiple: false
-      filter:
-        field: "resourcetype"
-        filter_type: "equals"
-        value: "Image"
     - label: "Department Numbers"
       min: 1
       multiple: true

--- a/static/js/resources/ocw-course-site-config.json
+++ b/static/js/resources/ocw-course-site-config.json
@@ -280,19 +280,6 @@
               "widget": "relation"
             },
             {
-              "collection": "resource",
-              "display_field": "title",
-              "filter": {
-                "field": "resourcetype",
-                "filter_type": "equals",
-                "value": "Image"
-              },
-              "label": "Course Image Thumbnail",
-              "multiple": false,
-              "name": "course_image_thumbnail",
-              "widget": "relation"
-            },
-            {
               "label": "Department Numbers",
               "min": 1,
               "multiple": true,

--- a/test_site_fixtures/test_website_content.json
+++ b/test_site_fixtures/test_website_content.json
@@ -44,10 +44,6 @@
         "department_numbers": ["8", "6", "18"],
         "extra_course_numbers": "456",
         "primary_course_number": "123",
-        "course_image_thumbnail": {
-          "content": "5388b0c3-c599-4c42-8a3c-f89beed7c154",
-          "website": "ocw-ci-test-course"
-        },
         "learning_resource_types": [
           "Activity Assignments",
           "Exams with Solutions"


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/3132

### Description (What does it do?)
As we removed the `course_image_thumbnail` field in `ocw-hugo-projects` (https://github.com/mitodl/ocw-hugo-projects/pull/297), this PR cleans up the codebase pertaining to the field.

### How can this be tested?
There isn't any specific way to test for the cleanup. While `course_image_thumbnail` is part of the test site fixture, there is no test against it. You can check the logs of the checks passed against this PR for the tests.
