### PR TITLE
Umar/6380 unrelated resources in offline course

### DIFF
--- a/websites/management/commands/detect_unrelated_content.py
+++ b/websites/management/commands/detect_unrelated_content.py
@@ -52,8 +52,9 @@ class Command(WebsiteFilterCommand):
     def handle(self, *args, **options):
         """
         Handle the command execution
-        :param args: Positional arguments
-        :param options: Keyword arguments
+        Args:
+            *args: Positional arguments
+            **options: Keyword arguments
         """
 
         super().handle(*args, **options)


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/6380

### Description (What does it do?)
Check unrelated content in courses added after the Plone migration.

### How can this be tested?
1. Switch to this branch and spin up `ocw-studio` in your local environment.
2. Create a `test` course in your local OCW Studio or select an existing one.
3. Go to your local instance of S3 (MinIO), which should be at `localhost:9001`, and log in.
5. Upload a file at `{AWS_STORAGE_BUCKET_NAME}/courses/{selected_course_name}/`
6. Run `docker-compose exec -it web ./manage.py detect_unrelated_content` in a terminal. This command should return the uploaded file name against the course.

### Additional Testing
1. Test related `thumbnails`, `transcripts` etc are not included in the results.