### PR TITLE
added latest version for transcoding app

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2079,14 +2079,14 @@ toolz = ">=0.10.0"
 
 [[package]]
 name = "mitol-django-transcoding"
-version = "2025.5.9"
+version = "2025.5.21"
 description = "MIT Open Learning Django app extension for Transcoding jobs"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "mitol_django_transcoding-2025.5.9-py3-none-any.whl", hash = "sha256:b437eddc193c97968e600a75f8fcc10ff0cb49db6c43ef7a9437ede801c9aa38"},
-    {file = "mitol_django_transcoding-2025.5.9.tar.gz", hash = "sha256:af2529703472547f2fcc1672e266761667e01d6896ca2edd3ee782befa210d7d"},
+    {file = "mitol_django_transcoding-2025.5.21-py3-none-any.whl", hash = "sha256:0bf29ca82adf059c66def1841b55bd117d9ce5e35b0db6a7bd30647880c24baa"},
+    {file = "mitol_django_transcoding-2025.5.21.tar.gz", hash = "sha256:456b444f606d7bad032a1249fd4c8789a3c5c08f15e72353bb00b8878cbe487f"},
 ]
 
 [package.dependencies]
@@ -3833,4 +3833,4 @@ ruamel = ["ruamel.yaml"]
 [metadata]
 lock-version = "2.1"
 python-versions = "~3.12"
-content-hash = "5218111d41164396c021066eefc02cdcde0ac19f809a8759ff3e25d61a74c80a"
+content-hash = "b65b7c504d72c0feadf6bd51fd0bcd83eceacaa6b7ff678d59a113d8d3998b53"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ uwsgitop = "^0.12"
 yamale = "6.0.0"
 xmlsec = "1.3.13"
 posthog = "^4.0.0"
-mitol-django-transcoding = "2025.5.9"
+mitol-django-transcoding = "^2025.5.21"
 
 [tool.poetry.group.dev.dependencies]
 bpython = "^0.25"


### PR DESCRIPTION
### What are the relevant tickets?
part of https://github.com/mitodl/hq/issues/7328

### Description (What does it do?)
This update transcoding app to latest version that does not supresss client errors

### How can this be tested?
1. Switch to this branch and spin up containers
2. Add a video via GDrive and wait for it to sync
3. Smoke test the transcoding workflow.