### PR TITLE
Cleanup headless related code (Hugo build options)

### DIFF
--- a/localdev/configs/ocw-www.yml
+++ b/localdev/configs/ocw-www.yml
@@ -130,10 +130,12 @@ collections:
     widget: markdown
     minimal: true
 
-  - label: Headless
-    name: headless
+  - label: Build
+    name: _build
     widget: hidden
-    default: true
+    default:
+      render: "never"
+      list: "always"
 
 - category: Content
   folder: content/testimonials
@@ -246,10 +248,6 @@ collections:
     widget: string
     required: false
 
-  - label: Headless
-    name: headless
-    widget: hidden
-    default: true
 
 - category: Settings
   label: Menu

--- a/ocw_import/api.py
+++ b/ocw_import/api.py
@@ -442,7 +442,6 @@ def import_ocw2hugo_sitemetadata(course_data, website):  # pylint:disable=too-ma
             text_id=text_id,
             defaults={
                 "metadata": {
-                    "headless": True,
                     "first_name": first_name,
                     "last_name": last_name,
                     "middle_initial": middle_initial,

--- a/ocw_import/api_test.py
+++ b/ocw_import/api_test.py
@@ -182,7 +182,6 @@ def test_import_ocw2hugo_course_metadata(settings, root_website):
                 "middle_initial": "",
                 "last_name": "Ulm",
                 "salutation": "Prof.",
-                "headless": True,
             },
         },
         {
@@ -194,7 +193,6 @@ def test_import_ocw2hugo_course_metadata(settings, root_website):
                 "middle_initial": "",
                 "last_name": "Buehler",
                 "salutation": "Prof.",
-                "headless": True,
             },
         },
     ]

--- a/static/js/resources/ocw-www.json
+++ b/static/js/resources/ocw-www.json
@@ -161,9 +161,12 @@
           "widget": "markdown"
         },
         {
-          "default": true,
-          "label": "Headless",
-          "name": "headless",
+          "default": {
+            "list": "always",
+            "render": "never"
+          },
+          "label": "Build",
+          "name": "_build",
           "widget": "hidden"
         }
       ],
@@ -309,12 +312,6 @@
           "name": "salutation",
           "required": false,
           "widget": "string"
-        },
-        {
-          "default": true,
-          "label": "Headless",
-          "name": "headless",
-          "widget": "hidden"
         }
       ],
       "folder": "content/instructors",

--- a/test_site_fixtures/test_website_content.json
+++ b/test_site_fixtures/test_website_content.json
@@ -1328,7 +1328,6 @@
       "markdown": null,
       "metadata": {
         "draft": false,
-        "headless": true,
         "last_name": "Two",
         "first_name": "Tester",
         "salutation": "",
@@ -1360,7 +1359,6 @@
       "markdown": null,
       "metadata": {
         "draft": false,
-        "headless": true,
         "last_name": "One",
         "first_name": "Tester",
         "salutation": "Prof.",
@@ -1392,7 +1390,6 @@
       "markdown": null,
       "metadata": {
         "draft": false,
-        "headless": true,
         "last_name": "Three",
         "first_name": "Another",
         "salutation": "",


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/6895

### Description (What does it do?)
Removes `headless: true` from tests and other places to cleanup redundant code and update it with new configuration.