### PR TITLE
Updated user agent header for external resource checking

### DIFF
--- a/external_resources/api.py
+++ b/external_resources/api.py
@@ -23,7 +23,20 @@ def is_url_broken(url: str) -> tuple[bool, Optional[int]]:
     log.debug("Making a HEAD request for url: %s", url)
 
     try:
-        response = requests.head(url, allow_redirects=True, timeout=30)
+        response = requests.head(
+            url,
+            allow_redirects=True,
+            timeout=30,
+            headers={
+                "Accept": "*/*",
+                "User-Agent": (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/114.0.0.0 "
+                    "Safari/537.36"
+                ),
+            },
+        )
     except Exception as ex:
         log.debug(ex)
         raise CheckFailedError from ex


### PR DESCRIPTION
### What are the relevant tickets?
Fixes https://github.com/mitodl/hq/issues/5278

### Description (What does it do?)
Added common browser user agent headers to external resource checking requests with requests module

### How can this be tested?
1. Open python interpreter
2. Import requests module: `import requests`
3. and run this command: `requests.head('https://coincentral.com/digital-asset-holdings/')`
4. The above command would result in 403 status code
5. Now try with updated headers:
`requests.head('https://coincentral.com/digital-asset-holdings/', headers={
     'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36'})`