### PR TITLE
Remove "name" field from the metadata of stories in WebsiteContent

### DIFF
--- a/websites/migrations/0059_remove_name_from_stories_websitecontent_metadata.py
+++ b/websites/migrations/0059_remove_name_from_stories_websitecontent_metadata.py
@@ -1,10 +1,17 @@
 # Manual migration to remove the "name" field from the metadata of existing stories
 
+import logging
 
 from django.db import migrations
 
+logger = logging.getLogger(__name__)
 
-def remove_name_from_stories_metadata(apps, schema_editor):
+
+def migrate_metadata_forward(apps, schema_editor):
+    """
+    Forward migration remove the "name" field from the metadata
+    of existing stories
+    """
     WebsiteContent = apps.get_model("websites", "WebsiteContent")
     stories = WebsiteContent.objects.filter(website__name="ocw-www", type="stories")
 
@@ -14,11 +21,22 @@ def remove_name_from_stories_metadata(apps, schema_editor):
             story.save(update_fields=["metadata"])
 
 
+def migrate_metadata_backward(apps, schema_editor):
+    """
+    Run migration in backward direction.
+    This will not return the DB to original state.
+    """
+    logger.warning(
+        "The reverse migration for '0059' of the websites"
+        "module cannot restore the original data state."
+    )
+
+
 class Migration(migrations.Migration):
     dependencies = [
         ("websites", "0058_websitecontent_referencing_content"),
     ]
 
     operations = [
-        migrations.RunPython(remove_name_from_stories_metadata),
+        migrations.RunPython(migrate_metadata_forward, migrate_metadata_backward),
     ]

--- a/websites/migrations/0059_remove_name_from_stories_websitecontent_metadata.py
+++ b/websites/migrations/0059_remove_name_from_stories_websitecontent_metadata.py
@@ -1,0 +1,24 @@
+# Manual migration to remove the "name" field from the metadata of existing stories
+
+
+from django.db import migrations
+
+
+def remove_name_from_stories_metadata(apps, schema_editor):
+    WebsiteContent = apps.get_model("websites", "WebsiteContent")
+    stories = WebsiteContent.objects.filter(website__name="ocw-www", type="stories")
+
+    for story in stories:
+        if story.metadata and "name" in story.metadata:
+            del story.metadata["name"]
+            story.save(update_fields=["metadata"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("websites", "0058_websitecontent_referencing_content"),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_name_from_stories_metadata),
+    ]


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/6320

### Description (What does it do?)
This PR introduces a manual migration to remove the name field from the metadata of stories in the WebsiteContent model. 

### How can this be tested?
Checkout to this branch, spin up OCW Studio locally, jump into the Web container in Docker and run: `python manage.py migrate`. Make sure `name` is no longer present in metadata.

