### PR TITLE
Add management command for deleting duplicate captions from YouTube

### DIFF
--- a/videos/management/commands/delete_duplicate_captions_youtube_test.py
+++ b/videos/management/commands/delete_duplicate_captions_youtube_test.py
@@ -1,8 +1,13 @@
 """
 Tests for the delete_duplicate_captions_youtube management command.
 
-Verifies that the command inspects YouTube caption tracks for each VideoFile and handles
-'ocw_studio_upload' vs. 'CC (English)' as expected.
+Verifies that the command:
+- Properly inspects YouTube caption tracks for each VideoFile
+- Handles 'ocw_studio_upload' vs. 'CC (English)' tracks appropriately:
+  - Copies content from 'ocw_studio_upload' to 'CC (English)' when the former is newer
+  - Only deletes 'ocw_studio_upload' when 'CC (English)' is newer
+- Ignores auto-generated caption tracks in any language
+- Takes no action when only auto-generated captions exist
 """
 
 import pytest
@@ -135,3 +140,165 @@ def test_delete_duplicate_captions_youtube_command_cc_english_newest(
     mock_youtube_api_cc_english_newest.client.captions.return_value.delete.assert_called_once_with(
         id="caption_id_legacy"
     )
+
+
+@pytest.fixture()
+def mock_youtube_api_with_auto_captions(mocker):
+    """
+    Fixture with our managed caption tracks plus auto-generated captions in other languages.
+    """
+    mock_api_cls = mocker.patch(
+        "videos.management.commands.delete_duplicate_captions_youtube.YouTubeApi"
+    )
+    mock_api = mock_api_cls.return_value
+
+    mock_api.client.captions.return_value.list.return_value.execute.return_value = {
+        "items": [
+            {
+                "id": "auto_ru_caption",
+                "snippet": {
+                    "videoId": "dummy_youtube_id",
+                    "lastUpdated": "2023-10-02T12:00:00.000Z",
+                    "trackKind": "asr",
+                    "language": "ru",
+                    "name": "",
+                    "audioTracktype": "unknown",
+                    "isCC": False,
+                },
+            },
+            {
+                "id": "caption_id_legacy",
+                "snippet": {
+                    "name": "ocw_studio_upload",
+                    "lastUpdated": "2023-09-30T12:00:00.000Z",
+                    "language": "en",
+                },
+            },
+            {
+                "id": "caption_id_other",
+                "snippet": {
+                    "name": CAPTION_UPLOAD_NAME,
+                    "lastUpdated": "2023-10-01T12:00:00.000Z",
+                    "language": "en",
+                },
+            },
+            {
+                "id": "auto_es_caption",
+                "snippet": {
+                    "videoId": "dummy_youtube_id",
+                    "lastUpdated": "2023-10-02T13:00:00.000Z",
+                    "trackKind": "asr",
+                    "language": "es",
+                    "name": "",
+                    "audioTracktype": "unknown",
+                    "isCC": False,
+                },
+            },
+        ]
+    }
+    mock_api.client.captions.return_value.download.return_value.execute.return_value = (
+        b"some vtt data"
+    )
+    return mock_api
+
+
+def test_delete_duplicate_captions_with_auto_captions(
+    mock_youtube_api_with_auto_captions,
+):
+    """
+    Test that managed caption tracks are correctly handled and auto-generated
+    captions in other languages are ignored, even if they are newer.
+    """
+    website = WebsiteFactory.create(name="Test Site", short_id="test-site-auto")
+    video = VideoFactory.create(website=website)
+    VideoFileFactory.create(
+        video=video,
+        destination=DESTINATION_YOUTUBE,
+        destination_id="dummy_youtube_id",
+    )
+
+    call_command("delete_duplicate_captions_youtube", filter="test-site-auto")
+
+    mock_youtube_api_with_auto_captions.client.captions.return_value.list.assert_called_with(
+        part="snippet", videoId="dummy_youtube_id"
+    )
+    mock_youtube_api_with_auto_captions.client.captions.return_value.download.assert_not_called()
+
+    mock_youtube_api_with_auto_captions.client.captions.return_value.delete.assert_called_once_with(
+        id="caption_id_legacy"
+    )
+
+    assert "auto_ru_caption" not in str(
+        mock_youtube_api_with_auto_captions.client.captions.return_value.delete.call_args_list
+    )
+    assert "auto_es_caption" not in str(
+        mock_youtube_api_with_auto_captions.client.captions.return_value.delete.call_args_list
+    )
+
+
+@pytest.fixture()
+def mock_youtube_api_only_auto_captions(mocker):
+    """
+    Fixture with only auto-generated captions, no managed tracks.
+    """
+    mock_api_cls = mocker.patch(
+        "videos.management.commands.delete_duplicate_captions_youtube.YouTubeApi"
+    )
+    mock_api = mock_api_cls.return_value
+
+    mock_api.client.captions.return_value.list.return_value.execute.return_value = {
+        "items": [
+            {
+                "id": "auto_ru_caption",
+                "snippet": {
+                    "videoId": "dummy_youtube_id",
+                    "lastUpdated": "2023-10-02T12:00:00.000Z",
+                    "trackKind": "asr",
+                    "language": "ru",
+                    "name": "",
+                    "audioTracktype": "unknown",
+                    "isCC": False,
+                },
+            },
+            {
+                "id": "auto_en_caption",
+                "snippet": {
+                    "videoId": "dummy_youtube_id",
+                    "lastUpdated": "2023-10-02T13:00:00.000Z",
+                    "trackKind": "asr",
+                    "language": "en",
+                    "name": "",
+                    "audioTracktype": "unknown",
+                    "isCC": False,
+                },
+            },
+        ]
+    }
+    return mock_api
+
+
+def test_with_only_auto_captions(
+    mock_youtube_api_only_auto_captions,
+):
+    """
+    Tests that nothing is done when there are only auto-generated captions and none
+    of the managed caption tracks.
+    """
+    website = WebsiteFactory.create(name="Test Site", short_id="test-site-auto-only")
+    video = VideoFactory.create(website=website)
+    VideoFileFactory.create(
+        video=video,
+        destination=DESTINATION_YOUTUBE,
+        destination_id="dummy_youtube_id",
+    )
+
+    call_command("delete_duplicate_captions_youtube", filter="test-site-auto-only")
+
+    mock_youtube_api_only_auto_captions.client.captions.return_value.list.assert_called_with(
+        part="snippet", videoId="dummy_youtube_id"
+    )
+
+    mock_youtube_api_only_auto_captions.client.captions.return_value.download.assert_not_called()
+    mock_youtube_api_only_auto_captions.client.captions.return_value.insert.assert_not_called()
+    mock_youtube_api_only_auto_captions.client.captions.return_value.update.assert_not_called()
+    mock_youtube_api_only_auto_captions.client.captions.return_value.delete.assert_not_called()


### PR DESCRIPTION
### What are the relevant tickets?

Final part of https://github.com/mitodl/hq/issues/1770.

### Description (What does it do?)

This PR adds a management command for deleting the legacy (duplicate) captions track from YouTube videos.

### How can this be tested?

First, use RC credentials to upload a sample video to YouTube. Then, open Django shell by running `docker compose exec web ./manage.py shell`, and execute something like the following, optionally changing the captions content and/or order of caption track uploads.

```
from io import BytesIO
from googleapiclient.errors import HttpError
from googleapiclient.http import MediaIoBaseUpload

from videos.youtube import YouTubeApi

LEGACY_CAPTIONS_NAME = "ocw_studio_upload"
CC_ENGLISH_CAPTIONS_NAME = "CC (English)"

HARD_CODED_VTT = b"""WEBVTT

00:00:00.000 --> 00:00:01.000
10

00:00:01.000 --> 00:00:02.000
9

00:00:02.000 --> 00:00:03.000
8

00:00:03.000 --> 00:00:04.000
7

00:00:04.000 --> 00:00:05.000
6

00:00:05.000 --> 00:00:06.000
5

00:00:06.000 --> 00:00:07.000
4

00:00:07.000 --> 00:00:08.000
3

00:00:08.000 --> 00:00:09.000
2

00:00:09.000 --> 00:00:10.000
1
"""

def upload_captions(video_id: str):
    yt = YouTubeApi()

    try:
        legacy_media = MediaIoBaseUpload(
            BytesIO(HARD_CODED_VTT),
            mimetype="text/vtt",
            chunksize=-1,
            resumable=True
        )
        legacy_response = yt.client.captions().insert(
            part="snippet",
            sync=False,
            body={
                "snippet": {
                    "language": "en",
                    "name": LEGACY_CAPTIONS_NAME,
                    "videoId": video_id,
                }
            },
            media_body=legacy_media,
        ).execute()

        legacy_id = legacy_response["id"]
        
        downloaded_data = yt.client.captions().download(id=legacy_id).execute()

        list_response = yt.client.captions().list(
            part="snippet", videoId=video_id
        ).execute()
        cc_track = [
            item for item in list_response.get("items", [])
            if item["snippet"].get("name") == CC_ENGLISH_CAPTIONS_NAME
        ]

        media_copy = MediaIoBaseUpload(
            BytesIO(downloaded_data),
            mimetype="text/vtt",
            chunksize=-1,
            resumable=True
        )
        if cc_track:
            yt.client.captions().update(
                part="snippet",
                body={"id": cc_track[0]["id"]},
                media_body=media_copy,
            ).execute()
        else:
            yt.client.captions().insert(
                part="snippet",
                sync=False,
                body={
                    "snippet": {
                        "language": "en",
                        "name": CC_ENGLISH_CAPTIONS_NAME,
                        "videoId": video_id,
                    }
                },
                media_body=media_copy,
            ).execute()

    except HttpError as http_err:
        print("YouTube API error:", http_err)
```

Then, run `upload_captions(<youtube video id>)`. There should now be two captions tracks for the YouTube video, allowing for testing the management command. Next, run `docker compose exec web ./manage.py delete_duplicate_captions_youtube --filter <website short id>` to test the management command, and verify that the legacy captions track has been deleted on YouTube.