### PR TITLE
included website url_path in prefix to detect unrelated files

### DIFF
--- a/websites/management/commands/detect_unrelated_content.py
+++ b/websites/management/commands/detect_unrelated_content.py
@@ -116,17 +116,11 @@ class Command(WebsiteFilterCommand):
             s3.meta.client, settings.AWS_STORAGE_BUCKET_NAME, prefix
         )
         if s3_file_keys:
-            website_content_files = WebsiteContent.objects.filter(
-                website=website, file__isnull=False
-            ).values_list("file", flat=True)
-            normalized_website_content_files = {
-                wc.removeprefix("/") for wc in website_content_files if wc
-            }
+            normalized_website_content_files = self._filter_unrelated_files(website)
 
             unrelated_website_files = list(
                 s3_file_keys - normalized_website_content_files
             )
-
             if unrelated_website_files:
                 self.unrelated_files_count += len(unrelated_website_files)
                 unrelated_files_by_site[website.name] = unrelated_website_files


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/6380

### Description (What does it do?)
This PR checks uses `s3_path` as prefix for matching files in s3. It was observed that the video metadata has file paths starting differently than the s3_path of website. This adds false positives in our detection for unrelated files.

### How can this be tested?
1. Switch to this branch and spin up `ocw-studio` in your local environment.
2. Create a `test` course in your local OCW Studio or select an existing one.
3. Go to your local instance of S3 (MinIO), which should be at `localhost:9001`, and log in.
5. Upload a file at `{AWS_STORAGE_BUCKET_NAME}/courses/{selected_course_name}/`
6. Run `docker-compose exec -it web ./manage.py detect_unrelated_content` in a terminal. This command should return the uploaded file name against the course.

### Additional Testing
1. Test related `thumbnails`, `transcripts`, etc are not included in the results.