### PR TITLE
Only send Learn webhook requests for live sites to update search index

### DIFF
--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
@@ -228,6 +228,7 @@ class EndToEndTestPipelineDefinition(Pipeline):
             SitePipelineOnlineTasks(
                 pipeline_vars=site_pipeline_vars,
                 fastly_var="test",
+                pipeline_name=VERSION_LIVE,
                 skip_cache_clear=is_dev(),
                 skip_search_index_update=True,
             )

--- a/content_sync/pipelines/definitions/concourse/mass_build_sites.py
+++ b/content_sync/pipelines/definitions/concourse/mass_build_sites.py
@@ -173,7 +173,7 @@ class MassBuildSitesResources(list[Resource]):
             )
         )
         self.append(SlackAlertResource())
-        if not is_dev():
+        if not is_dev() and config.version == "live":
             self.extend(
                 [OpenCatalogResource(url) for url in settings.OPEN_CATALOG_URLS]
             )
@@ -315,6 +315,7 @@ class MassBuildSitesPipelineDefinition(Pipeline):
                     SitePipelineOnlineTasks(
                         pipeline_vars=site_pipeline_vars,
                         fastly_var=config.version,
+                        pipeline_name=config.version,
                         destructive_sync=False,
                         filter_videos=True,
                     )
@@ -322,7 +323,9 @@ class MassBuildSitesPipelineDefinition(Pipeline):
             else:
                 site_build_tasks.extend(
                     SitePipelineOfflineTasks(
-                        pipeline_vars=site_pipeline_vars, fastly_var=config.version
+                        pipeline_vars=site_pipeline_vars,
+                        fastly_var=config.version,
+                        pipeline_name=config.version,
                     )
                 )
             if batch_number > 1:

