### PR TITLE
separate Posthog env vars between studio and published OCW

### DIFF
--- a/app.json
+++ b/app.json
@@ -487,6 +487,26 @@
       "description": "Frequency (in seconds) to run a check on potentially stalled publish builds",
       "required": false
     },
+    "PUBLISH_POSTHOG_API_HOST": {
+      "description": "API host for PostHog, published to pipelines",
+      "required": false
+    },
+    "PUBLISH_POSTHOG_ENABLED": {
+      "description": "Whether PostHog is enabled, published to pipelines",
+      "required": false
+    },
+    "PUBLISH_POSTHOG_FEATURE_FLAG_REQUEST_TIMEOUT_MS": {
+      "description": "Timeout (ms) for PostHog feature flag requests, published to pipelines",
+      "required": false
+    },
+    "PUBLISH_POSTHOG_MAX_RETRIES": {
+      "description": "Number of times requests to PostHog are retried if failed, published to pipelines",
+      "required": false
+    },
+    "PUBLISH_POSTHOG_PROJECT_API_KEY": {
+      "description": "API token for communicating with PostHog, published to pipelines",
+      "required": false
+    },
     "PUBLISH_STATUS_CUTOFF": {
       "description": "Number of seconds to wait for a publish build to fail/succeed before assuming it's stuck",
       "required": false

--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
@@ -85,14 +85,13 @@ class ThemeAssetsPipelineDefinition(Pipeline):
             "CONTENT_FILE_SEARCH_API_URL": settings.CONTENT_FILE_SEARCH_API_URL,
             "SENTRY_DSN": settings.OCW_HUGO_THEMES_SENTRY_DSN,
             "SENTRY_ENV": settings.ENVIRONMENT,
+            "POSTHOG_API_HOST": settings.PUBLISH_POSTHOG_API_HOST,
             "POSTHOG_ENV": settings.ENVIRONMENT,
         }
         if (
             settings.PUBLISH_POSTHOG_ENABLED
-            and settings.PUBLISH_POSTHOG_API_HOST
             and settings.PUBLISH_POSTHOG_PROJECT_API_KEY
         ):
-            themes_env["POSTHOG_API_HOST"] = settings.PUBLISH_POSTHOG_API_HOST
             themes_env["POSTHOG_ENABLED"] = str(
                 settings.PUBLISH_POSTHOG_ENABLED
             ).lower()

--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
@@ -79,6 +79,26 @@ class ThemeAssetsPipelineDefinition(Pipeline):
         )
         resource_types = []
         resources = [ocw_hugo_themes_resource]
