### PR TITLE
Use label instead of name for Min and Max error in Studio

### DIFF
--- a/static/js/components/forms/validation.ts
+++ b/static/js/components/forms/validation.ts
@@ -37,7 +37,7 @@ const minMax = (
   if (field.min) {
     schema = schema.min(
       field.min,
-      `${field.name} must have at least ${field.min} ${
+      `${field.label} must have at least ${field.min} ${
         field.min === 1 ? "entry" : "entries"
       }.`,
     )
@@ -45,7 +45,7 @@ const minMax = (
   if (field.max) {
     schema = schema.max(
       field.max,
-      `${field.name} may have at most ${field.max} entries.`,
+      `${field.label} may have at most ${field.max} entries.`,
     )
   }
   return schema


### PR DESCRIPTION
### What are the relevant tickets?
No ticket

### Description (What does it do?)
Previously we used `field.name` for minimum/maximum warnings, which includes dash/underscore, which I think is slightly less user-friendly. This PR changes that to use `field.label` instead.

**Eg. Instead of:**

<img width="1143" alt="image" src="https://github.com/user-attachments/assets/8f52c257-ecb5-456a-99b0-adb47399bd8d">

**To have this instead:**

<img width="576" alt="image" src="https://github.com/user-attachments/assets/d8008a87-28b4-4bb1-858c-016ea6b63968">

### How can this be tested?
There isn't currently any other field in Studio that uses `min` or `max`. Department Numbers had it but we recently removed it. `MIT Learn Topics` is being added that will use it.

For the sake of testing, you can:
1. Checkout to this branch
2. Spin up OCW Studio
3. From admin panel, go to ocw-course-v2 website starter, and add the `min: 1` in `department_numbers` as it was previously https://github.com/mitodl/ocw-hugo-projects/pull/301
4. Then you can trigger an error message without having a `department_number` in course.
5. The error message should say `Department Numbers should have at least 1 entry` instead of `department_numbers should have at least 1 entry`.

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
