### PR TITLE
chore(fix): updated color scheme and text for course states

### DIFF
--- a/static/js/pages/SitesDashboard.tsx
+++ b/static/js/pages/SitesDashboard.tsx
@@ -106,7 +106,7 @@ export const getMostRecentStatus = (
         site.draft_publish_status === PublishStatus.Success,
       statusText: "Draft",
       hoverText: "Draft updated",
-      className: "text-secondary",
+      className: "text-info",
       dateTime: site.draft_publish_date,
     },
     {
@@ -121,7 +121,7 @@ export const getMostRecentStatus = (
       active:
         site.unpublish_status &&
         site.unpublish_status === PublishStatus.Success,
-      statusText: "Unpublished from Production",
+      statusText: "Unpublished",
       className: "text-dark",
       dateTime: site.unpublish_status_updated_on,
     },
@@ -176,7 +176,7 @@ export const getMostRecentStatus = (
   // No active statuses - never published
   return {
     status: "Never Published",
-    statusClass: "text-danger",
+    statusClass: "text-orange",
     dateTime: null,
   }
 }

--- a/static/scss/common.scss
+++ b/static/scss/common.scss
@@ -43,3 +43,7 @@ a.underline {
 .font-size-75 {
   font-size: 75% !important;
 }
+
+.text-orange {
+  color: $studio-orange !important;
+}


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/6017

### Description (What does it do?)
This PR is a follow-up to https://github.com/mitodl/ocw-studio/pull/2407. In this PR we have incorporated the followinh changes:
- `Never Publish` to use an orange color.
- `Draft` to use a blue color
- Remove "from Production" from `Unpublished from Production`

### How can this be tested?
1. Switch to this branch
2. Go to the site listings page on `http://localhost:8043/sites/`
3. Create a new site or use an existing one to stage/publish.
4. Check that existing sites have the appropriate statuses