+        themes_env = {
+            "SEARCH_API_URL": settings.SEARCH_API_URL,
+            "COURSE_SEARCH_API_URL": settings.COURSE_SEARCH_API_URL,
+            "CONTENT_FILE_SEARCH_API_URL": settings.CONTENT_FILE_SEARCH_API_URL,
+            "SENTRY_DSN": settings.OCW_HUGO_THEMES_SENTRY_DSN,
+            "SENTRY_ENV": settings.ENVIRONMENT,
+            "POSTHOG_ENV": settings.ENVIRONMENT,
+        }
+        if (
+            settings.PUBLISH_POSTHOG_ENABLED
+            and settings.PUBLISH_POSTHOG_API_HOST
+            and settings.PUBLISH_POSTHOG_PROJECT_API_KEY
+        ):
+            themes_env["POSTHOG_API_HOST"] = settings.PUBLISH_POSTHOG_API_HOST
+            themes_env["POSTHOG_ENABLED"] = str(
+                settings.PUBLISH_POSTHOG_ENABLED
+            ).lower()
+            themes_env["POSTHOG_PROJECT_API_KEY"] = (
+                settings.PUBLISH_POSTHOG_PROJECT_API_KEY
+            )
         tasks = [
             GetStep(
                 get=OCW_HUGO_THEMES_GIT_IDENTIFIER,
@@ -91,17 +111,7 @@ class ThemeAssetsPipelineDefinition(Pipeline):
                     image_resource=OCW_COURSE_PUBLISHER_REGISTRY_IMAGE,
                     inputs=[Input(name=OCW_HUGO_THEMES_GIT_IDENTIFIER)],
                     outputs=[Output(name=OCW_HUGO_THEMES_GIT_IDENTIFIER)],
-                    params={
-                        "SEARCH_API_URL": settings.SEARCH_API_URL,
-                        "COURSE_SEARCH_API_URL": settings.COURSE_SEARCH_API_URL,
-                        "CONTENT_FILE_SEARCH_API_URL": settings.CONTENT_FILE_SEARCH_API_URL,  # noqa:E501
-                        "POSTHOG_API_HOST": settings.POSTHOG_API_HOST,
-                        "POSTHOG_ENABLED": str(settings.POSTHOG_ENABLED).lower(),
-                        "POSTHOG_PROJECT_API_KEY": settings.POSTHOG_PROJECT_API_KEY,
-                        "POSTHOG_ENV": settings.ENVIRONMENT,
-                        "SENTRY_DSN": settings.OCW_HUGO_THEMES_SENTRY_DSN,
-                        "SENTRY_ENV": settings.ENVIRONMENT,
-                    },
+                    params=themes_env,
                     run=Command(
                         path="sh",
                         args=[

--- a/main/settings.py
+++ b/main/settings.py
@@ -1307,6 +1307,41 @@ POSTHOG_PROJECT_API_KEY = get_string(
     description="API token for communicating with PostHog",
     required=False,
 )
+PUBLISH_POSTHOG_API_HOST = get_string(
+    name="PUBLISH_POSTHOG_API_HOST",
+    default="https://app.posthog.com",
+    description="API host for PostHog, published to pipelines",
+    required=False,
+)
+PUBLISH_POSTHOG_ENABLED = get_bool(
+    name="PUBLISH_POSTHOG_ENABLED",
+    default=False,
+    description="Whether PostHog is enabled, published to pipelines",
+    required=False,
+)
+PUBLISH_POSTHOG_FEATURE_FLAG_REQUEST_TIMEOUT_MS = get_int(
+    name="PUBLISH_POSTHOG_FEATURE_FLAG_REQUEST_TIMEOUT_MS",
+    default=3000,
+    description=(
+        "Timeout (ms) for PostHog feature flag requests, " "published to pipelines"
+    ),
+    required=False,
+)
+PUBLISH_POSTHOG_MAX_RETRIES = get_int(
+    name="PUBLISH_POSTHOG_MAX_RETRIES",
+    default=3,
+    description=(
+        "Number of times requests to PostHog are retried if failed, "
+        "published to pipelines"
+    ),
+    required=False,
+)
+PUBLISH_POSTHOG_PROJECT_API_KEY = get_string(
+    name="PUBLISH_POSTHOG_PROJECT_API_KEY",
+    default=None,
+    description="API token for communicating with PostHog, published to pipelines",
+    required=False,
+)
 OCW_STUDIO_DELETABLE_CONTENT_TYPES = get_delimited_list(
     name="OCW_STUDIO_DELETABLE_CONTENT_TYPES",
     default=[],


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7017

### Description (What does it do?)
This PR sets up a separate set of env vars for Posthog to be used with the published OCW site on the frontend. The theme assets pipeline definition was configured to use these vars instead of the ones used by `ocw-studio` itself.

### How can this be tested?
- Make sure you have a test Posthog project to work with
- In your `.env`, set the following:
```
PUBLISH_POSTHOG_ENABLED=true
PUBLISH_POSTHOG_PROJECT_API_KEY=<your API key here>
```
- Spin up `ocw-studio`
- Run `docker compose exec web ./manage.py upsert_theme_assets_pipeline`
- Run the theme assets pipeline in Concourse
- Publish a site
- Open the site in a browser, look at the development console and ensure that you see "Posthog is enabled"
- Switch to `PUBLISH_POSTHOG_ENABLED=false` and `docker compose restart web celery`
- Re-run the steps above, ensuring that in the browser you now see "Posthog is disabled"

### Checklist:
- [x] https://github.com/mitodl/ol-infrastructure/pull/3079 should be merged and deployed
