### PR TITLE
Fix gdrive_sync video processing issues and improve multipart upload reliability

### DIFF
--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -312,6 +312,10 @@ def stream_to_s3(drive_file: DriveFile):
         )
         drive_file.update_status(DriveFileStatus.UPLOAD_COMPLETE)
     except Exception as exc:
+        log.exception(
+            "An error occurred uploading Google Drive file %s to S3",
+            drive_file.name,
+        )
         drive_file.sync_error = f"An error occurred uploading Google Drive file {drive_file.name} to S3: {exc}"  # noqa: E501
         drive_file.update_status(DriveFileStatus.UPLOAD_FAILED)
         raise

--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -61,6 +61,9 @@ from websites.site_config_api import SiteConfig
 from websites.utils import get_valid_base_filename
 
 log = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+logging.getLogger("boto3").setLevel(logging.DEBUG)
+logging.getLogger("botocore").setLevel(logging.DEBUG)
 
 
 class GDriveStreamReader:

--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -61,9 +61,6 @@ from websites.site_config_api import SiteConfig
 from websites.utils import get_valid_base_filename
 
 log = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
-logging.getLogger("boto3").setLevel(logging.DEBUG)
-logging.getLogger("botocore").setLevel(logging.DEBUG)
 
 
 class GDriveStreamReader:

--- a/gdrive_sync/api_test.py
+++ b/gdrive_sync/api_test.py
@@ -788,8 +788,12 @@ def test_transcode_gdrive_video_error(settings, mocker):
     with pytest.raises(ClientError):
         transcode_gdrive_video(drive_file)
     drive_file.refresh_from_db()
-    mock_log.assert_called_once_with(
-        "Error creating transcode job for %s", drive_file.video.source_key
+    assert all(
+        call_args
+        == mocker.call(
+            "Error creating transcode job for %s", drive_file.video.source_key
+        )
+        for call_args in mock_log.call_args_list
     )
     assert drive_file.video.status == VideoStatus.FAILED
 

--- a/gdrive_sync/api_test.py
+++ b/gdrive_sync/api_test.py
@@ -176,30 +176,23 @@ def test_stream_to_s3(settings, mocker, is_video, current_s3_key):
 
 
 @pytest.mark.django_db()
-@pytest.mark.parametrize("num_errors", [2, 3, 4])
-def test_stream_to_s3_error(settings, mocker, num_errors):
-    """Task should mark DriveFile status as failed if an s3 upload error occurs more often than retries"""
+@pytest.mark.parametrize("fail_at", ["bucket", "upload"])
+def test_stream_to_s3_error_marks_failed(settings, mocker, fail_at):
+    """Task should mark DriveFile status as UPLOAD_FAILED and raise if S3 upload errors occur."""
     settings.ENVIRONMENT = "test"
-    settings.CONTENT_SYNC_RETRIES = 3
-    should_raise = num_errors >= 3
     mocker.patch("gdrive_sync.api.GDriveStreamReader")
     mock_boto3 = mocker.patch("main.s3_utils.boto3")
-    mock_boto3.resource.return_value.Bucket.side_effect = [
-        *[HTTPError() for _ in range(num_errors)],
-        mocker.Mock(),
-    ]
-    drive_file = DriveFileFactory.create(status=DriveFileStatus.CREATED)
-    if should_raise:
-        with pytest.raises(HTTPError):
-            api.stream_to_s3(drive_file)
+    if fail_at == "bucket":
+        mock_boto3.resource.return_value.Bucket.side_effect = HTTPError()
     else:
+        mock_bucket = mock_boto3.resource.return_value.Bucket.return_value
+        mock_bucket.upload_fileobj.side_effect = HTTPError()
+    drive_file = DriveFileFactory.create(status=DriveFileStatus.CREATED)
+    with pytest.raises(HTTPError):
         api.stream_to_s3(drive_file)
+
     drive_file.refresh_from_db()
-    assert drive_file.status == (
-        DriveFileStatus.UPLOAD_FAILED
-        if should_raise
-        else DriveFileStatus.UPLOAD_COMPLETE
-    )
+    assert drive_file.status == DriveFileStatus.UPLOAD_FAILED
 
 
 @pytest.mark.django_db()

--- a/gdrive_sync/api_test.py
+++ b/gdrive_sync/api_test.py
@@ -166,6 +166,7 @@ def test_stream_to_s3(settings, mocker, is_video, current_s3_key):
         Fileobj=mocker.ANY,
         Key=expected_key,
         ExtraArgs=expected_extra_args,
+        Config=mocker.ANY,
     )
     mock_download.assert_called_once_with(drive_file)
     drive_file.refresh_from_db()

--- a/videos/constants.py
+++ b/videos/constants.py
@@ -16,7 +16,7 @@ WEBVTT_FORMAT_ID = 51
 
 
 class VideoStatus:
