### PR TITLE
Add unit tests for Wayback Machine submission and status update tasks

### DIFF
--- a/external_resources/tasks.py
+++ b/external_resources/tasks.py
@@ -4,6 +4,7 @@ import logging
 from datetime import timedelta
 
 import celery
+from django.conf import settings
 from django.utils import timezone
 from mitol.common.utils import chunks
 from requests.exceptions import ConnectionError, ConnectTimeout, HTTPError, Timeout
@@ -25,7 +26,6 @@ from external_resources.constants import (
 )
 from external_resources.exceptions import CheckFailedError
 from external_resources.models import ExternalResourceState
-from main import settings
 from main.celery import app
 from websites.constants import (
     BATCH_SIZE_EXTERNAL_RESOURCE_STATUS_CHECK,


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/5355
Closes https://github.com/mitodl/hq/issues/5786

### Description (What does it do?)
Adds unit tests for the Wayback Machine integration tasks to ensure functionality and error handling across different scenarios.

### How can this be tested?
`docker-compose run --rm web pytest external_resources/tasks_test.py`
