### PR TITLE
Fix file size metadata mismatch when replacing Google Drive image in Studio

### DIFF
--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -487,7 +487,7 @@ def create_gdrive_resource_content(drive_file: DriveFile):
             )
         else:
             resource.file = drive_file.s3_key
-            if resource.metadata["file_size"] != drive_file.size:
+            if resource.metadata.get("file_size") != drive_file.size:
                 resource.metadata["file_size"] = drive_file.size
             if extension.lower() == ".pdf":
                 # update resource title if PDF metadata contains title

--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -487,6 +487,8 @@ def create_gdrive_resource_content(drive_file: DriveFile):
             )
         else:
             resource.file = drive_file.s3_key
+            if resource.metadata["file_size"] != drive_file.size:
+                resource.metadata["file_size"] = drive_file.size
             if extension.lower() == ".pdf":
                 # update resource title if PDF metadata contains title
                 pdf_title = get_pdf_title(drive_file)


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5602

### Description (What does it do?)
This PR addresses the issue where the `file_size` metadata of a `WebsiteContent` resource in Studio does not update correctly when an image is replaced on Google Drive and resynced.

### How can this be tested?
1. Checkout to this branch
2. Spin up OCW Studio locally
3. Upload an image to a course's Gdrive and sync
4. Go to admin panel, open the relevant WebsiteContent object, and check `file_size` from metadata.
5. Go to course's Gdrive again, delete the picture.
8. Upload any other picture there but with same name.
9. Sync with Gdrive again.
10. Go to admin panel, open the relevant WebsiteContent object, and check that `file_size` in metadata has successfully updated, while the other metadata fields stay same.
