### PR TITLE
Remove submitting to wayback machine logging when task is not executed

### DIFF
--- a/external_resources/signals.py
+++ b/external_resources/signals.py
@@ -42,7 +42,7 @@ def upsert_external_resource_state(
             )
             submit_url_to_wayback_task.delay(instance.id)
             log.info(
-                "New external resource created: %s. Submitting to Wayback Machine.",
+                "New external resource created: %s.",
                 instance.title,
             )
             log.debug(


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
This PR removes`submitting to wayback machine` logging in case the task is not executed. If it is executed, the logging is already present in the respective function.

### How can this be tested?
No need to run: just look at the code changes.
