### PR TITLE
Add SlackAlertStep in remove_unpublished_sites pipeline

### DIFF
--- a/content_sync/pipelines/definitions/concourse/remove_unpublished_sites.py
+++ b/content_sync/pipelines/definitions/concourse/remove_unpublished_sites.py
@@ -74,9 +74,6 @@ class UnpublishedSiteRemovalPipelineDefinition(Pipeline):
     def __init__(self, **kwargs):
         base = super()
         base.__init__(**kwargs)
-        namespace = ".:site."
-        short_id = f"(({namespace}short_id))"
-        site_name = f"(({namespace}site_name))"
         common_pipeline_vars = get_common_pipeline_vars()
         web_bucket = common_pipeline_vars["publish_bucket_name"]
         offline_bucket = common_pipeline_vars["offline_publish_bucket_name"]
@@ -223,14 +220,14 @@ class UnpublishedSiteRemovalPipelineDefinition(Pipeline):
             resources.append(self._slack_resource)
             job.on_failure = SlackAlertStep(
                 alert_type="failed",
-                text=f"""
-                Failed to remove unpublished site {short_id} (Site Name: {site_name}). Check the pipeline logs for more details.
+                text="""
+                Failed to remove unpublished site. Check the pipeline logs for more details.
                 """,  # noqa: E501
             )
             job.on_abort = SlackAlertStep(
                 alert_type="aborted",
-                text=f"""
-                User aborted the unpublish operation for site {short_id} (Site Name: {site_name}). Check the pipeline logs for more details.
+                text="""
+                User aborted the unpublish operation for site. Check the pipeline logs for more details.
                 """,  # noqa: E501
             )
         job.plan = tasks

--- a/content_sync/pipelines/definitions/concourse/remove_unpublished_sites.py
+++ b/content_sync/pipelines/definitions/concourse/remove_unpublished_sites.py
@@ -74,6 +74,8 @@ class UnpublishedSiteRemovalPipelineDefinition(Pipeline):
     def __init__(self, **kwargs):
         base = super()
         base.__init__(**kwargs)
+        namespace = ".:site."
+        short_id = f"(({namespace}short_id))"
         common_pipeline_vars = get_common_pipeline_vars()
         web_bucket = common_pipeline_vars["publish_bucket_name"]
         offline_bucket = common_pipeline_vars["offline_publish_bucket_name"]
