### PR TITLE
env variables for MIT Learn in theme assets pipeline

### DIFF
--- a/app.json
+++ b/app.json
@@ -98,6 +98,14 @@
       "description": "Early executed tasks propagate exceptions",
       "required": false
     },
+    "CHECK_EXTERNAL_RESOURCE_STATUS_FREQUENCY": {
+      "description": "Frequency (in seconds) to check potentially broken external urls",
+      "required": false
+    },
+    "CHECK_EXTERNAL_RESOURCE_TASK_STATUS": {
+      "description": "Enables celery task to check potentially broken external urls",
+      "required": false
+    },
     "CONCOURSE_HARD_PURGE": {
       "description": "Perform a hard purge of the fastly cache",
       "required": false
@@ -122,6 +130,10 @@
       "description": "The concourse-ci login username",
       "required": false
     },
+    "CONTENT_FILE_SEARCH_API_URL": {
+      "description": "The URL to open discussions content file search to inject into the theme assets build",
+      "required": false
+    },
     "CONTENT_SYNC_BACKEND": {
       "description": "The backend to sync websites/content with",
       "required": false
@@ -132,6 +144,10 @@
     },
     "CONTENT_SYNC_RETRIES": {
       "description": "Number of times to retry backend sync attempts",
+      "required": false
+    },
+    "COURSE_SEARCH_API_URL": {
+      "description": "The URL to open discussions learning resource search to inject into the theme assets build",
       "required": false
     },
     "DISABLE_WEBPACK_LOADER_STATS": {
@@ -158,24 +174,12 @@
       "description": "Gdrive folder for video uploads",
       "required": false
     },
+    "ENABLE_WAYBACK_TASKS": {
+      "description": "Enables tasks related to Wayback Machine submissions and status checks",
+      "required": false
+    },
     "ENV_NAME": {
       "description": "Name of environment from Heroku or other deployment",
-      "required": false
-    },
-    "FEATURE_SORTABLE_SELECT_PRESERVE_SEARCH_TEXT": {
-      "description": "Feature flag sortable select preserves search text",
-      "required": false
-    },
-    "FEATURE_SORTABLE_SELECT_HIDE_SELECTED": {
-      "description": "Feature flag sortable select hides selected items",
-      "required": false
-    },
-    "FEATURE_SORTABLE_SELECT_QUICK_ADD": {
-      "description": "Feature flag sortable select adds item on selection",
-      "required": false
-    },
-    "FEATURE_SELECT_FIELD_INFINITE_SCROLL": {
-      "description": "Feature flag select field allows infinite scroll",
       "required": false
     },
     "FIELD_METADATA_TITLE": {
@@ -302,6 +306,14 @@
       "description": "E-mail to use for reply-to address of emails",
       "required": false
     },
+    "MIT_LEARN_API_BASE_URL": {
+      "description": "URL to an instance of the MIT Learn API",
+      "required": "False"
+    },
+    "MIT_LEARN_BASE_URL": {
+      "description": "URL to an instance of MIT Learn",
+      "required": "False"
+    },
     "NEW_RELIC_APP_NAME": {
       "description": "Application identifier in New Relic."
     },
@@ -331,10 +343,6 @@
     },
     "OCW_MASS_BUILD_MAX_IN_FLIGHT": {
       "description": "The amount of sites to build simultaneously in each job created by MassBuildSitesPipelineDefinition",
-      "required": false
-    },
-    "OPEN_CATALOG_WEBHOOK_KEY": {
-      "description": "Open catalog webhook key",
       "required": false
     },
     "OCW_STUDIO_ADMIN_EMAIL": {
@@ -429,20 +437,20 @@
       "description": "Email address listed for customer support",
       "required": false
     },
+    "OCW_STUDIO_TEST_URL": {
+      "description": "The base url of the test site",
+      "required": false
+    },
     "OCW_STUDIO_USE_S3": {
       "description": "Use S3 for storage backend (required on Heroku)",
       "required": false
     },
