### PR TITLE
Use latest tag for ocw-course-publisher

### DIFF
--- a/content_sync/pipelines/definitions/concourse/common/image_resources.py
+++ b/content_sync/pipelines/definitions/concourse/common/image_resources.py
@@ -8,7 +8,7 @@ https://github.com/mitodl/ol-infrastructure/tree/main/dockerfiles/ocw/node-hugo
 """
 OCW_COURSE_PUBLISHER_REGISTRY_IMAGE = AnonymousResource(
     type=REGISTRY_IMAGE,
-    source=RegistryImage(repository="mitodl/ocw-course-publisher", tag="latest"),
+    source=RegistryImage(repository="mitodl/ocw-course-publisher", tag="0.8"),
 )
 
 AWS_CLI_REGISTRY_IMAGE = AnonymousResource(

--- a/content_sync/pipelines/definitions/concourse/common/image_resources.py
+++ b/content_sync/pipelines/definitions/concourse/common/image_resources.py
@@ -8,7 +8,7 @@ https://github.com/mitodl/ol-infrastructure/tree/main/dockerfiles/ocw/node-hugo
 """
 OCW_COURSE_PUBLISHER_REGISTRY_IMAGE = AnonymousResource(
     type=REGISTRY_IMAGE,
-    source=RegistryImage(repository="mitodl/ocw-course-publisher", tag="0.6"),
+    source=RegistryImage(repository="mitodl/ocw-course-publisher", tag="latest"),
 )
 
 AWS_CLI_REGISTRY_IMAGE = AnonymousResource(

--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
@@ -283,7 +283,7 @@ class EndToEndTestPipelineDefinition(Pipeline):
                 }
             )
         tasks.append(fetch_built_content_step)
-        playwright_commands = "corepack enable\nyarn install\nnpx playwright install firefox --with-deps\nnpx playwright install chrome --with-deps\nnpx playwright test"  # noqa: E501
+        playwright_commands = "export COREPACK_ENABLE_DOWNLOAD_PROMPT=0\ncorepack enable\nyarn install\nnpx playwright install firefox --with-deps\nnpx playwright install chrome --with-deps\nnpx playwright test"  # noqa: E501
         tasks.append(
             TaskStep(
                 task=playwright_task_identifier,

--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -101,7 +101,7 @@ jobs:
       platform: linux
       image_resource:
         type: registry-image
-        source: {repository: mitodl/ocw-course-publisher, tag: latest}
+        source: {repository: mitodl/ocw-course-publisher, tag: 0.8}
       inputs:
       - name: ocw-hugo-themes
       outputs:
@@ -162,7 +162,7 @@ jobs:
       platform: linux
       image_resource:
         type: registry-image
-        source: {repository: mitodl/ocw-course-publisher, tag: latest}
+        source: {repository: mitodl/ocw-course-publisher, tag: 0.8}
       inputs:
         - name: publishable_sites
         - name: ocw-hugo-projects

--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -101,7 +101,7 @@ jobs:
       platform: linux
       image_resource:
         type: registry-image
-        source: {repository: mitodl/ocw-course-publisher, tag: 0.6}
+        source: {repository: mitodl/ocw-course-publisher, tag: latest}
       inputs:
       - name: ocw-hugo-themes
       outputs:
@@ -161,7 +161,7 @@ jobs:
       platform: linux
       image_resource:
         type: registry-image
-        source: {repository: mitodl/ocw-course-publisher, tag: 0.6}
+        source: {repository: mitodl/ocw-course-publisher, tag: latest}
       inputs:
         - name: publishable_sites
         - name: ocw-hugo-projects

--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -114,6 +114,7 @@ jobs:
         - -exc
         - |
           cd ocw-hugo-themes
+          export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
           yarn install --immutable
           npm run build:webpack
           npm run build:githash

--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
@@ -104,6 +104,7 @@ class ThemeAssetsPipelineDefinition(Pipeline):
                             "-exc",
                             f"""
                             cd {OCW_HUGO_THEMES_GIT_IDENTIFIER}
+                            export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
                             corepack enable
                             yarn install --immutable
                             npm run build:webpack


### PR DESCRIPTION
### Description (What does it do?)
Uses `latest` tag for `ocw-course-publisher`, which uses the upgraded versions for Go, Hugo, and Node as specified here: https://github.com/mitodl/ol-infrastructure/pull/2993

Also adds `export COREPACK_ENABLE_DOWNLOAD_PROMPT=0` before `yarn install` in `theme_assets_pipeline.py`, `e2e_test_site_pipeline.py`, and `mass-build-sites.yml` to fix the interactive prompt:

<img width="844" alt="image" src="https://github.com/user-attachments/assets/f3d798f1-b5fe-47de-bc86-0901c31c136a" />


### How can this be tested?
I tested the `theme_assets_pipeline.py` pipeline locally and it worked fine. Rest of the stuff will be tested in RC.
Just make sure the code looks fine!