@@ -220,7 +222,13 @@ class UnpublishedSiteRemovalPipelineDefinition(Pipeline):
             resources.append(self._slack_resource)
             job.on_failure = SlackAlertStep(
                 alert_type="failed",
-                text="Failed to remove unpublished site. Check the pipeline logs for more details.",  # noqa: E501
+                text="Failed to remove unpublished site {short_id}. Check the pipeline logs for more details.",  # noqa: E501
+            )
+            job.on_abort = SlackAlertStep(
+                alert_type="aborted",
+                text=f"""
+                User aborted the operation for site {short_id}.
+                """,
             )
         job.plan = tasks
         base.__init__(

--- a/content_sync/pipelines/definitions/concourse/remove_unpublished_sites.py
+++ b/content_sync/pipelines/definitions/concourse/remove_unpublished_sites.py
@@ -76,6 +76,7 @@ class UnpublishedSiteRemovalPipelineDefinition(Pipeline):
         base.__init__(**kwargs)
         namespace = ".:site."
         short_id = f"(({namespace}short_id))"
+        site_name = (f"(({namespace}site_name))",)
         common_pipeline_vars = get_common_pipeline_vars()
         web_bucket = common_pipeline_vars["publish_bucket_name"]
         offline_bucket = common_pipeline_vars["offline_publish_bucket_name"]
@@ -222,13 +223,15 @@ class UnpublishedSiteRemovalPipelineDefinition(Pipeline):
             resources.append(self._slack_resource)
             job.on_failure = SlackAlertStep(
                 alert_type="failed",
-                text="Failed to remove unpublished site {short_id}. Check the pipeline logs for more details.",  # noqa: E501
+                text=f"""
+                Failed to remove unpublished site {short_id} (Site Name: {site_name}). Check the pipeline logs for more details.
+                """,  # noqa: E501
             )
             job.on_abort = SlackAlertStep(
                 alert_type="aborted",
                 text=f"""
-                User aborted the operation for site {short_id}.
-                """,
+                User aborted the unpublish operation for site {short_id} (Site Name: {site_name}). Check the pipeline logs for more details.
+                """,  # noqa: E501
             )
         job.plan = tasks
         base.__init__(

--- a/content_sync/pipelines/definitions/concourse/remove_unpublished_sites.py
+++ b/content_sync/pipelines/definitions/concourse/remove_unpublished_sites.py
@@ -33,6 +33,7 @@ from content_sync.pipelines.definitions.concourse.common.resources import (
 from content_sync.pipelines.definitions.concourse.common.steps import (
     ClearCdnCacheStep,
     OcwStudioWebhookCurlStep,
+    SlackAlertStep,
 )
 from content_sync.utils import (
     get_cli_endpoint_url,
@@ -212,6 +213,11 @@ class UnpublishedSiteRemovalPipelineDefinition(Pipeline):
             ),
         ]
         job = Job(name=self._remove_unpublished_sites_job_identifier, serial=True)
+
+        job.on_failure = SlackAlertStep(
+            alert_type="failed",
+            text="Failed to remove unpublished site. Check the pipeline logs for more details.",  # noqa: E501
+        )
 
         job.plan = tasks
         base.__init__(resource_types=resource_types, jobs=[job], **kwargs)

--- a/content_sync/pipelines/definitions/concourse/remove_unpublished_sites.py
+++ b/content_sync/pipelines/definitions/concourse/remove_unpublished_sites.py
@@ -76,7 +76,7 @@ class UnpublishedSiteRemovalPipelineDefinition(Pipeline):
         base.__init__(**kwargs)
         namespace = ".:site."
         short_id = f"(({namespace}short_id))"
-        site_name = (f"(({namespace}site_name))",)
+        site_name = f"(({namespace}site_name))"
         common_pipeline_vars = get_common_pipeline_vars()
         web_bucket = common_pipeline_vars["publish_bucket_name"]
         offline_bucket = common_pipeline_vars["offline_publish_bucket_name"]


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4857

### Description (What does it do?)
Adds Slack notification for unpublished sites failures and pipeline abort operation.

### Screenshots (if appropriate):
This isn't exact screenshot, as the messages should be: `"Failed to remove unpublished site {short_id} (Site Name: {site_name}). Check the pipeline logs for more details."` OR `"User aborted the unpublish operation for site {short_id} (Site Name: {site_name}). Check the pipeline logs for more details."` But it shows the notifications working in action.

<img width="1071" alt="image" src="https://github.com/user-attachments/assets/9359c599-117b-466f-9611-fb17354b685a">


### How can this be tested?

### Test Context:
1. You will need to set `OCW_STUDIO_ENVIRONMENT` to something other than `dev`. You can set it to `rc`. 
2. You can set `OCW_STUDIO_BASE_URL` to an incorrect value, such as `abc` to cause the unpublish pipeline to fail. Abort is simple, you unpublish the site, go to the pipeline, and abort it. But for abort, you will want to use correct values. You can set it to RC: `OCW_STUDIO_BASE_URL=http://ocw-studio-rc.odl.mit.edu` for abort. I think you may also need to have the database dump? you can try `ocw-www` site if you don't have dump.
3. The error messages will not be able to run in development. I added `site_name`, and `short_id`, which will be used via Vault in RC/Production, but they won't work locally. So in order to test, you should checkout to this branch, and modify the messages:
```
 text=f"""
                User aborted the unpublish operation for site {short_id} (Site Name: {site_name}). Check the pipeline logs for more details.
                """,  # noqa: E501
            )
```
to without the `short_id` and `site_name`. Same goes for fail message. (Example in screenshot). Only then the procedure will work.
4. You can create your own Slack webhook, but it should be easier if you use my personal Slack workspace webhook in `resources.py`, and `mass-build-sites.yml`. Under `((slack-url))`. Just DM me and I'll provide you with the URL.

### Steps:
5. Checkout to this branch.
6. Spin up OCW Studio. Modify the code from branch as shown above to test locally.
7. Upsert the `site_removal_pipeline`: `docker-compose exec web ./manage.py upsert_site_removal_pipeline`
  - Unpause the pipeline.
8. Go to any site, unpublish it. Immediately go to the `site_removal_pipeline` at `http://concourse:8080/` , and abort it.
9. For failure operation, use incorrect values for `OCW_STUDIO_BASE_URL`.

