### PR TITLE
added hover message and new statuses for the site listing page

### DIFF
--- a/static/js/components/PublishStatusIndicator.tsx
+++ b/static/js/components/PublishStatusIndicator.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 
 import { PublishStatus } from "../constants"
 
-const publishStatusMessage = (status: PublishStatus): string => {
+export const publishStatusMessage = (status: PublishStatus | null): string => {
   switch (status) {
     case PublishStatus.NotStarted:
       return "Not started"

--- a/static/js/pages/SitesDashboard.test.tsx
+++ b/static/js/pages/SitesDashboard.test.tsx
@@ -196,7 +196,7 @@ describe("StatusWithDateHover component", () => {
       />,
     )
 
-    const element = container.firstChild
+    const element = container.firstChild as HTMLElement
     fireEvent.mouseEnter(element)
 
     expect(getByText(/Published at \(Jan 15, 2023/)).toBeInTheDocument()
@@ -211,7 +211,7 @@ describe("StatusWithDateHover component", () => {
       />,
     )
 
-    const element = container.firstChild
+    const element = container.firstChild as HTMLElement
 
     // Hover
     fireEvent.mouseEnter(element)
@@ -236,7 +236,7 @@ describe("StatusWithDateHover component", () => {
 })
 
 describe("formatDateTime function", () => {
-  it("formats date strings correctly", () => {
+  it("formats date strings", () => {
     const result = formatDateTime("2023-01-15T12:30:45Z")
 
     expect(result).toContain("2023")
@@ -246,7 +246,7 @@ describe("formatDateTime function", () => {
 })
 
 describe("Site status indicators", () => {
-  it("shows correct status for different site states", async () => {
+  it("shows status for different site states", async () => {
     const testHelper = new IntegrationTestHelper()
     const testWebsites = makeWebsites(5)
 
@@ -269,18 +269,20 @@ describe("Site status indicators", () => {
         unpublished: true,
         updated_on: "2023-01-15T12:30:45Z",
       },
-      // Draft site - has only draft_publish_date and draft_publish_status
+      // Draft site - has draft_publish_status and draft_publish_date
+      // but no publish_date and unpublished is false
       draftSite = {
         ...testWebsites[2],
         name: "draft-site",
         uuid: "test-uuid-3",
         draft_publish_date: "2023-01-15T12:30:45Z",
-        draft_publish_status: "draft",
+        draft_publish_status: PublishStatus.Success,
         publish_date: null,
         live_publish_status: null,
         unpublished: false,
         updated_on: "2023-01-15T12:30:45Z",
       },
+      // Published site - has publish_date and live_publish_status
       publishedSite = {
         ...testWebsites[3],
         name: "published-site",
@@ -290,6 +292,7 @@ describe("Site status indicators", () => {
         unpublished: false,
         updated_on: "2023-01-15T12:30:45Z",
       },
+      // Failed site - has live_publish_status marked as errored
       failedSite = {
         ...testWebsites[4],
         name: "failed-site",

--- a/static/js/pages/SitesDashboard.test.tsx
+++ b/static/js/pages/SitesDashboard.test.tsx
@@ -267,6 +267,8 @@ describe("Site status indicators", () => {
         uuid: "test-uuid-2",
         publish_date: "2023-01-01T12:00:00Z",
         unpublished: true,
+        unpublish_status: PublishStatus.Success,
+        unpublish_status_updated_on: "2023-01-15T12:30:45Z",
         updated_on: "2023-01-15T12:30:45Z",
       },
       // Draft site - has draft_publish_status and draft_publish_date

--- a/static/js/pages/SitesDashboard.test.tsx
+++ b/static/js/pages/SitesDashboard.test.tsx
@@ -199,7 +199,7 @@ describe("StatusWithDateHover component", () => {
     const element = container.firstChild as HTMLElement
     fireEvent.mouseEnter(element)
 
-    expect(getByText(/Published at \(Jan 15, 2023/)).toBeInTheDocument()
+    expect(getByText(/Published on Jan 15, 2023/)).toBeInTheDocument()
   })
 
   it("reverts to status text when mouse leaves", () => {
@@ -215,7 +215,7 @@ describe("StatusWithDateHover component", () => {
 
     // Hover
     fireEvent.mouseEnter(element)
-    expect(getByText(/Published at \(/)).toBeInTheDocument()
+    expect(getByText(/Published on Jan 15, 2023/)).toBeInTheDocument()
 
     // Un-hover
     fireEvent.mouseLeave(element)

--- a/static/js/pages/SitesDashboard.tsx
+++ b/static/js/pages/SitesDashboard.tsx
@@ -100,7 +100,10 @@ export const getMostRecentStatus = (
   const statuses = [
     {
       type: "draft",
-      active: !site.publish_date,
+      active:
+        !site.publish_date &&
+        site.draft_publish_status &&
+        site.draft_publish_status === PublishStatus.Success,
       statusText: "Draft",
       hoverText: "Draft updated",
       className: "text-secondary",
@@ -139,6 +142,16 @@ export const getMostRecentStatus = (
       statusText: `Publish: ${publishStatusMessage(site.live_publish_status).toLowerCase().replace("...", "")}`,
       className: publishStatusIndicatorClass(site.live_publish_status),
       dateTime: site.live_publish_status_updated_on,
+    },
+    {
+      type: "draft not complete",
+      active:
+        !site.publish_date &&
+        site.draft_publish_status &&
+        site.draft_publish_status !== PublishStatus.Success,
+      statusText: `Draft: ${publishStatusMessage(site.draft_publish_status).toLowerCase().replace("...", "")}`,
+      className: publishStatusIndicatorClass(site.draft_publish_status),
+      dateTime: site.draft_publish_status_updated_on,
     },
   ]
 

--- a/static/js/pages/SitesDashboard.tsx
+++ b/static/js/pages/SitesDashboard.tsx
@@ -81,7 +81,7 @@ export const StatusWithDateHover = ({
       onMouseEnter={() => setShowDate(true)}
       onMouseLeave={() => setShowDate(false)}
     >
-      {showDate
+      {showDate && dateTime
         ? `${hoverText || statusText} on ${formatDateTime(dateTime)}`
         : statusText}
     </div>
@@ -160,7 +160,7 @@ export default function SitesDashboard(): JSX.Element {
                 ) : site.unpublished ? (
                   <StatusWithDateHover
                     statusText="Unpublished from Production"
-                    dateTime={site.updated_on}
+                    dateTime={site.unpublish_status_updated_on}
                     className="text-dark"
                   />
                 ) : site.draft_publish_date && !site.publish_date ? (
@@ -174,13 +174,13 @@ export default function SitesDashboard(): JSX.Element {
                 ) : PublishStatus.Success === site.live_publish_status ? (
                   <StatusWithDateHover
                     statusText="Published"
-                    dateTime={site.publish_date ?? site.updated_on}
+                    dateTime={site.publish_date}
                     className="text-success"
                   />
                 ) : (
                   <StatusWithDateHover
                     statusText={publishStatusMessage(site.live_publish_status)}
-                    dateTime={site.updated_on}
+                    dateTime={site.publish_date}
                     className={publishStatusIndicatorClass(
                       site.live_publish_status,
                     )}

--- a/static/js/pages/SitesDashboard.tsx
+++ b/static/js/pages/SitesDashboard.tsx
@@ -64,10 +64,12 @@ export const formatDateTime = (dateTimeString: string): string => {
 
 export const StatusWithDateHover = ({
   statusText,
+  hoverText,
   dateTime,
   className,
 }: {
   statusText: string
+  hoverText?: string
   dateTime: string
   className: string
 }) => {
@@ -79,7 +81,9 @@ export const StatusWithDateHover = ({
       onMouseEnter={() => setShowDate(true)}
       onMouseLeave={() => setShowDate(false)}
     >
-      {showDate ? `${statusText} at (${formatDateTime(dateTime)})` : statusText}
+      {showDate
+        ? `${hoverText || statusText} on ${formatDateTime(dateTime)}`
+        : statusText}
     </div>
   )
 }
@@ -160,11 +164,17 @@ export default function SitesDashboard(): JSX.Element {
                     className="text-dark"
                   />
                 ) : site.draft_publish_date && !site.publish_date ? (
-                  <div className="text-secondary">Draft</div>
+                  // <div className="text-secondary">Draft</div>
+                  <StatusWithDateHover
+                    statusText="Draft"
+                    hoverText="Draft updated"
+                    dateTime={site.draft_publish_date}
+                    className="text-secondary"
+                  />
                 ) : PublishStatus.Success === site.live_publish_status ? (
                   <StatusWithDateHover
                     statusText="Published"
-                    dateTime={site.updated_on}
+                    dateTime={site.publish_date ?? site.updated_on}
                     className="text-success"
                   />
                 ) : (

--- a/static/js/pages/SitesDashboard.tsx
+++ b/static/js/pages/SitesDashboard.tsx
@@ -50,6 +50,18 @@ export const publishStatusIndicatorClass = (
   }
 }
 
+const formatDateTime = (dateTimeString: string): string => {
+  const date = new Date(dateTimeString)
+  return date.toLocaleString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  })
+}
+
 export default function SitesDashboard(): JSX.Element {
   const [websiteToUnpublish, setWebsiteToUnpublish] =
     useState<WebsiteInitials | null>(null)
@@ -120,7 +132,9 @@ export default function SitesDashboard(): JSX.Element {
                 ) : site.unpublished ? (
                   <div
                     className="text-dark"
-                    title={`Unpublished from Production at ${site.updated_on.slice()}`}
+                    title={`Unpublished from Production at ${formatDateTime(
+                      site.updated_on,
+                    )}`}
                   >
                     Unpublished from Production
                   </div>
@@ -129,7 +143,12 @@ export default function SitesDashboard(): JSX.Element {
                 ) : PublishStatus.Success === site.live_publish_status ? (
                   <div
                     className="text-success"
-                    title={`${publishStatusMessage(site.live_publish_status?.replace("...", "") as PublishStatus)} at ${site.updated_on.slice()}`}
+                    title={`${publishStatusMessage(
+                      site.live_publish_status?.replace(
+                        "...",
+                        "",
+                      ) as PublishStatus,
+                    )} at ${formatDateTime(site.updated_on)}`}
                   >
                     Published
                   </div>
@@ -138,7 +157,12 @@ export default function SitesDashboard(): JSX.Element {
                     className={publishStatusIndicatorClass(
                       site.live_publish_status,
                     )}
-                    title={`${publishStatusMessage(site.live_publish_status?.replace("...", "") as PublishStatus)} at ${site.updated_on.slice()}`}
+                    title={`${publishStatusMessage(
+                      site.live_publish_status?.replace(
+                        "...",
+                        "",
+                      ) as PublishStatus,
+                    )} at ${formatDateTime(site.updated_on)}`}
                   >
                     {publishStatusMessage(site.live_publish_status)}
                   </div>

--- a/static/js/pages/SitesDashboard.tsx
+++ b/static/js/pages/SitesDashboard.tsx
@@ -62,6 +62,28 @@ const formatDateTime = (dateTimeString: string): string => {
   })
 }
 
+const StatusWithDateHover = ({
+  statusText,
+  dateTime,
+  className,
+}: {
+  statusText: string
+  dateTime: string
+  className: string
+}) => {
+  const [showDate, setShowDate] = useState(false)
+
+  return (
+    <div
+      className={className}
+      onMouseEnter={() => setShowDate(true)}
+      onMouseLeave={() => setShowDate(false)}
+    >
+      {showDate ? `${statusText} at (${formatDateTime(dateTime)})` : statusText}
+    </div>
+  )
+}
+
 export default function SitesDashboard(): JSX.Element {
   const [websiteToUnpublish, setWebsiteToUnpublish] =
     useState<WebsiteInitials | null>(null)
@@ -130,42 +152,27 @@ export default function SitesDashboard(): JSX.Element {
                 {!site.publish_date && !site.live_publish_status ? (
                   <div className="text-danger">Never Published</div>
                 ) : site.unpublished ? (
-                  <div
+                  <StatusWithDateHover
+                    statusText="Unpublished from Production"
+                    dateTime={site.updated_on}
                     className="text-dark"
-                    title={`Unpublished from Production at ${formatDateTime(
-                      site.updated_on,
-                    )}`}
-                  >
-                    Unpublished from Production
-                  </div>
+                  />
                 ) : site.draft_publish_date && !site.publish_date ? (
                   <div className="text-secondary">Draft</div>
                 ) : PublishStatus.Success === site.live_publish_status ? (
-                  <div
+                  <StatusWithDateHover
+                    statusText="Published"
+                    dateTime={site.updated_on}
                     className="text-success"
-                    title={`${publishStatusMessage(
-                      site.live_publish_status?.replace(
-                        "...",
-                        "",
-                      ) as PublishStatus,
-                    )} at ${formatDateTime(site.updated_on)}`}
-                  >
-                    Published
-                  </div>
+                  />
                 ) : (
-                  <div
+                  <StatusWithDateHover
+                    statusText={publishStatusMessage(site.live_publish_status)}
+                    dateTime={site.updated_on}
                     className={publishStatusIndicatorClass(
                       site.live_publish_status,
                     )}
-                    title={`${publishStatusMessage(
-                      site.live_publish_status?.replace(
-                        "...",
-                        "",
-                      ) as PublishStatus,
-                    )} at ${formatDateTime(site.updated_on)}`}
-                  >
-                    {publishStatusMessage(site.live_publish_status)}
-                  </div>
+                  />
                 )}
                 <Dropdown
                   website={{

--- a/static/js/pages/SitesDashboard.tsx
+++ b/static/js/pages/SitesDashboard.tsx
@@ -247,14 +247,6 @@ export default function SitesDashboard(): JSX.Element {
             >
               <div className="d-flex flex-row">
                 {(() => {
-                  if (
-                    !site.publish_date &&
-                    !site.live_publish_status &&
-                    !site.draft_publish_date
-                  ) {
-                    return <div className="text-danger">Never Published</div>
-                  }
-
                   const statusInfo = getMostRecentStatus(site)
 
                   return statusInfo.dateTime ? (

--- a/static/js/pages/SitesDashboard.tsx
+++ b/static/js/pages/SitesDashboard.tsx
@@ -136,7 +136,7 @@ export const getMostRecentStatus = (
         site.live_publish_status !== PublishStatus.Success,
       statusText: `Publish: ${publishStatusMessage(site.live_publish_status).toLowerCase().replace("...", "")}`,
       className: publishStatusIndicatorClass(site.live_publish_status),
-      dateTime: site.publish_date,
+      dateTime: site.live_publish_status_updated_on,
     },
   ]
 

--- a/static/js/pages/SitesDashboard.tsx
+++ b/static/js/pages/SitesDashboard.tsx
@@ -115,10 +115,7 @@ export default function SitesDashboard(): JSX.Element {
               key={site.uuid}
             >
               <div className="d-flex flex-row">
-                {!site.publish_date &&
-                !site.draft_publish_date &&
-                !site.live_publish_status &&
-                !site.draft_publish_status ? (
+                {!site.publish_date && !site.live_publish_status ? (
                   <div className="text-danger">Never Published</div>
                 ) : site.unpublished ? (
                   <div className="text-dark">Unpublished from Production</div>
@@ -127,7 +124,7 @@ export default function SitesDashboard(): JSX.Element {
                 ) : PublishStatus.Success === site.live_publish_status ? (
                   <div
                     className="text-success"
-                    title={`${publishStatusMessage(site.live_publish_status?.replace("...", "") as PublishStatus)} at ${site.updated_on}`}
+                    title={`${publishStatusMessage(site.live_publish_status?.replace("...", "") as PublishStatus)} at ${site.updated_on.slice()}`}
                   >
                     Published
                   </div>
@@ -136,7 +133,7 @@ export default function SitesDashboard(): JSX.Element {
                     className={publishStatusIndicatorClass(
                       site.live_publish_status,
                     )}
-                    title={`${publishStatusMessage(site.live_publish_status?.replace("...", "") as PublishStatus)} at ${site.updated_on}`}
+                    title={`${publishStatusMessage(site.live_publish_status?.replace("...", "") as PublishStatus)} at ${site.updated_on.slice()}`}
                   >
                     {publishStatusMessage(site.live_publish_status)}
                   </div>

--- a/static/js/pages/SitesDashboard.tsx
+++ b/static/js/pages/SitesDashboard.tsx
@@ -149,7 +149,9 @@ export default function SitesDashboard(): JSX.Element {
               key={site.uuid}
             >
               <div className="d-flex flex-row">
-                {!site.publish_date && !site.live_publish_status ? (
+                {!site.publish_date &&
+                !site.live_publish_status &&
+                !site.draft_publish_date ? (
                   <div className="text-danger">Never Published</div>
                 ) : site.unpublished ? (
                   <StatusWithDateHover

--- a/static/js/pages/SitesDashboard.tsx
+++ b/static/js/pages/SitesDashboard.tsx
@@ -50,7 +50,7 @@ export const publishStatusIndicatorClass = (
   }
 }
 
-const formatDateTime = (dateTimeString: string): string => {
+export const formatDateTime = (dateTimeString: string): string => {
   const date = new Date(dateTimeString)
   return date.toLocaleString("en-US", {
     year: "numeric",
@@ -62,7 +62,7 @@ const formatDateTime = (dateTimeString: string): string => {
   })
 }
 
-const StatusWithDateHover = ({
+export const StatusWithDateHover = ({
   statusText,
   dateTime,
   className,

--- a/static/js/pages/SitesDashboard.tsx
+++ b/static/js/pages/SitesDashboard.tsx
@@ -130,7 +130,7 @@ export const getMostRecentStatus = (
       dateTime: site.unpublish_status_updated_on,
     },
     {
-      type: "other",
+      type: "publish not complete",
       active:
         site.live_publish_status &&
         site.live_publish_status !== PublishStatus.Success,

--- a/static/js/pages/SitesDashboard.tsx
+++ b/static/js/pages/SitesDashboard.tsx
@@ -100,7 +100,7 @@ export const getMostRecentStatus = (
   const statuses = [
     {
       type: "draft",
-      active: site.draft_publish_date && !site.publish_date,
+      active: !site.publish_date,
       statusText: "Draft",
       hoverText: "Draft updated",
       className: "text-secondary",
@@ -116,7 +116,8 @@ export const getMostRecentStatus = (
     {
       type: "unpublished",
       active:
-        site.unpublished && site.unpublish_status === PublishStatus.Success,
+        site.unpublish_status &&
+        site.unpublish_status === PublishStatus.Success,
       statusText: "Unpublished from Production",
       className: "text-dark",
       dateTime: site.unpublish_status_updated_on,
@@ -124,7 +125,8 @@ export const getMostRecentStatus = (
     {
       type: "unpublish not complete",
       active:
-        site.unpublished && site.unpublish_status !== PublishStatus.Success,
+        site.unpublish_status &&
+        site.unpublish_status !== PublishStatus.Success,
       statusText: `Unpublish: ${publishStatusMessage(site.unpublish_status).toLowerCase().replace("...", "")}`,
       className: publishStatusIndicatorClass(site.unpublish_status),
       dateTime: site.unpublish_status_updated_on,

--- a/static/js/pages/SitesDashboard.tsx
+++ b/static/js/pages/SitesDashboard.tsx
@@ -118,7 +118,12 @@ export default function SitesDashboard(): JSX.Element {
                 {!site.publish_date && !site.live_publish_status ? (
                   <div className="text-danger">Never Published</div>
                 ) : site.unpublished ? (
-                  <div className="text-dark">Unpublished from Production</div>
+                  <div
+                    className="text-dark"
+                    title={`Unpublished from Production at ${site.updated_on.slice()}`}
+                  >
+                    Unpublished from Production
+                  </div>
                 ) : site.draft_publish_date && !site.publish_date ? (
                   <div className="text-secondary">Draft</div>
                 ) : PublishStatus.Success === site.live_publish_status ? (

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -258,6 +258,7 @@ export type Website = WebsiteStatus & {
   url_path: string | null
   url_suggestion: string
   s3_path: string | null
+  live_publish_status: PublishStatus | null
 }
 
 type WebsiteRoleEditable = typeof ROLE_ADMIN | typeof ROLE_EDITOR

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -237,6 +237,7 @@ export interface WebsiteStatus {
   sync_errors: Array<string> | null
   unpublished: boolean
   unpublish_status_updated_on: string | null
+  unpublish_status: PublishStatus | null
 }
 
 export type Website = WebsiteStatus & {

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -236,6 +236,7 @@ export interface WebsiteStatus {
   synced_on: string | null
   sync_errors: Array<string> | null
   unpublished: boolean
+  unpublish_status_updated_on: string | null
 }
 
 export type Website = WebsiteStatus & {
@@ -259,6 +260,7 @@ export type Website = WebsiteStatus & {
   url_suggestion: string
   s3_path: string | null
   live_publish_status: PublishStatus | null
+  unpublish_status_updated_on: string | null
 }
 
 type WebsiteRoleEditable = typeof ROLE_ADMIN | typeof ROLE_EDITOR

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -260,6 +260,7 @@ export type Website = WebsiteStatus & {
   url_suggestion: string
   s3_path: string | null
   live_publish_status: PublishStatus | null
+  unpublish_status: PublishStatus | null
   unpublish_status_updated_on: string | null
 }
 

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -261,6 +261,7 @@ export type Website = WebsiteStatus & {
   url_suggestion: string
   s3_path: string | null
   live_publish_status: PublishStatus | null
+  live_publish_status_updated_on: string | null
   unpublish_status: PublishStatus | null
   unpublish_status_updated_on: string | null
 }

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -264,6 +264,8 @@ export type Website = WebsiteStatus & {
   live_publish_status_updated_on: string | null
   unpublish_status: PublishStatus | null
   unpublish_status_updated_on: string | null
+  draft_publish_status: PublishStatus | null
+  draft_publish_status_updated_on: string | null
 }
 
 type WebsiteRoleEditable = typeof ROLE_ADMIN | typeof ROLE_EDITOR

--- a/static/js/util/factories/websites.ts
+++ b/static/js/util/factories/websites.ts
@@ -227,6 +227,8 @@ export const makeWebsiteDetail = (
   url_suggestion: "[sitemetadata:primary_course_number]-[sitemetdata:title]",
   s3_path: `courses/${casual.word}`,
   unpublished: false,
+  unpublish_status: null,
+  unpublish_status_updated_on: null,
   ...overrides,
 })
 
@@ -249,6 +251,8 @@ export const makeWebsiteStatus = (
     synced_on: null,
     sync_errors: null,
     unpublished: false,
+    unpublish_status: website.unpublish_status || null,
+    unpublish_status_updated_on: website.unpublish_status_updated_on || null,
   }
 }
 

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -111,6 +111,8 @@ class WebsiteSerializer(serializers.ModelSerializer):
             "unpublish_status_updated_on",
             "live_publish_status",
             "live_publish_status_updated_on",
+            "draft_publish_status",
+            "draft_publish_status_updated_on",
         ]
         extra_kwargs = {"owner": {"write_only": True}}
 

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -110,6 +110,7 @@ class WebsiteSerializer(serializers.ModelSerializer):
             "unpublish_status",
             "unpublish_status_updated_on",
             "live_publish_status",
+            "live_publish_status_updated_on",
         ]
         extra_kwargs = {"owner": {"write_only": True}}
 

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -107,8 +107,9 @@ class WebsiteSerializer(serializers.ModelSerializer):
             "owner",
             "url_path",
             "unpublished",
-            "live_publish_status",
+            "unpublish_status",
             "unpublish_status_updated_on",
+            "live_publish_status",
         ]
         extra_kwargs = {"owner": {"write_only": True}}
 

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -108,6 +108,7 @@ class WebsiteSerializer(serializers.ModelSerializer):
             "url_path",
             "unpublished",
             "live_publish_status",
+            "unpublish_status_updated_on",
         ]
         extra_kwargs = {"owner": {"write_only": True}}
 

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -107,6 +107,7 @@ class WebsiteSerializer(serializers.ModelSerializer):
             "owner",
             "url_path",
             "unpublished",
+            "live_publish_status",
         ]
         extra_kwargs = {"owner": {"write_only": True}}
 

--- a/websites/views.py
+++ b/websites/views.py
@@ -297,6 +297,7 @@ class WebsiteViewSet(
                 )
             else:
                 website.unpublish_status = PUBLISH_STATUS_NOT_STARTED
+                website.unpublish_status_updated_on = now_in_utc()
                 website.last_unpublished_by = request.user
                 website.save()
                 trigger_unpublished_removal(website)


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/6017

### Description (What does it do?)
Add the statuses as mentioned on the [ticket](https://github.com/mitodl/hq/issues/6017) to the Sites Listing Page and incorporate feedback from [here](https://github.com/mitodl/ocw-studio/pull/2407#issuecomment-2647798005)

### How can this be tested?
1. Switch to this branch
2. Go to site listings page on `http://localhost:8043/sites/`
3. Create a new site or use an existing one to publish on live.
4. Check that existing sites have the appropriate statuses shown as below
<img width="1443" alt="Screenshot 2025-01-30 at 10 56 41 AM" src="https://github.com/user-attachments/assets/0f5b6fd6-33e6-4233-980b-3bd5b3104bb2" />
5. Also check hover is diplayed for statuses in `PublishStatus` enum

Note: Status is updated according to Live Publish Status