### PR TITLE
fix(build-offline-site): extract MP4s from static_resources before Hugo build

### DIFF
--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -670,7 +670,7 @@ class SitePipelineOfflineTasks(list[StepModifierMixin]):
         MP4_COUNT="$(ls -1 ./content/static_resources/*.mp4 2>/dev/null | wc -l)"
         if [ $MP4_COUNT != 0 ];
         then
-        mv ../videos/* ./content/static_resources
+        mv ./content/static_resources/*.mp4 ../videos
         fi
         touch ./content/static_resources/_index.md
         cp -r ../{WEBPACK_ARTIFACTS_IDENTIFIER}/static_shared/. ./static/static_shared/


### PR DESCRIPTION
### Description (What does it do?)
Restores the `build-offline-site` step modified in https://github.com/mitodl/ocw-studio/pull/2479
From:
`mv ../videos/* ./content/static_resources`

Back to:
`mv ./content/static_resources/*.mp4 ../videos`

For non-root sites, we need to pull any MP4s out of `content/static_resources` into `../videos` before running Hugo. That extract step was accidentally overwritten in the above PR.

### How can this be tested?
Although there are a number of ways to test this, but the simpler way is to just look at the logs over here:

Where the step causes build error: https://cicd-qa.odl.mit.edu/teams/ocw/pipelines/draft/jobs/offline-site-job/builds/148?vars.site=%22ibrahims-cat-course%22

And here, where site hadn't been backpopulated yet so it worked same as before:
https://cicd-qa.odl.mit.edu/teams/ocw/pipelines/draft/jobs/offline-site-job/builds/147?vars.site=%22ibrahims-cat-course%22 (`build-offline-site`)
