### PR TITLE
Add environment to PostHog feature flags

### DIFF
--- a/static/js/lib/util.ts
+++ b/static/js/lib/util.ts
@@ -25,7 +25,7 @@ if (SETTINGS.posthog_api_host && SETTINGS.posthog_project_api_key) {
   // @ts-expect-error: SETTINGS.user is intentionally untyped
   if (SETTINGS.user) {
     // @ts-expect-error: SETTINGS.user is intentionally untyped
-    posthog.identify(SETTINGS.user.email)
+    posthog.identify(SETTINGS.user.email, { environment: SETTINGS.environment })
   }
 }
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5910.

### Description (What does it do?)
This PR adds the `environment` variable to users for PostHog, allowing feature flags to be rolled out for certain values of the environment variable, such as only on RC.

### How can this be tested?

First, set the variable `OCW_STUDIO_ENVIRONMENT` to `rc` in your `.env` file. Then, restart the Docker OCW Studio containers. Verify that the behavior described in the testing instructions for https://github.com/mitodl/ocw-studio/pull/2279 is valid. Now, change the value of `OCW_STUDIO_ENVIRONMENT` to any other value (such as `prod`). Restart the Studio containers. Verify that links are now editable as before.
