### PR TITLE
Umar/4903 external resources false broken

### DIFF
--- a/external_resources/tasks.py
+++ b/external_resources/tasks.py
@@ -62,16 +62,19 @@ def check_external_resources(resources: list[int]):
                 url_status not in RESOURCE_UNCHECKED_STATUSES
                 or backup_url_status not in RESOURCE_UNCHECKED_STATUSES
             ):
-                if is_url_broken and is_backup_url_broken:
+                is_broken = is_url_broken and (
+                    backup_url_status is None or is_backup_url_broken
+                )
+                if is_broken:
                     # both external_url and backup_url are broken.
                     state.status = ExternalResourceState.Status.BROKEN
                 else:
                     # Either external_url or backup_url is valid.
                     state.status = ExternalResourceState.Status.VALID
 
-            if is_url_broken and not resource.metadata.get("is_broken", False):
-                resource.metadata["is_broken"] = True
-                resource.save()
+                if resource.metadata.get("is_broken") != is_broken:
+                    resource.metadata["is_broken"] = is_broken
+                    resource.save()
         finally:
             state.last_checked = timezone.now()
 

--- a/external_resources/tasks.py
+++ b/external_resources/tasks.py
@@ -58,6 +58,7 @@ def check_external_resources(resources: list[int]):
             log.debug(ex)
             state.status = ExternalResourceState.Status.CHECK_FAILED
         else:
+            # Status and flag should be updated if codes are not in ignored cases
             if (
                 url_status not in RESOURCE_UNCHECKED_STATUSES
                 or backup_url_status not in RESOURCE_UNCHECKED_STATUSES

--- a/external_resources/tasks_test.py
+++ b/external_resources/tasks_test.py
@@ -157,7 +157,9 @@ def test_check_external_resources(  # noqa: PLR0913
     assert updated_state.external_url_response_code == url_status_code
     assert updated_state.backup_url_response_code == backup_url_status_code
 
-    assert updated_state.content.metadata.get("is_broken", False) is url_status
+    assert updated_state.content.metadata.get("is_broken", False) == (
+        url_status and (backup_url_status_code is None or backup_url_status)
+    )
 
 
 @pytest.mark.django_db()


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/4903

### Description (What does it do?)
Fixes the false `is_broken` flag in case of `Ignored HTTP status codes`. And adds the functionality to update `is_broken` flag on each check rather waiting to be set manually.

### How can this be tested?

1. switch to branch 'umar/4903-external-resources-false-broken'
2. Restart containers.
3. From celery logs, verify a repeated task should be added in the celery with name `check-broken-external-urls`. Task is set to repeat every week. Frequency can be modified by changing `CHECK_EXTERNAL_RESOURCE_STATUS_FREQUENCY` in main/settings.py
4. Go to http://localhost:8043/admin/external_resources/externalresourcestate/. This should already be created.
5. External Resource States should have been populated with existing url checks after first execution of task.

### Additional Testing
#### To manually test the functionality locally with a batch of urls
1. Spin up containers
2. Get into Django shell: `docker-compose exec web ./manage.py shell`
3. Run following commands to import necessary code: 
     - `from external_resources.tasks import check_external_resources`
     - `from websites.models import WebsiteContent`
     - `from websites.constants import CONTENT_TYPE_EXTERNAL_RESOURCE`
4. Get website content data:
    `external_resources = list(WebsiteContent.objects.filter(type=CONTENT_TYPE_EXTERNAL_RESOURCE).values_list("id", flat=True))`
5. (Optional) check length of data and splice if necessary: `len(external_resources)` and `external_resources = external_resources[:1]`
6. run checking task: `check_external_resources(external_resources)`
7. to validate resource was updated or created, retrieve resource from.DB:
    - `resources = WebsiteContent.objects.filter(id__in=external_resources).select_related("external_resource_state")`
    - `resource = next(resources.iterator())`
    - `str(resource.external_resource_state.last_checked)` 
    - `resource.metadata['is_broken']`
8. To test if flag is updated on each try, manually update flag and save.
    - `resource.metadata['is_broken'] = not resource.metadata['is_broken']`
    - `resource.save()`
9. execute step 6
10. Validate `last_checked` and flag again of the updated resource.
    - `resource = WebsiteContent.objects.get(id=resource.id)`
    - `print(str(resource.external_resource_state.last_checked), resource.metadata['is_broken'])`

#### To manually execute task in celery
1. Spin up containers
2. Get into Django shell: `docker-compose exec web ./manage.py shell`
3. Run following commands to import necessary code: 
     - `from external_resources.tasks import check_external_resources_for_breakages`
     - `results = check_external_resources_for_breakages.apply()`

** This might produce large number of urls to check and may take some time to complete.