-    """Simple class for possible VideoFile statuses"""
+    """Simple class for possible Video statuses"""
 
     CREATED = STATUS_CREATED
     TRANSCODING = "Transcoding"

--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -189,6 +189,7 @@ def update_youtube_statuses(self):
                     )
                     resource.save()
                     video_file.status = VideoFileStatus.COMPLETE
+                    video_file.save()
                     group_tasks.append(start_transcript_job.s(video_file.video.id))
                     mail_youtube_upload_success(video_file)
 

--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -149,7 +149,7 @@ def start_transcript_job(video_id: int):
 
 @app.task(bind=True)
 @single_task(timeout=settings.YT_STATUS_UPDATE_FREQUENCY, raise_block=False)
-def update_youtube_statuses(self):  # noqa: C901
+def update_youtube_statuses(self):
     """
     Update the status of recently uploaded YouTube videos if complete
     """
@@ -165,14 +165,17 @@ def update_youtube_statuses(self):  # noqa: C901
     for video_file in videos_processing:
         try:
             with transaction.atomic():
-                video_file.destination_status = youtube.video_status(
-                    video_file.destination_id
-                )
-                if video_file.destination_status == YouTubeStatus.PROCESSED:
-                    video_file.status = VideoFileStatus.COMPLETE
-                video_file.save()
+                if video_file.destination_status != YouTubeStatus.PROCESSED:
+                    video_file.destination_status = youtube.video_status(
+                        video_file.destination_id
+                    )
+                    video_file.save()
                 drive_file = DriveFile.objects.filter(video=video_file.video).first()
-                if drive_file and drive_file.resource:
+                if (
+                    video_file.destination_status == YouTubeStatus.PROCESSED
+                    and drive_file
+                    and drive_file.resource
+                ):
                     resource = drive_file.resource
                     set_dict_field(
                         resource.metadata,
@@ -185,10 +188,9 @@ def update_youtube_statuses(self):  # noqa: C901
                         YT_THUMBNAIL_IMG.format(video_id=video_file.destination_id),
                     )
                     resource.save()
-                    if video_file.status == VideoFileStatus.COMPLETE:
-                        group_tasks.append(start_transcript_job.s(video_file.video.id))
-            if video_file.status == VideoFileStatus.COMPLETE:
-                mail_youtube_upload_success(video_file)
+                    video_file.status = VideoFileStatus.COMPLETE
+                    group_tasks.append(start_transcript_job.s(video_file.video.id))
+                    mail_youtube_upload_success(video_file)
 
         except IndexError:
             # Video might be a dupe or deleted, mark it as failed and continue to next one.  # noqa: E501

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -477,14 +477,20 @@ def test_mail_youtube_upload_success_trigger(mocker, youtube_status, file_status
     mock_mail_success = mocker.patch("videos.tasks.mail_youtube_upload_success")
     mock_video_status = mocker.patch("videos.tasks.YouTubeApi.video_status")
     mock_video_status.return_value = youtube_status
+    mocker.patch("videos.tasks.start_transcript_job.s")
+    mocker.patch.object(update_youtube_statuses, "replace")
 
-    VideoFileFactory.create(
+    video_file = VideoFileFactory.create(
         id=1,
         status=file_status,
         destination_status=youtube_status,
         destination=DESTINATION_YOUTUBE,
     )
-
+    drive_file = DriveFileFactory.create(video=video_file.video)
+    resource = WebsiteContentFactory.create(website=drive_file.website)
+    resource.save()
+    drive_file.resource = resource
+    drive_file.save()
     update_youtube_statuses.delay()
 
     # The following is the combination of statuses that moves the VideoFile


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7086

### Description (What does it do?)
There were two issues reported for different courses where `gdrive_sync` process for videos failed/stalled/worked partially. Some of the videos in both cases were also very large in size (~6gb+).

These are the tickets:
https://github.com/mitodl/hq/issues/7114
https://github.com/mitodl/hq/issues/6818

The error in them as returned by Celery was `drive_file.resource` returned `None` in `update_youtube_statuses`.
In one course, WebsiteContent objects were not made and in another, WebsiteContent objects were not updated to add `youtube_id`.
Another thing reported by Celery was there were 4 unfinished `process_drive_file` tasks, started by 1 unfinished `import_website_files` task.

This PR attempts to fix these problems by implementing different things:
  - Refactoring code to not update VideoFileStatus to COMPLETE if the WebsiteContent is not yet ready; thus allowing it to be retried until it is created
  - Adding a retry logic with backoff in `process_drive_file`
  - Using `TransferConfig` with custom configuration (64 mb chunks) for better multiparting in stream_to_s3 function for large video uploads.
  - Making the overall video process robust: e.g., hitting `YouTubeAPI` only when needed

### How can this be tested?
Make sure the video process works as expected. Try uploading large videos (1gb+) to gdrive and sync. Make sure all the relevant objects are made (`WebsiteContent`, `Video`, `DriveFile`).
