### PR TITLE
Refactoring Django code

### DIFF
--- a/content_sync/__init__.py
+++ b/content_sync/__init__.py
@@ -1,3 +1,1 @@
 """content_sync init file"""
-
-default_app_config = "content_sync.apps.ContentSyncApp"

--- a/content_sync/admin.py
+++ b/content_sync/admin.py
@@ -6,6 +6,7 @@ from mitol.common.admin import TimestampedModelAdmin
 from content_sync.models import ContentSyncState
 
 
+@admin.register(ContentSyncState)
 class ContentSyncStateAdmin(TimestampedModelAdmin):
     """ContentSyncState Admin"""
 
@@ -29,26 +30,26 @@ class ContentSyncStateAdmin(TimestampedModelAdmin):
     def get_queryset(self, request):  # noqa: ARG002
         return self.model.objects.get_queryset().select_related("content__website")
 
+    @admin.display(
+        description="Content Title",
+        ordering="content__title",
+    )
     def get_content_title(self, obj):
         """Returns the related WebsiteContent title"""  # noqa: D401
         return obj.content.title
 
-    get_content_title.short_description = "Content Title"
-    get_content_title.admin_order_field = "content__title"
-
+    @admin.display(
+        description="Content Text ID",
+        ordering="content__text_id",
+    )
     def get_content_text_id(self, obj):
         """Returns the related WebsiteContent text ID"""  # noqa: D401
         return obj.content.text_id
 
-    get_content_text_id.short_description = "Content Text ID"
-    get_content_text_id.admin_order_field = "content__text_id"
-
+    @admin.display(
+        description="Website",
+        ordering="content__website__name",
+    )
     def get_website_name(self, obj):
         """Returns the related Website name"""  # noqa: D401
         return obj.content.website.name
-
-    get_website_name.short_description = "Website"
-    get_website_name.admin_order_field = "content__website__name"
-
-
-admin.site.register(ContentSyncState, ContentSyncStateAdmin)

--- a/external_resources/admin.py
+++ b/external_resources/admin.py
@@ -6,6 +6,7 @@ from mitol.common.admin import TimestampedModelAdmin
 from external_resources.models import ExternalResourceState
 
 
+@admin.register(ExternalResourceState)
 class ExternalResourceStateAdmin(TimestampedModelAdmin):
     """ExternalResourceState Admin"""
 
@@ -31,26 +32,26 @@ class ExternalResourceStateAdmin(TimestampedModelAdmin):
         """Return data along with the related WebsiteContent"""
         return self.model.objects.get_queryset().select_related("content__website")
 
+    @admin.display(
+        description="Content Title",
+        ordering="content__title",
+    )
     def get_content_title(self, obj):
         """Return the related WebsiteContent title"""
         return obj.content.title
 
-    get_content_title.short_description = "Content Title"
-    get_content_title.admin_order_field = "content__title"
-
+    @admin.display(
+        description="Content Text ID",
+        ordering="content__text_id",
+    )
     def get_content_text_id(self, obj):
         """Return the related WebsiteContent text ID"""
         return obj.content.text_id
 
-    get_content_text_id.short_description = "Content Text ID"
-    get_content_text_id.admin_order_field = "content__text_id"
-
+    @admin.display(
+        description="Website",
+        ordering="content__website__name",
+    )
     def get_website_name(self, obj):
         """Return the related Website name"""
         return obj.content.website.name
-
-    get_website_name.short_description = "Website"
-    get_website_name.admin_order_field = "content__website__name"
-
-
-admin.site.register(ExternalResourceState, ExternalResourceStateAdmin)

--- a/gdrive_sync/__init__.py
+++ b/gdrive_sync/__init__.py
@@ -1,3 +1,1 @@
 """gdrive_sync init file"""
-
-default_app_config = "gdrive_sync.apps.GDriveSyncApp"

--- a/gdrive_sync/admin.py
+++ b/gdrive_sync/admin.py
@@ -6,6 +6,7 @@ from mitol.common.admin import TimestampedModelAdmin
 from gdrive_sync.models import DriveApiQueryTracker, DriveFile
 
 
+@admin.register(DriveApiQueryTracker)
 class DriveApiQueryTrackerAdmin(TimestampedModelAdmin):
     """DriveApiQueryTracker Admin"""
 
@@ -17,6 +18,7 @@ class DriveApiQueryTrackerAdmin(TimestampedModelAdmin):
     )
 
 
+@admin.register(DriveFile)
 class DriveFileAdmin(TimestampedModelAdmin):
     """DriveFile Admin"""
 
@@ -45,7 +47,3 @@ class DriveFileAdmin(TimestampedModelAdmin):
         "created_time",
         "download_link",
     ]
-
-
-admin.site.register(DriveFile, DriveFileAdmin)
-admin.site.register(DriveApiQueryTracker, DriveApiQueryTrackerAdmin)

--- a/main/__init__.py
+++ b/main/__init__.py
@@ -1,3 +1,1 @@
 """Set the default AppConfig so we can validate settings"""
-
-default_app_config = "main.apps.RootConfig"

