### PR TITLE
Exclude courses which have the download button disabled from mirror drives

### DIFF
--- a/content_sync/constants.py
+++ b/content_sync/constants.py
@@ -19,3 +19,8 @@ WEBSITE_LISTING_DIRPATH = "content/websites"
 DEV_DRAFT_URL = "http://10.1.0.102:8044"
 DEV_LIVE_URL = "http://10.1.0.102:8045"
 DEV_TEST_URL = "http://10.1.0.102:8046"
+
+
+# Publish Date Constants
+PUBLISH_DATE_LIVE = "publish_date"
+PUBLISH_DATE_DRAFT = "draft_publish_date"

--- a/content_sync/pipelines/definitions/concourse/common/identifiers.py
+++ b/content_sync/pipelines/definitions/concourse/common/identifiers.py
@@ -10,7 +10,7 @@ S3_IAM_RESOURCE_TYPE_IDENTIFIER = Identifier("s3-resource-iam").root
 OCW_STUDIO_WEBHOOK_RESOURCE_TYPE_IDENTIFIER = Identifier("ocw-studio-webhook").root
 OCW_STUDIO_WEBHOOK_CURL_STEP_IDENTIFIER = Identifier("ocw-studio-webhook-curl").root
 OCW_STUDIO_WEBHOOK_ALLOW_OFFLINE_BUILD_IDENTIFIER = Identifier(
-    "ocw-studio-webhook-allow-offline"
+    "ocw-studio-webhook-build-offline"
 ).root
 SLACK_ALERT_RESOURCE_IDENTIFIER = Identifier("slack-alert").root
 WEBPACK_MANIFEST_S3_IDENTIFIER = Identifier("webpack-manifest-s3").root

--- a/content_sync/pipelines/definitions/concourse/common/identifiers.py
+++ b/content_sync/pipelines/definitions/concourse/common/identifiers.py
@@ -9,9 +9,7 @@ KEYVAL_RESOURCE_TYPE_IDENTIFIER = Identifier("keyval").root
 S3_IAM_RESOURCE_TYPE_IDENTIFIER = Identifier("s3-resource-iam").root
 OCW_STUDIO_WEBHOOK_RESOURCE_TYPE_IDENTIFIER = Identifier("ocw-studio-webhook").root
 OCW_STUDIO_WEBHOOK_CURL_STEP_IDENTIFIER = Identifier("ocw-studio-webhook-curl").root
