### PR TITLE
regenerate mass build pipeline on site unpublish from UI

### DIFF
--- a/content_sync/api.py
+++ b/content_sync/api.py
@@ -199,7 +199,9 @@ def publish_website(  # pylint: disable=too-many-arguments
         raise
     finally:
         Website.objects.filter(name=name).update(**update_kwargs)
-        tasks.update_mass_build_pipelines_on_publish(version=version, website=website)
+        tasks.update_mass_build_pipelines_on_publish.delay(
+            version=version, website_pk=website.pk
+        )
 
 
 def throttle_git_backend_calls(backend: object, min_delay: Optional[int] = None):

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -248,7 +248,7 @@ def sync_website_content(website_name: str):
 
 
 @app.task(acks_late=True)
-def update_mass_build_pipelines_on_publish(version: str, website: Website):
+def update_mass_build_pipelines_on_publish(version: str, website_pk: int):
     """
     Update the mass-build-sites pipeline definitions upon publishing of a new website,
     but only do so if the site has never been published before or has been unpublished
@@ -261,6 +261,7 @@ def update_mass_build_pipelines_on_publish(version: str, website: Website):
         publish_date_field = (
             "publish_date" if version == VERSION_LIVE else "draft_publish_date"
         )
+        website = Website.objects.get(pk=website_pk)
         publish_date = getattr(website, publish_date_field)
         if not publish_date or website.unpublish_status:
             pipeline = api.get_mass_build_sites_pipeline(version)

--- a/content_sync/tasks_test.py
+++ b/content_sync/tasks_test.py
@@ -119,23 +119,35 @@ def test_update_mass_build_pipelines(api_mock):
     fake_date = factory.Faker("date_time", tzinfo=pytz.utc)
     website.draft_publish_date = None
     website.publish_date = None
-    tasks.update_mass_build_pipelines_on_publish(version=VERSION_DRAFT, website=website)
+    tasks.update_mass_build_pipelines_on_publish.delay(
+        version=VERSION_DRAFT, website_pk=website.pk
+    )
     api_mock.get_mass_build_sites_pipeline.assert_any_call(VERSION_DRAFT)
     api_mock.get_mass_build_sites_pipeline.assert_any_call(VERSION_DRAFT, offline=True)
     assert api_mock.get_mass_build_sites_pipeline.call_count == 2
     website.draft_publish_date = fake_date
-    tasks.update_mass_build_pipelines_on_publish(version=VERSION_DRAFT, website=website)
+    tasks.update_mass_build_pipelines_on_publish.delay(
+        version=VERSION_DRAFT, website_pk=website.pk
+    )
     assert api_mock.get_mass_build_sites_pipeline.call_count == 2
-    tasks.update_mass_build_pipelines_on_publish(version=VERSION_LIVE, website=website)
+    tasks.update_mass_build_pipelines_on_publish.delay(
+        version=VERSION_LIVE, website_pk=website.pk
+    )
     api_mock.get_mass_build_sites_pipeline.assert_any_call(VERSION_LIVE)
     api_mock.get_mass_build_sites_pipeline.assert_any_call(VERSION_LIVE, offline=True)
     assert api_mock.get_mass_build_sites_pipeline.call_count == 4
     website.publish_date = fake_date
-    tasks.update_mass_build_pipelines_on_publish(version=VERSION_LIVE, website=website)
+    tasks.update_mass_build_pipelines_on_publish.delay(
+        version=VERSION_LIVE, website_pk=website.pk
+    )
     assert api_mock.get_mass_build_sites_pipeline.call_count == 4
     website.unpublish_status = PUBLISH_STATUS_NOT_STARTED
-    tasks.update_mass_build_pipelines_on_publish(version=VERSION_DRAFT, website=website)
-    tasks.update_mass_build_pipelines_on_publish(version=VERSION_LIVE, website=website)
+    tasks.update_mass_build_pipelines_on_publish.delay(
+        version=VERSION_DRAFT, website_pk=website.pk
+    )
+    tasks.update_mass_build_pipelines_on_publish.delay(
+        version=VERSION_LIVE, website_pk=website.pk
+    )
     assert api_mock.get_mass_build_sites_pipeline.call_count == 8
 
 

--- a/content_sync/tasks_test.py
+++ b/content_sync/tasks_test.py
@@ -113,9 +113,10 @@ def test_sync_website_content_not_exists(api_mock, log_mock):
     api_mock.get_sync_backend.assert_not_called()
 
 
-def test_update_mass_build_pipelines(api_mock):
+def test_update_mass_build_pipelines(api_mock, mocker):
     """Verify that mass_build_sites pipelines are upserted under the proper conditions"""
     website = WebsiteFactory.create()
+    mocker.patch("content_sync.tasks.Website.objects.get", return_value=website)
     fake_date = factory.Faker("date_time", tzinfo=pytz.utc)
     website.draft_publish_date = None
     website.publish_date = None

--- a/websites/management/commands/unpublish_sites.py
+++ b/websites/management/commands/unpublish_sites.py
@@ -121,8 +121,8 @@ class Command(WebsiteFilterCommand):
                 site_pipeline = api.get_site_pipeline(website)
                 site_pipeline.pause_pipeline(VERSION_LIVE)
                 remove_website_in_root_website(website)
-                update_mass_build_pipelines_on_publish(
-                    version=VERSION_LIVE, website=website
+                update_mass_build_pipelines_on_publish.delay(
+                    version=VERSION_LIVE, website_pk=website.pk
                 )
         removal_pipeline = api.get_unpublished_removal_pipeline()
         removal_pipeline.unpause()

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -460,7 +460,6 @@ def test_websites_endpoint_unpublish_error(drf_client, mocker):
     resp = drf_client.post(
         reverse("websites_api-unpublish", kwargs={"name": website.name})
     )
-    assert True
     assert resp.status_code == 500
     assert resp.data == {"details": "oops"}
 

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -460,6 +460,7 @@ def test_websites_endpoint_unpublish_error(drf_client, mocker):
     resp = drf_client.post(
         reverse("websites_api-unpublish", kwargs={"name": website.name})
     )
+    assert True
     assert resp.status_code == 500
     assert resp.data == {"details": "oops"}
 


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7049

### Description (What does it do?)
This PR adds a call to `update_mass_build_pipelines_on_publish` when the unpublish button is clicked from the `ocw-studio` UI. This will regenerate and upsert the live online mass build pipeline when sites are unpublished, ensuring that they are not unintentionally re-published during runs of the mass build.

### How can this be tested?
- Make sure that you can run `ocw-studio` locally and are set up to publish course sites locally. This means you have pushed up the theme assets pipeline and run it at least one, pushed up individual site pipelines with the `backpopulate_pipelines` command and published `ocw-www` at least once so all instructors are published and ready for query.
- Make sure you have the `fly` CLI installed and have your locally running Concourse set up as a target called `local`
- Spin up `ocw-studio` on this branch
- Make sure you have the mass build pipeline in your Concourse instance by running `docker compose exec web ./manage.py upsert_mass_build_pipeline`
- Make sure you have the site removal pipeline upserted with `docker compose exec web ./manage.py upsert_site_removal_pipeline`
- Make sure you have the individual site pipeline upserted to Concourse for the site you are testing, for example `docker compose exec web ./manage.py backpopulate_pipelines --filter 18-102-introduction-to-functional-analysis-spring-2021`
- First of all, publish your site live from the UI at http://localhost:8043/sites
- Verify that the site is included in the mass build pipeline definition by running `fly -t local get-pipeline -p 'mass-build-sites/offline:false,prefix:"",projects_branch:main,starter:"",themes_branch:main,version:live' | grep 18-102-introduction-to-functional-analysis-spring-2021 -A 5 -B 5`, replacing the course name in my example here with the name of whatever course you're testing. You should see many lines of output that looks like:

```yaml
      - artifacts_bucket: ol-eng-artifacts
        base_url: courses/18-102-introduction-to-functional-analysis-spring-2021
        delete_flag: ' --delete'
        hugo_args_offline: --themesDir ../ocw-hugo-themes-git/ --config ../ocw-hugo-projects-git/ocw-course-v2/config-offline.yaml
          --baseURL / --destination output-offline
        hugo_args_online: --themesDir ../ocw-hugo-themes-git/ --config ../ocw-hugo-projects-git/ocw-course-v2/config.yaml
          --baseURL /courses/18-102-introduction-to-functional-analysis-spring-2021
          --destination output-online
        instance_vars: ?vars=%7B%22site%22%3A%20%2218-102-introduction-to-functional-analysis-spring-2021%22%7D
        is_root_website: 0
        noindex: "true"
        ocw_hugo_projects_branch: main
        ocw_hugo_projects_url: https://github.com/mitodl/ocw-hugo-projects.git
        ocw_hugo_themes_branch: main
        ocw_studio_url: http://10.1.0.102:8043
        offline_bucket: ocw-content-offline-live
        pipeline_name: live
        prefix: ""
        resource_base_url: https://ocw.c4103.com
        s3_path: courses/18-102-introduction-to-functional-analysis-spring-2021
        short_id: 18.102-spring-2021
        site_content_branch: release
        site_name: 18-102-introduction-to-functional-analysis-spring-2021
        sitemap_domain: live-qa.ocw.mit.edu
        static_api_url: http://10.1.0.102:8045
        static_resources_subdirectory: /
        storage_bucket: ol-ocw-studio-app
        url_path: courses/18-102-introduction-to-functional-analysis-spring-2021
        web_bucket: ocw-content-live
```
- Go back to http://localhost:8043/sites and find your course in the list, then click the 3 dots context menu on the right and click unpublish, then confirm the unpublish in the dialog
- In Concourse, ensure that the site removal pipeline ran and removed the site
- Re-run the above `fly` command and you should see no output, indicating that the site has been removed from the mass build pipeline definition. You may need to wait a few minutes depending on the Celery queue and the speed of your machine.