### PR TITLE
added management command to detect unrelated files in a website

### DIFF
--- a/websites/management/commands/detect_unrelated_content.py
+++ b/websites/management/commands/detect_unrelated_content.py
@@ -63,21 +63,21 @@ class Command(WebsiteFilterCommand):
                 unrelated_files[website.name] = unrelated_website_files
 
         if unrelated_files:
+            self.style.SUCCESS("Unrelated content found in the bucket!")
             content = json.dumps(unrelated_files, indent=4)
 
-            with NamedTemporaryFile(delete=False, suffix=".json") as tmp_file:
-                tmp_file_path = tmp_file.name
             if total_files > self.UNRELATED_FILES_THRESHOLD:
+                with NamedTemporaryFile(delete=False, suffix=".json") as tmp_file:
+                    tmp_file_path = tmp_file.name
+                    tmp_file.write(content.encode("utf-8"))
                 self.stdout.write(
                     self.style.SUCCESS(
                         "Unrelated content found in the bucket!"
                         "And the content has been written to a "
-                        "temporary file located at: ",
-                        tmp_file_path,
+                        f"temporary file located at: {tmp_file_path}"
                     )
                 )
             else:
-                self.style.SUCCESS("Unrelated content found in the bucket!")
                 self.stdout.write(content)
 
         else:

--- a/websites/management/commands/detect_unrelated_content.py
+++ b/websites/management/commands/detect_unrelated_content.py
@@ -63,7 +63,9 @@ class Command(WebsiteFilterCommand):
                 unrelated_files[website.name] = unrelated_website_files
 
         if unrelated_files:
-            self.style.SUCCESS("Unrelated content found in the bucket!")
+            self.stdout.write(
+                self.style.SUCCESS("Unrelated content found in the bucket!")
+            )
             content = json.dumps(unrelated_files, indent=4)
 
             if total_files > self.UNRELATED_FILES_THRESHOLD:
@@ -72,8 +74,7 @@ class Command(WebsiteFilterCommand):
                     tmp_file.write(content.encode("utf-8"))
                 self.stdout.write(
                     self.style.SUCCESS(
-                        "Unrelated content found in the bucket!"
-                        "And the content has been written to a "
+                        "The content has been written to a "
                         f"temporary file located at: {tmp_file_path}"
                     )
                 )

--- a/websites/management/commands/detect_unrelated_content.py
+++ b/websites/management/commands/detect_unrelated_content.py
@@ -45,7 +45,7 @@ class Command(WebsiteFilterCommand):
                 Prefix=f"courses/{website.name}/",
             )
             files_in_s3 = (
-                {content["Key"] for content in files.get("Contents", [])}
+                {("/" + content["Key"]) for content in files.get("Contents", [])}
                 if files.get("KeyCount")
                 else set()
             )

--- a/websites/management/commands/detect_unrelated_content.py
+++ b/websites/management/commands/detect_unrelated_content.py
@@ -50,17 +50,18 @@ class Command(WebsiteFilterCommand):
                 else set()
             )
 
-            website_content_files = set(
-                WebsiteContent.objects.filter(
-                    website=website, file__in=files_in_s3
-                ).values_list("file", flat=True)
-            )
+            if files_in_s3:
+                website_content_files = set(
+                    WebsiteContent.objects.filter(
+                        website=website, file__in=files_in_s3
+                    ).values_list("file", flat=True)
+                )
 
-            unrelated_website_files = list(files_in_s3 - website_content_files)
+                unrelated_website_files = list(files_in_s3 - website_content_files)
 
