### PR TITLE
Add Video Resource Functionality

### DIFF
--- a/static/js/components/RepeatableContentListing.test.tsx
+++ b/static/js/components/RepeatableContentListing.test.tsx
@@ -164,7 +164,7 @@ describe("RepeatableContentListing", () => {
       const addLink = wrapper.find("a.add")
       expect(driveLink.exists()).toBe(isGdriveEnabled && isResource)
       expect(syncLink.exists()).toBe(isGdriveEnabled && isResource)
-      expect(addLink.exists()).toBe(!isGdriveEnabled || !isResource)
+      expect(addLink.exists()).toBe(true)
     },
   )
 
@@ -489,8 +489,12 @@ describe("RepeatableContentListing", () => {
       }
       const { wrapper } = await render()
       expect(wrapper.find("h2").text()).toBe(configItem.label)
-      const link = wrapper.find(".cyan-button .add").at(1)
-      expect(link.text()).toBe(`Add ${expectedLabel}`)
+      const link = wrapper.find(".cyan-button .add").at(0)
+      if (configItem.name === "resource") {
+        expect(link.text()).toBe("Add Video Resource")
+      } else {
+        expect(link.text()).toBe(`Add ${expectedLabel}`)
+      }
       expect(link.prop("href")).toBe(
         siteContentNewUrl
           .param({
@@ -581,5 +585,28 @@ describe("RepeatableContentListing", () => {
         name: website.name,
       }).pathname,
     ])
+  })
+  it('should display "Add Video Resource" link if configItem is "resource"', async () => {
+    configItem = makeRepeatableConfigItem("resource")
+    helper.mockGetRequest(
+      siteApiContentListingUrl
+        .param({
+          name: website.name,
+        })
+        .query({ offset: 0, type: configItem.name })
+        .toString(),
+      apiResponse,
+    )
+    const { wrapper } = await render({ configItem })
+    const addLink = wrapper.find("a.add")
+    expect(addLink.text()).toBe("Add Video Resource")
+    expect(addLink.prop("href")).toBe(
+      siteContentNewUrl
+        .param({
+          name: website.name,
+          contentType: configItem.name,
+        })
+        .toString(),
+    )
   })
 })

