### PR TITLE
use latest python 3.12 and poetry 2.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38   # v5
       with:
-        python-version: "~3.12"
+        python-version: "3.12"
         cache: "poetry"
 
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Install poetry
       uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
       with:
-        version: 1.5.1
+        version: 2.1.1
         virtualenvs-create: true
         virtualenvs-in-project: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38   # v5
       with:
-        python-version: "3.12.5"
+        python-version: "~3.12"
         cache: "poetry"
 
     - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.5
+FROM python:3.12
 LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
 
 # Add package files, install updated node and pip
@@ -20,7 +20,7 @@ RUN mkdir /var/media && chown -R mitodl:mitodl /var/media
 # Install Python packages
 ## Set some poetry config
 ENV  \
-  POETRY_VERSION=1.5.1 \
+  POETRY_VERSION=2.1.1 \
   POETRY_VIRTUALENVS_CREATE=false \
   POETRY_CACHE_DIR='/tmp/cache/poetry' \
   POETRY_HOME='/home/mitodl/.local' \

--- a/poetry.lock
+++ b/poetry.lock
@@ -3781,5 +3781,5 @@ ruamel = ["ruamel.yaml"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = "3.12.5"
-content-hash = "dd78800c46ea885154ee7244d524b3863f28fc2a8c56a0b273a61a5912c2551f"
+python-versions = "~3.12"
+content-hash = "4e5622686b13e4d02974f86d72827dd639954145b5cd2ef9ccba0d7ca82c2c51"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,10 @@ authors = ["MITODL"]
 license = "BSD-3"
 readme = "README.md"
 version = "0.0.0"
+package-mode = false
 
 [tool.poetry.dependencies]
-python = "3.12.5"
+python = "~3.12"
 
 beautifulsoup4 = "^4.12.2"
 boto3 = "1.37.4"


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6954

### Description (What does it do?)
This PR changes the Python version in the project to use whatever the latest patch version of Python 3.12 is, as well as upgrading Poetry from 1.5 to 2.1.1.

### How can this be tested?
 - Make sure your environment is set up to run `ocw-studio` locally
 - Check out this branch
 - Run `docker compose up --build -d` and verify that containers are built successfully and the app starts without issue