-    "OCW_TEST_COURSE_STARTER_SLUG": {
-      "description": "The slug of the course Website used to run end to end tests",
-      "required": false
-    },
-    "OCW_TEST_WWW_STARTER_SLUG": {
-      "description": "The slug of the root Website used to run end to end tests",
-      "required": false
-    },
     "OPEN_CATALOG_URLS": {
-      "description": "List of open catalog urls",
+      "description": "Open catalog urls",
+      "required": false
+    },
+    "OPEN_CATALOG_WEBHOOK_KEY": {
+      "description": "Open discussions webhook key",
       "required": false
     },
     "PGBOUNCER_DEFAULT_POOL_SIZE": {
@@ -461,6 +469,10 @@
     },
     "POSTHOG_FEATURE_FLAG_REQUEST_TIMEOUT_MS": {
       "description": "Timeout (ms) for PostHog feature flag requests",
+      "required": false
+    },
+    "POSTHOG_MAX_RETRIES": {
+      "description": "Number of times requests to PostHog are retried if failed",
       "required": false
     },
     "POSTHOG_PROJECT_API_KEY": {
@@ -513,14 +525,6 @@
     },
     "SEARCH_API_URL": {
       "description": "The URL to open discussions search to inject into the theme assets build",
-      "required": false
-    },
-    "COURSE_SEARCH_API_URL": {
-      "description": "The URL to open discussions learning resource search to inject into the theme assets build",
-      "required": false
-    },
-    "CONTENT_FILE_SEARCH_API_URL": {
-      "description": "The URL to open discussions content file search to inject into the theme assets build",
       "required": false
     },
     "SECRET_KEY": {
@@ -604,6 +608,10 @@
       "description": "Token to access the status API.",
       "required": false
     },
+    "TEST_ROOT_WEBSITE_NAME": {
+      "description": "The Website name for the site at the root of the test domain",
+      "required": false
+    },
     "THREEPLAY_API_KEY": {
       "description": "3play api key",
       "required": false
@@ -622,6 +630,10 @@
     },
     "UPDATE_TAGGED_3PLAY_TRANSCRIPT_FREQUENCY": {
       "description": "The frequency to check for videos tagged as updated in 3play",
+      "required": false
+    },
+    "UPDATE_WAYBACK_JOBS_STATUS_FREQUENCY": {
+      "description": "Frequency (in seconds) to check the status of Wayback Machine jobs",
       "required": false
     },
     "USE_X_FORWARDED_HOST": {
@@ -652,17 +664,8 @@
       "description": "Secret key for the Wayback Machine API",
       "required": false
     },
-    "UPDATE_WAYBACK_JOBS_STATUS_FREQUENCY": {
-      "description": "Frequency (in seconds) to check the status of Wayback Machine jobs",
-      "required": false
-    },
     "WAYBACK_SUBMISSION_INTERVAL_DAYS": {
       "description": "Number of days between Wayback submissions",
-      "required": false,
-      "value": "30"
-    },
-    "ENABLE_WAYBACK_TASKS": {
-      "description": "Enables tasks related to Wayback Machine submissions and status checks",
       "required": false
     },
     "YT_ACCESS_TOKEN": {

--- a/app.json
+++ b/app.json
@@ -308,11 +308,11 @@
     },
     "MIT_LEARN_API_BASE_URL": {
       "description": "URL to an instance of the MIT Learn API",
-      "required": "False"
+      "required": false
     },
     "MIT_LEARN_BASE_URL": {
       "description": "URL to an instance of MIT Learn",
-      "required": "False"
+      "required": false
     },
     "NEW_RELIC_APP_NAME": {
       "description": "Application identifier in New Relic."

--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
@@ -101,8 +101,6 @@ class ThemeAssetsPipelineDefinition(Pipeline):
                         "POSTHOG_ENV": settings.ENVIRONMENT,
                         "SENTRY_DSN": settings.OCW_HUGO_THEMES_SENTRY_DSN,
                         "SENTRY_ENV": settings.ENVIRONMENT,
-                        "POSTHOG_ENABLED": "true",
-                        "POSTHOG_PROJECT_API_KEY": settings.POSTHOG_PROJECT_API_KEY,
                         "MIT_LEARN_BASE_URL": settings.MIT_LEARN_BASE_URL,
                         "MIT_LEARN_API_BASE_URL": settings.MIT_LEARN_API_BASE_URL,
                     },