--- a/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
@@ -393,7 +393,7 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
     )
     assert (
         upload_online_build_task["on_success"]["try"]["params"]["text"]
-        == f'{{"version": "{config.vars['pipeline_name']}", "status": "succeeded"}}'
+        == f'{{"version": "{config.vars["pipeline_name"]}", "status": "succeeded"}}'
     )
     if is_dev:
         assert set(
@@ -409,21 +409,22 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
         clear_cdn_cache_online_success_steps = clear_cdn_cache_online_step[
             "on_success"
         ]["try"]["do"]
-        open_discussions_webhook_step_online_params = json.loads(
-            clear_cdn_cache_online_success_steps[0]["try"]["params"]["text"]
-        )
-        assert (
-            open_discussions_webhook_step_online_params["webhook_key"]
-            == settings.OPEN_CATALOG_WEBHOOK_KEY
-        )
-        assert (
-            open_discussions_webhook_step_online_params["prefix"]
-            == f"{config.vars['url_path']}/"
-        )
-        assert (
-            open_discussions_webhook_step_online_params["version"]
-            == config.vars["pipeline_name"]
-        )
+        if config.vars["pipeline_name"] == "live":
+            open_discussions_webhook_step_online_params = json.loads(
+                clear_cdn_cache_online_success_steps[0]["try"]["params"]["text"]
+            )
+            assert (
+                open_discussions_webhook_step_online_params["webhook_key"]
+                == settings.OPEN_CATALOG_WEBHOOK_KEY
+            )
+            assert (
+                open_discussions_webhook_step_online_params["prefix"]
+                == f"{config.vars['url_path']}/"
+            )
+            assert (
+                open_discussions_webhook_step_online_params["version"]
+                == config.vars["pipeline_name"]
+            )
     assert (
         online_site_tasks[-1]["put"]
         == pipeline_definition._offline_build_gate_identifier  # noqa: SLF001
@@ -580,21 +581,22 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
         clear_cdn_cache_offline_success_steps = clear_cdn_cache_offline_step[
             "on_success"
         ]["try"]["do"]
-        open_discussions_webhook_step_offline_params = json.loads(
-            clear_cdn_cache_offline_success_steps[0]["try"]["params"]["text"]
-        )
-        assert (
-            open_discussions_webhook_step_offline_params["webhook_key"]
-            == settings.OPEN_CATALOG_WEBHOOK_KEY
-        )
-        assert (
-            open_discussions_webhook_step_offline_params["prefix"]
-            == f"{config.vars['url_path']}/"
-        )
-        assert (
-            open_discussions_webhook_step_offline_params["version"]
-            == config.vars["pipeline_name"]
-        )
+        if config.vars["pipeline_name"] == "live":
+            open_discussions_webhook_step_offline_params = json.loads(
+                clear_cdn_cache_offline_success_steps[0]["try"]["params"]["text"]
+            )
+            assert (
+                open_discussions_webhook_step_offline_params["webhook_key"]
+                == settings.OPEN_CATALOG_WEBHOOK_KEY
+            )
+            assert (
+                open_discussions_webhook_step_offline_params["prefix"]
+                == f"{config.vars['url_path']}/"
+            )
+            assert (
+                open_discussions_webhook_step_offline_params["version"]
+                == config.vars["pipeline_name"]
+            )
     expected_prefix = f"{prefix.strip('/')}/" if prefix != "" else prefix
     site_dummy_var_source = get_dict_list_item_by_field(
         rendered_definition["var_sources"], "name", "site"

--- a/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
@@ -599,6 +599,8 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
                 open_discussions_webhook_step_offline_params["version"]
                 == config.vars["pipeline_name"]
             )
+        elif branch_vars["pipeline_name"] == VERSION_DRAFT:
+            assert "webhook_key" not in open_discussions_webhook_step_online_params
     expected_prefix = f"{prefix.strip('/')}/" if prefix != "" else prefix
     site_dummy_var_source = get_dict_list_item_by_field(
         rendered_definition["var_sources"], "name", "site"

--- a/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
@@ -409,7 +409,7 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
         clear_cdn_cache_online_success_steps = clear_cdn_cache_online_step[
             "on_success"
         ]["try"]["do"]
-        if config.vars["pipeline_name"] == "live":
+        if branch_vars["pipeline_name"] == VERSION_LIVE:
             open_discussions_webhook_step_online_params = json.loads(
                 clear_cdn_cache_online_success_steps[0]["try"]["params"]["text"]
             )
@@ -581,7 +581,7 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
         clear_cdn_cache_offline_success_steps = clear_cdn_cache_offline_step[
             "on_success"
         ]["try"]["do"]
-        if config.vars["pipeline_name"] == "live":
+        if branch_vars["pipeline_name"] == VERSION_LIVE:
             open_discussions_webhook_step_offline_params = json.loads(
                 clear_cdn_cache_offline_success_steps[0]["try"]["params"]["text"]
             )

--- a/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
@@ -412,7 +412,9 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
         open_discussions_webhook_step_online_params = json.loads(
             clear_cdn_cache_online_success_steps[0]["try"]["params"]["text"]
         )
-        if branch_vars["pipeline_name"] == VERSION_LIVE:
+        if branch_vars["pipeline_name"] == VERSION_DRAFT:
+            assert "webhook_key" not in open_discussions_webhook_step_online_params
+        elif branch_vars["pipeline_name"] == VERSION_LIVE:
             assert (
                 open_discussions_webhook_step_online_params["webhook_key"]
                 == settings.OPEN_CATALOG_WEBHOOK_KEY
@@ -425,8 +427,6 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
                 open_discussions_webhook_step_online_params["version"]
                 == config.vars["pipeline_name"]
             )
-        elif branch_vars["pipeline_name"] == VERSION_DRAFT:
-            assert "webhook_key" not in open_discussions_webhook_step_online_params
     assert (
         online_site_tasks[-1]["put"]
         == pipeline_definition._offline_build_gate_identifier  # noqa: SLF001
@@ -583,10 +583,12 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
         clear_cdn_cache_offline_success_steps = clear_cdn_cache_offline_step[
             "on_success"
         ]["try"]["do"]
-        if branch_vars["pipeline_name"] == VERSION_LIVE:
-            open_discussions_webhook_step_offline_params = json.loads(
-                clear_cdn_cache_offline_success_steps[0]["try"]["params"]["text"]
-            )
+        open_discussions_webhook_step_offline_params = json.loads(
+            clear_cdn_cache_offline_success_steps[0]["try"]["params"]["text"]
+        )
+        if branch_vars["pipeline_name"] == VERSION_DRAFT:
+            assert "webhook_key" not in open_discussions_webhook_step_offline_params
+        elif branch_vars["pipeline_name"] == VERSION_LIVE:
             assert (
                 open_discussions_webhook_step_offline_params["webhook_key"]
                 == settings.OPEN_CATALOG_WEBHOOK_KEY
@@ -599,8 +601,6 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
                 open_discussions_webhook_step_offline_params["version"]
                 == config.vars["pipeline_name"]
             )
-        elif branch_vars["pipeline_name"] == VERSION_DRAFT:
-            assert "webhook_key" not in open_discussions_webhook_step_offline_params
     expected_prefix = f"{prefix.strip('/')}/" if prefix != "" else prefix
     site_dummy_var_source = get_dict_list_item_by_field(
         rendered_definition["var_sources"], "name", "site"

--- a/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
@@ -600,7 +600,7 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
                 == config.vars["pipeline_name"]
             )
         elif branch_vars["pipeline_name"] == VERSION_DRAFT:
-            assert "webhook_key" not in open_discussions_webhook_step_online_params
+            assert "webhook_key" not in open_discussions_webhook_step_offline_params
     expected_prefix = f"{prefix.strip('/')}/" if prefix != "" else prefix
     site_dummy_var_source = get_dict_list_item_by_field(
         rendered_definition["var_sources"], "name", "site"

--- a/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
@@ -409,10 +409,10 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
         clear_cdn_cache_online_success_steps = clear_cdn_cache_online_step[
             "on_success"
         ]["try"]["do"]
+        open_discussions_webhook_step_online_params = json.loads(
+            clear_cdn_cache_online_success_steps[0]["try"]["params"]["text"]
+        )
         if branch_vars["pipeline_name"] == VERSION_LIVE:
-            open_discussions_webhook_step_online_params = json.loads(
-                clear_cdn_cache_online_success_steps[0]["try"]["params"]["text"]
-            )
             assert (
                 open_discussions_webhook_step_online_params["webhook_key"]
                 == settings.OPEN_CATALOG_WEBHOOK_KEY
@@ -425,6 +425,8 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
                 open_discussions_webhook_step_online_params["version"]
                 == config.vars["pipeline_name"]
             )
+        elif branch_vars["pipeline_name"] == VERSION_DRAFT:
+            assert "webhook_key" not in open_discussions_webhook_step_online_params
     assert (
         online_site_tasks[-1]["put"]
         == pipeline_definition._offline_build_gate_identifier  # noqa: SLF001


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/2074

### Description (What does it do?)
Only send Learn webhook requests for live sites (individual and mass-build) to update search index.

### How can this be tested?
1. Change the value of `OCW_STUDIO_ENVIRONMENT` to `rc`
2. Use `ocw-studio-rc`'s values for: `OPEN_CATALOG_URLS`, `OPEN_CATALOG_WEBHOOK_KEY` in your local `.env`
3. Run the following commands:
```
./manage.py upsert_theme_assets_pipeline --delete
./manage.py upsert_mass_build_pipeline --delete
./manage.py upsert_site_removal_pipeline --delete
./manage.py backpopulate_pipelines --filter <site-name>
```
4. Using `fly`, run the following commands:
```
 fly -t local get-pipeline -p 'mass-build-sites/offline:false,prefix:"",projects_branch:main,starter:"",themes_branch:main,version:live ' > mass_publish_live.yml
 fly -t local get-pipeline -p 'mass-build-sites/offline:false,prefix:"",projects_branch:main,starter:"",themes_branch:main,version:draft ' > mass_publish_draft.yml
 fly -t local get-pipeline -p live/site:site_name > single_site_live.yml
 fly -t local get-pipeline -p draft/site:site_name > single_site_draft.yml
```
Open the respective created files.
 * In the live pipeline configurations, verify that `open-catalog-webhook` resources and job plans are present.
 * In the draft pipeline configurations, confirm that the `open-catalog-webhook` resources and plans are absent, as they should only be defined for live sites.