### PR TITLE
Fix PostHog initialization if user is not logged in

### DIFF
--- a/static/js/lib/util.ts
+++ b/static/js/lib/util.ts
@@ -22,7 +22,10 @@ if (SETTINGS.posthog_api_host && SETTINGS.posthog_project_api_key) {
     },
   })
   // @ts-expect-error: SETTINGS.user is intentionally untyped
-  posthog.identify(SETTINGS.user.email)
+  if (SETTINGS.user) {
+    // @ts-expect-error: SETTINGS.user is intentionally untyped
+    posthog.identify(SETTINGS.user.email)
+  }
 }
 
 export const isErrorStatusCode = (statusCode: number): boolean =>


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/2305.

### Description (What does it do?)
This PR handles the case when the user is not logged in for initializing PostHog.

### How can this be tested?
Testing instructions are analogous to https://github.com/mitodl/ocw-studio/pull/2291 but verify that there are no errors after logging out and logging back into OCW Studio.