--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
@@ -101,6 +101,10 @@ class ThemeAssetsPipelineDefinition(Pipeline):
                         "POSTHOG_ENV": settings.ENVIRONMENT,
                         "SENTRY_DSN": settings.OCW_HUGO_THEMES_SENTRY_DSN,
                         "SENTRY_ENV": settings.ENVIRONMENT,
+                        "POSTHOG_ENABLED": "true",
+                        "POSTHOG_PROJECT_API_KEY": settings.POSTHOG_PROJECT_API_KEY,
+                        "MIT_LEARN_BASE_URL": settings.MIT_LEARN_BASE_URL,
+                        "MIT_LEARN_API_BASE_URL": settings.MIT_LEARN_API_BASE_URL,
                     },
                     run=Command(
                         path="sh",

--- a/content_sync/serializers.py
+++ b/content_sync/serializers.py
@@ -3,6 +3,7 @@
 import abc
 import json
 import re
+from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse
 
@@ -70,11 +71,15 @@ class HugoMarkdownFileSerializer(BaseContentFileSerializer):
     """Serializer/deserializer class for Hugo Markdown content and files"""
 
     def serialize(self, website_content: WebsiteContent) -> str:
+        file_path = Path(
+            "/", website_content.website.get_url_path(), website_content.filename
+        )
         front_matter = {
             **(website_content.full_metadata or {}),
             "uid": website_content.text_id,
             "title": website_content.title,
             "content_type": website_content.type,
+            "file": f"{file_path}",
         }
         # NOTE: yaml.dump adds a newline to the end of its output by default
         return f"---\n{yaml.dump(front_matter)}---\n{website_content.markdown or ''}"

--- a/content_sync/serializers.py
+++ b/content_sync/serializers.py
@@ -72,14 +72,16 @@ class HugoMarkdownFileSerializer(BaseContentFileSerializer):
 
     def serialize(self, website_content: WebsiteContent) -> str:
         file_path = Path(
-            "/", website_content.website.get_url_path(), website_content.filename
+            "/",
+            website_content.website.get_url_path(),
+            Path(website_content.file.name).name,
         )
         front_matter = {
             **(website_content.full_metadata or {}),
             "uid": website_content.text_id,
             "title": website_content.title,
             "content_type": website_content.type,
-            "file": f"{file_path}",
+            "file": file_path.as_posix(),
         }
         # NOTE: yaml.dump adds a newline to the end of its output by default
         return f"---\n{yaml.dump(front_matter)}---\n{website_content.markdown or ''}"

--- a/content_sync/serializers_test.py
+++ b/content_sync/serializers_test.py
@@ -2,6 +2,7 @@
 
 import json
 import re
+from pathlib import Path
 
 import pytest
 import yaml
@@ -122,6 +123,7 @@ def test_hugo_file_serialize(settings, markdown, exp_sections):
         file=SimpleUploadedFile("mysite/test.pdf", b"content"),
         website=WebsiteFactory.create(name="mysite", url_path="sites/mysite-fall-2025"),
     )