-            if unrelated_website_files:
-                total_files += len(unrelated_website_files)
-                unrelated_files[website.name] = unrelated_website_files
+                if unrelated_website_files:
+                    total_files += len(unrelated_website_files)
+                    unrelated_files[website.name] = unrelated_website_files
 
         if unrelated_files:
             self.stdout.write(

--- a/websites/management/commands/detect_unrelated_content.py
+++ b/websites/management/commands/detect_unrelated_content.py
@@ -1,3 +1,12 @@
+"""
+This script defines a Django management command to detect unrelated content in an AWS S3
+ bucket for courses.
+
+Usage:
+    This command can be run using Django's manage.py:
+    `python manage.py detect_unrelated_content`
+"""  # noqa: INP001
+
 import json
 from tempfile import NamedTemporaryFile
 

--- a/websites/management/commands/detect_unrelated_content.py
+++ b/websites/management/commands/detect_unrelated_content.py
@@ -1,0 +1,77 @@
+import json
+from tempfile import NamedTemporaryFile
+
+from django.conf import settings
+
+from main.management.commands.filter import WebsiteFilterCommand
+from main.s3_utils import get_boto3_resource
+from websites.models import Website, WebsiteContent
+
+
+class Command(WebsiteFilterCommand):
+    """Detect unrelated content in AWS S3 bucket for courses"""
+
+    help = __doc__
+
+    UNRELATED_FILES_THRESHOLD = 100
+
+    def handle(self, *args, **options):
+        super().handle(*args, **options)
+
+        website_queryset = self.filter_websites(websites=Website.objects.all())
+
+        s3 = get_boto3_resource("s3")
+        unrelated_files = {}
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Checking for unrelated content in {website_queryset.count()} "
+                "websites."
+            )
+        )
+
+        total_files = 0
+        for website in website_queryset:
+            files = s3.meta.client.list_objects_v2(
+                Bucket=settings.AWS_STORAGE_BUCKET_NAME,
+                Prefix=f"courses/{website.name}/",
+            )
+            files_in_s3 = (
+                {content["Key"] for content in files.get("Contents", [])}
+                if files.get("KeyCount")
+                else {}
+            )
+
+            website_content_files = set(
+                WebsiteContent.objects.filter(
+                    website=website, file__in=files_in_s3
+                ).values_list("file", flat=True)
+            )
+
+            unrelated_website_files = list(files_in_s3 - website_content_files)
+
+            if unrelated_website_files:
+                total_files += len(unrelated_website_files)
+                unrelated_files[website.name] = unrelated_website_files
+
+        if unrelated_files:
+            content = json.dumps(unrelated_files, indent=4)
+
+            with NamedTemporaryFile(delete=False, suffix=".json") as tmp_file:
+                tmp_file_path = tmp_file.name
+            if total_files > self.UNRELATED_FILES_THRESHOLD:
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        "Unrelated content found in the bucket!"
+                        "And the content has been written to a "
+                        "temporary file located at: ",
+                        tmp_file_path,
+                    )
+                )
+            else:
+                self.style.SUCCESS("Unrelated content found in the bucket!")
+                self.stdout.write(content)
+
+        else:
+            self.stdout.write(
+                self.style.WARNING("No unrelated content found in the bucket")
+            )

--- a/websites/management/commands/detect_unrelated_content.py
+++ b/websites/management/commands/detect_unrelated_content.py
@@ -47,7 +47,7 @@ class Command(WebsiteFilterCommand):
             files_in_s3 = (
                 {content["Key"] for content in files.get("Contents", [])}
                 if files.get("KeyCount")
-                else {}
+                else set()
             )
 
             website_content_files = set(


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6457

### Description (What does it do?)
A management to check for unrelated files in a website.

### How can this be tested?
1. Switch to this branch and spin up `ocw-studio` in your local environment.
2. Create a `test` course in your local ocw-studio or select an existing one.
3. Got to your local instance of s3 (MinIO) which should at `localhost:9001` and log in.
5. Upload a file at `{AWS_STORAGE_BUCKET_NAME}/courses/{selected_course_name}/`
6. run `docker-compose exec -it web ./manage.py detect_unrelated_content` in terminal. This command should return the uploaded file name against the course.