### PR TITLE
Allow external resources to be deleted

### DIFF
--- a/static/js/components/RepeatableContentListing.test.tsx
+++ b/static/js/components/RepeatableContentListing.test.tsx
@@ -216,16 +216,17 @@ describe("RepeatableContentListing", () => {
   })
 
   it("should delete an external resource", async () => {
-    const configItemExternal = makeRepeatableConfigItem("external-resource")
-    const externalContentListingItem = makeWebsiteContentListItem()
+    const externalResourceConfigItem =
+      makeRepeatableConfigItem("external-resource")
+    const externalContentItem = makeWebsiteContentListItem()
     websiteContentDetailsLookup = {
       [contentDetailKey({
         name: website.name,
-        textId: externalContentListingItem.text_id,
-      })]: externalContentListingItem,
+        textId: externalContentItem.text_id,
+      })]: externalContentItem,
     }
-    const externalApiResponse = {
-      results: [externalContentListingItem],
+    const externalResourceApiResponse = {
+      results: [externalContentItem],
       count: 1,
       next: null,
       previous: null,
@@ -233,11 +234,13 @@ describe("RepeatableContentListing", () => {
     const contentListingLookup = {
       [contentListingKey({
         name: website.name,
-        type: configItemExternal.name,
+        type: externalResourceConfigItem.name,
         offset: 0,
       })]: {
-        ...externalApiResponse,
-        results: externalApiResponse.results.map((item) => item.text_id),
+        ...externalResourceApiResponse,
+        results: externalResourceApiResponse.results.map(
+          (item) => item.text_id,
+        ),
       },
     }
     helper.mockGetRequest(
@@ -245,9 +248,9 @@ describe("RepeatableContentListing", () => {
         .param({
           name: website.name,
         })
-        .query({ offset: 0, type: configItemExternal.name })
+        .query({ offset: 0, type: externalResourceConfigItem.name })
         .toString(),
-      externalApiResponse,
+      externalResourceApiResponse,
     )
     render = helper.configureRenderer(
       (props) => (
@@ -255,7 +258,7 @@ describe("RepeatableContentListing", () => {
           <RepeatableContentListing {...props} />
         </WebsiteContext.Provider>
       ),
-      { configItem: configItemExternal },
+      { configItem: externalResourceConfigItem },
       {
         entities: {
           websiteDetails: { [website.name]: website },
@@ -265,7 +268,7 @@ describe("RepeatableContentListing", () => {
         queries: {},
       },
     )
-    const contentItemToDelete = externalContentListingItem
+    const contentItemToDelete = externalContentItem
     const getStatusStub = helper.mockGetRequest(
       siteApiDetailUrl
         .param({ name: website.name })

--- a/static/js/components/RepeatableContentListing.tsx
+++ b/static/js/components/RepeatableContentListing.tsx
@@ -162,6 +162,7 @@ export default function RepeatableContentListing(props: {
       return
     } else if (fetchWebsiteContentListing) {
       fetchWebsiteContentListing()
+      await store.dispatch(requestAsync(websiteStatusRequest(website.name)))
     }
   }
 
@@ -253,14 +254,17 @@ export default function RepeatableContentListing(props: {
       <Dialog
         open={deleteModal}
         onCancel={closeDeleteModal}
-        headerContent={"Remove content"}
+        headerContent={`Remove ${labelSingular}`}
         bodyContent={`Are you sure you want to remove ${
           selectedContent && selectedContent.title
             ? selectedContent.title
             : "this content"
         }?`}
         acceptText="Delete"
-        onAccept={onDelete}
+        onAccept={() => {
+          onDelete()
+          closeDeleteModal()
+        }}
       />
     </>
   )

--- a/static/js/components/RepeatableContentListing.tsx
+++ b/static/js/components/RepeatableContentListing.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import React, {
   MouseEvent as ReactMouseEvent,
   useCallback,
@@ -154,6 +153,18 @@ export default function RepeatableContentListing(props: {
     )
   })
 
+  const onDelete = async () => {
+    if (deleteQueryState.isPending) {
+      return
+    }
+    const response = await deleteContent()
+    if (!response) {
+      return
+    } else if (fetchWebsiteContentListing) {
+      fetchWebsiteContentListing()
+    }
+  }
+
   return (
     <>
       <div className="d-flex flex-direction-row align-items-center justify-content-between py-3">
@@ -239,6 +250,18 @@ export default function RepeatableContentListing(props: {
           fetchWebsiteContentListing={fetchWebsiteContentListing}
         />
       </Route>
+      <Dialog
+        open={deleteModal}
+        onCancel={closeDeleteModal}
+        headerContent={"Remove content"}
+        bodyContent={`Are you sure you want to remove ${
+          selectedContent && selectedContent.title
+            ? selectedContent.title
+            : "this content"
+        }?`}
+        acceptText="Delete"
+        onAccept={onDelete}
+      />
     </>
   )
 }

--- a/static/js/components/RepeatableContentListing.tsx
+++ b/static/js/components/RepeatableContentListing.tsx
@@ -228,9 +228,9 @@ export default function RepeatableContentListing(props: {
               .toString()}
             title={item.title ?? ""}
             subtitle={`Updated ${formatUpdatedOn(item)}`}
-            {...(isExternalResource && {
-              menuOptions: [["Delete", startDelete(item)]],
-            })}
+            menuOptions={
+              isExternalResource ? [["Delete", startDelete(item)]] : undefined
+            }
           />
         ))}
       </StudioList>

--- a/static/js/components/RepeatableContentListing.tsx
+++ b/static/js/components/RepeatableContentListing.tsx
@@ -228,7 +228,6 @@ export default function RepeatableContentListing(props: {
               .toString()}
             title={item.title ?? ""}
             subtitle={`Updated ${formatUpdatedOn(item)}`}
-            menuOptions={[["Delete", startDelete(item)]]}
             {...(isExternalResource && {
               menuOptions: [["Delete", startDelete(item)]],
             })}

--- a/static/js/components/widgets/MenuField.tsx
+++ b/static/js/components/widgets/MenuField.tsx
@@ -417,7 +417,7 @@ export default function MenuField(props: MenuFieldProps): JSX.Element {
       <Dialog
         open={!!itemToRemove}
         onCancel={closeRemoveDialog}
-        headerContent={"Remove collaborator"}
+        headerContent={"Remove Menu"}
         bodyContent={`Are you sure you want to remove "${itemToRemove?.text}"`}
         acceptText="Remove"
         onAccept={() => {

--- a/static/js/components/widgets/MenuField.tsx
+++ b/static/js/components/widgets/MenuField.tsx
@@ -417,7 +417,7 @@ export default function MenuField(props: MenuFieldProps): JSX.Element {
       <Dialog
         open={!!itemToRemove}
         onCancel={closeRemoveDialog}
-        headerContent={"Remove Menu"}
+        headerContent={"Remove collaborator"}
         bodyContent={`Are you sure you want to remove "${itemToRemove?.text}"`}
         acceptText="Remove"
         onAccept={() => {

--- a/static/js/query-configs/websites.ts
+++ b/static/js/query-configs/websites.ts
@@ -54,6 +54,22 @@ export type WebsiteListingParams = {
   published?: boolean
 }
 
+export const deleteWebsiteContentMutation = (
+  websiteName: string,
+  contentId: string,
+): QueryConfig => {
+  return {
+    queryKey: "deleteWebsiteContentMutation",
+    url: siteApiContentDetailUrl
+      .param({ name: websiteName, textId: contentId })
+      .toString(),
+    options: {
+      method: "DELETE",
+      ...DEFAULT_POST_OPTIONS,
+    },
+  }
+}
+
 export type WebsiteListingResponse = PaginatedResponse<Website>
 
 export type WebsitesListing = Record<string, PaginatedResponse<string>>

--- a/static/js/query-configs/websites.ts
+++ b/static/js/query-configs/websites.ts
@@ -54,22 +54,6 @@ export type WebsiteListingParams = {
   published?: boolean
 }
 
-export const deleteWebsiteContentMutation = (
-  websiteName: string,
-  contentId: string,
-): QueryConfig => {
-  return {
-    queryKey: "deleteWebsiteContentMutation",
-    url: siteApiContentDetailUrl
-      .param({ name: websiteName, textId: contentId })
-      .toString(),
-    options: {
-      method: "DELETE",
-      ...DEFAULT_POST_OPTIONS,
-    },
-  }
-}
-
 export type WebsiteListingResponse = PaginatedResponse<Website>
 
 export type WebsitesListing = Record<string, PaginatedResponse<string>>
@@ -515,6 +499,22 @@ export const createWebsiteContentMutation = (
     }),
   },
 })
+
+export const deleteWebsiteContentMutation = (
+  websiteName: string,
+  contentId: string,
+): QueryConfig => {
+  return {
+    queryKey: "deleteWebsiteContentMutation",
+    url: siteApiContentDetailUrl
+      .param({ name: websiteName, textId: contentId })
+      .toString(),
+    options: {
+      method: "DELETE",
+      ...DEFAULT_POST_OPTIONS,
+    },
+  }
+}
 
 export const syncWebsiteContentMutation = (siteName: string): QueryConfig => ({
   url: siteApiContentSyncGDriveUrl.param({ name: siteName }).toString(),


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4837

### Description (What does it do?)
Adds delete option for Repeatable Content (such as resources, pages, course lists, etc) but shown only for External Resources.

### Screenshots (if appropriate):
<img width="1157" alt="image" src="https://github.com/user-attachments/assets/0abe209f-419a-4342-b93e-0a56132863e1">

### How can this be tested?
1. Checkout to this branch
2. Spin up ocw-studio
3. Create external resources (or use existing ones)
4. You should see three-dots menu on the right of item. Click it, and Delete the item from there.
5. Make sure the delete functionality works as expected.
You can check s3 bucket (minio), django admin, etc for the deleted item.

### Additional testing

Also, you can test deletion of any repeatable content. Just remove the conditional rendering from these lines locally:
https://github.com/mitodl/ocw-studio/pull/2255/files#diff-276b07e051532856e31c9d984e242ba6e676ff4ebe7deed94e17c9e594c28903R231-R233
And add: `menuOptions={[["Delete", startDelete(item)]]}` instead

