### PR TITLE
Upgrade mitol-django-transcoding and boto3 libraries

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -148,34 +148,34 @@ files = [
 
 [[package]]
 name = "boto3"
-version = "1.37.11"
+version = "1.38.13"
 description = "The AWS SDK for Python"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "boto3-1.37.11-py3-none-any.whl", hash = "sha256:da6c22fc8a7e9bca5d7fc465a877ac3d45b6b086d776bd1a6c55bdde60523741"},
-    {file = "boto3-1.37.11.tar.gz", hash = "sha256:8eec08363ef5db05c2fbf58e89f0c0de6276cda2fdce01e76b3b5f423cd5c0f4"},
+    {file = "boto3-1.38.13-py3-none-any.whl", hash = "sha256:668400d13889d2d2fcd66ce785cc0b0fc040681f58a9c7f67daa9149a52b6c63"},
+    {file = "boto3-1.38.13.tar.gz", hash = "sha256:6633bce2b73284acce1453ca85834c7c5a59e0dbcce1170be461cc079bdcdfcf"},
 ]
 
 [package.dependencies]
-botocore = ">=1.37.11,<1.38.0"
+botocore = ">=1.38.13,<1.39.0"
 jmespath = ">=0.7.1,<2.0.0"
-s3transfer = ">=0.11.0,<0.12.0"
+s3transfer = ">=0.12.0,<0.13.0"
 
 [package.extras]
 crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.37.11"
+version = "1.38.13"
 description = "Low-level, data-driven core of boto 3."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "botocore-1.37.11-py3-none-any.whl", hash = "sha256:02505309b1235f9f15a6da79103ca224b3f3dc5f6a62f8630fbb2c6ed05e2da8"},
-    {file = "botocore-1.37.11.tar.gz", hash = "sha256:72eb3a9a58b064be26ba154e5e56373633b58f951941c340ace0d379590d98b5"},
+    {file = "botocore-1.38.13-py3-none-any.whl", hash = "sha256:de29fee43a1f02787fb5b3756ec09917d5661ed95b2b2d64797ab04196f69e14"},
+    {file = "botocore-1.38.13.tar.gz", hash = "sha256:22feee15753cd3f9f7179d041604078a1024701497d27b22be7c6707e8d13ccb"},
 ]
 
 [package.dependencies]
@@ -2057,18 +2057,18 @@ toolz = ">=0.10.0"
 
 [[package]]
 name = "mitol-django-transcoding"
-version = "2025.4.23"
+version = "2025.5.9"
 description = "MIT Open Learning Django app extension for Transcoding jobs"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "mitol_django_transcoding-2025.4.23-py3-none-any.whl", hash = "sha256:be56f66cee7b41196d1c7ea7f27fb7b6e4f6267a3aa0d1c2bf99582a26f6e1cb"},
-    {file = "mitol_django_transcoding-2025.4.23.tar.gz", hash = "sha256:91a0eb522b288f18d397390ffb032f8816173fefd0b31ff379f0f3d4286c1015"},
+    {file = "mitol_django_transcoding-2025.5.9-py3-none-any.whl", hash = "sha256:b437eddc193c97968e600a75f8fcc10ff0cb49db6c43ef7a9437ede801c9aa38"},
+    {file = "mitol_django_transcoding-2025.5.9.tar.gz", hash = "sha256:af2529703472547f2fcc1672e266761667e01d6896ca2edd3ee782befa210d7d"},
 ]
 
 [package.dependencies]
-boto3 = "1.37.11"
+boto3 = ">=1.37.11,<2.0"
 django = ">=3.0"
 django-stubs = ">=1.13.1"
 mitol-django-common = "*"
@@ -3219,21 +3219,21 @@ files = [
 
 [[package]]
 name = "s3transfer"
-version = "0.11.1"
+version = "0.12.0"
 description = "An Amazon S3 Transfer Manager"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "s3transfer-0.11.1-py3-none-any.whl", hash = "sha256:8fa0aa48177be1f3425176dfe1ab85dcd3d962df603c3dbfc585e6bf857ef0ff"},
-    {file = "s3transfer-0.11.1.tar.gz", hash = "sha256:3f25c900a367c8b7f7d8f9c34edc87e300bde424f779dc9f0a8ae4f9df9264f6"},
+    {file = "s3transfer-0.12.0-py3-none-any.whl", hash = "sha256:35b314d7d82865756edab59f7baebc6b477189e6ab4c53050e28c1de4d9cce18"},
+    {file = "s3transfer-0.12.0.tar.gz", hash = "sha256:8ac58bc1989a3fdb7c7f3ee0918a66b160d038a147c7b5db1500930a607e9a1c"},
 ]
 
 [package.dependencies]
-botocore = ">=1.36.0,<2.0a.0"
+botocore = ">=1.37.4,<2.0a.0"
 
 [package.extras]
-crt = ["botocore[crt] (>=1.36.0,<2.0a.0)"]
+crt = ["botocore[crt] (>=1.37.4,<2.0a.0)"]
 
 [[package]]
 name = "semantic-version"
@@ -3822,4 +3822,4 @@ ruamel = ["ruamel.yaml"]
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.12"
-content-hash = "d7cef425923896e7c19ed7a4f404172589ab7b94744697e5500cb1ed2b2377f5"
+content-hash = "823c2845f71de4b009d4af76885dce09caaf26af9c6c757b8f706f3472efb803"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ package-mode = false
 python = "~3.12"
 
 beautifulsoup4 = "^4.12.2"
-boto3 = "1.37.11"
+boto3 = "1.38.13"
 celery = "^5.3.0"
 cryptography = "^44.0.0"
 dj-database-url = "2.3.0"
@@ -56,7 +56,7 @@ uwsgitop = "^0.12"
 yamale = "6.0.0"
 xmlsec = "1.3.13"
 posthog = "^3.7.0"
-mitol-django-transcoding = "2025.4.23"
+mitol-django-transcoding = "2025.5.9"
 
 [tool.poetry.group.dev.dependencies]
 bpython = "^0.25"


### PR DESCRIPTION
### What are the relevant tickets?
N/A; follow-up to https://github.com/mitodl/ol-django/pull/243.

### Description (What does it do?)
This PR upgrades the `mitol-django-transcoding` and `boto3` libraries to the latest versions. Automatic updates of `boto3` had not been possible before because of the strict `boto3` version dependency in `mitol-django-transcoding`. Now that this has been resolved, this PR updates `ocw-studio` to use the latest versions.

### How can this be tested?
Smoke-test the functionality associated with S3, including syncing with Google Drive.