### PR TITLE
set mit learn base urls on the theme assets pipeline

### DIFF
--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
@@ -87,7 +87,7 @@ class ThemeAssetsPipelineDefinition(Pipeline):
             "MIT_LEARN_API_BASE_URL": settings.MIT_LEARN_API_BASE_URL,
             "SENTRY_DSN": settings.OCW_HUGO_THEMES_SENTRY_DSN,
             "SENTRY_ENV": settings.ENVIRONMENT,
-            "POSTHOG_ENABLED": str(settings.POSTHOG_ENABLED).lower(),
+            "POSTHOG_ENABLED": str(settings.PUBLISH_POSTHOG_ENABLED).lower(),
             "POSTHOG_API_HOST": settings.PUBLISH_POSTHOG_API_HOST,
             "POSTHOG_ENV": settings.ENVIRONMENT,
         }

--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
@@ -83,8 +83,11 @@ class ThemeAssetsPipelineDefinition(Pipeline):
             "SEARCH_API_URL": settings.SEARCH_API_URL,
             "COURSE_SEARCH_API_URL": settings.COURSE_SEARCH_API_URL,
             "CONTENT_FILE_SEARCH_API_URL": settings.CONTENT_FILE_SEARCH_API_URL,
+            "MIT_LEARN_BASE_URL": settings.MIT_LEARN_BASE_URL,
+            "MIT_LEARN_API_BASE_URL": settings.MIT_LEARN_API_BASE_URL,
             "SENTRY_DSN": settings.OCW_HUGO_THEMES_SENTRY_DSN,
             "SENTRY_ENV": settings.ENVIRONMENT,
+            "POSTHOG_ENABLED": str(settings.POSTHOG_ENABLED).lower(),
             "POSTHOG_API_HOST": settings.PUBLISH_POSTHOG_API_HOST,
             "POSTHOG_ENV": settings.ENVIRONMENT,
         }


### PR DESCRIPTION
### What are the relevant tickets?
Follow-up to https://github.com/mitodl/ocw-studio/pull/2462

### Description (What does it do?)
This is a follow-up to the above PR, which added new settings for `MIT_LEARN_BASE_URL` and `MIT_LEARN_API_BASE_URL`. This PR takes those settings and applies them to the environment used in the webpack build in the theme assets pipeline.

### How can this be tested?
 - Ensure you have a Posthog API key, and in your Posthog project you have created a feature flag named `ocw-learn-integration` and enabled it
 - In your `.env` in `ocw-studio`, make sure you have:
```
OCW_HUGO_THEMES_BRANCH=cg/add-login-button
OCW_HUGO_PROJECTS_BRANCH=main

POSTHOG_PROJECT_API_KEY=YOUR_API_KEY_HERE
POSTHOG_ENABLED=true

MIT_LEARN_BASE_URL=https://rc.learn.mit.edu
MIT_LEARN_API_BASE_URL=https://api.rc.learn.mit.edu
```
 - Spin up `ocw-studio`
 - Run `docker compose exec web ./manage.py upsert_theme_assets_pipeline`
 - Browse to Concourse at http://localhost:8080/ and log in
 - Find the theme assets pipeline, unpause the pipeline and run it
 - Ensure that the pipeline completes successfully
 - Upsert the pipeline for any site by using the `backpopulate_pipelines` management command with the `--filter` argument to specify which site
 - Publish the site
 - View the site and open the developer console
 - Ensure that you see a "Posthog loaded successfully" message
 - Ensure you see a "Log In" button in the upper right
 - Click the "Log In" button and you should be redirected to RC Learn
 
 We don't need to test actually using the login button, that will come later. The purpose of this PR is just to make certain that the proper values are being injected into the bundle.