### PR TITLE
Removed duplication of custom plugin in config

### DIFF
--- a/static/js/components/widgets/MarkdownEditor.tsx
+++ b/static/js/components/widgets/MarkdownEditor.tsx
@@ -152,14 +152,19 @@ export default function MarkdownEditor(props: Props): JSX.Element {
       // Function cannot be directly passed in config
       [REFERENCED_CONTENT]: { add: addReferences, remove: removeReferences },
     }
+
+    // Create a copy of plugins to avoid mutating the original
+    const plugins = minimal
+      ? [...MinimalEditorConfig.plugins]
+      : [...FullEditorConfig.plugins]
     if (isCustomLinkUIEnabled) {
-      MinimalEditorConfig.plugins.push(CustomLink)
-      FullEditorConfig.plugins.push(CustomLink)
+      plugins.push(CustomLink)
     }
 
     if (minimal) {
       return {
         ...MinimalEditorConfig,
+        plugins,
         [CKEDITOR_RESOURCE_UTILS]: {
           renderResource,
           openResourcePicker,
@@ -176,6 +181,7 @@ export default function MarkdownEditor(props: Props): JSX.Element {
       // and then use it to render resources within the editor.
       return {
         ...FullEditorConfig,
+        plugins,
         [CKEDITOR_RESOURCE_UTILS]: {
           renderResource,
           openResourcePicker,


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/6160

### Description (What does it do?)
The underlying function for tracking config changes for CKEditor uses `useMemo` to recompute its value whenever one of the dependencies changes via ===-comparison, which, for objects, is object-reference. Generating the config again and again sometimes adds duplicate copies of custom plugins, so they end up being different via JSON serialization.

### How can this be tested?
1. First, identify the issue that exists in the `master` branch of `ocw-studio`.
2. Then switch to `umar/6160-issue-in-editor-for-ocw-stories` branch in `ocw-studio` and restart containers.
3. Go To `sites/ocw-www/type/stories/` in `ocw-studio`.
4. Try to edit body of any Story (add a new story or edit existing), It shouldn't cause any issue.