### PR TITLE
set posthog env vars in the themes assets pipeline

### DIFF
--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
@@ -95,6 +95,10 @@ class ThemeAssetsPipelineDefinition(Pipeline):
                         "SEARCH_API_URL": settings.SEARCH_API_URL,
                         "COURSE_SEARCH_API_URL": settings.COURSE_SEARCH_API_URL,
                         "CONTENT_FILE_SEARCH_API_URL": settings.CONTENT_FILE_SEARCH_API_URL,  # noqa:E501
+                        "POSTHOG_API_HOST": settings.POSTHOG_API_HOST,
+                        "POSTHOG_ENABLED": str(settings.POSTHOG_ENABLED).lower(),
+                        "POSTHOG_PROJECT_API_KEY": settings.POSTHOG_PROJECT_API_KEY,
+                        "POSTHOG_ENV": settings.ENVIRONMENT,
                         "SENTRY_DSN": settings.OCW_HUGO_THEMES_SENTRY_DSN,
                         "SENTRY_ENV": settings.ENVIRONMENT,
                     },

--- a/main/settings.py
+++ b/main/settings.py
@@ -1279,7 +1279,7 @@ ENV_NAME = get_string(
 )
 POSTHOG_API_HOST = get_string(
     name="POSTHOG_API_HOST",
-    default=None,
+    default="https://app.posthog.com",
     description="API host for PostHog",
     required=False,
 )


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6937

### Description (What does it do?)
This PR:

- Adds the following env vars to the `ocw-theme-assets` pipeline, based on their values in the `ocw-studio` environment:
  - `POSTHOG_ENABLED`
  - `POSTHOG_API_HOST`
  - `POSTOG_PROJECT_API_KEY`
  - `POSTHOG_ENV`
- Sets a default value for `POSTHOG_API_HOST` with a value of https://app.posthog.com

### How can this be tested?
- Make sure your local OCW setup is configured to publish pipelines, and you have the above Posthog variables set in your `.env` as well
- Upsert the theme assets pipeline with `docker compose exec web ./manage.py upsert_theme_assets_pipeline`
- Browse to Concourse at http://localhost:8080/
- Go to the theme assets pipeline, unpause it and run it
- Once the build has completed, browse to `ocw-studio` at http://localhost:8043/sites and publish any site live
- Once the site is published, view it using the URL in the publish drawer
- Open your browser's developer console
- Verify that you see "PostHog loaded successfully" in the console