### PR TITLE
Update page URL when title changes

### DIFF
--- a/websites/constants.py
+++ b/websites/constants.py
@@ -58,6 +58,8 @@ PERMISSION_PUBLISH = "websites.publish_website"
 PERMISSION_EDIT_CONTENT = "websites.edit_content_website"
 PERMISSION_COLLABORATE = "websites.add_collaborators_website"
 
+POSTHOG_ENABLE_EDITABLE_PAGE_URLS = "OCW_STUDIO_EDITABLE_PAGE_URLS"
+
 ROLE_ADMINISTRATOR = "admin"
 ROLE_EDITOR = "editor"
 ROLE_GLOBAL = "global_admin"

--- a/websites/signals.py
+++ b/websites/signals.py
@@ -5,6 +5,8 @@ from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 from django.utils.text import slugify
 
+from main.posthog import is_feature_enabled
+from websites.constants import POSTHOG_ENABLE_EDITABLE_PAGE_URLS
 from websites.models import Website, WebsiteContent
 from websites.permissions import setup_website_groups_permissions
 
@@ -34,7 +36,14 @@ def update_page_url_on_title_change(
     instance,
     **kwargs,  # noqa: ARG001
 ):
-    """Update page URL when title changes for page content"""
+    """
+    Update page URL when title changes for page content.
+    This is currently behind the PostHog feature flag
+    OCW_STUDIO_EDITABLE_PAGE_URLS.
+    """
+
+    if not is_feature_enabled(POSTHOG_ENABLE_EDITABLE_PAGE_URLS):
+        return
 
     if instance.is_page_content and instance.title:
         new_filename = slugify(instance.title)

--- a/websites/signals.py
+++ b/websites/signals.py
@@ -29,7 +29,11 @@ def handle_website_save(
 
 
 @receiver(pre_save, sender=WebsiteContent)
-def update_page_url_on_title_change(_sender, instance, **_kwargs):
+def update_page_url_on_title_change(
+    sender,  # noqa: ARG001
+    instance,
+    **kwargs,  # noqa: ARG001
+):
     """Update page URL when title changes for page content"""
 
     if instance.is_page_content and instance.title:

--- a/websites/signals.py
+++ b/websites/signals.py
@@ -47,6 +47,8 @@ def update_page_url_on_title_change(
 
     if instance.is_page_content and instance.title:
         new_filename = slugify(instance.title)
+        if instance.filename == new_filename:
+            return
         cur_filename = WebsiteContent.objects.filter(
             website=instance.website,
             dirpath=instance.dirpath,

--- a/websites/signals.py
+++ b/websites/signals.py
@@ -1,10 +1,11 @@
 """Signals for websites"""
 
 from django.db import transaction
-from django.db.models.signals import post_save
+from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
+from django.utils.text import slugify
 
-from websites.models import Website
+from websites.models import Website, WebsiteContent
 from websites.permissions import setup_website_groups_permissions
 
 
@@ -25,3 +26,20 @@ def handle_website_save(
     """
     if created:
         setup_website_groups_permissions(instance)
+
+
+@receiver(pre_save, sender=WebsiteContent)
+def update_page_url_on_title_change(_sender, instance, **_kwargs):
+    """Update page URL when title changes for page content"""
+
+    if instance.is_page_content and instance.title:
+        new_filename = slugify(instance.title)
+        cur_filename = WebsiteContent.objects.filter(
+            website=instance.website,
+            dirpath=instance.dirpath,
+            filename=new_filename,
+            is_page_content=True,
+        ).exclude(pk=instance.pk)
+
+        if not cur_filename.exists():
+            instance.filename = new_filename

--- a/websites/signals_test.py
+++ b/websites/signals_test.py
@@ -1,10 +1,11 @@
 """Tests for signals"""
 
 import pytest
+from django.utils.text import slugify
 
 from users.factories import UserFactory
 from websites import constants
-from websites.factories import WebsiteFactory
+from websites.factories import WebsiteContentFactory, WebsiteFactory
 
 
 @pytest.mark.django_db()
@@ -14,3 +15,21 @@ def test_handle_website_save():
     assert website.admin_group is not None
     assert website.editor_group is not None
     assert website.owner.has_perm(constants.PERMISSION_EDIT, website)
+
+
+@pytest.mark.django_db()
+def test_update_page_url_on_title_change(mocker):
+    """
+    Filename should update to slugified title if feature flag
+    is enabled and no conflict exists
+    """
+    website = WebsiteFactory.create(owner=UserFactory.create())
+    mocker.patch("websites.signals.is_feature_enabled", return_value=True)
+
+    page = WebsiteContentFactory.create(
+        website=website, is_page_content=True, title="Test Page", filename="test-page"
+    )
+    page.title = "Some New Title"
+    page.save()
+    page.refresh_from_db()
+    assert page.filename == slugify("Some New Title")


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/5357.

### Description (What does it do?)
This PR adds the feature that page URLs can be edited after page creation by modifying the page titles. This is currently behind a PostHog feature flag.

### How can this be tested?
First, make sure that PostHog integration is properly set up. Navigate to the OCW project page on PostHog and toggle the `OCW_STUDIO_EDITABLE_PAGE_URLS` feature flag. When this is set to on, changes to the title of a page in OCW Studio should trigger a change to the URL, which will be visible after publishing the site.

For any page in a course, change the title of the page and re-publish the course. The URL should now be the slugified version of the page title.

Note the following limitation: if the new slugified title conflicts with an existing slugified title, the page URL will not be updated. Adding a user notification about any page URL conflicts, as well as displaying the URL of a page in the drawer, will be added in a follow-up PR.