### PR TITLE
Add management commands for submitting and checking Wayback Machine resources

### DIFF
--- a/external_resources/management/commands/check_wayback_status.py
+++ b/external_resources/management/commands/check_wayback_status.py
@@ -1,0 +1,57 @@
+"""Management command to check the status of Wayback Machine jobs"""
+
+from external_resources.constants import WAYBACK_PENDING_STATUS
+from external_resources.models import ExternalResourceState
+from external_resources.tasks import check_wayback_jobs_status_batch
+from main.management.commands.filter import WebsiteFilterCommand
+from websites.models import Website
+
+
+class Command(WebsiteFilterCommand):
+    """Check status of Wayback Machine jobs for websites' external resources"""
+
+    help = __doc__
+
+    def handle(self, *args, **options):
+        super().handle(*args, **options)
+
+        websites = Website.objects.all()
+        websites = self.filter_websites(websites)
+
+        if not websites.exists():
+            self.stdout.write("No websites found with the given filters.")
+            return
+
+        self.stdout.write(
+            f"Checking Wayback Machine job statuses for {websites.count()} websites."
+        )
+
+        # Get ExternalResourceState objects with pending Wayback jobs
+        pending_states = ExternalResourceState.objects.filter(
+            content__website__in=websites,
+            wayback_status=WAYBACK_PENDING_STATUS,
+            wayback_job_id__isnull=False,
+        )
+
+        if not pending_states.exists():
+            self.stdout.write(
+                "No pending Wayback Machine jobs found for the selected websites."
+            )
+            return
+
+        job_ids = list(pending_states.values_list("wayback_job_id", flat=True))
+
+        if job_ids:
+            check_wayback_jobs_status_batch.delay(job_ids=job_ids)
+            self.stdout.write(
+                "Enqueued task to check Wayback Machine job statuses "
+                "for filtered websites."
+            )
+        else:
+            check_wayback_jobs_status_batch.delay()
+            self.stdout.write(
+                "No specific job IDs found. "
+                "Enqueued task to check all pending Wayback Machine jobs."
+            )
+
+        self.stdout.write("Enqueued task to check Wayback Machine job statuses.")

--- a/external_resources/management/commands/submit_sites_to_wayback.py
+++ b/external_resources/management/commands/submit_sites_to_wayback.py
@@ -1,4 +1,4 @@
-"""Management command to submit external resources of websites to the Wayback Machine"""
+"""Management command to submit external resources to the Wayback Machine"""
 
 from external_resources.tasks import submit_website_resources_to_wayback_task
 from main.management.commands.filter import WebsiteFilterCommand
@@ -6,7 +6,7 @@ from websites.models import Website
 
 
 class Command(WebsiteFilterCommand):
-    """Submit external resources of websites to the Wayback Machine"""
+    """Submit external resources to the Wayback Machine"""
 
     help = __doc__
 

--- a/external_resources/management/commands/submit_sites_to_wayback.py
+++ b/external_resources/management/commands/submit_sites_to_wayback.py
@@ -10,6 +10,14 @@ class Command(WebsiteFilterCommand):
 
     help = __doc__
 
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Force submission even if resources were submitted recently.",
+        )
+
     def handle(self, *args, **options):
         super().handle(*args, **options)
         force_submission = options.get("force", False)

--- a/external_resources/management/commands/submit_sites_to_wayback.py
+++ b/external_resources/management/commands/submit_sites_to_wayback.py
@@ -1,0 +1,34 @@
+"""Management command to submit external resources of websites to the Wayback Machine"""
+
+from external_resources.tasks import submit_website_resources_to_wayback_task
+from main.management.commands.filter import WebsiteFilterCommand
+from websites.models import Website
+
+
+class Command(WebsiteFilterCommand):
+    """Submit external resources of websites to the Wayback Machine"""
+
+    help = __doc__
+
+    def handle(self, *args, **options):
+        super().handle(*args, **options)
+        force_submission = options.get("force", False)
+
+        websites = Website.objects.all()
+        websites = self.filter_websites(websites)
+
+        if not websites.exists():
+            self.stdout.write("No websites found with the given filters.")
+            return
+
+        self.stdout.write(
+            f"Submitting external resources for {websites.count()} websites."
+        )
+
+        for website in websites:
+            submit_website_resources_to_wayback_task.delay(
+                website.name, ignore_last_submission=force_submission
+            )
+            self.stdout.write(f"Enqueued submission for website: {website.name}")
+
+        self.stdout.write("All tasks have been enqueued.")

