### PR TITLE
Added deletable content type list in environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,12 @@ This feature sets up a cron job to validate external resource urls. The workflow
 
 PostHog is used for dynamically testing and rolling out features that may not be ready for permanent deployment as part of OCW Studio. For example, we use the feature flag `OCW_STUDIO_CONTENT_DELETABLE` to control whether content can be deleted.
 
+The following delimited list should be set in `.env` file to allow which type of content can be deleted:
+
+```
+OCW_STUDIO_DELETABLE_CONTENT_TYPES=external-resource,instructor,page
+```
+
 The following variables should be set in the `.env` file for PostHog integration:
 
 ```

--- a/app.json
+++ b/app.json
@@ -357,6 +357,10 @@
       "description": "Disables Postgres server side cursors",
       "required": false
     },
+    "OCW_STUDIO_DELETABLE_CONTENT_TYPES": {
+      "description": "List of content types that can be deleted",
+      "required": false
+    },
     "OCW_STUDIO_DRAFT_URL": {
       "description": "The base url of the preview site",
       "required": false

--- a/main/settings.py
+++ b/main/settings.py
@@ -1307,3 +1307,8 @@ POSTHOG_PROJECT_API_KEY = get_string(
     description="API token for communicating with PostHog",
     required=False,
 )
+OCW_STUDIO_DELETABLE_CONTENT_TYPES = get_delimited_list(
+    name="OCW_STUDIO_DELETABLE_CONTENT_TYPES",
+    default=[],
+    description="List of content types that can be deleted",
+)

--- a/main/views.py
+++ b/main/views.py
@@ -30,6 +30,7 @@ def _index(request):
         "posthog_project_api_key": settings.POSTHOG_PROJECT_API_KEY,
         "sitemapDomain": settings.SITEMAP_DOMAIN,
         "maxTitle": constants.CONTENT_FILENAME_MAX_LEN,
+        "deletableContentTypes": settings.OCW_STUDIO_DELETABLE_CONTENT_TYPES,
     }
 
     user = request.user

--- a/main/views_test.py
+++ b/main/views_test.py
@@ -98,6 +98,7 @@ def test_react_page(  # pylint: disable=too-many-arguments  # noqa: PLR0913
             "posthog_project_api_key": settings.POSTHOG_PROJECT_API_KEY,
             "sitemapDomain": settings.SITEMAP_DOMAIN,
             "maxTitle": CONTENT_FILENAME_MAX_LEN,
+            "deletableContentTypes": settings.OCW_STUDIO_DELETABLE_CONTENT_TYPES,
         }
     else:
         assert response.status_code == HTTP_302_FOUND

--- a/static/js/components/RepeatableContentListing.test.tsx
+++ b/static/js/components/RepeatableContentListing.test.tsx
@@ -70,6 +70,8 @@ describe("RepeatableContentListing", () => {
     websiteContentDetailsLookup: Record<string, WebsiteContentListItem>
 
   beforeEach(() => {
+    SETTINGS.deletableContentTypes = []
+
     helper = new IntegrationTestHelper()
     website = makeWebsiteDetail()
     configItem = makeRepeatableConfigItem("resource")
@@ -227,6 +229,7 @@ describe("RepeatableContentListing", () => {
   ]
   deletableTestCases.forEach(({ name, configName }) => {
     it(`should delete ${name}`, async () => {
+      SETTINGS.deletableContentTypes = [configName]
       const configItem = makeRepeatableConfigItem(configName)
       const contentItem = makeWebsiteContentListItem()
       websiteContentDetailsLookup = {

--- a/static/js/components/RepeatableContentListing.tsx
+++ b/static/js/components/RepeatableContentListing.tsx
@@ -67,7 +67,7 @@ export default function RepeatableContentListing(props: {
 
   const isDeletable =
     isContentDeletable &&
-    ["external-resource", "instructor", "page"].includes(configItem.name)
+    SETTINGS.deletableContentTypes.includes(configItem.name)
 
   const getListingParams = useCallback(
     (search: string): ContentListingParams => {

--- a/static/js/types/globals.d.ts
+++ b/static/js/types/globals.d.ts
@@ -16,6 +16,7 @@ interface SETTINGS {
   posthog_project_api_key: string?;
   sitemapDomain: string;
   maxTitle: number;
+  deletableContentTypes: string[];
   /**
    * Settings.user does exist, but leaving it untyped to help encourage using
    * `store.user` instead.


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/6333

### Description (What does it do?)
The PR aims to accept delimited Deletable Content Type list from environment variable to allow which content type can be deleted when PostHog feature flag is set

### How can this be tested?
1. Set the `OCW_STUDIO_DELETABLE_CONTENT_TYPES=external-resource,instructor,page,course-collection` in `.env`.
2. Switch to this branch: `umar/6333-delete-course-collection-from-studio`.
3. Build web container: `docker-compose up -d web --build`.
4. Spin up OCW-Studio.
5. Create a site with `ocw-www` starter or use an existing one.
6. Go to the `Course Collections` tab in the Content menu in `ocw-www` site.
7. Create a new course collection or use an existing one.
8. You should see the vertical dots menu `⋮`, with the Delete option, for the course collection.
9. Try deleting the course collection.

### Additional Testing
General testing instructions can be found in [here](https://github.com/mitodl/ocw-studio/pull/2255)

