### PR TITLE
Revert ocw course publisher tag temporarily

### DIFF
--- a/content_sync/pipelines/definitions/concourse/common/image_resources.py
+++ b/content_sync/pipelines/definitions/concourse/common/image_resources.py
@@ -8,7 +8,7 @@ https://github.com/mitodl/ol-infrastructure/tree/main/dockerfiles/ocw/node-hugo
 """
 OCW_COURSE_PUBLISHER_REGISTRY_IMAGE = AnonymousResource(
     type=REGISTRY_IMAGE,
-    source=RegistryImage(repository="mitodl/ocw-course-publisher", tag="0.8"),
+    source=RegistryImage(repository="mitodl/ocw-course-publisher", tag="0.6"),
 )
 
 AWS_CLI_REGISTRY_IMAGE = AnonymousResource(

--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
@@ -283,7 +283,7 @@ class EndToEndTestPipelineDefinition(Pipeline):
                 }
             )
         tasks.append(fetch_built_content_step)
-        playwright_commands = "export COREPACK_ENABLE_DOWNLOAD_PROMPT=0\ncorepack enable\nyarn install\nnpx playwright install firefox --with-deps\nnpx playwright install chrome --with-deps\nnpx playwright test"  # noqa: E501
+        playwright_commands = "corepack enable\nyarn install\nnpx playwright install firefox --with-deps\nnpx playwright install chrome --with-deps\nnpx playwright test"  # noqa: E501
         tasks.append(
             TaskStep(
                 task=playwright_task_identifier,

--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -101,7 +101,7 @@ jobs:
       platform: linux
       image_resource:
         type: registry-image
-        source: {repository: mitodl/ocw-course-publisher, tag: 0.8}
+        source: {repository: mitodl/ocw-course-publisher, tag: 0.6}
       inputs:
       - name: ocw-hugo-themes
       outputs:
@@ -162,7 +162,7 @@ jobs:
       platform: linux
       image_resource:
         type: registry-image
-        source: {repository: mitodl/ocw-course-publisher, tag: 0.8}
+        source: {repository: mitodl/ocw-course-publisher, tag: 0.6}
       inputs:
         - name: publishable_sites
         - name: ocw-hugo-projects

--- a/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
+++ b/content_sync/pipelines/definitions/concourse/mass-build-sites.yml
@@ -114,7 +114,6 @@ jobs:
         - -exc
         - |
           cd ocw-hugo-themes
-          export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
           yarn install --immutable
           npm run build:webpack
           npm run build:githash

--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
@@ -104,7 +104,6 @@ class ThemeAssetsPipelineDefinition(Pipeline):
                             "-exc",
                             f"""
                             cd {OCW_HUGO_THEMES_GIT_IDENTIFIER}
-                            export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
                             corepack enable
                             yarn install --immutable
                             npm run build:webpack


### PR DESCRIPTION
Reverts https://github.com/mitodl/ocw-studio/pull/2426 because we just had a pre-mature release

