### PR TITLE
added change to restrict the parentheses encoding/decoding to anchor …

### DIFF
--- a/static/js/lib/ckeditor/plugins/Markdown.test.ts
+++ b/static/js/lib/ckeditor/plugins/Markdown.test.ts
@@ -186,7 +186,7 @@ describe("Handling of raw HTML", () => {
     <a href="http://host.com/with_(parentheses)/uri">Hello World</a>
     </p>
     `
-    expect(encodeParentheses(html2md(html))).toBe(
+    expect(html2md(encodeParentheses(html))).toBe(
       `[Hello World](http://host.com/with_%28parentheses%29/uri)`,
     )
   })

--- a/static/js/lib/ckeditor/plugins/Markdown.test.ts
+++ b/static/js/lib/ckeditor/plugins/Markdown.test.ts
@@ -205,4 +205,50 @@ describe("Handling of raw HTML", () => {
       `<p><a href="http://host.com/with_(parentheses)/uri">Hello World</a></p>`,
     )
   })
+
+  test("Text with parentheses is unchanged in encoding", async () => {
+    const editor = await getEditor("", {
+      "markdown-config": { allowedHtml: ["sup", "span"] },
+    })
+    const { html2md } = getConverters(editor)
+
+    const html = `
+    <p>
+    Text with (parentheses) is unchanged out of anchor tag and
+    <a href="http://host.com/with_(parentheses)/uri">(inside) the anchor tag</a>
+    as well.
+    </p>
+    `
+    expect(html2md(encodeParentheses(html))).toBe(
+      `Text with (parentheses) is unchanged out of anchor tag and [(inside) the anchor tag](http://host.com/with_%28parentheses%29/uri) as well.`,
+    )
+  })
+
+  test("Text with parentheses is unchanged in decoding", async () => {
+    const editor = await getEditor("", {
+      "markdown-config": { allowedHtml: ["sup", "span"] },
+    })
+    const { md2html } = getConverters(editor)
+
+    const html = `<p>Text with (parentheses) is unchanged out of anchor tag and <a href="http://host.com/with_(parentheses)/uri">(inside) the anchor tag</a> as well.</p>`
+    expect(
+      decodeParentheses(
+        md2html(
+          `Text with (parentheses) is unchanged out of anchor tag and [(inside) the anchor tag](http://host.com/with_%28parentheses%29/uri) as well.`,
+        ),
+      ),
+    ).toBe(html)
+  })
+
+  test("URL with parentheses", async () => {
+    const editor = await getEditor("", {
+      "markdown-config": { allowedHtml: ["sup", "span"] },
+    })
+    const { md2html, html2md } = getConverters(editor)
+
+    const html = `<p>Text with (parentheses) is unchanged out of anchor tag and <a href="http://host.com/with_(parentheses)/uri">(inside) the anchor tag</a> as well.</p>`
+    expect(decodeParentheses(md2html(html2md(encodeParentheses(html))))).toBe(
+      html,
+    )
+  })
 })

--- a/static/js/lib/ckeditor/plugins/Markdown.ts
+++ b/static/js/lib/ckeditor/plugins/Markdown.ts
@@ -69,7 +69,7 @@ export class MarkdownDataProcessor extends GFMDataProcessor {
     const html = this._htmlDP.toData(viewFragment)
 
     // Encode parentheses in URL to HTML encoding for URLs
-    return encodeParentheses(this.html2md(html))
+    return this.html2md(encodeParentheses(html))
   }
 }
 