-OCW_STUDIO_WEBHOOK_ALLOW_OFFLINE_BUILD_IDENTIFIER = Identifier(
-    "ocw-studio-webhook-build-offline"
-).root
+OCW_STUDIO_WEBHOOK_OFFLINE_GATE_IDENTIFIER = Identifier("offline-build-gate").root
 SLACK_ALERT_RESOURCE_IDENTIFIER = Identifier("slack-alert").root
 WEBPACK_MANIFEST_S3_IDENTIFIER = Identifier("webpack-manifest-s3").root
 WEBPACK_MANIFEST_S3_TRIGGER_IDENTIFIER = Identifier(

--- a/content_sync/pipelines/definitions/concourse/common/identifiers.py
+++ b/content_sync/pipelines/definitions/concourse/common/identifiers.py
@@ -9,6 +9,9 @@ KEYVAL_RESOURCE_TYPE_IDENTIFIER = Identifier("keyval").root
 S3_IAM_RESOURCE_TYPE_IDENTIFIER = Identifier("s3-resource-iam").root
 OCW_STUDIO_WEBHOOK_RESOURCE_TYPE_IDENTIFIER = Identifier("ocw-studio-webhook").root
 OCW_STUDIO_WEBHOOK_CURL_STEP_IDENTIFIER = Identifier("ocw-studio-webhook-curl").root
+OCW_STUDIO_WEBHOOK_ALLOW_OFFLINE_BUILD_IDENTIFIER = Identifier(
+    "ocw-studio-webhook-allow-offline"
+).root
 SLACK_ALERT_RESOURCE_IDENTIFIER = Identifier("slack-alert").root
 WEBPACK_MANIFEST_S3_IDENTIFIER = Identifier("webpack-manifest-s3").root
 WEBPACK_MANIFEST_S3_TRIGGER_IDENTIFIER = Identifier(

--- a/content_sync/pipelines/definitions/concourse/common/resource_types.py
+++ b/content_sync/pipelines/definitions/concourse/common/resource_types.py
@@ -17,7 +17,7 @@ class HttpResourceType(ResourceType):
         super().__init__(
             name=HTTP_RESOURCE_TYPE_IDENTIFIER,
             type=REGISTRY_IMAGE,
-            source={"repository": "jgriff/http-resource", "tag": "latest"},
+            source={"repository": "umar8hassan/http-resource", "tag": "latest"},
             **kwargs,
         )
 

--- a/content_sync/pipelines/definitions/concourse/common/resources.py
+++ b/content_sync/pipelines/definitions/concourse/common/resources.py
@@ -11,7 +11,7 @@ from content_sync.pipelines.definitions.concourse.common.identifiers import (
     HTTP_RESOURCE_TYPE_IDENTIFIER,
     OCW_HUGO_PROJECTS_GIT_IDENTIFIER,
     OCW_HUGO_THEMES_GIT_IDENTIFIER,
-    OCW_STUDIO_WEBHOOK_ALLOW_OFFLINE_BUILD_IDENTIFIER,
+    OCW_STUDIO_WEBHOOK_OFFLINE_GATE_IDENTIFIER,
     OCW_STUDIO_WEBHOOK_RESOURCE_TYPE_IDENTIFIER,
     S3_IAM_RESOURCE_TYPE_IDENTIFIER,
     SLACK_ALERT_RESOURCE_IDENTIFIER,
@@ -147,14 +147,14 @@ class OcwStudioOfflineGateResource(Resource):
         )
         api_url = f"{urljoin(ocw_studio_url, api_path)}/"
         super().__init__(
-            name=OCW_STUDIO_WEBHOOK_ALLOW_OFFLINE_BUILD_IDENTIFIER,
+            name=OCW_STUDIO_WEBHOOK_OFFLINE_GATE_IDENTIFIER,
             icon="language-python",
             type=HTTP_RESOURCE_TYPE_IDENTIFIER,
             check_every="never",
             source={
                 "url": api_url,
                 "method": "GET",
-                "sensitive": True,
+                "version": {"jq": ".version.created_at", "default": None},
                 "headers": {
                     "Content-Type": "application/json",
                     "Authorization": f"Bearer {api_token}",

--- a/content_sync/pipelines/definitions/concourse/common/resources.py
+++ b/content_sync/pipelines/definitions/concourse/common/resources.py
@@ -154,7 +154,7 @@ class OcwStudioOfflineGateResource(Resource):
             source={
                 "url": api_url,
                 "method": "GET",
-                "version": {"jq": ".version.created_at", "default": "none"},
+                "version": {"jq": ".version", "default": "none"},
                 "headers": {
                     "Content-Type": "application/json",
                     "Authorization": f"Bearer {api_token}",

--- a/content_sync/pipelines/definitions/concourse/common/resources.py
+++ b/content_sync/pipelines/definitions/concourse/common/resources.py
@@ -11,6 +11,7 @@ from content_sync.pipelines.definitions.concourse.common.identifiers import (
     HTTP_RESOURCE_TYPE_IDENTIFIER,
     OCW_HUGO_PROJECTS_GIT_IDENTIFIER,
     OCW_HUGO_THEMES_GIT_IDENTIFIER,
+    OCW_STUDIO_WEBHOOK_ALLOW_OFFLINE_BUILD_IDENTIFIER,
     OCW_STUDIO_WEBHOOK_RESOURCE_TYPE_IDENTIFIER,
     S3_IAM_RESOURCE_TYPE_IDENTIFIER,
     SLACK_ALERT_RESOURCE_IDENTIFIER,
@@ -115,6 +116,45 @@ class OcwStudioWebhookResource(Resource):
                 "url": api_url,
                 "method": "POST",
                 "out_only": True,
+                "headers": {
+                    "Content-Type": "application/json",
+                    "Authorization": f"Bearer {api_token}",
+                },
+            },
+            **kwargs,
+        )
+
+
+class OcwStudioOfflineGateResource(Resource):
+    """
+    A Resource for making API calls to ocw-studio to check if a Website's
+    offline version is downloadable.
+
+    args:
+        site_name(str): The name of the site the status is in reference to
+        api_token(str): The ocw-studio API token
+    """
+
+    def __init__(
+        self,
+        site_name: str,
+        api_token: str,
+        **kwargs,
+    ):
+        ocw_studio_url = get_ocw_studio_api_url()
+        api_path = os.path.join(  # noqa: PTH118
+            "api", "websites", site_name, "allow_offline_build"
+        )
+        api_url = f"{urljoin(ocw_studio_url, api_path)}/"
+        super().__init__(
+            name=OCW_STUDIO_WEBHOOK_ALLOW_OFFLINE_BUILD_IDENTIFIER,
+            icon="language-python",
+            type=HTTP_RESOURCE_TYPE_IDENTIFIER,
+            check_every="never",
+            source={
+                "url": api_url,
+                "method": "GET",
+                "sensitive": True,
                 "headers": {
                     "Content-Type": "application/json",
                     "Authorization": f"Bearer {api_token}",

--- a/content_sync/pipelines/definitions/concourse/common/resources.py
+++ b/content_sync/pipelines/definitions/concourse/common/resources.py
@@ -154,7 +154,7 @@ class OcwStudioOfflineGateResource(Resource):
             source={
                 "url": api_url,
                 "method": "GET",
-                "version": {"jq": ".version.created_at", "default": "null"},
+                "version": {"jq": ".version.created_at", "default": "none"},
                 "headers": {
                     "Content-Type": "application/json",
                     "Authorization": f"Bearer {api_token}",

--- a/content_sync/pipelines/definitions/concourse/common/resources.py
+++ b/content_sync/pipelines/definitions/concourse/common/resources.py
@@ -154,7 +154,7 @@ class OcwStudioOfflineGateResource(Resource):
             source={
                 "url": api_url,
                 "method": "GET",
-                "version": {"jq": ".version.created_at", "default": None},
+                "version": {"jq": ".version.created_at", "default": "null"},
                 "headers": {
                     "Content-Type": "application/json",
                     "Authorization": f"Bearer {api_token}",

--- a/content_sync/pipelines/definitions/concourse/common/resources.py
+++ b/content_sync/pipelines/definitions/concourse/common/resources.py
@@ -143,7 +143,7 @@ class OcwStudioOfflineGateResource(Resource):
     ):
         ocw_studio_url = get_ocw_studio_api_url()
         api_path = os.path.join(  # noqa: PTH118
-            "api", "websites", site_name, "allow_offline_build"
+            "api", "websites", site_name, "hide_download"
         )
         api_url = f"{urljoin(ocw_studio_url, api_path)}/"
         super().__init__(

--- a/content_sync/pipelines/definitions/concourse/common/steps.py
+++ b/content_sync/pipelines/definitions/concourse/common/steps.py
@@ -7,6 +7,7 @@ from ol_concourse.lib.models.pipeline import (
     AnonymousResource,
     Command,
     DoStep,
+    GetStep,
     Identifier,
     Output,
     PutStep,
@@ -217,11 +218,10 @@ class OcwStudioOfflineGateWebhookStep(TryStep):
 
     def __init__(self, **kwargs):
         super().__init__(
-            try_=PutStep(
-                put=OCW_STUDIO_WEBHOOK_ALLOW_OFFLINE_BUILD_IDENTIFIER,
+            try_=GetStep(
+                get=OCW_STUDIO_WEBHOOK_ALLOW_OFFLINE_BUILD_IDENTIFIER,
                 timeout="1m",
                 attempts=3,
-                get_params={"response": True},
             ),
             **kwargs,
         )

--- a/content_sync/pipelines/definitions/concourse/common/steps.py
+++ b/content_sync/pipelines/definitions/concourse/common/steps.py
@@ -18,6 +18,7 @@ from ol_concourse.lib.models.pipeline import (
 )
 
 from content_sync.pipelines.definitions.concourse.common.identifiers import (
+    OCW_STUDIO_WEBHOOK_ALLOW_OFFLINE_BUILD_IDENTIFIER,
     OCW_STUDIO_WEBHOOK_CURL_STEP_IDENTIFIER,
     OCW_STUDIO_WEBHOOK_RESOURCE_TYPE_IDENTIFIER,
     SITE_CONTENT_GIT_IDENTIFIER,
@@ -200,6 +201,27 @@ class OcwStudioWebhookStep(TryStep):
                     "text": json.dumps({"version": pipeline_name, "status": status})
                 },
                 inputs=[],
+            ),
+            **kwargs,
+        )
+
+
+class OcwStudioOfflineGateWebhookStep(TryStep):
+    """
+    A PutStep to the ocw-studio api resource that sets a status on a given pipeline
+
+    Args:
+        pipeline_name(str): The name of the pipeline to set the status on
+        status: (str): The status to set on the pipeline (failed, errored, succeeded)
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(
+            try_=PutStep(
+                put=OCW_STUDIO_WEBHOOK_ALLOW_OFFLINE_BUILD_IDENTIFIER,
+                timeout="1m",
+                attempts=3,
+                get_params={"response": True},
             ),
             **kwargs,
         )

--- a/content_sync/pipelines/definitions/concourse/common/steps.py
+++ b/content_sync/pipelines/definitions/concourse/common/steps.py
@@ -7,7 +7,6 @@ from ol_concourse.lib.models.pipeline import (
     AnonymousResource,
     Command,
     DoStep,
-    GetStep,
     Identifier,
     Output,
     PutStep,
@@ -19,7 +18,6 @@ from ol_concourse.lib.models.pipeline import (
 )
 
 from content_sync.pipelines.definitions.concourse.common.identifiers import (
-    OCW_STUDIO_WEBHOOK_ALLOW_OFFLINE_BUILD_IDENTIFIER,
     OCW_STUDIO_WEBHOOK_CURL_STEP_IDENTIFIER,
     OCW_STUDIO_WEBHOOK_RESOURCE_TYPE_IDENTIFIER,
     SITE_CONTENT_GIT_IDENTIFIER,
@@ -202,26 +200,6 @@ class OcwStudioWebhookStep(TryStep):
                     "text": json.dumps({"version": pipeline_name, "status": status})
                 },
                 inputs=[],
-            ),
-            **kwargs,
-        )
-
-
-class OcwStudioOfflineGateWebhookStep(TryStep):
-    """
-    A PutStep to the ocw-studio api resource that sets a status on a given pipeline
-
-    Args:
-        pipeline_name(str): The name of the pipeline to set the status on
-        status: (str): The status to set on the pipeline (failed, errored, succeeded)
-    """
-
-    def __init__(self, **kwargs):
-        super().__init__(
-            try_=GetStep(
-                get=OCW_STUDIO_WEBHOOK_ALLOW_OFFLINE_BUILD_IDENTIFIER,
-                timeout="1m",
-                attempts=3,
             ),
             **kwargs,
         )

--- a/content_sync/pipelines/definitions/concourse/mass_build_sites.py
+++ b/content_sync/pipelines/definitions/concourse/mass_build_sites.py
@@ -90,7 +90,7 @@ class MassBuildSitesPipelineDefinitionConfig:
         hugo_arg_overrides: Optional[str] = None,
     ):
         vars = get_common_pipeline_vars()  # noqa: A001
-        sites = list(get_publishable_sites(version))
+        sites = list(get_publishable_sites(version, is_offline=offline))
         shuffle(sites)
         self.sites = sites
         self.version = version

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -848,7 +848,7 @@ class SitePipelineDefinition(Pipeline):
                 put=self._offline_build_gate_identifier,
                 timeout="1m",
                 attempts=3,
-                params={"strict": True},
+                get_params={"out_only": True, "strict": True},
             ),
             step_description=f"{self._offline_build_gate_identifier} put step",
             pipeline_name=config.vars["pipeline_name"],

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -849,7 +849,7 @@ class SitePipelineDefinition(Pipeline):
             type=KEYVAL_RESOURCE_TYPE_IDENTIFIER,
             icon="gate",
             check_every="never",
-            source={"initial_mapping": ""},
+            source={"initial_mapping": "timestamp = now()"},
         )
         resources.append(offline_build_gate_resource)
         online_job = self.get_online_build_job(config=config)
@@ -857,7 +857,7 @@ class SitePipelineDefinition(Pipeline):
             step=PutStep(
                 put=self._offline_build_gate_identifier,
                 params={
-                    "mapping": "((.:conditional_version.timestamp))",
+                    "version": "((.:conditional_version.timestamp))",
                 },
                 inputs=[],
             ),
@@ -892,7 +892,7 @@ class SitePipelineDefinition(Pipeline):
                             if [ $RESPONSE = true ]; then
                                 cp {OCW_STUDIO_WEBHOOK_ALLOW_OFFLINE_BUILD_IDENTIFIER}/body {OCW_STUDIO_WEBHOOK_ALLOW_OFFLINE_BUILD_IDENTIFIER}/version.json
                             else
-                                echo "{{}}" > {OCW_STUDIO_WEBHOOK_ALLOW_OFFLINE_BUILD_IDENTIFIER}/version.json
+                                echo '{{"timestamp": ""}}' > {OCW_STUDIO_WEBHOOK_ALLOW_OFFLINE_BUILD_IDENTIFIER}/version.json
                             fi
                             cat {OCW_STUDIO_WEBHOOK_ALLOW_OFFLINE_BUILD_IDENTIFIER}/version.json
                             """,  # noqa: E501

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -848,6 +848,7 @@ class SitePipelineDefinition(Pipeline):
                 put=self._offline_build_gate_identifier,
                 timeout="1m",
                 attempts=3,
+                params={"strict": True},
             ),
             step_description=f"{self._offline_build_gate_identifier} put step",
             pipeline_name=config.vars["pipeline_name"],

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -862,7 +862,6 @@ class SitePipelineDefinition(Pipeline):
                 get=self._offline_build_gate_identifier,
                 passed=[self._online_site_job_identifier],
                 trigger=True,
-                params={"strict": True},
             ),
             step_description=f"{self._offline_build_gate_identifier} get step",
             pipeline_name=config.vars["pipeline_name"],

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -861,6 +861,7 @@ class SitePipelineDefinition(Pipeline):
                 get=self._offline_build_gate_identifier,
                 passed=[self._online_site_job_identifier],
                 trigger=True,
+                params={"strict": True},
             ),
             step_description=f"{self._offline_build_gate_identifier} get step",
             pipeline_name=config.vars["pipeline_name"],

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -843,17 +843,13 @@ class SitePipelineDefinition(Pipeline):
         resource_types.append(KeyvalResourceType())
         resources = SitePipelineResources(config=config)
         online_job = self.get_online_build_job(config=config)
-        offline_build_gate_put_step = add_error_handling(
-            step=PutStep(
+        offline_build_gate_put_step = TryStep(
+            try_=PutStep(
                 put=self._offline_build_gate_identifier,
                 timeout="1m",
-                attempts=3,
-                get_params={"out_only": True, "strict": True},
-            ),
-            step_description=f"{self._offline_build_gate_identifier} put step",
-            pipeline_name=config.vars["pipeline_name"],
-            short_id=config.vars["short_id"],
-            instance_vars=config.vars["instance_vars"],
+                attempts=1,
+                get_params={"no_get": True, "strict": True},
+            )
         )
         online_job.plan.append(offline_build_gate_put_step)
         offline_job = self.get_offline_build_job(config=config)

--- a/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
@@ -428,7 +428,7 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
                 == config.vars["pipeline_name"]
             )
     assert (
-        online_site_tasks[-1]["put"]
+        online_site_tasks[-1]["try"]["put"]
         == pipeline_definition._offline_build_gate_identifier  # noqa: SLF001
     )
     offline_site_job = get_dict_list_item_by_field(

--- a/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
@@ -191,7 +191,7 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
         field="name",
         value=pipeline_definition._offline_build_gate_identifier,  # noqa: SLF001
     )
-    assert offline_build_gate_resource["type"] == "keyval"
+    assert offline_build_gate_resource["type"] == "http-resource"
     site_content_git_resource = get_dict_list_item_by_field(
         items=resources, field="name", value=SITE_CONTENT_GIT_IDENTIFIER
     )

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -465,6 +465,10 @@ def update_websites_in_root_website():
         sites = get_publishable_sites(is_offline=True)
         # Exclude the root website
         sites = sites.exclude(name=settings.ROOT_WEBSITE_NAME)
+
+        # Remove the content for unpublished or not downloadable sites
+        WebsiteContent.objects.exclude(website__in=sites).delete()
+
         fields = [
             "website",
             "type",

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -20,6 +20,7 @@ from content_sync.apis import github
 from content_sync.constants import VERSION_DRAFT, VERSION_LIVE, WEBSITE_LISTING_DIRPATH
 from content_sync.decorators import single_task
 from content_sync.models import ContentSyncState
+from content_sync.utils import get_publishable_sites
 from main.celery import app
 from main.s3_utils import get_boto3_resource
 from websites.api import (
@@ -460,11 +461,8 @@ def update_websites_in_root_website():
     if settings.CONTENT_SYNC_BACKEND:
         root_website = Website.objects.get(name=settings.ROOT_WEBSITE_NAME)
         # Get all sites, minus any sites that have never been successfully published
-        sites = Website.objects.exclude(
-            Q(**{"draft_publish_date__isnull": True})
-            & Q(**{"publish_date__isnull": True})
-        )
-        sites = sites.exclude(Q(url_path__isnull=True))
+        # and have downloading disabled
+        sites = get_publishable_sites(is_offline=True)
         # Exclude the root website
         sites = sites.exclude(name=settings.ROOT_WEBSITE_NAME)
         fields = [

--- a/content_sync/utils.py
+++ b/content_sync/utils.py
@@ -158,7 +158,7 @@ def get_ocw_studio_api_url():
     return "http://10.1.0.102:8043" if is_dev() else settings.SITE_BASE_URL
 
 
-def get_publishable_sites(version: str, *, is_offline: bool):
+def get_publishable_sites(version: str, *, is_offline: bool = False):
     """
     Get a QuerySet of Website objects that are eligible for publishing
 

--- a/content_sync/utils.py
+++ b/content_sync/utils.py
@@ -29,7 +29,7 @@ from content_sync.constants import (
 )
 from main.s3_utils import get_boto3_resource
 from main.utils import is_dev
-from websites.constants import WEBSITE_CONTENT_FILETYPE
+from websites.constants import CONTENT_TYPE_METADATA, WEBSITE_CONTENT_FILETYPE
 from websites.models import Website, WebsiteContent
 from websites.site_config_api import SiteConfig
 
@@ -158,12 +158,13 @@ def get_ocw_studio_api_url():
     return "http://10.1.0.102:8043" if is_dev() else settings.SITE_BASE_URL
 
 
-def get_publishable_sites(version: str):
+def get_publishable_sites(version: str, *, is_offline: bool):
     """
     Get a QuerySet of Website objects that are eligible for publishing
 
     Args:
         version(str): The version (draft/live) to check publish eligibility with
+        is_offline(bool): Is the build type offline or not
     """
     publish_date_field = (
         "publish_date" if version == VERSION_LIVE else "draft_publish_date"
@@ -176,6 +177,14 @@ def get_publishable_sites(version: str):
         .exclude(unpublish_status__isnull=False)
         .exclude(name__in=settings.OCW_TEST_SITE_SLUGS)
     )
+
+    if is_offline:
+        # filter sites with download disabled
+        download_disabled_sites = WebsiteContent.objects.filter(
+            type=CONTENT_TYPE_METADATA, metadata__hide_download=True
+        ).values_list("website__short_id", flat=True)
+        sites = sites.exclude(short_id__in=download_disabled_sites)
+
     return sites.prefetch_related("starter")
 
 

--- a/websites/views.py
+++ b/websites/views.py
@@ -315,15 +315,17 @@ class WebsiteViewSet(
         )
         return Response(status=200)
 
-    @action(detail=True, methods=["get"], permission_classes=[])
+    @action(detail=True, methods=["get"], permission_classes=[BearerTokenPermission])
     def allow_offline_build(self, request, name=None):  # noqa: ARG002
         """Process webhook requests from concourse pipeline runs"""
         website = get_object_or_404(Website, name=name)
         content = WebsiteContent.objects.get(
             website=website, type=CONTENT_TYPE_METADATA
         )
-        is_offline = content.metadata["hide_download"]
-        return Response(status=200, data={"is_offline": is_offline})
+        allow_offline = content.metadata["hide_download"]
+        return Response(
+            status=200, data={"allow_offline": allow_offline, "timestamp": now_in_utc()}
+        )
 
 
 class WebsiteMassBuildViewSet(viewsets.ViewSet):

--- a/websites/views.py
+++ b/websites/views.py
@@ -316,20 +316,16 @@ class WebsiteViewSet(
         return Response(status=200)
 
     @action(detail=True, methods=["get"], permission_classes=[BearerTokenPermission])
-    def allow_offline_build(self, request, name=None):  # noqa: ARG002
+    def hide_download(self, request, name=None):  # noqa: ARG002
         """Process webhook requests from concourse pipeline runs"""
         website = get_object_or_404(Website, name=name)
         content = WebsiteContent.objects.get(
             website=website, type=CONTENT_TYPE_METADATA
         )
-        allow_offline = content.metadata["hide_download"]
+        hide_download = content and content.metadata.get("hide_download")
         return Response(
             status=200,
-            data={
-                "version": {"created_at": str(now_in_utc().timestamp())}
-                if not allow_offline
-                else {}
-            },
+            data={} if hide_download else {"version": str(now_in_utc().timestamp())},
         )
 
 

--- a/websites/views.py
+++ b/websites/views.py
@@ -327,7 +327,7 @@ class WebsiteViewSet(
             status=200,
             data={
                 "version": {"created_at": str(now_in_utc().timestamp())}
-                if allow_offline
+                if not allow_offline
                 else {}
             },
         )

--- a/websites/views.py
+++ b/websites/views.py
@@ -324,7 +324,12 @@ class WebsiteViewSet(
         )
         allow_offline = content.metadata["hide_download"]
         return Response(
-            status=200, data={"allow_offline": allow_offline, "timestamp": now_in_utc()}
+            status=200,
+            data={
+                "version": {"created_at": str(now_in_utc().timestamp())}
+                if allow_offline
+                else {}
+            },
         )
 
 

--- a/websites/views.py
+++ b/websites/views.py
@@ -315,6 +315,16 @@ class WebsiteViewSet(
         )
         return Response(status=200)
 
+    @action(detail=True, methods=["get"], permission_classes=[])
+    def allow_offline_build(self, request, name=None):  # noqa: ARG002
+        """Process webhook requests from concourse pipeline runs"""
+        website = get_object_or_404(Website, name=name)
+        content = WebsiteContent.objects.get(
+            website=website, type=CONTENT_TYPE_METADATA
+        )
+        is_offline = content.metadata["hide_download"]
+        return Response(status=200, data={"is_offline": is_offline})
+
 
 class WebsiteMassBuildViewSet(viewsets.ViewSet):
     """Return a list of previously published sites, with the info required by the mass-build-sites pipeline"""  # noqa: E501


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/4473

### Description (What does it do?)
This excludes the sites in offline mass build which has `hide_download` button set for them.

### How can this be tested?
1. Switch `main` branch in `ocw-studio`
2. Create a site locally at `localhost:8043/sites` or use existing one
3. In metadata form for site, set `hide_download` to `True`
4. Trigger a mass_build: `docker-compose exec web ./manage.py mass_publish <live/draft> --filter <site-name>` and wait for the build to complete successfully.
5. Open `minio` console at `localhost:9001` and check course data in `ocw-content-offline-<live/draft>-local/courses/<site-name>` for your site.
6. Verify that data has been updated recently.
7. Switch to `umar/4473-exclude-courses-which-have-the-download-button-disabled-from-mirror-drives` in `ocw-studio`
8. Repeat steps `2 - 6` and data should not be updated for `offline` version sites.