--- a/main/urls.py
+++ b/main/urls.py
@@ -15,11 +15,10 @@ Including another URLconf
 """
 
 from django.conf import settings
-from django.conf.urls import include
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.contrib.auth.views import LogoutView
-from django.urls import path, re_path
+from django.urls import include, path, re_path
 
 from main.views import public_index, restricted_index
 
@@ -27,9 +26,9 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("robots.txt", include("robots.urls")),
     path("", include("social_django.urls", namespace="social")),
-    re_path(r"^hijack/", include("hijack.urls", namespace="hijack")),
+    path("hijack/", include("hijack.urls", namespace="hijack")),
     # Example view
-    re_path("^$", public_index, name="main-index"),
+    path("", public_index, name="main-index"),
     path("login/", public_index, name="login"),
     path("privacy-policy/", public_index, name="privacy-policy"),
     re_path(r"^sites/.*$", restricted_index, name="sites"),

--- a/users/admin.py
+++ b/users/admin.py
@@ -8,6 +8,7 @@ from mitol.common.admin import TimestampedModelAdmin
 from users.models import User
 
 
+@admin.register(User)
 class UserAdmin(ContribUserAdmin, TimestampedModelAdmin):
     """Admin views for user"""
 
@@ -50,6 +51,3 @@ class UserAdmin(ContribUserAdmin, TimestampedModelAdmin):
     search_fields = ("username", "name", "email")
     ordering = ("email",)
     readonly_fields = ("last_login",)
-
-
-admin.site.register(User, UserAdmin)

--- a/videos/__init__.py
+++ b/videos/__init__.py
@@ -1,3 +1,1 @@
 """videos init file"""
-
-default_app_config = "videos.apps.VideoApp"

--- a/videos/admin.py
+++ b/videos/admin.py
@@ -27,6 +27,7 @@ class VideoJobsInline(admin.TabularInline):
         return False
 
 
+@admin.register(Video)
 class VideoAdmin(TimestampedModelAdmin):
     """Video Admin"""
 
@@ -48,6 +49,3 @@ class VideoAdmin(TimestampedModelAdmin):
     )
     list_filter = ("status",)
     ordering = ("-updated_on",)
-
-
-admin.site.register(Video, VideoAdmin)

--- a/videos/urls.py
+++ b/videos/urls.py
@@ -1,17 +1,17 @@
 """Urls for video"""
 
-from django.urls import re_path
+from django.urls import path, re_path
 
 from videos.views import TranscodeJobView, TranscriptJobView, YoutubeTokensView
 
 urlpatterns = [
-    re_path(
-        r"api/transcode-jobs/$",
+    path(
+        "api/transcode-jobs/",
         TranscodeJobView.as_view(),
         name="transcode_jobs",
     ),
-    re_path(
-        r"api/transcription-jobs/$",
+    path(
+        "api/transcription-jobs/",
         TranscriptJobView.as_view(),
         name="transcript_jobs",
     ),

--- a/websites/__init__.py
+++ b/websites/__init__.py
@@ -1,3 +1,1 @@
 """websites init file"""
-
-default_app_config = "websites.apps.WebsitesConfig"

--- a/websites/admin.py
+++ b/websites/admin.py
@@ -13,6 +13,7 @@ from websites.config_schema.api import validate_parsed_site_config
 from websites.models import Website, WebsiteContent, WebsiteStarter
 
 
+@admin.register(Website)
 class WebsiteAdmin(TimestampedModelAdmin, GuardedModelAdmin):
     """Website Admin"""
 
@@ -38,6 +39,7 @@ class WebsiteAdmin(TimestampedModelAdmin, GuardedModelAdmin):
     ordering = ("-created_on",)
 
 
+@admin.register(WebsiteContent)
 class WebsiteContentAdmin(TimestampedModelAdmin, SafeDeleteAdmin):
     """WebsiteContent Admin"""
 
@@ -68,12 +70,13 @@ class WebsiteContentAdmin(TimestampedModelAdmin, SafeDeleteAdmin):
     def get_queryset(self, request):  # noqa: ARG002
         return self.model.objects.get_queryset().select_related("website", "parent")
 
+    @admin.display(
+        description="Website",
+        ordering="website__title",
+    )
     def get_website_title(self, obj):
         """Returns the related Website title"""  # noqa: D401
         return obj.website.title
-
-    get_website_title.short_description = "Website"
-    get_website_title.admin_order_field = "website__title"
 
 
 class WebsiteStarterForm(forms.ModelForm):
@@ -100,6 +103,7 @@ class WebsiteStarterForm(forms.ModelForm):
         return config
 
 
+@admin.register(WebsiteStarter)
 class WebsiteStarterAdmin(TimestampedModelAdmin):
     """WebsiteStarter Admin"""
 
@@ -110,8 +114,3 @@ class WebsiteStarterAdmin(TimestampedModelAdmin):
     list_display = ("id", "name", "status", "source", "commit")
     list_filter = ("source",)
     search_fields = ("name", "path")
-
-
-admin.site.register(Website, WebsiteAdmin)
-admin.site.register(WebsiteContent, WebsiteContentAdmin)
-admin.site.register(WebsiteStarter, WebsiteStarterAdmin)

--- a/websites/urls.py
+++ b/websites/urls.py
@@ -1,6 +1,6 @@
 """websites URL Configuration"""
 
-from django.urls import include, re_path
+from django.urls import include, path
 from rest_framework_extensions.routers import ExtendedSimpleRouter as SimpleRouter
 
 from websites import views
@@ -33,5 +33,5 @@ router.register(
 )
 
 urlpatterns = [
-    re_path(r"^api/", include(router.urls)),
+    path("api/", include(router.urls)),
 ]


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4078

### Description (What does it do?)
This PR refactors Django code in our codebase using the `django-upgrade` tool, targeting Django version 4.2. The changes include:
- Removing `default_app_config`
- Replacing `admin.site.register` with `@admin.register()` and using `@admin.display()` decorators
- Converting `re_path` to `path` where applicable

### How can this be tested?
1. Checkout to this branch.
2. Spin up ocw-studio.
3. Verify that all relevant URLs and admin panel functionalities work as expected.
4. Verify that all apps function as expected after the removal of `default_app_config`.

