### PR TITLE
Update the detect_unrelated_content management command to add delete option

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -248,7 +248,7 @@ services:
         ipv4_address: 10.1.0.104
 
   s3:
-    image: minio/minio
+    image: minio/minio:latest
     ports:
     - "9000:9000"
     - "9001:9001"

--- a/websites/management/commands/detect_unrelated_content.py
+++ b/websites/management/commands/detect_unrelated_content.py
@@ -58,7 +58,7 @@ class Command(WebsiteFilterCommand):
         unrelated_files_by_site = {}
         self.stdout.write(
             self.style.SUCCESS(
-                f"Checking for unrelated content in {websites.count()} " "websites."
+                f"Checking for unrelated content in {websites.count()} websites."
             )
         )
 

--- a/websites/management/commands/detect_unrelated_content.py
+++ b/websites/management/commands/detect_unrelated_content.py
@@ -55,7 +55,7 @@ class Command(WebsiteFilterCommand):
                     website=website, file__isnull=False
                 ).values_list("file", flat=True)
                 normalized_website_content_files = {
-                    f.lstrip("/") for f in website_content_files
+                    wc.removeprefix("/") for wc in website_content_files if wc
                 }
                 # flake8: noqa: T201
                 print("\nWebsite:", website.name)

--- a/websites/management/commands/detect_unrelated_content.py
+++ b/websites/management/commands/detect_unrelated_content.py
@@ -63,10 +63,6 @@ class Command(WebsiteFilterCommand):
                 normalized_website_content_files = {
                     wc.removeprefix("/") for wc in website_content_files if wc
                 }
-                # flake8: noqa: T201
-                print("\nWebsite:", website.name)
-                print("S3 Files:", files_in_s3)
-                print("DB Files:", normalized_website_content_files)
 
                 unrelated_website_files = list(
                     files_in_s3 - normalized_website_content_files

--- a/websites/management/commands/detect_unrelated_content.py
+++ b/websites/management/commands/detect_unrelated_content.py
@@ -84,7 +84,7 @@ class Command(WebsiteFilterCommand):
                 deleted_files_count = 0
                 for _, files in unrelated_files.values():
                     for file in files:
-                        key = file  # Remove the leading slash for the actual S3 key
+                        key = file
                         s3.meta.client.delete_object(
                             Bucket=settings.AWS_STORAGE_BUCKET_NAME, Key=key
                         )


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6380#issuecomment-2672711498

### Description (What does it do?)
There was a slash `/` normalization problem in the existing `detect_unrelated_content` command which resulted in false-positives. (explained here: https://github.com/mitodl/hq/issues/6380#issuecomment-2786856316)
This PR fixes that and updates the management command to add delete option by using `--delete` in the management command to delete those unrelated contents from the s3 `AWS_STORAGE_BUCKET_NAME` bucket for the course.

This PR also implements pagination for `list_objects_v2` to allow listing more than 1,000 keys per site.
Also, `minio` docker image was updated to use latest tag because of this error while using `delete_objects()`: https://github.com/fsspec/s3fs/issues/931

### How can this be tested?
**Note: Please make sure you're using Minio locally (and not AWS's RC or Prod credentials) because using the `--delete` argument will work in the respective environment.**

1. Switch to this branch and spin up `ocw-studio` in your local environment.
2. Create a `test` course in your local ocw-studio or select an existing one.
3. Got to your local instance of s3 (MinIO) which should at `localhost:9001` and log in.
5. Upload a file at `{AWS_STORAGE_BUCKET_NAME}/courses/{selected_course_name}/`
6. run `docker-compose exec -it web ./manage.py detect_unrelated_content --filter "<course>" --delete` in terminal. This command will delete the uploaded file from s3 bucket and return the filename as well.
