### PR TITLE
Umar/5356 migrate links in markdown to external resources

### DIFF
--- a/websites/management/commands/markdown_cleaning/rules/link_to_external_resource.py
+++ b/websites/management/commands/markdown_cleaning/rules/link_to_external_resource.py
@@ -194,11 +194,9 @@ class LinkToExternalResourceRule(PyparsingRule):
             title=link_text,
         )
 
-        if self.options.get("commit", True):
+        if self.options.get("commit", False):
             resource.save()
-
-        resource.referencing_content.add(website_content)
-        resource.save()
+            resource.referencing_content.add(website_content)
 
         shortcode = ShortcodeTag.resource_link(resource.text_id, link_text)
 
@@ -287,11 +285,9 @@ class NavItemToExternalResourceRule(MarkdownCleanupRule):
             title=link_text,
         )
 
-        if self.options.get("commit", True):
+        if self.options.get("commit", False):
             resource.save()
-
-        resource.referencing_content.add(website_content)
-        resource.save()
+            resource.referencing_content.add(website_content)
 
         item_replacement = {
             **item,

--- a/websites/management/commands/markdown_cleanup.py
+++ b/websites/management/commands/markdown_cleanup.py
@@ -23,7 +23,10 @@ log = logging.getLogger(__name__)
 
 class Command(WebsiteFilterCommand):
     """
-    Performs replacements on markdown. Excludes unpublished websites.
+    Performs replacements on markdown.
+
+    By default, processes all websites (published and unpublished).
+    Use --published-only to process only published websites.
 
     In general, these commands can be run in any order and are independent from
     one another. It may be useful to run LinkUnescape before other link fixes if
@@ -99,6 +102,13 @@ class Command(WebsiteFilterCommand):
             default=None,
             help="If supplied, at most this many WebsiteContent pages will be scanned.",
         )
+        parser.add_argument(
+            "--published-only",
+            dest="published_only",
+            action="store_true",
+            default=False,
+            help="If provided, only process published websites. Otherwise, process all websites.",  # noqa: E501
+        )
 
     @classmethod
     def validate_options(cls, options):
@@ -117,11 +127,15 @@ class Command(WebsiteFilterCommand):
         super().handle(*args, **options)
         self.validate_options(options)
         website_contents = (
-            WebsiteContent.all_objects.all()
-            .exclude(website__publish_date__isnull=True)
-            .order_by("id")
-            .prefetch_related("website")
+            WebsiteContent.all_objects.all().order_by("id").prefetch_related("website")
         )
+
+        # Only exclude unpublished websites if --published-only is specified
+        if options["published_only"]:
+            website_contents = website_contents.exclude(
+                website__publish_date__isnull=True
+            )
+
         website_contents = self.filter_website_contents(
             website_contents=website_contents
         )


### PR DESCRIPTION
### What are the relevant tickets?
part of https://github.com/mitodl/hq/issues/5356

### Description (What does it do?)
This PR adds proper referencing content tracking for the `link_to_external_resource` rule and introduces a new `--published-only` option for the markdown cleanup command.

### How can this be tested?
## Testing

### Manual Testing
```bash
# Test default behavior (all websites)
`docker compose exec web ./manage.py markdown_cleanup link_to_external_resource --filter my_site --commit`

# Test published-only behavior  
`docker compose exec web ./manage.py markdown_cleanup link_to_external_resource --filter my_site --commit --published-only`