### PR TITLE
improved transcoding workflow for local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,3 +104,10 @@ OPEN_CATALOG_WEBHOOK_KEY=changeme
 WAYBACK_MACHINE_ACCESS_KEY=changeme
 WAYBACK_MACHINE_SECRET_KEY=changeme
 ENABLE_WAYBACK_TASKS=false
+
+# Video transcoding settings
+VIDEO_TRANSCODING_STATUS_UPDATE_FREQUENCY=30
+TRANSCODE_RESULT_TEMPLATE=./test_videos_webhook/cloudwatch_sns_complete.json
+TRANSCODE_ERROR_TEMPLATE=./test_videos_webhook/cloudwatch_sns_error.json
+VIDEO_S3_TRANSCODE_BUCKET=changeme
+POST_TRANSCODE_ACTIONS=videos.api.update_video_job

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -113,9 +113,9 @@
         "filename": "README.md",
         "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
         "is_verified": false,
-        "line_number": 247
+        "line_number": 262
       }
     ]
   },
-  "generated_at": "2024-09-04T01:40:31Z"
+  "generated_at": "2025-06-23T07:34:17Z"
 }

--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 OCW Studio manages deployments for OCW courses.
 
+## Recent Updates
+
+### Video Transcoding Enhancements (December 2024)
+
+Recent improvements to the video transcoding system include:
+
+- **Enhanced error handling** in video processing and transcoding workflows
+- **Local testing support** for video transcoding with mock AWS MediaConvert callbacks
+- **Improved video job status tracking** with comprehensive unit test coverage
+- **New API functions** for MediaConvert job management (`get_media_convert_job`, `prepare_job_results`)
+- **Automated transcoding status updates** via periodic Celery tasks for development environments
+- **Template-based result mocking** for testing transcoding workflows without AWS dependencies
+
+For detailed configuration, see the [Enabling AWS MediaConvert transcoding](#enabling-aws-mediaconvert-transcoding) section.
+
 **SECTIONS**
 
 - [ocw_studio](#ocw_studio)
@@ -480,13 +495,28 @@ AWS_ACCESS_KEY_ID
 AWS_SECRET_ACCESS_KEY
 AWS_STORAGE_BUCKET_NAME
 VIDEO_S3_TRANSCODE_ENDPOINT
+VIDEO_S3_TRANSCODE_PREFIX
+VIDEO_S3_TRANSCODE_BUCKET
 AWS_ROLE_NAME
 DRIVE_SHARED_ID
 DRIVE_SERVICE_ACCOUNT_CREDS
 API_BEARER_TOKEN
+POST_TRANSCODE_ACTIONS
 ```
 
 This will allow for videos to be submitted for transcoding to the AWS MediaConvert service. This is done automatically once a video has been synced to Studio from Google Drive.
+
+## Local Development and Testing
+
+For local development and testing, additional environment variables can be configured to mock transcoding behavior:
+
+```
+VIDEO_TRANSCODING_STATUS_UPDATE_FREQUENCY=30
+TRANSCODE_RESULT_TEMPLATE=./test_videos_webhook/cloudwatch_sns_complete.json
+TRANSCODE_ERROR_TEMPLATE=./test_videos_webhook/cloudwatch_sns_error.json
+```
+
+These settings enable a periodic task that simulates AWS MediaConvert callbacks for testing video transcoding workflows locally without requiring actual AWS MediaConvert services.
 
 # Enabling 3Play integration
 

--- a/app.json
+++ b/app.json
@@ -751,6 +751,26 @@
     "YT_UPLOAD_LIMIT": {
       "description": "Max Youtube uploads allowed per day",
       "required": false
+    },
+    "VIDEO_TRANSCODING_STATUS_UPDATE_FREQUENCY": {
+      "description": "Frequency in seconds for checking transcoding video statuses (dev only)",
+      "required": false
+    },
+    "TRANSCODE_RESULT_TEMPLATE": {
+      "description": "Template file for mock transcoding results (dev only)",
+      "required": false
+    },
+    "TRANSCODE_ERROR_TEMPLATE": {
+      "description": "Template file for mock transcoding error results (dev only)",
+      "required": false
+    },
+    "VIDEO_S3_TRANSCODE_BUCKET": {
+      "description": "S3 bucket name for MediaConvert transcoded videos",
+      "required": false
+    },
+    "POST_TRANSCODE_ACTIONS": {
+      "description": "Python function path for post-transcoding actions",
+      "required": false
     }
   },
   "keywords": ["Django", "Python", "MIT", "Office of Digital Learning"],

--- a/main/settings.py
+++ b/main/settings.py
@@ -553,6 +553,29 @@ YT_UPLOAD_LIMIT = get_int(
     default=50,
     description="Max Youtube uploads allowed per day",
 )
+
+# Transcoding settings for local testing
+VIDEO_TRANSCODING_STATUS_UPDATE_FREQUENCY = get_int(
+    name="VIDEO_TRANSCODING_STATUS_UPDATE_FREQUENCY",
+    default=30,
+    dev_only=True,
+    description="Frequency in seconds for checking transcoding video statuses",
+)
+
+TRANSCODE_RESULT_TEMPLATE = get_string(
+    name="TRANSCODE_RESULT_TEMPLATE",
+    default="./test_videos_webhook/cloudwatch_sns_complete.json",
+    dev_only=True,
+    description="Template file for mock transcoding results",
+)
+
+TRANSCODE_ERROR_TEMPLATE = get_string(
+    name="TRANSCODE_ERROR_TEMPLATE",
+    default="./test_videos_webhook/cloudwatch_sns_error.json",
+    dev_only=True,
+    description="Template file for mock transcoding error results",
+)
+
 # OCW metadata fields
 FIELD_RESOURCETYPE = get_string(
     name="FIELD_RESOURCETYPE",
@@ -762,6 +785,12 @@ if ENABLE_CHECK_EXTERNAL_RESOURCE_TASK:
     CELERY_BEAT_SCHEDULE["check-broken-external-urls"] = {
         "task": "external_resources.tasks.check_external_resources_for_breakages",
         "schedule": CHECK_EXTERNAL_RESOURCE_STATUS_FREQUENCY,
+    }
+
+if ENVIRONMENT.lower() == "staging":
+    CELERY_BEAT_SCHEDULE["update-video-transcoding-statuses"] = {
+        "task": "videos.tasks.update_video_transcoding_statuses",
+        "schedule": VIDEO_TRANSCODING_STATUS_UPDATE_FREQUENCY,
     }
 
 # django cache back-ends
@@ -1307,7 +1336,7 @@ PUBLISH_POSTHOG_FEATURE_FLAG_REQUEST_TIMEOUT_MS = get_int(
     name="PUBLISH_POSTHOG_FEATURE_FLAG_REQUEST_TIMEOUT_MS",
     default=3000,
     description=(
-        "Timeout (ms) for PostHog feature flag requests, " "published to pipelines"
+        "Timeout (ms) for PostHog feature flag requests, published to pipelines"
     ),
     required=False,
 )

--- a/test_videos_webhook/cloudwatch_sns_complete.json
+++ b/test_videos_webhook/cloudwatch_sns_complete.json
@@ -3,17 +3,17 @@
   "id": "c120fe11-87db-c292-b3e5-1cc90740f6e1",
   "detail-type": "MediaConvert Job State Change",
   "source": "aws.mediaconvert",
-  "account": "AWS_ACCOUNT_ID",
+  "account": "<AWS_ACCOUNT_ID>",
   "time": "2021-08-05T16:52:33Z",
-  "region": "{aws_region}",
+  "region": "<AWS_REGION>",
   "resources": [
-    "arn:aws:mediaconvert:AWS_REGION:AWS_ACCOUNT_ID:jobs/26235173873033-qav1eq"
+    "arn:aws:mediaconvert:<AWS_REGION>:<AWS_ACCOUNT_ID>:jobs/<VIDEO_JOB_ID>"
   ],
   "detail": {
     "timestamp": 1628172900136,
-    "accountId": "AWS_ACCOUNT_ID",
-    "queue": "arn:aws:mediaconvert:AWS_REGION:AWS_ACCOUNT_ID:queues/Default",
-    "jobId": "VIDEO_JOB_ID",
+    "accountId": "<AWS_ACCOUNT_ID>",
+    "queue": "arn:aws:mediaconvert:<AWS_REGION>:<AWS_ACCOUNT_ID>:queues/<VIDEO_TRANSCODE_QUEUE>",
+    "jobId": "<VIDEO_JOB_ID>",
     "status": "COMPLETE",
     "userMetadata": {},
     "outputGroupDetails": [
@@ -21,7 +21,7 @@
         "outputDetails": [
           {
             "outputFilePaths": [
-              "s3://AWS_BUCKET/TRANSCODE_PREFIX/SHORT_ID/DRIVE_FILE_ID/testvid_youtube.mp4"
+              "s3://<AWS_STORAGE_BUCKET_NAME>/<VIDEO_S3_TRANSCODE_PREFIX>/<SHORT_ID>/<DRIVE_FILE_ID>/<VIDEO_NAME>_youtube.mp4"
             ],
             "durationInMs": 132033,
             "videoDetails": {
@@ -31,7 +31,7 @@
           },
           {
             "outputFilePaths": [
-              "s3://AWS_BUCKET/TRANSCODE_PREFIX/SHORT_ID/DRIVE_FILE_ID/testvid_360p_16_9.mp4"
+              "s3://<AWS_STORAGE_BUCKET_NAME>/<VIDEO_S3_TRANSCODE_PREFIX>/<SHORT_ID>/<DRIVE_FILE_ID>/<VIDEO_NAME>_360p_16_9.mp4"
             ],
             "durationInMs": 132033,
             "videoDetails": {
@@ -41,7 +41,7 @@
           },
           {
             "outputFilePaths": [
-              "s3://AWS_BUCKET/TRANSCODE_PREFIX/SHORT_ID/DRIVE_FILE_ID/testvid_360p_4_3.mp4"
+              "s3://<AWS_STORAGE_BUCKET_NAME>/<VIDEO_S3_TRANSCODE_PREFIX>/<SHORT_ID>/<DRIVE_FILE_ID>/<VIDEO_NAME>_360p_4_3.mp4"
             ],
             "durationInMs": 132033,
             "videoDetails": {

--- a/test_videos_webhook/cloudwatch_sns_error.json
+++ b/test_videos_webhook/cloudwatch_sns_error.json
@@ -3,17 +3,17 @@
   "id": "c8879bt5-730e-6a80-3340-80712099846e",
   "detail-type": "MediaConvert Job State Change",
   "source": "aws.mediaconvert",
-  "account": "AWS_ACCOUNT_ID",
+  "account": "<AWS_ACCOUNT_ID>",
   "time": "2021-08-05T19:15:37Z",
-  "region": "AWS_REGION",
+  "region": "<AWS_REGION>",
   "resources": [
-    "arn:aws:mediaconvert:AWS_REGION:AWS_ACCOUNT_ID:jobs/VIDEO_JOB_ID"
+    "arn:aws:mediaconvert:<AWS_REGION>:<AWS_ACCOUNT_ID>:jobs/<VIDEO_JOB_ID>"
   ],
   "detail": {
     "timestamp": 1628190937233,
-    "accountId": "919801701561",
-    "queue": "arn:aws:mediaconvert:AWS_REGION:AWS_ACCOUNT_ID:queues/Default",
-    "jobId": "VIDEO_JOB_ID",
+    "accountId": "<AWS_ACCOUNT_ID>",
+    "queue": "arn:aws:mediaconvert:<AWS_REGION>:<AWS_ACCOUNT_ID>:queues/<VIDEO_TRANSCODE_QUEUE>",
+    "jobId": "<VIDEO_JOB_ID>",
     "status": "ERROR",
     "errorCode": 1030,
     "errorMessage": "Video codec [indeo4] is not a supported input video codec",

--- a/videos/api_test.py
+++ b/videos/api_test.py
@@ -4,10 +4,13 @@ import json
 from os import path
 
 import pytest
+from botocore.exceptions import ClientError
 
 from gdrive_sync.factories import DriveFileFactory
 from videos.api import (
     create_media_convert_job,
+    get_media_convert_job,
+    prepare_job_results,
     prepare_video_download_file,
     process_video_outputs,
     update_video_job,
@@ -158,3 +161,381 @@ def test_update_video_job_error(mocker):
     assert video_job.status == VideoJobStatus.FAILED
     assert video_job.video.status == VideoStatus.FAILED
     mock_log.assert_called_once()
+
+
+def test_update_video_job_unknown_status(mocker):
+    """The video job should handle unknown status gracefully"""
+    video_job = VideoJobFactory.create(status=VideoJobStatus.CREATED)
+    mock_job = mocker.patch("videos.api.VideoJob.objects.get")
+    mock_job.return_value = video_job
+
+    # Create mock data with unknown status
+    data = {
+        "jobId": video_job.job_id,
+        "status": "UNKNOWN_STATUS",
+        "outputGroupDetails": [],
+    }
+
+    update_video_job(data)
+    video_job.refresh_from_db()
+
+    # Should update job_output but not change status since it's unknown
+    assert video_job.job_output == data
+    assert video_job.status == VideoJobStatus.CREATED  # Should remain unchanged
+
+
+def test_update_video_job_missing_output_group_details(mocker):
+    """The video job should handle missing outputGroupDetails gracefully"""
+    video_job = VideoJobFactory.create(status=VideoJobStatus.CREATED)
+    mock_job = mocker.patch("videos.api.VideoJob.objects.get")
+    mock_job.return_value = video_job
+
+    # Create mock data without outputGroupDetails
+    data = {"jobId": video_job.job_id, "status": "COMPLETE"}
+
+    mock_process_outputs = mocker.patch("videos.api.process_video_outputs")
+
+    update_video_job(data)
+    video_job.refresh_from_db()
+
+    # Should still call process_video_outputs even with empty outputGroupDetails
+    mock_process_outputs.assert_called_once_with(video_job.video, [])
+    assert video_job.status == VideoJobStatus.COMPLETE
+
+
+def test_update_video_job_empty_error_details(mocker):
+    """The video job should handle missing error details in error status"""
+    video_job = VideoJobFactory.create(status=VideoJobStatus.CREATED)
+    mock_job = mocker.patch("videos.api.VideoJob.objects.get")
+    mock_job.return_value = video_job
+    mock_log = mocker.patch("videos.api.log.error")
+
+    # Create mock data with error status but no error details
+    data = {"jobId": video_job.job_id, "status": "ERROR"}
+
+    update_video_job(data)
+    video_job.refresh_from_db()
+
+    assert video_job.status == VideoJobStatus.FAILED
+    assert video_job.video.status == VideoStatus.FAILED
+    assert video_job.error_code == "None"  # str(None)
+    assert video_job.error_message is None
+    mock_log.assert_called_once()
+
+
+def test_update_video_job_case_insensitive_status(mocker):
+    """The video job should handle case-insensitive status matching"""
+    video_job = VideoJobFactory.create(status=VideoJobStatus.CREATED)
+    mock_job = mocker.patch("videos.api.VideoJob.objects.get")
+    mock_job.return_value = video_job
+
+    test_cases = ["complete", "COMPLETE", "Complete", "error", "ERROR", "Error"]
+
+    for status in test_cases:
+        video_job.status = VideoJobStatus.CREATED
+        video_job.save()
+
+        data = {"jobId": video_job.job_id, "status": status, "outputGroupDetails": []}
+
+        update_video_job(data)
+        video_job.refresh_from_db()
+
+        if status.lower() == "complete":
+            assert video_job.status == VideoJobStatus.COMPLETE
+        elif status.lower() == "error":
+            assert video_job.status == VideoJobStatus.FAILED
+            assert video_job.video.status == VideoStatus.FAILED
+
+
+def test_get_media_convert_job(settings, mocker):
+    """get_media_convert_job should return MediaConvert job details"""
+    job_id = "test_job_id"
+    mock_boto = mocker.patch("videos.api.boto3")
+    mock_job_data = {
+        "Job": {
+            "Id": job_id,
+            "Status": "COMPLETE",
+            "Settings": {},
+        }
+    }
+    mock_boto.client.return_value.get_job.return_value = mock_job_data
+
+    result = get_media_convert_job(job_id)
+
+    mock_boto.client.assert_called_once_with(
+        "mediaconvert",
+        region_name=settings.AWS_REGION,
+        aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+        endpoint_url=settings.VIDEO_S3_TRANSCODE_ENDPOINT,
+    )
+    mock_boto.client.return_value.get_job.assert_called_once_with(Id=job_id)
+    assert result == mock_job_data
+
+
+def test_get_media_convert_job_client_error(settings, mocker):
+    """get_media_convert_job should handle AWS client errors gracefully"""
+    job_id = "test_job_id"
+    mock_boto = mocker.patch("videos.api.boto3")
+    mock_boto.client.return_value.get_job.side_effect = ClientError(
+        {"Error": {"Code": "JobNotFound", "Message": "Job not found"}}, "GetJob"
+    )
+
+    with pytest.raises(ClientError):
+        get_media_convert_job(job_id)
+
+    mock_boto.client.assert_called_once_with(
+        "mediaconvert",
+        region_name=settings.AWS_REGION,
+        aws_access_key_id=settings.AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+        endpoint_url=settings.VIDEO_S3_TRANSCODE_ENDPOINT,
+    )
+
+
+@pytest.mark.parametrize(
+    "missing_setting",
+    [
+        "AWS_REGION",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "VIDEO_S3_TRANSCODE_ENDPOINT",
+    ],
+)
+def test_get_media_convert_job_missing_settings(settings, mocker, missing_setting):
+    """get_media_convert_job should handle missing AWS settings"""
+    job_id = "test_job_id"
+
+    # Remove the setting
+    delattr(settings, missing_setting)
+
+    mock_boto = mocker.patch("videos.api.boto3")
+
+    # This should still work as boto3 client handles missing values gracefully
+    # by using None or defaults
+    get_media_convert_job(job_id)
+
+    mock_boto.client.assert_called_once()
+
+
+def test_prepare_job_results(settings):
+    """prepare_job_results should replace template placeholders with actual values"""
+    video = VideoFactory.create()
+    # Set a proper source_key format for testing DRIVE_FILE_ID extraction
+    video.source_key = "gdrive_uploads/test_short_id/test_drive_file_id/test_video.mp4"
+    video.save()
+    video_job = VideoJobFactory.create(video=video)
+
+    # Set up required settings
+    settings.AWS_ACCOUNT_ID = "123456789"
+    settings.AWS_REGION = "us-east-1"
+    settings.VIDEO_TRANSCODE_QUEUE = "test-queue"
+    settings.VIDEO_S3_TRANSCODE_BUCKET = "test-bucket"
+    settings.VIDEO_S3_TRANSCODE_PREFIX = "test-prefix"
+
+    template_results = """
+    {
+      "jobId": "<VIDEO_JOB_ID>",
+      "status": "COMPLETE",
+      "accountId": "<AWS_ACCOUNT_ID>",
+      "region": "<AWS_REGION>",
+      "queue": "<VIDEO_TRANSCODE_QUEUE>",
+      "bucket": "<VIDEO_S3_TRANSCODE_BUCKET>",
+      "prefix": "<VIDEO_S3_TRANSCODE_PREFIX>",
+      "shortId": "<SHORT_ID>",
+      "driveFileId": "<DRIVE_FILE_ID>",
+      "videoName": "<VIDEO_NAME>"
+    }
+    """
+
+    result = prepare_job_results(video, video_job, template_results)
+
+    assert result["jobId"] == video_job.job_id
+    assert result["accountId"] == settings.AWS_ACCOUNT_ID
+    assert result["region"] == settings.AWS_REGION
+    assert result["queue"] == settings.VIDEO_TRANSCODE_QUEUE
+    assert result["bucket"] == settings.VIDEO_S3_TRANSCODE_BUCKET
+    assert result["prefix"] == settings.VIDEO_S3_TRANSCODE_PREFIX
+    assert result["shortId"] == video.website.short_id
+    assert result["driveFileId"] == "test_drive_file_id"
+    assert result["videoName"] == "video"
+
+
+def test_prepare_job_results_invalid_json(mocker):
+    """prepare_job_results should handle invalid JSON gracefully"""
+    mock_log = mocker.patch("videos.api.log.exception")
+    video = VideoFactory.create()
+    video_job = VideoJobFactory.create(video=video)
+
+    invalid_json = "{ invalid json }"
+
+    result = prepare_job_results(video, video_job, invalid_json)
+
+    assert result == {}
+    mock_log.assert_called_once_with("Failed to decode MediaConvert job results")
+
+
+def test_prepare_job_results_missing_settings(settings):
+    """prepare_job_results should handle missing settings gracefully"""
+    video = VideoFactory.create()
+    video_job = VideoJobFactory.create(video=video)
+
+    # Remove some settings
+    delattr(settings, "AWS_ACCOUNT_ID")
+    delattr(settings, "VIDEO_TRANSCODE_QUEUE")
+
+    template_results = """
+    {
+      "jobId": "<VIDEO_JOB_ID>",
+      "accountId": "<AWS_ACCOUNT_ID>",
+      "queue": "<VIDEO_TRANSCODE_QUEUE>"
+    }
+    """
+
+    result = prepare_job_results(video, video_job, template_results)
+
+    assert result["jobId"] == video_job.job_id
+    # Missing settings should be replaced with empty strings
+    assert result["accountId"] == ""
+    assert result["queue"] == ""
+
+
+def test_prepare_job_results_empty_template():
+    """prepare_job_results should handle empty template gracefully"""
+    video = VideoFactory.create()
+    video_job = VideoJobFactory.create(video=video)
+
+    empty_template = ""
+    result = prepare_job_results(video, video_job, empty_template)
+
+    assert result == {}
+
+
+def test_prepare_job_results_malformed_json():
+    """prepare_job_results should handle malformed JSON beyond just invalid syntax"""
+    video = VideoFactory.create()
+    video_job = VideoJobFactory.create(video=video)
+
+    # JSON with unmatched braces after template replacement
+    malformed_template = '{"jobId": "<VIDEO_JOB_ID>", "data": {'
+
+    result = prepare_job_results(video, video_job, malformed_template)
+
+    assert result == {}
+
+
+@pytest.mark.parametrize(
+    "template_placeholders",
+    [
+        ("<VIDEO_JOB_ID>", "job_id_value"),
+        ("<SHORT_ID>", "short_id_value"),
+        ("<DRIVE_FILE_ID>", "drive_file_id_value"),
+        ("<VIDEO_NAME>", "video"),
+    ],
+)
+def test_prepare_job_results_individual_placeholders(settings, template_placeholders):
+    """Test that individual placeholders are correctly replaced"""
+    video = VideoFactory.create()
+    video.website.short_id = "short_id_value"
+    video.website.save()
+    # Set a proper source_key format for testing DRIVE_FILE_ID extraction
+    video.source_key = (
+        "gdrive_uploads/short_id_value/drive_file_id_value/test_video.mp4"
+    )
+    video.save()
+    video_job = VideoJobFactory.create(video=video, job_id="job_id_value")
+
+    placeholder, expected_value = template_placeholders
+    template = f'{{"test": "{placeholder}"}}'
+
+    result = prepare_job_results(video, video_job, template)
+
+    if placeholder == "<DRIVE_FILE_ID>":
+        # Extract drive file ID from source_key (second to last part)
+        try:
+            source_key_parts = video.source_key.split("/")
+            expected_value = source_key_parts[-2] if len(source_key_parts) >= 3 else ""
+        except (AttributeError, IndexError):
+            expected_value = ""
+    elif placeholder == "<SHORT_ID>":
+        expected_value = video.website.short_id
+    elif placeholder == "<VIDEO_JOB_ID>":
+        expected_value = video_job.job_id
+
+    assert result["test"] == expected_value
+
+
+def test_process_video_outputs_empty_output_group(mocker):
+    """process_video_outputs should handle empty output group gracefully"""
+    mock_prepare_download = mocker.patch("videos.api.prepare_video_download_file")
+    video = VideoFactory.create()
+
+    # Test with empty output group details list
+    process_video_outputs(video, [])
+
+    # Should not call prepare_video_download_file when output group is empty
+    mock_prepare_download.assert_not_called()
+    assert video.videofiles.count() == 0
+
+
+def test_process_video_outputs_malformed_paths(mocker):
+    """process_video_outputs should handle malformed S3 paths gracefully"""
+    mock_prepare_download = mocker.patch("videos.api.prepare_video_download_file")
+    video = VideoFactory.create()
+
+    # Test with malformed S3 paths
+    malformed_outputs = [
+        {
+            "outputDetails": [
+                {
+                    "outputFilePaths": [
+                        "invalid-path-without-s3-prefix",
+                        "s3://",  # Empty path after s3://
+                        "s3://bucket/",  # Path with only bucket
+                    ]
+                }
+            ]
+        }
+    ]
+
+    process_video_outputs(video, malformed_outputs)
+
+    # Should create at least one VideoFile object despite malformed paths
+    # Due to unique constraint on s3_key, multiple empty/same keys result in only one object
+    assert video.videofiles.count() >= 1
+    mock_prepare_download.assert_called_once_with(video)
+
+
+@pytest.mark.parametrize("file_extension", [".mp4", ".mov", ".avi", ".webm", ""])
+def test_process_video_outputs_various_extensions(mocker, file_extension):
+    """process_video_outputs should handle various file extensions"""
+    mock_prepare_download = mocker.patch("videos.api.prepare_video_download_file")
+    video = VideoFactory.create()
+
+    outputs = [
+        {
+            "outputDetails": [
+                {
+                    "outputFilePaths": [
+                        f"s3://bucket/path/video_youtube{file_extension}",
+                        f"s3://bucket/path/video_archive{file_extension}",
+                    ]
+                }
+            ]
+        }
+    ]
+
+    process_video_outputs(video, outputs)
+
+    assert video.videofiles.count() == 2
+
+    # Check destinations are correctly assigned based on filename
+    youtube_files = video.videofiles.filter(destination=DESTINATION_YOUTUBE)
+    archive_files = video.videofiles.filter(destination=DESTINATION_ARCHIVE)
+
+    assert youtube_files.count() == 1
+    assert archive_files.count() == 1
+    assert "youtube" in youtube_files.first().s3_key
+    assert "archive" in archive_files.first().s3_key
+
+    mock_prepare_download.assert_called_once_with(video)

--- a/videos/constants.py
+++ b/videos/constants.py
@@ -33,6 +33,7 @@ class VideoJobStatus:
     CREATED = STATUS_CREATED
     FAILED = STATUS_FAILED
     COMPLETE = STATUS_COMPLETE
+    ERROR = "Error"
 
 
 class VideoFileStatus:


### PR DESCRIPTION
### What are the relevant tickets?


### Description (What does it do?)
This PR address the **Phase - 1:** of the linked issue which involves the following steps:

1. `environment = dev`:
  If the task does `NOT` involve testing Transcoding with MediaConvert, simply copy/paste the original video in the locations to mock the Transcoding task
2. `environment = staging`:
  If the task involves testing Transcoding with MediaConvert, submit the task to AWS and mock the callback on completion. This would involve the following steps:

    - Celery Beat: to check task status periodically for all submitted Jobs
    - Mock Callback: Compile results from a template and complete/fail job

### How can this be tested?
TBA