### PR TITLE
populated referencing content field for the website content

### DIFF
--- a/static/js/components/SiteContentEditor.tsx
+++ b/static/js/components/SiteContentEditor.tsx
@@ -56,10 +56,17 @@ export default function SiteContentEditor(
 
   const [references, setReferences] = useState({ link: [], unlink: [] })
 
-  function addReferences(key, item) {
+  function addReferences(item) {
     setReferences((prev) => ({
       ...prev,
-      [key]: [...(prev[key] || []), item],
+      link: [...(prev.link || []), item],
+    }))
+  }
+
+  function removeReferences(item) {
+    setReferences((prev) => ({
+      ...prev,
+      unlink: (prev.unlink || []).filter((value) => value !== item),
     }))
   }
 
@@ -179,7 +186,9 @@ export default function SiteContentEditor(
 
   return (
     <ErrorBoundary>
-      <ReferencesContext.Provider value={{ references, addReferences }}>
+      <ReferencesContext.Provider
+        value={{ references, addReferences, removeReferences }}
+      >
         <SiteContentForm
           onSubmit={onSubmitForm}
           configItem={configItem}

--- a/static/js/components/SiteContentEditor.tsx
+++ b/static/js/components/SiteContentEditor.tsx
@@ -27,6 +27,7 @@ import {
   EditableConfigItem,
   WebsiteContentModalState,
   WebsiteContent,
+  ReferencedContent,
 } from "../types/websites"
 import { SiteFormValues } from "../types/forms"
 import ErrorBoundary from "./ErrorBoundary"
@@ -54,19 +55,22 @@ export default function SiteContentEditor(
     setDirty,
   } = props
 
-  const [references, setReferences] = useState({ link: [], unlink: [] })
+  const [references, setReferences] = useState<ReferencedContent>({
+    link: [],
+    unlink: [],
+  })
 
-  function addReferences(item) {
+  function addReferences(item: string) {
     setReferences((prev) => ({
       ...prev,
       link: [...(prev.link || []), item],
     }))
   }
 
-  function removeReferences(item) {
+  function removeReferences(item: string) {
     setReferences((prev) => ({
-      ...prev,
-      unlink: (prev.unlink || []).filter((value) => value !== item),
+      link: (prev.link || []).filter((value) => value !== item),
+      unlink: [...(prev.unlink || []), item],
     }))
   }
 
@@ -136,11 +140,10 @@ export default function SiteContentEditor(
       payload["text_id"] = configItem.name
     }
 
+    const references = values.references as ReferencedContent
     if (
-      (Array.isArray(values.references?.link) &&
-        values.references.link.length > 0) ||
-      (Array.isArray(values.references?.unlink) &&
-        values.references.unlink.length > 0)
+      (Array.isArray(references?.link) && references.link.length > 0) ||
+      (Array.isArray(references?.unlink) && references.unlink.length > 0)
     ) {
       payload["references"] = values.references
     }

--- a/static/js/components/SiteContentEditor.tsx
+++ b/static/js/components/SiteContentEditor.tsx
@@ -63,14 +63,14 @@ export default function SiteContentEditor(
   function addReferences(item: string) {
     setReferences((prev) => ({
       ...prev,
-      link: [...(prev.link || []), item],
+      link: [...prev.link, item],
     }))
   }
 
   function removeReferences(item: string) {
     setReferences((prev) => ({
-      link: (prev.link || []).filter((value) => value !== item),
-      unlink: [...(prev.unlink || []), item],
+      link: prev.link.filter((value) => value !== item),
+      unlink: prev.link.includes(item) ? prev.unlink : [...prev.unlink, item],
     }))
   }
 

--- a/static/js/components/SiteContentEditor.tsx
+++ b/static/js/components/SiteContentEditor.tsx
@@ -148,7 +148,6 @@ export default function SiteContentEditor(
       payload["references"] = values.references
     }
 
-    console.log(payload, values)
     const response = editorState.editing()
       ? await editWebsiteContent(payload, editorState.wrapped)
       : await addWebsiteContent(payload as NewWebsiteContentPayload)

--- a/static/js/components/forms/SiteContentForm.test.tsx
+++ b/static/js/components/forms/SiteContentForm.test.tsx
@@ -23,6 +23,7 @@ import ObjectField from "../widgets/ObjectField"
 
 import * as Website from "../../context/Website"
 import Label from "../widgets/Label"
+import { useReferences } from "../../context/References"
 const { useWebsite: mockUseWebsite } = Website as jest.Mocked<typeof Website>
 
 // ckeditor is not working properly in tests, but we don't need to test it here so just mock it away
@@ -42,6 +43,18 @@ jest.mock("../widgets/SelectField", () => ({
 
 jest.mock("../../context/Website")
 jest.mock("../../util/dom")
+
+jest.mock("../../context/References", () => ({
+  ...jest.requireActual("../../context/References"),
+  useReferences: jest.fn(),
+}))
+
+const mockedUseReferences = jest.mocked(useReferences)
+mockedUseReferences.mockReturnValue({
+  references: { link: [], unlink: [] },
+  addReferences: jest.fn(),
+  removeReferences: jest.fn(),
+})
 
 const { contentInitialValues, renameNestedFields } = siteContent as jest.Mocked<
   typeof siteContent
@@ -284,6 +297,7 @@ test("SiteContentField creates new values", () => {
   ]
   const { form } = setup(data)
   expect(form.find(FormFields).prop("values")).toEqual({
+    references: {},
     "test-name": "test-default",
   })
 })
@@ -294,7 +308,8 @@ test("SiteContentField uses existing values when editing", () => {
     ...data,
     editorState: createModalState("editing", "id"),
   })
-  expect(form.find(FormFields).prop("values")).toEqual(
-    contentInitialValues(data.content, data.configItem.fields, data.website),
-  )
+  expect(form.find(FormFields).prop("values")).toEqual({
+    references: {},
+    ...contentInitialValues(data.content, data.configItem.fields, data.website),
+  })
 })

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -180,7 +180,6 @@ export function FormFields(props: InnerFormProps): JSX.Element {
           Save
         </button>
       </div>
-      {console.log("Formik values:", values)}
       {status && (
         // Status is being used to store non-field errors
         <div className="form-error">{status}</div>

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -9,6 +9,7 @@ import {
   validateYupSchema,
   yupToFormErrors,
   FormikErrors,
+  useFormikContext,
 } from "formik"
 
 import SiteContentField from "./SiteContentField"
@@ -33,6 +34,7 @@ import {
 import { SiteFormValues } from "../../types/forms"
 import { getContentSchema } from "./validation"
 import { useWebsite } from "../../context/Website"
+import { useReferences } from "../../context/References"
 
 export interface FormProps {
   onSubmit: (
@@ -51,14 +53,16 @@ export default function SiteContentForm(props: FormProps): JSX.Element {
   const website = useWebsite()
 
   const initialValues: SiteFormValues = useMemo(
-    () =>
-      editorState.adding()
+    () => ({
+      ...(editorState.adding()
         ? newInitialValues(configItem.fields, website)
         : contentInitialValues(
             content as WebsiteContent,
             configItem.fields,
             website,
-          ),
+          )),
+      references: {}, // Add this to ensure Formik tracks the `references` field
+    }),
     [configItem.fields, editorState, content, website],
   )
 
@@ -114,6 +118,9 @@ export function FormFields(props: InnerFormProps): JSX.Element {
     [configItem],
   )
 
+  const { setFieldValue } = useFormikContext()
+  const { references } = useReferences()
+
   useEffect(() => {
     setDirty(dirty)
   }, [setDirty, dirty])
@@ -168,10 +175,12 @@ export function FormFields(props: InnerFormProps): JSX.Element {
           type="submit"
           disabled={isSubmitting}
           className="px-5 btn cyan-button"
+          onClick={() => setFieldValue("references", references)}
         >
           Save
         </button>
       </div>
+      {console.log("Formik values:", values)}
       {status && (
         // Status is being used to store non-field errors
         <div className="form-error">{status}</div>

--- a/static/js/components/widgets/MarkdownEditor.test.tsx
+++ b/static/js/components/widgets/MarkdownEditor.test.tsx
@@ -15,6 +15,7 @@ import {
   ADD_RESOURCE_LINK,
   CKEDITOR_RESOURCE_UTILS,
   MARKDOWN_CONFIG_KEY,
+  REFERENCED_CONTENT,
   RESOURCE_EMBED,
   RESOURCE_LINK,
   RESOURCE_LINK_CONFIG_KEY,
@@ -26,6 +27,7 @@ import { useWebsite } from "../../context/Website"
 import { makeWebsiteDetail } from "../../util/factories/websites"
 import ResourceLink from "../../lib/ckeditor/plugins/ResourceLink"
 import { useParams } from "react-router"
+import { useReferences } from "../../context/References"
 
 jest.mock("../../lib/ckeditor/CKEditor", () => {
   const originalModule = jest.requireActual("../../lib/ckeditor/CKEditor")
@@ -65,6 +67,12 @@ const render = (props = {}) => {
 const mocUseWebsite = jest.mocked(useWebsite)
 const useParamsMock = jest.mocked(useParams)
 
+jest.mock("../../context/References", () => ({
+  ...jest.requireActual("../../context/References"),
+  useReferences: jest.fn(),
+}))
+const mockedUseReferences = jest.mocked(useReferences)
+
 describe("MarkdownEditor", () => {
   let sandbox: SinonSandbox
 
@@ -73,6 +81,11 @@ describe("MarkdownEditor", () => {
     const website = makeWebsiteDetail()
     mocUseWebsite.mockReturnValue(website)
     useParamsMock.mockReturnValue({ uuid: "test-uuid" })
+    mockedUseReferences.mockReturnValue({
+      references: { link: [], unlink: [] },
+      addReferences: jest.fn(),
+      removeReferences: jest.fn(),
+    })
   })
 
   afterEach(() => {
@@ -113,6 +126,7 @@ describe("MarkdownEditor", () => {
           MARKDOWN_CONFIG_KEY,
           RESOURCE_LINK_CONFIG_KEY,
           WEBSITE_NAME,
+          REFERENCED_CONTENT,
         ],
         ckWrapper.prop("config"),
       )

--- a/static/js/components/widgets/MarkdownEditor.test.tsx
+++ b/static/js/components/widgets/MarkdownEditor.test.tsx
@@ -18,6 +18,7 @@ import {
   RESOURCE_EMBED,
   RESOURCE_LINK,
   RESOURCE_LINK_CONFIG_KEY,
+  WEBSITE_CONTENT_ID,
   WEBSITE_NAME,
 } from "../../lib/ckeditor/plugins/constants"
 import ResourcePickerDialog from "../../components/widgets/ResourcePickerDialog"
@@ -105,6 +106,7 @@ describe("MarkdownEditor", () => {
           MARKDOWN_CONFIG_KEY,
           RESOURCE_LINK_CONFIG_KEY,
           WEBSITE_NAME,
+          WEBSITE_CONTENT_ID,
         ],
         ckWrapper.prop("config"),
       )

--- a/static/js/components/widgets/MarkdownEditor.test.tsx
+++ b/static/js/components/widgets/MarkdownEditor.test.tsx
@@ -26,7 +26,6 @@ import { getMockEditor } from "../../test_util"
 import { useWebsite } from "../../context/Website"
 import { makeWebsiteDetail } from "../../util/factories/websites"
 import ResourceLink from "../../lib/ckeditor/plugins/ResourceLink"
-import { useParams } from "react-router"
 import { useReferences } from "../../context/References"
 
 jest.mock("../../lib/ckeditor/CKEditor", () => {
@@ -65,7 +64,6 @@ const render = (props = {}) => {
 }
 
 const mocUseWebsite = jest.mocked(useWebsite)
-const useParamsMock = jest.mocked(useParams)
 
 jest.mock("../../context/References", () => ({
   ...jest.requireActual("../../context/References"),
@@ -80,7 +78,6 @@ describe("MarkdownEditor", () => {
     sandbox = sinon.createSandbox()
     const website = makeWebsiteDetail()
     mocUseWebsite.mockReturnValue(website)
-    useParamsMock.mockReturnValue({ uuid: "test-uuid" })
     mockedUseReferences.mockReturnValue({
       references: { link: [], unlink: [] },
       addReferences: jest.fn(),

--- a/static/js/components/widgets/MarkdownEditor.test.tsx
+++ b/static/js/components/widgets/MarkdownEditor.test.tsx
@@ -18,7 +18,6 @@ import {
   RESOURCE_EMBED,
   RESOURCE_LINK,
   RESOURCE_LINK_CONFIG_KEY,
-  WEBSITE_CONTENT_ID,
   WEBSITE_NAME,
 } from "../../lib/ckeditor/plugins/constants"
 import ResourcePickerDialog from "../../components/widgets/ResourcePickerDialog"
@@ -114,7 +113,6 @@ describe("MarkdownEditor", () => {
           MARKDOWN_CONFIG_KEY,
           RESOURCE_LINK_CONFIG_KEY,
           WEBSITE_NAME,
-          WEBSITE_CONTENT_ID,
         ],
         ckWrapper.prop("config"),
       )

--- a/static/js/components/widgets/MarkdownEditor.test.tsx
+++ b/static/js/components/widgets/MarkdownEditor.test.tsx
@@ -26,6 +26,7 @@ import { getMockEditor } from "../../test_util"
 import { useWebsite } from "../../context/Website"
 import { makeWebsiteDetail } from "../../util/factories/websites"
 import ResourceLink from "../../lib/ckeditor/plugins/ResourceLink"
+import { useParams } from "react-router"
 
 jest.mock("../../lib/ckeditor/CKEditor", () => {
   const originalModule = jest.requireActual("../../lib/ckeditor/CKEditor")
@@ -51,6 +52,11 @@ jest.mock("@ckeditor/ckeditor5-react", () => ({
   CKEditor: () => <div />,
 }))
 
+jest.mock("react-router", () => ({
+  ...jest.requireActual("react-router"),
+  useParams: jest.fn(),
+}))
+
 const render = (props = {}) => {
   return shallow(
     <MarkdownEditor allowedHtml={[]} link={[]} embed={[]} {...props} />,
@@ -58,6 +64,7 @@ const render = (props = {}) => {
 }
 
 const mocUseWebsite = jest.mocked(useWebsite)
+const useParamsMock = jest.mocked(useParams)
 
 describe("MarkdownEditor", () => {
   let sandbox: SinonSandbox
@@ -66,6 +73,7 @@ describe("MarkdownEditor", () => {
     sandbox = sinon.createSandbox()
     const website = makeWebsiteDetail()
     mocUseWebsite.mockReturnValue(website)
+    useParamsMock.mockReturnValue({ uuid: "test-uuid" })
   })
 
   afterEach(() => {

--- a/static/js/components/widgets/MarkdownEditor.tsx
+++ b/static/js/components/widgets/MarkdownEditor.tsx
@@ -31,7 +31,6 @@ import { useWebsite } from "../../context/Website"
 import { siteContentRerouteUrl } from "../../lib/urls"
 import { checkFeatureFlag } from "../../lib/util"
 import CustomLink from "../../lib/ckeditor/plugins/CustomLink"
-import { useParams } from "react-router"
 import { useReferences } from "../../context/References"
 
 export interface Props {
@@ -56,7 +55,6 @@ export default function MarkdownEditor(props: Props): JSX.Element {
   const { link, embed, value, name, onChange, minimal, allowedHtml } = props
   const throwSynchronously = useThrowSynchronously()
   const website = useWebsite()
-  const { uuid } = useParams<{ uuid: string }>()
   const [isCustomLinkUIEnabled, setIsCustomLinkUIEnabled] = useState(false)
   const { addReferences, removeReferences } = useReferences()
 
@@ -200,8 +198,9 @@ export default function MarkdownEditor(props: Props): JSX.Element {
     embed,
     allowedHtml,
     website.name,
-    uuid,
     isCustomLinkUIEnabled,
+    addReferences,
+    removeReferences,
   ])
 
   const onChangeCB = useCallback(

--- a/static/js/components/widgets/MarkdownEditor.tsx
+++ b/static/js/components/widgets/MarkdownEditor.tsx
@@ -23,6 +23,7 @@ import {
   MARKDOWN_CONFIG_KEY,
   RESOURCE_LINK_CONFIG_KEY,
   WEBSITE_NAME,
+  REFERENCED_CONTENT,
 } from "../../lib/ckeditor/plugins/constants"
 import ResourcePickerDialog from "./ResourcePickerDialog"
 import useThrowSynchronously from "../../hooks/useAsyncError"
@@ -151,7 +152,7 @@ export default function MarkdownEditor(props: Props): JSX.Element {
       [WEBSITE_NAME]: website.name,
 
       // Function cannot be directly passed in config
-      REFERENCED_CONTENT: { add: addReferences, remove: removeReferences },
+      [REFERENCED_CONTENT]: { add: addReferences, remove: removeReferences },
     }
     if (isCustomLinkUIEnabled) {
       MinimalEditorConfig.plugins.push(CustomLink)

--- a/static/js/components/widgets/MarkdownEditor.tsx
+++ b/static/js/components/widgets/MarkdownEditor.tsx
@@ -23,7 +23,6 @@ import {
   MARKDOWN_CONFIG_KEY,
   RESOURCE_LINK_CONFIG_KEY,
   WEBSITE_NAME,
-  WEBSITE_CONTENT_ID,
 } from "../../lib/ckeditor/plugins/constants"
 import ResourcePickerDialog from "./ResourcePickerDialog"
 import useThrowSynchronously from "../../hooks/useAsyncError"
@@ -150,7 +149,7 @@ export default function MarkdownEditor(props: Props): JSX.Element {
         }`,
       },
       [WEBSITE_NAME]: website.name,
-      [WEBSITE_CONTENT_ID]: uuid,
+
       // Function cannot be directly passed in config
       referencedContent: { add: addReferences, remove: removeReferences },
     }

--- a/static/js/components/widgets/MarkdownEditor.tsx
+++ b/static/js/components/widgets/MarkdownEditor.tsx
@@ -151,7 +151,7 @@ export default function MarkdownEditor(props: Props): JSX.Element {
       [WEBSITE_NAME]: website.name,
 
       // Function cannot be directly passed in config
-      referencedContent: { add: addReferences, remove: removeReferences },
+      REFERENCED_CONTENT: { add: addReferences, remove: removeReferences },
     }
     if (isCustomLinkUIEnabled) {
       MinimalEditorConfig.plugins.push(CustomLink)

--- a/static/js/components/widgets/MarkdownEditor.tsx
+++ b/static/js/components/widgets/MarkdownEditor.tsx
@@ -58,9 +58,7 @@ export default function MarkdownEditor(props: Props): JSX.Element {
   const website = useWebsite()
   const { uuid } = useParams<{ uuid: string }>()
   const [isCustomLinkUIEnabled, setIsCustomLinkUIEnabled] = useState(false)
-  const { addReferences } = useReferences()
-
-  console.log("check this", addReferences)
+  const { addReferences, removeReferences } = useReferences()
 
   useEffect(() => {
     checkFeatureFlag(
@@ -153,7 +151,8 @@ export default function MarkdownEditor(props: Props): JSX.Element {
       },
       [WEBSITE_NAME]: website.name,
       [WEBSITE_CONTENT_ID]: uuid,
-      ["addReferences"]: addReferences,
+      // Function cannot be directly passed in config
+      referencedContent: { add: addReferences, remove: removeReferences },
     }
     if (isCustomLinkUIEnabled) {
       MinimalEditorConfig.plugins.push(CustomLink)

--- a/static/js/components/widgets/MarkdownEditor.tsx
+++ b/static/js/components/widgets/MarkdownEditor.tsx
@@ -32,6 +32,7 @@ import { siteContentRerouteUrl } from "../../lib/urls"
 import { checkFeatureFlag } from "../../lib/util"
 import CustomLink from "../../lib/ckeditor/plugins/CustomLink"
 import { useParams } from "react-router"
+import { useReferences } from "../../context/References"
 
 export interface Props {
   value?: string
@@ -56,8 +57,10 @@ export default function MarkdownEditor(props: Props): JSX.Element {
   const throwSynchronously = useThrowSynchronously()
   const website = useWebsite()
   const { uuid } = useParams<{ uuid: string }>()
-
   const [isCustomLinkUIEnabled, setIsCustomLinkUIEnabled] = useState(false)
+  const { addReferences } = useReferences()
+
+  console.log("check this", addReferences)
 
   useEffect(() => {
     checkFeatureFlag(
@@ -150,6 +153,7 @@ export default function MarkdownEditor(props: Props): JSX.Element {
       },
       [WEBSITE_NAME]: website.name,
       [WEBSITE_CONTENT_ID]: uuid,
+      ["addReferences"]: addReferences,
     }
     if (isCustomLinkUIEnabled) {
       MinimalEditorConfig.plugins.push(CustomLink)

--- a/static/js/components/widgets/MarkdownEditor.tsx
+++ b/static/js/components/widgets/MarkdownEditor.tsx
@@ -197,6 +197,7 @@ export default function MarkdownEditor(props: Props): JSX.Element {
     embed,
     allowedHtml,
     website.name,
+    uuid,
     isCustomLinkUIEnabled,
   ])
 

--- a/static/js/components/widgets/MarkdownEditor.tsx
+++ b/static/js/components/widgets/MarkdownEditor.tsx
@@ -23,6 +23,7 @@ import {
   MARKDOWN_CONFIG_KEY,
   RESOURCE_LINK_CONFIG_KEY,
   WEBSITE_NAME,
+  WEBSITE_CONTENT_ID,
 } from "../../lib/ckeditor/plugins/constants"
 import ResourcePickerDialog from "./ResourcePickerDialog"
 import useThrowSynchronously from "../../hooks/useAsyncError"
@@ -30,6 +31,7 @@ import { useWebsite } from "../../context/Website"
 import { siteContentRerouteUrl } from "../../lib/urls"
 import { checkFeatureFlag } from "../../lib/util"
 import CustomLink from "../../lib/ckeditor/plugins/CustomLink"
+import { useParams } from "react-router"
 
 export interface Props {
   value?: string
@@ -53,6 +55,7 @@ export default function MarkdownEditor(props: Props): JSX.Element {
   const { link, embed, value, name, onChange, minimal, allowedHtml } = props
   const throwSynchronously = useThrowSynchronously()
   const website = useWebsite()
+  const { uuid } = useParams<{ uuid: string }>()
 
   const [isCustomLinkUIEnabled, setIsCustomLinkUIEnabled] = useState(false)
 
@@ -146,6 +149,7 @@ export default function MarkdownEditor(props: Props): JSX.Element {
         }`,
       },
       [WEBSITE_NAME]: website.name,
+      [WEBSITE_CONTENT_ID]: uuid,
     }
     if (isCustomLinkUIEnabled) {
       MinimalEditorConfig.plugins.push(CustomLink)

--- a/static/js/components/widgets/ResourcePickerDialog.test.tsx
+++ b/static/js/components/widgets/ResourcePickerDialog.test.tsx
@@ -24,7 +24,7 @@ import WebsiteContext from "../../context/Website"
 import { Website } from "../../types/websites"
 import origResourcePickerListing from "./ResourcePickerListing"
 import { assertNotNil } from "../../test_util"
-import { useMutation } from "redux-query-react"
+import { useReferences } from "../../context/References"
 
 jest.mock("../../hooks/state")
 const useDebouncedState = jest.mocked(hooksState.useDebouncedState)
@@ -39,11 +39,11 @@ jest.mock("./ResourcePickerListing", () => {
 })
 const ResourcePickerListing = jest.mocked(origResourcePickerListing)
 
-jest.mock("redux-query-react", () => ({
-  ...jest.requireActual("redux-query-react"),
-  useMutation: jest.fn(),
+jest.mock("../../context/References", () => ({
+  ...jest.requireActual("../../context/References"),
+  useReferences: jest.fn(),
 }))
-const mockedUseMutation = jest.mocked(useMutation)
+const mockedUseReferences = jest.mocked(useReferences)
 
 const focusResource = (wrapper: ReactWrapper, resource: WebsiteContent) => {
   act(() => {
@@ -65,13 +65,11 @@ describe("ResourcePickerDialog", () => {
     helper = new IntegrationTestHelper()
     website = makeWebsiteDetail()
 
-    mockedUseMutation.mockReturnValue([
-      {
-        isFinished: false,
-        isPending: false,
-      },
-      jest.fn(),
-    ])
+    mockedUseReferences.mockReturnValue({
+      references: {},
+      addReferences: jest.fn(),
+      removerefernces: jest.fn(),
+    })
 
     insertEmbedStub = helper.sandbox.stub()
     closeDialogStub = helper.sandbox.stub()

--- a/static/js/components/widgets/ResourcePickerDialog.test.tsx
+++ b/static/js/components/widgets/ResourcePickerDialog.test.tsx
@@ -65,7 +65,13 @@ describe("ResourcePickerDialog", () => {
     helper = new IntegrationTestHelper()
     website = makeWebsiteDetail()
 
-    mockedUseMutation.mockReturnValue([{}, jest.fn()])
+    mockedUseMutation.mockReturnValue([
+      {
+        isFinished: false,
+        isPending: false,
+      },
+      jest.fn(),
+    ])
 
     insertEmbedStub = helper.sandbox.stub()
     closeDialogStub = helper.sandbox.stub()

--- a/static/js/components/widgets/ResourcePickerDialog.test.tsx
+++ b/static/js/components/widgets/ResourcePickerDialog.test.tsx
@@ -24,6 +24,7 @@ import WebsiteContext from "../../context/Website"
 import { Website } from "../../types/websites"
 import origResourcePickerListing from "./ResourcePickerListing"
 import { assertNotNil } from "../../test_util"
+import { useMutation } from "redux-query-react"
 
 jest.mock("../../hooks/state")
 const useDebouncedState = jest.mocked(hooksState.useDebouncedState)
@@ -37,6 +38,12 @@ jest.mock("./ResourcePickerListing", () => {
   }
 })
 const ResourcePickerListing = jest.mocked(origResourcePickerListing)
+
+jest.mock("redux-query-react", () => ({
+  ...jest.requireActual("redux-query-react"),
+  useMutation: jest.fn(),
+}))
+const mockedUseMutation = jest.mocked(useMutation)
 
 const focusResource = (wrapper: ReactWrapper, resource: WebsiteContent) => {
   act(() => {
@@ -57,6 +64,8 @@ describe("ResourcePickerDialog", () => {
   beforeEach(() => {
     helper = new IntegrationTestHelper()
     website = makeWebsiteDetail()
+
+    mockedUseMutation.mockReturnValue([{}, jest.fn()])
 
     insertEmbedStub = helper.sandbox.stub()
     closeDialogStub = helper.sandbox.stub()

--- a/static/js/components/widgets/ResourcePickerDialog.test.tsx
+++ b/static/js/components/widgets/ResourcePickerDialog.test.tsx
@@ -66,9 +66,9 @@ describe("ResourcePickerDialog", () => {
     website = makeWebsiteDetail()
 
     mockedUseReferences.mockReturnValue({
-      references: {},
+      references: { link: [], unlink: [] },
       addReferences: jest.fn(),
-      removerefernces: jest.fn(),
+      removeReferences: jest.fn(),
     })
 
     insertEmbedStub = helper.sandbox.stub()

--- a/static/js/components/widgets/ResourcePickerDialog.tsx
+++ b/static/js/components/widgets/ResourcePickerDialog.tsx
@@ -20,6 +20,12 @@ import {
 import { WebsiteContent } from "../../types/websites"
 import { useWebsite } from "../../context/Website"
 import _, { keyBy } from "lodash"
+import { useParams } from "react-router-dom"
+import { useMutation } from "redux-query-react"
+import {
+  editWebsiteContentMutation,
+  EditWebsiteContentPayload,
+} from "../../query-configs/websites"
 
 interface Props {
   mode: ResourceDialogMode
@@ -159,6 +165,13 @@ export default function ResourcePickerDialog(props: Props): JSX.Element {
     null,
   )
 
+  const [, editWebsiteContent] = useMutation(
+    (payload: EditWebsiteContentPayload | FormData, name: string, id: string) =>
+      editWebsiteContentMutation({ name: name, textId: id }, payload),
+  )
+
+  const { uuid } = useParams<{ uuid: string }>()
+
   const addResource = useCallback(() => {
     if (focusedResource && isOpen) {
       insertEmbed(
@@ -167,6 +180,11 @@ export default function ResourcePickerDialog(props: Props): JSX.Element {
         mode,
       )
       closeDialog()
+      editWebsiteContent(
+        { referencingContent: uuid },
+        website.name,
+        focusedResource.text_id,
+      )
     }
   }, [insertEmbed, focusedResource, closeDialog, isOpen, mode])
 

--- a/static/js/components/widgets/ResourcePickerDialog.tsx
+++ b/static/js/components/widgets/ResourcePickerDialog.tsx
@@ -172,7 +172,7 @@ export default function ResourcePickerDialog(props: Props): JSX.Element {
       closeDialog()
       addReferences(focusedResource.text_id)
     }
-  }, [insertEmbed, focusedResource, closeDialog, isOpen, mode])
+  }, [insertEmbed, focusedResource, closeDialog, isOpen, mode, addReferences])
 
   const { acceptText, title } = modeText[mode]
 

--- a/static/js/components/widgets/ResourcePickerDialog.tsx
+++ b/static/js/components/widgets/ResourcePickerDialog.tsx
@@ -20,12 +20,7 @@ import {
 import { WebsiteContent } from "../../types/websites"
 import { useWebsite } from "../../context/Website"
 import _, { keyBy } from "lodash"
-import { useParams } from "react-router-dom"
-import { useMutation } from "redux-query-react"
-import {
-  editWebsiteContentMutation,
-  EditWebsiteContentPayload,
-} from "../../query-configs/websites"
+import { useReferences } from "../../context/References"
 
 interface Props {
   mode: ResourceDialogMode
@@ -165,12 +160,7 @@ export default function ResourcePickerDialog(props: Props): JSX.Element {
     null,
   )
 
-  const [, editWebsiteContent] = useMutation(
-    (payload: EditWebsiteContentPayload | FormData, name: string, id: string) =>
-      editWebsiteContentMutation({ name: name, textId: id }, payload),
-  )
-
-  const { uuid } = useParams<{ uuid: string }>()
+  const { addReferences } = useReferences()
 
   const addResource = useCallback(() => {
     if (focusedResource && isOpen) {
@@ -180,11 +170,7 @@ export default function ResourcePickerDialog(props: Props): JSX.Element {
         mode,
       )
       closeDialog()
-      editWebsiteContent(
-        { referencingContent: uuid },
-        website.name,
-        focusedResource.text_id,
-      )
+      addReferences(focusedResource.text_id)
     }
   }, [insertEmbed, focusedResource, closeDialog, isOpen, mode])
 

--- a/static/js/context/References.ts
+++ b/static/js/context/References.ts
@@ -1,4 +1,5 @@
 import React, { useContext } from "react"
+import { ReferencesContextType } from "../types/websites"
 
 /**
  * This allows us to set references context for a whole component
@@ -15,7 +16,9 @@ import React, { useContext } from "react"
  * const references = useReferences()
  * ```
  **/
-const ReferencesContext = React.createContext<null>(null)
+const ReferencesContext = React.createContext<ReferencesContextType | null>(
+  null,
+)
 export default ReferencesContext
 
 /**

--- a/static/js/context/References.ts
+++ b/static/js/context/References.ts
@@ -1,0 +1,38 @@
+import React, { useContext } from "react"
+
+/**
+ * This allows us to set references context for a whole component
+ * tree, starting, for instance, with our SiteContentForm component.
+ * This makes it then easy to grab the current References from anywhere in
+ * the component tree.
+ *
+ * The easiest way to use it is with the `useReferences` hook defined in
+ * this file, like so:
+ *
+ * ```ts
+ * import { useReferences } from '../context/References'
+ *
+ * const references = useReferences()
+ * ```
+ **/
+const ReferencesContext = React.createContext<null>(null)
+export default ReferencesContext
+
+/**
+ * A Utility hook for accessing the references context.
+ *
+ * This ensures that we're only reading from the context in a setting
+ * where the component has an ancestor component setting the value.
+ *
+ * Additionally, this simplifies the typing of the context value. Since
+ * we have a nice run-time guard against a null value we can safely type
+ * the return value as `References`, instead of `References | null`.
+ **/
+export function useReferences() {
+  const referencesContext = useContext(ReferencesContext)
+  if (referencesContext === null) {
+    throw new Error("useReferences must be within ReferencesContext.Provider")
+  }
+
+  return referencesContext
+}

--- a/static/js/lib/ckeditor/plugins/CustomLink.ts
+++ b/static/js/lib/ckeditor/plugins/CustomLink.ts
@@ -8,7 +8,7 @@ import { getCookie } from "../../api/util"
 import LinkCommand from "@ckeditor/ckeditor5-link/src/linkcommand"
 import UnlinkCommand from "@ckeditor/ckeditor5-link/src/unlinkcommand"
 import { Link } from "@ckeditor/ckeditor5-link"
-import { WEBSITE_NAME } from "./constants"
+import { REFERENCED_CONTENT, WEBSITE_NAME } from "./constants"
 import { Range } from "@ckeditor/ckeditor5-engine"
 import { DiffItem } from "@ckeditor/ckeditor5-engine/src/model/differ"
 import Writer from "@ckeditor/ckeditor5-engine/src/model/writer"
@@ -32,7 +32,7 @@ class CustomLinkCommand extends LinkCommand {
           )
 
           // Add the updated Resource Link ID in references context
-          const referencedContent = this.editor.config.get("referencedContent")
+          const referencedContent = this.editor.config.get(REFERENCED_CONTENT)
           referencedContent.add(externalResource.textId)
         }
       },
@@ -52,7 +52,7 @@ class CustomUnlinkCommand extends UnlinkCommand {
         .getResourceLinkID(String(href))
       if (resourceID) {
         console.log("element: ", resourceID)
-        const referencedContent = this.editor.config.get("referencedContent")
+        const referencedContent = this.editor.config.get(REFERENCED_CONTENT)
         referencedContent.remove(resourceID)
       }
     }
@@ -119,8 +119,7 @@ export default class CustomLink extends Plugin {
             })
 
             // Add the updated Resource Link ID in references context
-            const referencedContent =
-              this.editor.config.get("referencedContent")
+            const referencedContent = this.editor.config.get(REFERENCED_CONTENT)
             referencedContent.add(externalResource.textId)
           }
         })

--- a/static/js/lib/ckeditor/plugins/CustomLink.ts
+++ b/static/js/lib/ckeditor/plugins/CustomLink.ts
@@ -7,7 +7,7 @@ import { siteApiContentUrl } from "../../urls"
 import { getCookie } from "../../api/util"
 import LinkCommand from "@ckeditor/ckeditor5-link/src/linkcommand"
 import { Link } from "@ckeditor/ckeditor5-link"
-import { WEBSITE_NAME } from "./constants"
+import { WEBSITE_CONTENT_ID, WEBSITE_NAME } from "./constants"
 import { Range } from "@ckeditor/ckeditor5-engine"
 import { DiffItem } from "@ckeditor/ckeditor5-engine/src/model/differ"
 import Writer from "@ckeditor/ckeditor5-engine/src/model/writer"
@@ -23,15 +23,16 @@ class CustomLinkCommand extends LinkCommand {
       }
     }
 
-    getExternalResource(this.editor.config.get(WEBSITE_NAME), href, title).then(
-      (externalResource) => {
-        if (externalResource) {
-          updateHref(externalResource, this.editor, (href) =>
-            super.execute(href),
-          )
-        }
-      },
-    )
+    getExternalResource(
+      this.editor.config.get(WEBSITE_NAME),
+      this.editor.config.get(WEBSITE_CONTENT_ID),
+      href,
+      title,
+    ).then((externalResource) => {
+      if (externalResource) {
+        updateHref(externalResource, this.editor, (href) => super.execute(href))
+      }
+    })
   }
 }
 
@@ -77,6 +78,7 @@ export default class CustomLink extends Plugin {
 
         getExternalResource(
           this.editor.config.get(WEBSITE_NAME),
+          this.editor.config.get(WEBSITE_CONTENT_ID),
           String(originalHref),
           "",
         ).then((externalResource) => {
@@ -104,6 +106,7 @@ export default class CustomLink extends Plugin {
 
 async function getExternalResource(
   siteName: string,
+  contentId: string,
   linkValue: string,
   title: string,
 ): Promise<{ title: string; textId: string } | null> {
@@ -124,6 +127,7 @@ async function getExternalResource(
       is_broken: "",
       backup_url: "",
     },
+    referencing_content: [contentId],
   }
 
   try {

--- a/static/js/lib/ckeditor/plugins/CustomLink.ts
+++ b/static/js/lib/ckeditor/plugins/CustomLink.ts
@@ -33,7 +33,7 @@ class CustomLinkCommand extends LinkCommand {
 
           // Add the updated Resource Link ID in references context
           const referencedContent = this.editor.config.get("referencedContent")
-          referencedContent.add("link", externalResource.textId)
+          referencedContent.add(externalResource.textId)
         }
       },
     )
@@ -43,16 +43,15 @@ class CustomLinkCommand extends LinkCommand {
 class CustomUnlinkCommand extends UnlinkCommand {
   execute() {
     // Add the updated Resource Link ID in references context
-    const element = this.editor.model.document.selection.getSelectedElement()
-
-    if (element && element.is("element", "a")) {
-      const href = element.getAttribute("href")
+    const href = this.editor.model.document.selection.getAttribute("linkHref")
+    if (href) {
       console.log("Unlinking this URL:", href)
 
       const resourceID = this.editor.plugins
         .get(ResourceLinkMarkdownSyntax)
         .getResourceLinkID(href)
       if (resourceID) {
+        console.log("element: ", resourceID)
         const referencedContent = this.editor.config.get("referencedContent")
         referencedContent.remove(resourceID)
       }

--- a/static/js/lib/ckeditor/plugins/CustomLink.ts
+++ b/static/js/lib/ckeditor/plugins/CustomLink.ts
@@ -49,7 +49,7 @@ class CustomUnlinkCommand extends UnlinkCommand {
 
       const resourceID = this.editor.plugins
         .get(ResourceLinkMarkdownSyntax)
-        .getResourceLinkID(href)
+        .getResourceLinkID(String(href))
       if (resourceID) {
         console.log("element: ", resourceID)
         const referencedContent = this.editor.config.get("referencedContent")

--- a/static/js/lib/ckeditor/plugins/CustomLink.ts
+++ b/static/js/lib/ckeditor/plugins/CustomLink.ts
@@ -45,13 +45,10 @@ class CustomUnlinkCommand extends UnlinkCommand {
     // Add the updated Resource Link ID in references context
     const href = this.editor.model.document.selection.getAttribute("linkHref")
     if (href) {
-      console.log("Unlinking this URL:", href)
-
       const resourceID = this.editor.plugins
         .get(ResourceLinkMarkdownSyntax)
         .getResourceLinkID(String(href))
       if (resourceID) {
-        console.log("element: ", resourceID)
         const referencedContent = this.editor.config.get(REFERENCED_CONTENT)
         referencedContent.remove(resourceID)
       }
@@ -78,7 +75,6 @@ export default class CustomLink extends Plugin {
   init() {
     this.editor.commands.add("link", new CustomLinkCommand(this.editor))
     this.editor.commands.add("unlink", new CustomUnlinkCommand(this.editor))
-    console.log("CustomLink Plugin is initialized")
 
     // Intercept change in document
     this.editor.model.document.on("change:data", () => {
@@ -143,7 +139,7 @@ async function getExternalResource(
   try {
     hasWarning = new URL(linkValue).hostname !== SETTINGS.sitemapDomain
   } catch (error) {
-    console.log("Invalid URL provided!")
+    //Invalid URL provided! Ignored as this could be due to a missing scheme.
   }
 
   const payload = {

--- a/static/js/lib/ckeditor/plugins/CustomLink.ts
+++ b/static/js/lib/ckeditor/plugins/CustomLink.ts
@@ -31,6 +31,11 @@ class CustomLinkCommand extends LinkCommand {
     ).then((externalResource) => {
       if (externalResource) {
         updateHref(externalResource, this.editor, (href) => super.execute(href))
+
+        // Add the updated Resource Link ID in references context
+        const addReferences = this.editor.config.get("addReferences")
+        console.log("type of ", addReferences)
+        addReferences(externalResource.textId)
       }
     })
   }
@@ -91,6 +96,11 @@ export default class CustomLink extends Plugin {
                 item,
               )
             })
+
+            // Add the updated Resource Link ID in references context
+            const addReferences = this.editor.config.get("addReferences")
+            console.log("type of ", addReferences)
+            addReferences(externalResource.textId)
           }
         })
       }

--- a/static/js/lib/ckeditor/plugins/CustomLink.ts
+++ b/static/js/lib/ckeditor/plugins/CustomLink.ts
@@ -127,7 +127,7 @@ async function getExternalResource(
       is_broken: "",
       backup_url: "",
     },
-    referencing_content: [contentId],
+    referencing_content: contentId,
   }
 
   try {

--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
@@ -77,7 +77,7 @@ export default class ResourceLinkMarkdownSyntax extends MarkdownSyntaxPlugin {
     }
   }
 
-  getResourceLinkID = (href?: string): string | null => {
+  getResourceLinkID = (href: string): string | null => {
     if (this.isResourceLinkHref(href)) {
       const url = new URL(href)
       return url.searchParams.get(queryKeys.uuid)

--- a/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/ResourceLinkMarkdownSyntax.ts
@@ -77,6 +77,15 @@ export default class ResourceLinkMarkdownSyntax extends MarkdownSyntaxPlugin {
     }
   }
 
+  getResourceLinkID = (href?: string): string | null => {
+    if (this.isResourceLinkHref(href)) {
+      const url = new URL(href)
+      return url.searchParams.get(queryKeys.uuid)
+    } else {
+      return ""
+    }
+  }
+
   makeResourceLinkHref = (uuid: string, suffix = "") => {
     const href = new URL(this.hrefTemplate.replace(/:uuid/g, uuid))
     href.searchParams.set(queryKeys.uuid, uuid)

--- a/static/js/lib/ckeditor/plugins/constants.ts
+++ b/static/js/lib/ckeditor/plugins/constants.ts
@@ -16,8 +16,6 @@ export const RESOURCE_LINK_CONFIG_KEY = "resource-link-config"
 
 export const WEBSITE_NAME = "website-name"
 
-export const WEBSITE_CONTENT_ID = "website-content-id"
-
 import TurndownService from "turndown"
 
 /**

--- a/static/js/lib/ckeditor/plugins/constants.ts
+++ b/static/js/lib/ckeditor/plugins/constants.ts
@@ -16,6 +16,8 @@ export const RESOURCE_LINK_CONFIG_KEY = "resource-link-config"
 
 export const WEBSITE_NAME = "website-name"
 
+export const WEBSITE_CONTENT_ID = "website-content-id"
+
 import TurndownService from "turndown"
 
 /**

--- a/static/js/lib/ckeditor/plugins/constants.ts
+++ b/static/js/lib/ckeditor/plugins/constants.ts
@@ -16,6 +16,8 @@ export const RESOURCE_LINK_CONFIG_KEY = "resource-link-config"
 
 export const WEBSITE_NAME = "website-name"
 
+export const REFERENCED_CONTENT = "referenced-content"
+
 import TurndownService from "turndown"
 
 /**

--- a/static/js/query-configs/websites.ts
+++ b/static/js/query-configs/websites.ts
@@ -424,6 +424,7 @@ export type EditWebsiteContentPayload = {
   body?: string
   metadata?: any
   file?: File
+  referencingContent?: any
 }
 
 export const editWebsiteContentMutation = (

--- a/static/js/query-configs/websites.ts
+++ b/static/js/query-configs/websites.ts
@@ -424,7 +424,6 @@ export type EditWebsiteContentPayload = {
   body?: string
   metadata?: any
   file?: File
-  referencingContent?: any
 }
 
 export const editWebsiteContentMutation = (

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -328,3 +328,14 @@ export interface WebsiteInitials {
   title: string
   short_id: string
 }
+
+export type ReferencedContent = {
+  link: string[]
+  unlink: string[]
+}
+
+export type ReferencesContextType = {
+  references: ReferencedContent
+  addReferences: (item: string) => void
+  removeReferences: (item: string) => void
+}

--- a/websites/views.py
+++ b/websites/views.py
@@ -699,6 +699,17 @@ class WebsiteContentViewSet(
         serializer.save(updated_by=self.request.user)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
+    def perform_update(self, serializer):
+        """
+        Override the update request for content
+        """
+        instance = serializer.save()
+
+        if content_id := self.request.data.get("referencingContent"):
+            content = WebsiteContent.objects.get(text_id=content_id)
+            instance.referencing_content.add(content)
+            instance.save()
+
     @action(
         detail=False,
         methods=["post"],


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/5851

### Description (What does it do?)
This adds the references of the website contents that are using this WebsiteContent

### How can this be tested?
1. Open `ocw-studio`
2. Add a new page or edit an existing one
3. From resource picker, add a link for an external resource or page.
<img width="766" alt="Screenshot 2024-10-28 at 2 13 50 PM" src="https://github.com/user-attachments/assets/d98fe15c-e3bb-43c4-baca-27fa6139da2c">

4. Go to the `Admin` panel and check the `referencing_content` field for the selected resource. it should have the reference of the page where the link was added.
5. Type links in editor which would create External Resources with page reference (refer [here](https://github.com/mitodl/ocw-studio/pull/2279) for details on testing this feature)