### PR TITLE
set POSTHOG_ENV on playwright tests

### DIFF
--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
@@ -312,6 +312,7 @@ class EndToEndTestPipelineDefinition(Pipeline):
                         "FIELDS_HUGO_CONFIG_PATH": f"../{OCW_HUGO_PROJECTS_GIT_IDENTIFIER}/mit-fields/config.yaml",  # noqa: E501
                         "GIT_CONTENT_SOURCE": "git@github.mit.edu:ocw-content-rc",
                         "OCW_TEST_COURSE": course_content_git_identifier,
+                        "POSTHOG_ENV": "development",
                         "RESOURCE_BASE_URL": static_api_base_url,
                         "SITEMAP_DOMAIN": sitemap_domain,
                         "SEARCH_API_URL": "https://discussions-rc.odl.mit.edu/api/v0/search/",


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6968

### Description (What does it do?)
This PR sets the `POSTHOG_ENV` var on the end to end test pipeline so that the build does not fail

### How can this be tested?
- Ensure you have the `ocw-ci-test-www` and `ocw-ci-test-course` sites in your local database. These can be obtained by restoring a production backup or manually pushing the Github repos to your test org. To do the latter, follow these steps. Create empty sites in your local with the same slugs first. Then, push up the content from the following repos into the repos in your test org. Afterwards, import each one with the `sync_backend_to_db` management command. Afterwards, publish the sites live.
  - https://github.mit.edu/mitocwcontent/ocw-ci-test-www
  - https://github.mit.edu/mitocwcontent/ocw-ci-test-course
- Upsert the end to end test pipeline with `docker compose exec web ./manage.py upsert_e2e_test_pipeline
- Find the pipeline in the Concourse UI and run it