--- a/static/js/lib/ckeditor/plugins/util.test.ts
+++ b/static/js/lib/ckeditor/plugins/util.test.ts
@@ -511,13 +511,21 @@ describe("Shortcode", () => {
 describe("urlWithParentheses", () => {
   it("decode URL with Parentheses", () => {
     expect(
-      decodeParentheses(`http://host.com/with_%28parentheses%29/uri`),
-    ).toBe(`http://host.com/with_(parentheses)/uri`)
+      decodeParentheses(
+        `<p><a href="http://host.com/with_%28parentheses%29/uri">URL Test</a></p>`,
+      ),
+    ).toBe(
+      `<p><a href="http://host.com/with_(parentheses)/uri">URL Test</a></p>`,
+    )
   })
 
   it("encode URL with Parentheses", () => {
     expect(
-      encodeParentheses(`http://host.com/with_\\\(parentheses\\\)/uri`), //eslint-disable-line
-    ).toBe(`http://host.com/with_%28parentheses%29/uri`)
+      encodeParentheses(
+        `<p><a href="http://host.com/with_(parentheses)/uri">URL Test</a></p>`,
+      ),
+    ).toBe(
+      `<p><a href="http://host.com/with_%28parentheses%29/uri">URL Test</a></p>`,
+    )
   })
 })

--- a/static/js/lib/ckeditor/plugins/util.ts
+++ b/static/js/lib/ckeditor/plugins/util.ts
@@ -384,10 +384,22 @@ export const escapeShortcodes = (text: string) => {
 /**
  *
  * Encode parentheses in URL which are escaped in markdown string,
- * `"\("` --> `"%28"` and `"\)"` --> `"%29"`
+ * `"("` --> `"%28"` and `")"` --> `"%29"`
  */
 export const encodeParentheses = (text: string) => {
-  return text.replace(/\\\(/g, "%28").replace(/\\\)/g, "%29")
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(text, "text/html")
+
+  // Find all anchor tags (<a>)
+  const anchorTags = Array.from(doc.querySelectorAll("a"))
+
+  // Loop through anchor tags and encode parentheses within their href
+  for (const anchor of anchorTags) {
+    anchor.href = anchor.href?.replace(/\(/g, "%28").replace(/\)/g, "%29")
+  }
+
+  // Return the modified HTML string
+  return doc.body.innerHTML
 }
 
 /**
@@ -396,5 +408,17 @@ export const encodeParentheses = (text: string) => {
  * `"%28"` --> `"("` and `"%29"` --> `")"`
  */
 export const decodeParentheses = (text: string) => {
-  return text.replace(/%28/g, "(").replace(/%29/g, ")")
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(text, "text/html")
+
+  // Find all anchor tags (<a>)
+  const anchorTags = Array.from(doc.querySelectorAll("a"))
+
+  // Loop through anchor tags and decode parentheses within their href
+  for (const anchor of anchorTags) {
+    anchor.href = anchor.href?.replace(/%28/g, "(").replace(/%29/g, ")")
+  }
+  console.log(text, doc.body.innerHTML)
+  // Return the modified HTML string
+  return doc.body.innerHTML
 }

--- a/static/js/lib/ckeditor/plugins/util.ts
+++ b/static/js/lib/ckeditor/plugins/util.ts
@@ -418,7 +418,6 @@ export const decodeParentheses = (text: string) => {
   for (const anchor of anchorTags) {
     anchor.href = anchor.href?.replace(/%28/g, "(").replace(/%29/g, ")")
   }
-  console.log(text, doc.body.innerHTML)
   // Return the modified HTML string
   return doc.body.innerHTML
 }


### PR DESCRIPTION
### What are the relevant tickets?
closes 

### Description (What does it do?)
<!--- Describe your changes in detail -->

### How can this be tested?
1. switch to branch `umar/4950-mathjax-not-rendering` in `ocw-studio` and spin up containers.
2.  Create any type of resource e.g.`Page` and open editor
3. Add a text in markdown e.g `Einstein theorized \(E=mc^2\) and I say \(d > 1\)`
4. Link a url with parentheses to any plain text like `URL`, e.g
`https://commons.wikimedia.org/wiki/File:Saint_Joseph_charpentier_(La_Tour).jpg`
5. Save and publish changes.
6. Visit the published site. The markdown text should be converted to math symbols. 
7. Click on the URL, it should resolve to a proper URL in browser.

### Additional Testing
1. The content data in markdown should be save in encoded format.
<img width="929" alt="Screenshot 2024-07-24 at 3 57 42 PM" src="https://github.com/user-attachments/assets/5e6e3950-2ca6-4bd4-9026-0583eaf7248e">