--- a/static/js/components/RepeatableContentListing.tsx
+++ b/static/js/components/RepeatableContentListing.tsx
@@ -221,7 +221,7 @@ export default function RepeatableContentListing(props: {
             onChange={setSearchInput}
           />
           <Link
-            className="btn cyan-button text-nowrap"
+            className="btn add cyan-button text-nowrap"
             to={siteContentNewUrl
               .param({
                 name: website.name,

--- a/static/js/components/RepeatableContentListing.tsx
+++ b/static/js/components/RepeatableContentListing.tsx
@@ -50,14 +50,19 @@ export default function RepeatableContentListing(props: {
   const website = useWebsite()
 
   const [isContentDeletable, setIsContentDeletable] = useState(false)
+  const [isAddVideoEnabled, setIsAddVideoEnabled] = useState(false)
 
   useEffect(() => {
-    const checkFeatureFlag = async () => {
-      const flagEnabled =
+    const checkFeatureFlags = async () => {
+      const deletableFlag =
         posthog.isFeatureEnabled("OCW_STUDIO_CONTENT_DELETABLE") ?? false
-      setIsContentDeletable(flagEnabled)
+      setIsContentDeletable(deletableFlag)
+
+      const addVideoResourceFlag =
+        posthog.isFeatureEnabled("OCW_STUDIO_ADD_VIDEO_RESOURCE") ?? false
+      setIsAddVideoEnabled(addVideoResourceFlag)
     }
-    checkFeatureFlag()
+    checkFeatureFlags()
   }, [])
 
   const isDeletable =
@@ -220,18 +225,20 @@ export default function RepeatableContentListing(props: {
             value={searchInput}
             onChange={setSearchInput}
           />
-          <Link
-            className="btn add cyan-button text-nowrap"
-            to={siteContentNewUrl
-              .param({
-                name: website.name,
-                contentType: configItem.name,
-              })
-              .query(searchParams)
-              .toString()}
-          >
-            {isResource ? "Add Video Resource" : `Add ${labelSingular}`}
-          </Link>
+          {((isResource && isAddVideoEnabled) || !isResource) && (
+            <Link
+              className="btn add cyan-button text-nowrap"
+              to={siteContentNewUrl
+                .param({
+                  name: website.name,
+                  contentType: configItem.name,
+                })
+                .query(searchParams)
+                .toString()}
+            >
+              {isResource ? "Add Video Resource" : `Add ${labelSingular}`}
+            </Link>
+          )}
           {SETTINGS.gdrive_enabled && isResource && website.gdrive_url ? (
             <div className="d-flex flex-column">
               <div className="d-flex">

--- a/static/js/components/RepeatableContentListing.tsx
+++ b/static/js/components/RepeatableContentListing.tsx
@@ -213,49 +213,46 @@ export default function RepeatableContentListing(props: {
     <>
       <div className="d-flex flex-direction-row align-items-center justify-content-between py-3">
         <h2 className="m-0 p-0">{configItem.label}</h2>
-        <div className="d-flex flex-direction-row align-items-top">
+        <div className="d-flex flex-direction-row align-items-baseline">
           <input
             placeholder={`Search for a ${labelSingular}`}
             className="site-search-input mr-3 form-control"
             value={searchInput}
             onChange={setSearchInput}
           />
-          {SETTINGS.gdrive_enabled && isResource ? (
-            website.gdrive_url ? (
-              <div className="d-flex flex-column">
-                <div className="d-flex">
-                  <button
-                    className="btn cyan-button sync ml-2 text-nowrap"
-                    onClick={onSubmitContentSync}
-                  >
-                    Sync w/Google Drive
-                  </button>
-                  <a
-                    className="view"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    href={website.gdrive_url}
-                  >
-                    <i className="material-icons gdrive-link">open_in_new</i>
-                  </a>
-                </div>
-                <DriveSyncStatusIndicator website={website} />
+          <Link
+            className="btn cyan-button text-nowrap"
+            to={siteContentNewUrl
+              .param({
+                name: website.name,
+                contentType: configItem.name,
+              })
+              .query(searchParams)
+              .toString()}
+          >
+            {isResource ? "Add Video Resource" : `Add ${labelSingular}`}
+          </Link>
+          {SETTINGS.gdrive_enabled && isResource && website.gdrive_url ? (
+            <div className="d-flex flex-column">
+              <div className="d-flex">
+                <button
+                  className="btn cyan-button sync ml-2 text-nowrap"
+                  onClick={onSubmitContentSync}
+                >
+                  Sync w/Google Drive
+                </button>
+                <a
+                  className="view"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  href={website.gdrive_url}
+                >
+                  <i className="material-icons gdrive-link">open_in_new</i>
+                </a>
               </div>
-            ) : null
-          ) : (
-            <Link
-              className="btn cyan-button add flex-shrink-0"
-              to={siteContentNewUrl
-                .param({
-                  name: website.name,
-                  contentType: configItem.name,
-                })
-                .query(searchParams)
-                .toString()}
-            >
-              Add {labelSingular}
-            </Link>
-          )}
+              <DriveSyncStatusIndicator website={website} />
+            </div>
+          ) : null}
         </div>
       </div>
       <StudioList>

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -50,15 +50,40 @@ export default function SiteContentForm(props: FormProps): JSX.Element {
 
   const website = useWebsite()
 
-  const initialValues: SiteFormValues = useMemo(
-    () =>
-      editorState.adding()
-        ? newInitialValues(configItem.fields, website)
-        : contentInitialValues(
+  const initialValues: SiteFormValues = useMemo(() => ({
+    ...(editorState.adding()
+    ? {
+      ...newInitialValues(configItem.fields, website),
+      ...(configItem.name === "resource"
+        ? { resourcetype: "Video" }
+        : {}),
+    }
+    : contentInitialValues(
+      content as WebsiteContent,
+      configItem.fields,
+      website,
+    )),
+    if (!editorState.adding() && configItem.name === "resource") {
+      return {
+        ...contentInitialValues(
+          content as WebsiteContent,
+          configItem.fields,
+          website,
+        ),
+      }
+    }
+
+    return editorState.adding()
+      ? {
+          ...newInitialValues(configItem.fields, website),
+        }
+      : {
+          ...contentInitialValues(
             content as WebsiteContent,
             configItem.fields,
             website,
-          ),
+          )),
+    }),
     [configItem.fields, editorState, content, website],
   )
 
@@ -66,7 +91,6 @@ export default function SiteContentForm(props: FormProps): JSX.Element {
     values: FormikValues,
   ): Promise<FormikErrors<SiteFormValues>> => {
     const schema = getContentSchema(configItem, values)
-
     try {
       await validateYupSchema(values, schema)
     } catch (e) {
@@ -122,7 +146,7 @@ export function FormFields(props: InnerFormProps): JSX.Element {
     <Form
       onSubmit={async (event) => {
         handleSubmit(event)
-        const { target } = event // get target before the await; https://reactjs.org/docs/legacy-event-pooling.html
+        const { target } = event
         const errors = await validate(values)
         if (Object.keys(errors).length > 0) {
           scrollToElement(target as HTMLElement, ".form-error")
@@ -172,6 +196,7 @@ export function FormFields(props: InnerFormProps): JSX.Element {
           Save
         </button>
       </div>
+
       {status && (
         // Status is being used to store non-field errors
         <div className="form-error">{status}</div>

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -146,7 +146,7 @@ export function FormFields(props: InnerFormProps): JSX.Element {
     <Form
       onSubmit={async (event) => {
         handleSubmit(event)
-        const { target } = event
+        const { target } = event // get target before the await; https://reactjs.org/docs/legacy-event-pooling.html
         const errors = await validate(values)
         if (Object.keys(errors).length > 0) {
           scrollToElement(target as HTMLElement, ".form-error")
@@ -196,7 +196,6 @@ export function FormFields(props: InnerFormProps): JSX.Element {
           Save
         </button>
       </div>
-
       {status && (
         // Status is being used to store non-field errors
         <div className="form-error">{status}</div>

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -48,42 +48,20 @@ export interface FormProps {
 export default function SiteContentForm(props: FormProps): JSX.Element {
   const { onSubmit, configItem, content, editorState } = props
   const website = useWebsite()
-
-  const initialValues: SiteFormValues = useMemo(() => ({
-    ...(editorState.adding()
-    ? {
-      ...newInitialValues(configItem.fields, website),
-      ...(configItem.name === "resource"
-        ? { resourcetype: "Video" }
-        : {}),
-    }
-    : contentInitialValues(
-      content as WebsiteContent,
-      configItem.fields,
-      website,
-    )),
-    if (!editorState.adding() && configItem.name === "resource") {
-      return {
-        ...contentInitialValues(
-          content as WebsiteContent,
-          configItem.fields,
-          website,
-        ),
-      }
-    }
-
-    return editorState.adding()
-      ? {
-          ...newInitialValues(configItem.fields, website),
-        }
-      : {
-          ...contentInitialValues(
+  const initialValues: SiteFormValues = useMemo(
+    () =>
+      editorState.adding()
+        ? {
+            ...newInitialValues(configItem.fields, website),
+            ...(configItem.name === "resource"
+              ? { resourcetype: "Video" }
+              : {}),
+          }
+        : contentInitialValues(
             content as WebsiteContent,
             configItem.fields,
             website,
-          )),
-      references: {}, // Add this to ensure Formik tracks the `references` field
-    }),
+          ),
     [configItem.fields, configItem.name, editorState, content, website],
   )
 

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -47,7 +47,6 @@ export interface FormProps {
 
 export default function SiteContentForm(props: FormProps): JSX.Element {
   const { onSubmit, configItem, content, editorState } = props
-
   const website = useWebsite()
 
   const initialValues: SiteFormValues = useMemo(() => ({
@@ -83,6 +82,7 @@ export default function SiteContentForm(props: FormProps): JSX.Element {
             configItem.fields,
             website,
           )),
+      references: {}, // Add this to ensure Formik tracks the `references` field
     }),
     [configItem.fields, editorState, content, website],
   )
@@ -99,9 +99,28 @@ export default function SiteContentForm(props: FormProps): JSX.Element {
     return {}
   }
 
+  // Auto-populate thumbnail for Video Resource on Save
+  const handleSubmit = async (
+    values: FormikValues,
+    formikHelpers: FormikHelpers<any>,
+  ) => {
+    if (values.resourcetype === "Video") {
+      const youtubeId = values?.video_metadata?.youtube_id
+      if (youtubeId) {
+        if (!values.video_files) {
+          values.video_files = {}
+        }
+        if (!values.video_files.video_thumbnail_file) {
+          values.video_files.video_thumbnail_file = `https://img.youtube.com/vi/${youtubeId}/default.jpg`
+        }
+      }
+    }
+    return onSubmit(values, formikHelpers)
+  }
+
   return (
     <Formik
-      onSubmit={onSubmit}
+      onSubmit={handleSubmit}
       validate={validate}
       initialValues={initialValues}
       enableReinitialize={true}
@@ -129,10 +148,10 @@ export function FormFields(props: InnerFormProps): JSX.Element {
     setDirty,
     handleSubmit,
     validate,
+    editorState,
   } = props
 
   const contentContext = content?.content_context ?? null
-
   const renamedFields: ConfigField[] = useMemo(
     () => renameNestedFields(configItem.fields),
     [configItem],
@@ -156,8 +175,16 @@ export function FormFields(props: InnerFormProps): JSX.Element {
       <div>
         {renamedFields
           .filter((field) => fieldIsVisible(field, values))
-          .map((field) =>
-            field.widget === WidgetVariant.Object ? (
+          .map((field) => {
+            // Hide `resourcetype` and `file` in case of Add Video Resource (using YouTube ID)
+            if (
+              configItem.name === "resource" &&
+              (field.name === "resourcetype" || field.name === "file") &&
+              editorState.adding()
+            ) {
+              return null
+            }
+            return field.widget === WidgetVariant.Object ? (
               <ObjectField
                 field={field}
                 key={field.name}
@@ -184,8 +211,8 @@ export function FormFields(props: InnerFormProps): JSX.Element {
                 contentContext={contentContext}
                 onChange={handleChange}
               />
-            ),
-          )}
+            )
+          })}
       </div>
       <div className="form-group d-flex w-100 justify-content-end">
         <button

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -84,13 +84,14 @@ export default function SiteContentForm(props: FormProps): JSX.Element {
           )),
       references: {}, // Add this to ensure Formik tracks the `references` field
     }),
-    [configItem.fields, editorState, content, website],
+    [configItem.fields, configItem.name, editorState, content, website],
   )
 
   const validate = async (
     values: FormikValues,
   ): Promise<FormikErrors<SiteFormValues>> => {
     const schema = getContentSchema(configItem, values)
+
     try {
       await validateYupSchema(values, schema)
     } catch (e) {
@@ -176,7 +177,7 @@ export function FormFields(props: InnerFormProps): JSX.Element {
         {renamedFields
           .filter((field) => fieldIsVisible(field, values))
           .map((field) => {
-            // Hide `resourcetype` and `file` in case of Add Video Resource (using YouTube ID)
+            // Hide `resourcetype` and `file` in case of adding Video Resource (using YouTube ID)
             if (
               configItem.name === "resource" &&
               (field.name === "resourcetype" || field.name === "file") &&


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/4709

### Description (What does it do?)
This PR adds functionality to add Video Resources using YouTube ID.

Functional changes introduced:
- Video thumbnail field is auto-populated using YouTube ID (if empty) on Save.
- In case of adding (as in the case of Add Video Resource Button), "File" and "Resource Type" will be hidden, defaulting to "Video" for Resource Type.
- Existing editing behavior for resources will be same, that is, File and Resource Type will not be hidden or affected. 
- These changes are managed through the PostHog Feature Flag `OCW_STUDIO_ADD_VIDEO_RESOURCE`.

### Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/6d6b9fca-c5ae-463b-858b-b1cd7a209da3)
![image](https://github.com/user-attachments/assets/0bebc807-4bf6-40c7-9218-13cab132dec6)


### How can this be tested?
1. Checkout to this branch.
2. Spin up OCW Studio locally.
3. Make sure the `OCW_STUDIO_ADD_VIDEO_RESOURCE` feature flag is enabled in PostHog's web interface.
4. Go to `ocw-www` or any course site locally and go to resources.
5. Click on the new "Add Video Resource" button.
6. Add a title and YouTube ID, and any other fields you like. Save.
7. Embed the video in any page and make sure it works fine -- like a regular video resource.