--- a/external_resources/management/commands/update_wayback_status.py
+++ b/external_resources/management/commands/update_wayback_status.py
@@ -59,7 +59,7 @@ class Command(WebsiteFilterCommand):
 
         if sync_execution:
             self.stdout.write("Running updates synchronously...")
-            update_wayback_jobs_status_batch.apply(job_ids=job_ids)
+            update_wayback_jobs_status_batch.run(job_ids=job_ids)
         else:
             self.stdout.write(
                 "Enqueuing tasks to update job statuses asynchronously..."

--- a/external_resources/management/commands/update_wayback_status.py
+++ b/external_resources/management/commands/update_wayback_status.py
@@ -1,14 +1,14 @@
-"""Management command to check the status of Wayback Machine jobs"""
+"""Management command to update the status of Wayback Machine jobs"""
 
 from external_resources.constants import WAYBACK_PENDING_STATUS
 from external_resources.models import ExternalResourceState
-from external_resources.tasks import check_wayback_jobs_status_batch
+from external_resources.tasks import update_wayback_jobs_status_batch
 from main.management.commands.filter import WebsiteFilterCommand
 from websites.models import Website
 
 
 class Command(WebsiteFilterCommand):
-    """Check status of Wayback Machine jobs for websites' external resources"""
+    """Update status of Wayback Machine pending jobs"""
 
     help = __doc__
 
@@ -23,7 +23,7 @@ class Command(WebsiteFilterCommand):
             return
 
         self.stdout.write(
-            f"Checking Wayback Machine job statuses for {websites.count()} websites."
+            f"Updating Wayback Machine job statuses for {websites.count()} websites."
         )
 
         # Get ExternalResourceState objects with pending Wayback jobs
@@ -42,16 +42,16 @@ class Command(WebsiteFilterCommand):
         job_ids = list(pending_states.values_list("wayback_job_id", flat=True))
 
         if job_ids:
-            check_wayback_jobs_status_batch.delay(job_ids=job_ids)
+            update_wayback_jobs_status_batch.delay(job_ids=job_ids)
             self.stdout.write(
-                "Enqueued task to check Wayback Machine job statuses "
+                "Enqueued task to update Wayback Machine job statuses "
                 "for filtered websites."
             )
         else:
-            check_wayback_jobs_status_batch.delay()
+            update_wayback_jobs_status_batch.delay()
             self.stdout.write(
                 "No specific job IDs found. "
-                "Enqueued task to check all pending Wayback Machine jobs."
+                "Enqueued task to update all pending Wayback Machine jobs."
             )
 
         self.stdout.write("Enqueued task to check Wayback Machine job statuses.")

--- a/external_resources/management/commands/update_wayback_status.py
+++ b/external_resources/management/commands/update_wayback_status.py
@@ -57,17 +57,15 @@ class Command(WebsiteFilterCommand):
 
         job_ids = list(pending_states.values_list("wayback_job_id", flat=True))
 
-        if job_ids:
-            update_wayback_jobs_status_batch.delay(job_ids=job_ids)
-            self.stdout.write(
-                "Enqueued task to update Wayback Machine job statuses "
-                "for filtered websites."
-            )
+        if sync_execution:
+            self.stdout.write("Running updates synchronously...")
+            update_wayback_jobs_status_batch.apply(job_ids=job_ids)
+            self.stdout.write("Wayback Machine job statuses updated synchronously.")
         else:
-            update_wayback_jobs_status_batch.delay()
             self.stdout.write(
-                "No specific job IDs found. "
-                "Enqueued task to update all pending Wayback Machine jobs."
+                "Enqueuing tasks to update job statuses asynchronously..."
             )
+            update_wayback_jobs_status_batch.delay(job_ids=job_ids)
+            self.stdout.write("Tasks enqueued to update Wayback Machine job statuses.")
 
-        self.stdout.write("Enqueued task to check Wayback Machine job statuses.")
+        self.stdout.write("Command execution completed.")

--- a/external_resources/management/commands/update_wayback_status.py
+++ b/external_resources/management/commands/update_wayback_status.py
@@ -60,12 +60,10 @@ class Command(WebsiteFilterCommand):
         if sync_execution:
             self.stdout.write("Running updates synchronously...")
             update_wayback_jobs_status_batch.apply(job_ids=job_ids)
-            self.stdout.write("Wayback Machine job statuses updated synchronously.")
         else:
             self.stdout.write(
                 "Enqueuing tasks to update job statuses asynchronously..."
             )
             update_wayback_jobs_status_batch.delay(job_ids=job_ids)
-            self.stdout.write("Tasks enqueued to update Wayback Machine job statuses.")
 
         self.stdout.write("Command execution completed.")

--- a/external_resources/tasks.py
+++ b/external_resources/tasks.py
@@ -129,6 +129,7 @@ def submit_website_resources_to_wayback_task(
     tasks = [
         submit_url_to_wayback_task.s(resource.id, ignore_last_submission)
         for resource in external_resources
+        if ExternalResourceState.objects.get_or_create(content=resource)
     ]
     if tasks:
         return self.replace(celery.group(tasks))
@@ -182,7 +183,11 @@ def submit_url_to_wayback_task(self, resource_id, ignore_last_submission=None):
                 resource_id,
             )
             return
-
+        log.info(
+            "Submitting URL to Wayback Machine for resource '%s' (ID: %s)",
+            state.content.title,
+            resource_id,
+        )
         response = api.submit_url_to_wayback(url)
         job_id = response.get("job_id")
         status_ext = response.get("status_ext")

--- a/external_resources/tasks.py
+++ b/external_resources/tasks.py
@@ -136,8 +136,10 @@ def submit_website_resources_to_wayback_task(
     return None
 
 
-def should_skip_wayback_submission(state):
+def should_skip_wayback_submission(state, ignore_last_submission=None):
     """Check if we should skip submission based on the last successful submission."""
+    if ignore_last_submission:
+        return False
     if state.wayback_last_successful_submission:
         retry_period = timezone.now() - timedelta(
             days=settings.WAYBACK_SUBMISSION_INTERVAL_DAYS
@@ -170,7 +172,7 @@ def submit_url_to_wayback_task(self, resource_id, ignore_last_submission=None):
 
     try:
         state = ExternalResourceState.objects.get(content_id=resource_id)
-        if should_skip_wayback_submission(state):
+        if should_skip_wayback_submission(state, ignore_last_submission):
             return
         url = state.content.metadata.get("external_url", "")
         if not url:

--- a/external_resources/tasks.py
+++ b/external_resources/tasks.py
@@ -249,7 +249,7 @@ def submit_url_to_wayback_task(self, resource_id, ignore_last_submission=None):
 )
 @single_task(10)
 def update_wayback_jobs_status_batch(self, job_ids=None):
-    """Batch check the status of Wayback Machine jobs."""
+    """Batch update the status of Wayback Machine jobs."""
     try:
         if job_ids:
             pending_states = ExternalResourceState.objects.filter(


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5779

### Description (What does it do?)
This PR introduces management commands for handling Wayback Machine submissions and status updates for external resources.

* `submit_sites_to_wayback.py`: to submit external resources of websites to the Wayback Machine, with an option to force submission (`--force`) (skipping `WAYBACK_SUBMISSION_INTERVAL_DAYS` defined in `settings.py`)
* `update_wayback_status.py`: to update the status of pending Wayback Machine jobs, with an option to run synchronously (`--sync`)

The `--sync` argument, however, will only work if the filter for sites is given. By default, the behavior is async.
Note: without `--filter`, the task will run for all sites.

### How can this be tested?
First, you will need to follow these testing steps coming from the branch PR `ibrahim/5355-wayback-integration-models-tasks` https://github.com/mitodl/ocw-studio/pull/2308. The steps are:
1. DM me for `access_key` and `secret_key`.
2. Checkout to the `ocw-hugo-projects` branch [in the PR](https://github.com/mitodl/ocw-hugo-projects/pull/307) and copy the code for `ocw-www/ocw-studio.yaml` and `ocw-course-v2/ocw-studio.yaml` and update your Starters configuration for both via Django admin.
3. Run the migration: `docker-compose exec web ./manage.py migrate`

Run in web container and monitor `celery` logs: 
```
1. ./manage.py submit_sites_to_wayback --filter "course1" --force
2. ./manage.py update_wayback_status --filter "course1"
3. ./manage.py update_wayback_status --filter "course1" --sync
4. ./manage.py update_wayback_status --filter "course1, course2"
5. ./manage.py submit_sites_to_wayback --filter "course1"

```
