### PR TITLE
Downgrade reactstrap to v8.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "react-select": "^4.3.0",
     "react-select-async-paginate": "^0.7.3",
     "react-test-renderer": "^16.13.1",
-    "reactstrap": "^8.9.0",
+    "reactstrap": "8.10.1",
     "redux": "^4.0.5",
     "redux-query": "^3.4.2",
     "redux-query-interface-superagent": "^3.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11166,7 +11166,7 @@ __metadata:
     react-select: ^4.3.0
     react-select-async-paginate: ^0.7.3
     react-test-renderer: ^16.13.1
-    reactstrap: ^8.9.0
+    reactstrap: 8.10.1
     redux: ^4.0.5
     redux-query: ^3.4.2
     redux-query-interface-superagent: ^3.4.2
@@ -12817,7 +12817,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"reactstrap@npm:^8.9.0":
+"reactstrap@npm:8.10.1":
   version: 8.10.1
   resolution: "reactstrap@npm:8.10.1"
   dependencies:


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7536.

### Description (What does it do?)
In https://github.com/mitodl/ocw-studio/pull/2535, reactstrap was upgraded to v9. However, this version is not compatible with the Bootstrap version currently in use (v4), causing an issue where some icons in OCW Studio fail to display. While a longer-term solution involves rethinking the UI and possibly updating both Bootstrap and reactstrap, this PR fixes the immediate issue.

### How can this be tested?
Run `docker compose up` to bring up OCW Studio locally. Verify that the window icons now display properly.