+    file_path = Path("/", content.website.get_url_path(), Path(content.file.name).name)
     site_config = SiteConfig(content.website.starter.config)
 
     file_content = HugoMarkdownFileSerializer(site_config).serialize(
@@ -142,6 +144,7 @@ def test_hugo_file_serialize(settings, markdown, exp_sections):
             f"title: {content.title}",
             f"content_type: {content.type}",
             f"uid: {content.text_id}",
+            f"file: {file_path}",
         ]
         + [f"{k}: {v}" for k, v in metadata.items()]
     )

--- a/main/settings.py
+++ b/main/settings.py
@@ -1316,11 +1316,11 @@ MIT_LEARN_BASE_URL = get_string(
     name="MIT_LEARN_BASE_URL",
     default=None,
     description="URL to an instance of MIT Learn",
-    required="False",
+    required=False,
 )
 MIT_LEARN_API_BASE_URL = get_string(
     name="MIT_LEARN_API_BASE_URL",
     default=None,
     description="URL to an instance of the MIT Learn API",
-    required="False",
+    required=False,
 )

--- a/main/settings.py
+++ b/main/settings.py
@@ -1312,3 +1312,15 @@ OCW_STUDIO_DELETABLE_CONTENT_TYPES = get_delimited_list(
     default=[],
     description="List of content types that can be deleted",
 )
+MIT_LEARN_BASE_URL = get_string(
+    name="MIT_LEARN_BASE_URL",
+    default=None,
+    description="URL to an instance of MIT Learn",
+    required="False",
+)
+MIT_LEARN_API_BASE_URL = get_string(
+    name="MIT_LEARN_API_BASE_URL",
+    default=None,
+    description="URL to an instance of the MIT Learn API",
+    required="False",
+)

--- a/websites/views.py
+++ b/websites/views.py
@@ -326,10 +326,12 @@ class WebsiteViewSet(
     def hide_download(self, request, name=None):  # noqa: ARG002
         """Process webhook requests from concourse pipeline runs"""
         website = get_object_or_404(Website, name=name)
-        content = WebsiteContent.objects.get(
-            website=website, type=CONTENT_TYPE_METADATA
-        )
-        hide_download = content and content.metadata.get("hide_download")
+        hide_download = False
+        if website.name != settings.ROOT_WEBSITE_NAME:
+            content = WebsiteContent.objects.get(
+                website=website, type=CONTENT_TYPE_METADATA
+            )
+            hide_download = content and content.metadata.get("hide_download")
         return Response(
             status=200,
             data={} if hide_download else {"version": str(now_in_utc().timestamp())},


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/ocw-studio/issues/2444

### Description (What does it do?)
This PR adds some environment variables to the theme assets pipeline for both Posthog support as well as supporting the MIT Learn integration functionality

### How can this be tested?
 - Ensure you have a Posthog API key
 - In your `.env` in `ocw-studio`, make sure you have:
```
OCW_HUGO_THEMES_BRANCH=cg/add-login-button
OCW_HUGO_PROJECTS_BRANCH=main

POSTHOG_PROJECT_API_KEY=YOUR_API_KEY_HERE
POSTHOG_ENABLED=true

MIT_LEARN_BASE_URL=https://rc.learn.mit.edu
MIT_LEARN_API_BASE_URL=https://api.rc.learn.mit.edu
```
 - Spin up `ocw-studio`
 - Run `docker compose exec web ./manage.py upsert_theme_assets_pipeline --themes-branch cg/add-login-button`
 - Browse to Concourse at http://localhost:8080/ and log in
 - Find the theme assets pipeline for the branch we specified, unpause the pipeline and run it
 - Ensure that the pipeline completes successfully
 - Upsert the pipeline for any site by using the `backpopulate_pipelines` management command with the `--filter` argument to specify which site
 - Publish the site
 - View the site and open the developer console
 - Ensure that you see a "Posthog loaded successfully" message
 - Ensure you see a "Log In" button in the upper right
 - Click the "Log In" button and you should be redirected to RC Learn
 
 We don't need to test actually using the login button, that will come later. The purpose of this PR is just to make certain that the proper values are being injected into the bundle.
