### PR TITLE
Add S3 sync to enable content deletion for root website

### DIFF
--- a/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
@@ -383,7 +383,6 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
             config.vars["base_url"],
         )
     )
-
     # root-website: sync each subdirectory (excluding static_shared) with --delete
     assert (
         f'for dir in $(find {SITE_CONTENT_GIT_IDENTIFIER}/output-online -mindepth 1 -maxdepth 1 -type d -not -name "static_shared"); do'
@@ -393,19 +392,16 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
         f'aws s3{cli_endpoint_url} sync "$dir" "s3://{config.vars["web_bucket"]}{base_url}$(basename "$dir")" --delete --metadata site-id={config.vars["site_name"]}'
         in upload_online_build_command
     )
-
     # root-website: copy only root-level files
     assert (
         f'find {SITE_CONTENT_GIT_IDENTIFIER}/output-online -mindepth 1 -maxdepth 1 -type f -exec aws s3{cli_endpoint_url} cp {{}} "s3://{config.vars["web_bucket"]}{base_url}" --metadata site-id={config.vars["site_name"]} \\;'
         in upload_online_build_command
     )
-
     # non-root: fallback to a single sync
     assert (
         f'aws s3{cli_endpoint_url} sync {SITE_CONTENT_GIT_IDENTIFIER}/output-online "s3://{config.vars["web_bucket"]}{base_url}"'
         in upload_online_build_command
     )
-
     upload_online_build_expected_inputs = [SITE_CONTENT_GIT_IDENTIFIER]
     for input in upload_online_build_task["config"]["inputs"]:  # noqa: A001
         assert input["name"] in upload_online_build_expected_inputs

--- a/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
@@ -376,14 +376,36 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
     upload_online_build_command = "\n".join(
         upload_online_build_task["config"]["run"]["args"]
     )
+
+    base_url = "/".join(
+        (
+            config.vars["prefix"],
+            config.vars["base_url"],
+        )
+    )
+
+    # root-website: sync each subdirectory (excluding static_shared) with --delete
     assert (
-        f"if [ $IS_ROOT_WEBSITE = 1 ] ; then\n            aws s3{cli_endpoint_url} cp {SITE_CONTENT_GIT_IDENTIFIER}/output-online s3://{config.vars['web_bucket']}/{config.vars['prefix']}{config.vars['base_url']} --recursive --metadata site-id={config.vars['site_name']}{config.vars['delete_flag']}"
+        f'for dir in $(find {SITE_CONTENT_GIT_IDENTIFIER}/output-online -mindepth 1 -maxdepth 1 -type d -not -name "static_shared"); do'
         in upload_online_build_command
     )
     assert (
-        f"aws s3{cli_endpoint_url} sync {SITE_CONTENT_GIT_IDENTIFIER}/output-online s3://{config.vars['web_bucket']}/{config.vars['prefix']}{config.vars['base_url']} --exclude='{config.vars['short_id']}.zip' --exclude='{config.vars['short_id']}-video.zip' --metadata site-id={config.vars['site_name']}{config.vars['delete_flag']}"
+        f'aws s3{cli_endpoint_url} sync "$dir" "s3://{config.vars["web_bucket"]}{base_url}$(basename "$dir")" --delete --metadata site-id={config.vars["site_name"]}'
         in upload_online_build_command
     )
+
+    # root-website: copy only root-level files
+    assert (
+        f'find {SITE_CONTENT_GIT_IDENTIFIER}/output-online -mindepth 1 -maxdepth 1 -type f -exec aws s3{cli_endpoint_url} cp {{}} "s3://{config.vars["web_bucket"]}{base_url}" --metadata site-id={config.vars["site_name"]} \\;'
+        in upload_online_build_command
+    )
+
+    # non-root: fallback to a single sync
+    assert (
+        f'aws s3{cli_endpoint_url} sync {SITE_CONTENT_GIT_IDENTIFIER}/output-online "s3://{config.vars["web_bucket"]}{base_url}"'
+        in upload_online_build_command
+    )
+
     upload_online_build_expected_inputs = [SITE_CONTENT_GIT_IDENTIFIER]
     for input in upload_online_build_task["config"]["inputs"]:  # noqa: A001
         assert input["name"] in upload_online_build_expected_inputs


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/6333
### Description (What does it do?)
This change fixes the `course‑collection` (and other content types) not being deleted from the S3 bucket upon removal. It wasn't deleted because we were using the `cp` command instead of `sync`. We use `sync` for courses, and previously, we used `sync` for `ocw-www` as well, but we switched to using `cp` for performance concerns -- especially related to Concourse workers. `sync` is now re-added but only on a narrowed target to avoid degrading Concourse performance.

This adds deletion behavior while avoiding a full‑bucket sync.

Thanks to @gumaerc for implementing the fix.

### How can this be tested?
 - Check out this branch and make sure you have a recent database restore as well as all the prerequisites outlined in the README for publishing courses locally set up. 
 - Then spin up `ocw-studio` with `docker-compose up`.
 - Backpopulate the `ocw-www` pipeline on your local Concourse with `docker-compose exec web ./manage.py backpopulate_pipelines --filter ocw-www`
 - Open the `ocw-studio` UI (http://localhost:8043/sites/) as well as the Concourse UI (http://localhost:8080) in two tabs
 - Create an external resource in `ocw-www`. Publish `ocw-www` from the `ocw-studio` UI. Now delete the external resource you created from the studio UI, and republish it.
 - Then find its pipeline in the Concourse UI. Wait for the `upload-online-build` task to complete for the most recent run and check the logs. It should have a `delete:` log for the ER that was deleted.
