### PR TITLE
fix: Add necessary context for Pydantic subclasses with custom init

### DIFF
--- a/content_sync/pipelines/definitions/concourse/common/steps.py
+++ b/content_sync/pipelines/definitions/concourse/common/steps.py
@@ -119,6 +119,7 @@ class ErrorHandlingStep(TryStep):
             ),
             **kwargs,
         )
+        self.model_rebuild()
 
 
 class SlackAlertStep(TryStep):
@@ -145,6 +146,7 @@ class SlackAlertStep(TryStep):
             ),
             **kwargs,
         )
+        self.model_rebuild()
 
 
 class ClearCdnCacheStep(TaskStep):
@@ -182,6 +184,7 @@ class ClearCdnCacheStep(TaskStep):
             ),
             **kwargs,
         )
+        self.model_rebuild()
 
 
 class OcwStudioWebhookStep(TryStep):
@@ -207,6 +210,7 @@ class OcwStudioWebhookStep(TryStep):
             ),
             **kwargs,
         )
+        self.model_rebuild()
 
 
 class OcwStudioWebhookCurlStep(TryStep):
@@ -246,6 +250,7 @@ class OcwStudioWebhookCurlStep(TryStep):
             ),
             **kwargs,
         )
+        self.model_rebuild()
 
 
 class OpenCatalogWebhookStep(TryStep):
@@ -279,6 +284,7 @@ class OpenCatalogWebhookStep(TryStep):
             ),
             **kwargs,
         )
+        self.model_rebuild()
 
 
 class SiteContentGitTaskStep(TaskStep):
@@ -328,17 +334,4 @@ class SiteContentGitTaskStep(TaskStep):
             ),
             **kwargs,
         )
-
-
-models = [
-    ClearCdnCacheStep,
-    ErrorHandlingStep,
-    OcwStudioWebhookStep,
-    OcwStudioWebhookCurlStep,
-    OpenCatalogWebhookStep,
-    SiteContentGitTaskStep,
-    SlackAlertStep,
-]
-
-for model in models:
-    model.model_rebuild()
+        self.model_rebuild()

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -3,6 +3,7 @@ from urllib.parse import urlparse
 
 from django.conf import settings
 from ol_concourse.lib.models.pipeline import (
+    AcrossVar,  # noqa: F401
     Command,
     DoStep,
     DummyConfig,
@@ -416,6 +417,7 @@ class FilterWebpackArtifactsStep(TaskStep):
         if is_dev():
             self.params["AWS_ACCESS_KEY_ID"] = settings.AWS_ACCESS_KEY_ID
             self.params["AWS_SECRET_ACCESS_KEY"] = settings.AWS_SECRET_ACCESS_KEY
+        self.model_rebuild()
 
 
 class StaticResourcesTaskStep(TaskStep):
@@ -456,6 +458,7 @@ class StaticResourcesTaskStep(TaskStep):
         if is_dev():
             self.params["AWS_ACCESS_KEY_ID"] = settings.AWS_ACCESS_KEY_ID or ""
             self.params["AWS_SECRET_ACCESS_KEY"] = settings.AWS_SECRET_ACCESS_KEY or ""
+        self.model_rebuild()
 
 
 class SitePipelineOnlineTasks(list[StepModifierMixin]):
@@ -960,9 +963,3 @@ class SitePipelineDefinition(Pipeline):
             serial=True,
             plan=steps,
         )
-
-
-models = [FilterWebpackArtifactsStep, StaticResourcesTaskStep]
-
-for model in models:
-    model.model_rebuild()


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Addresses a failure with recent versions of Pydantic where a model subclass with a custom init method causes a loss of type information when initializing the model.

This came up when trying to backpopulate pipelines for individual courses.

### How can this be tested?
Launch OCW Studio with `docker compose up` and run `docker compose exec -it web /bin/bash`
Inside the container launch a Python repl and run the following script with and without this change:
```python
import django
django.setup()
from content_sync.pipelines.definitions.concourse.common.steps import SlackAlertStep
SlackAlertStep('foo', 'bar')
```

Without these changes you should see a traceback similar to:
```
>>> OcwStudioWebhookStep('foo', 'bar')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/src/content_sync/pipelines/definitions/concourse/common/steps.py", line 195, in __init__
    super().__init__(
  File "/opt/venv/lib/python3.12/site-packages/pydantic/main.py", line 243, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venv/lib/python3.12/site-packages/pydantic/_internal/_mock_val_ser.py", line 100, in __getattr__
    raise PydanticUserError(self._error_message, code=self._code)
pydantic.errors.PydanticUserError: `OcwStudioWebhookStep` is not fully defined; you should define `Optional`, then call `OcwStudioWebhookStep.model_rebuild()`.
```

Spin up OCW Studio with a fresh Celery container by running
```
docker compose stop
docker compose rm web celery
docker compose build web celery --no-cache --pull
docker compose up
```

Verify that backpopulating pipelines works, by running `docker compose exec web ./manage.py backpopulate_pipelines --filter <course name>`. Check that the pipeline is visible in Concourse.

