### PR TITLE
Ability to delete video resources

### DIFF
--- a/static/js/components/RepeatableContentListing.tsx
+++ b/static/js/components/RepeatableContentListing.tsx
@@ -270,23 +270,26 @@ export default function RepeatableContentListing(props: {
         </div>
       </div>
       <StudioList>
-        {listing.results.map((item: WebsiteContentListItem) => (
-          <StudioListItem
-            key={item.text_id}
-            to={siteContentDetailUrl
-              .param({
-                name: website.name,
-                contentType: configItem.name,
-                uuid: item.text_id,
-              })
-              .toString()}
-            title={item.title ?? ""}
-            subtitle={`Updated ${formatUpdatedOn(item)}`}
-            menuOptions={
-              isDeletable ? [["Delete", startDelete(item)]] : undefined
-            }
-          />
-        ))}
+        {listing.results.map((item: WebsiteContentListItem) => {
+          const showDelete = isDeletable && item.is_deletable_by_resourcetype
+          return (
+            <StudioListItem
+              key={item.text_id}
+              to={siteContentDetailUrl
+                .param({
+                  name: website.name,
+                  contentType: configItem.name,
+                  uuid: item.text_id,
+                })
+                .toString()}
+              title={item.title ?? ""}
+              subtitle={`Updated ${formatUpdatedOn(item)}`}
+              menuOptions={
+                showDelete ? [["Delete", startDelete(item)]] : undefined
+              }
+            />
+          )
+        })}
       </StudioList>
       <PaginationControls previous={pages.previous} next={pages.next} />
       <Route

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -290,6 +290,7 @@ export interface WebsiteContentListItem {
   /** ISO 8601 formatted datetime string */
   updated_on: string
   is_deletable?: boolean
+  is_deletable_by_resourcetype?: boolean
 }
 
 export interface WebsiteContent extends WebsiteContentListItem {

--- a/static/js/util/factories/websites.ts
+++ b/static/js/util/factories/websites.ts
@@ -304,6 +304,7 @@ export const makeWebsiteContentListItem = (): WebsiteContentListItem => ({
   type: casual.word,
   updated_on: randomISO8601(),
   is_deletable: true,
+  is_deletable_by_resourcetype: true,
 })
 
 export const makeWebsiteContentDetail = (): WebsiteContent => ({

--- a/websites/deletion_utils.py
+++ b/websites/deletion_utils.py
@@ -1,0 +1,47 @@
+import logging
+
+from django.db.models import Q
+from mitol.common.utils.datetime import now_in_utc
+
+from gdrive_sync.api import delete_drive_file, get_drive_service
+from gdrive_sync.models import DriveFile
+from videos.tasks import delete_s3_objects
+from websites.models import WebsiteContent
+
+log = logging.getLogger(__name__)
+
+
+def delete_resource(content: WebsiteContent):
+    """
+    Delete a resouce: WebsiteContent object, driveFile, S3 object,
+    and file itself from gdrive.
+    """
+    drive_file = DriveFile.objects.filter(resource=content).first()
+    drive_file_id = drive_file.file_id if drive_file else None
+    if drive_file_id:
+        delete_drive_file(drive_file, sync_datetime=now_in_utc())
+        ds = get_drive_service()
+        ds.files().delete(fileId=drive_file_id, supportsAllDrives=True).execute()
+        if content.file:
+            delete_s3_objects.delay(key=drive_file.s3_key)
+    content.delete()
+
+
+def delete_related_captions_and_transcript(content: WebsiteContent):
+    """
+    Delete related captions and transcript file for a video.
+    """
+    video_files = content.metadata.get("video_files", {}) or {}
+    for attr in ("video_captions_file", "video_transcript_file"):
+        key = video_files.get(attr)
+        if not key:
+            continue
+        filename = key.split("/")[-1]
+        base_name = filename.rsplit(".", 1)[0]
+        qs = WebsiteContent.objects.filter(website=content.website)
+        related = qs.filter(
+            Q(file=key) | Q(file=key.strip("/")) | Q(filename=base_name)
+        ).first()
+        if related:
+            # if captions or transcript file is found, delete it
+            delete_resource(related)

--- a/websites/deletion_utils.py
+++ b/websites/deletion_utils.py
@@ -1,26 +1,42 @@
+import logging
 from pathlib import Path
 
 from django.db.models import Q
 from mitol.common.utils.datetime import now_in_utc
 
+from content_sync.decorators import retry_on_failure
 from gdrive_sync.api import delete_drive_file, get_drive_service
 from gdrive_sync.models import DriveFile
 from videos.tasks import delete_s3_objects
 from websites.models import WebsiteContent
 
+log = logging.getLogger(__name__)
+
+
+@retry_on_failure
+def delete_drive_file_from_gdrive(file_id: str):
+    """
+    Delete a file from Google Drive using drive_file.file_id.
+    """
+    log.info("Deleting Google Drive file %s", file_id)
+    try:
+        ds = get_drive_service()
+        ds.files().delete(fileId=file_id, supportsAllDrives=True).execute()
+        log.info("Successfully deleted Google Drive file %s", file_id)
+    except Exception:
+        log.exception("Failed to delete Google Drive file %s", file_id)
+        raise
+
 
 def delete_resource(content: WebsiteContent):
     """
-    Delete a resouce: WebsiteContent object, driveFile, S3 object,
+    Delete a resource: WebsiteContent object, driveFile, S3 object,
     and file itself from gdrive.
     """
     drive_file = DriveFile.objects.filter(resource=content).first()
     if drive_file:
         if drive_file.file_id:
-            ds = get_drive_service()
-            ds.files().delete(
-                fileId=drive_file.file_id, supportsAllDrives=True
-            ).execute()
+            delete_drive_file_from_gdrive(drive_file.file_id)
             if content.file:
                 delete_s3_objects.delay(key=drive_file.s3_key)
         delete_drive_file(drive_file, sync_datetime=now_in_utc())

--- a/websites/deletion_utils.py
+++ b/websites/deletion_utils.py
@@ -13,8 +13,7 @@ def delete_resource(content: WebsiteContent):
     and file itself from gdrive.
     """
     drive_file = DriveFile.objects.filter(resource=content).first()
-    drive_file_id = drive_file.file_id if drive_file else None
-    if drive_file_id:
+    if drive_file_id := drive_file and drive_file.file_id:
         delete_drive_file(drive_file, sync_datetime=now_in_utc())
         ds = get_drive_service()
         ds.files().delete(fileId=drive_file_id, supportsAllDrives=True).execute()
@@ -27,7 +26,7 @@ def delete_related_captions_and_transcript(content: WebsiteContent):
     """
     Delete related captions and transcript file for a video.
     """
-    video_files = content.metadata.get("video_files", {}) or {}
+    video_files = content.metadata.get("video_files", {})
     for attr in ("video_captions_file", "video_transcript_file"):
         key = video_files.get(attr)
         if not key:

--- a/websites/deletion_utils.py
+++ b/websites/deletion_utils.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from django.db.models import Q
 from mitol.common.utils.datetime import now_in_utc
 
@@ -31,8 +33,7 @@ def delete_related_captions_and_transcript(content: WebsiteContent):
         key = video_files.get(attr)
         if not key:
             continue
-        filename = key.split("/")[-1]
-        base_name = filename.rsplit(".", 1)[0]
+        base_name = Path(key).stem
         qs = WebsiteContent.objects.filter(website=content.website)
         related = qs.filter(
             Q(file=key) | Q(file=key.strip("/")) | Q(filename=base_name)

--- a/websites/deletion_utils.py
+++ b/websites/deletion_utils.py
@@ -17,14 +17,12 @@ def delete_resource(content: WebsiteContent):
     drive_file = DriveFile.objects.filter(resource=content).first()
     if drive_file:
         if drive_file.file_id:
-            # Only perform external cleanup if file_id exists
             ds = get_drive_service()
             ds.files().delete(
                 fileId=drive_file.file_id, supportsAllDrives=True
             ).execute()
             if content.file:
                 delete_s3_objects.delay(key=drive_file.s3_key)
-        # Always delete the DriveFile object from database
         delete_drive_file(drive_file, sync_datetime=now_in_utc())
     content.delete()
 

--- a/websites/deletion_utils.py
+++ b/websites/deletion_utils.py
@@ -1,5 +1,3 @@
-import logging
-
 from django.db.models import Q
 from mitol.common.utils.datetime import now_in_utc
 
@@ -7,8 +5,6 @@ from gdrive_sync.api import delete_drive_file, get_drive_service
 from gdrive_sync.models import DriveFile
 from videos.tasks import delete_s3_objects
 from websites.models import WebsiteContent
-
-log = logging.getLogger(__name__)
 
 
 def delete_resource(content: WebsiteContent):

--- a/websites/deletion_utils_test.py
+++ b/websites/deletion_utils_test.py
@@ -1,0 +1,61 @@
+"""Tests for deletion utilities related to WebsiteContent."""
+
+import pytest
+
+from websites.constants import CONTENT_TYPE_RESOURCE, RESOURCE_TYPE_VIDEO
+from websites.deletion_utils import (
+    delete_related_captions_and_transcript,
+    delete_resource,
+)
+from websites.factories import WebsiteContentFactory, WebsiteFactory
+from websites.models import WebsiteContent
+
+
+@pytest.mark.django_db()
+def test_delete_video_deletes_captions_and_transcripts(mocker):
+    """
+    Deleting a video should also delete its associated caption and transcript WebsiteContent
+    objects.
+    """
+    website = WebsiteFactory.create()
+
+    mocker.patch("websites.deletion_utils.delete_drive_file")
+    mocker.patch("websites.deletion_utils.get_drive_service")
+    mocker.patch("websites.deletion_utils.delete_s3_objects.delay")
+
+    base_name = "E8uZtq_vOYM"
+    course_path = f"/courses/{website.name}/"
+    caption_path = f"{course_path}{base_name}_captions.vtt"
+    transcript_path = f"{course_path}{base_name}_transcript.pdf"
+
+    video_metadata = {
+        "resourcetype": RESOURCE_TYPE_VIDEO,
+        "video_files": {
+            "video_captions_file": caption_path,
+            "video_transcript_file": transcript_path,
+        },
+    }
+
+    video = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        metadata=video_metadata,
+    )
+
+    caption = WebsiteContentFactory.create(
+        website=website, file=caption_path, filename=f"{base_name}_captions"
+    )
+    transcript = WebsiteContentFactory.create(
+        website=website, file=transcript_path, filename=f"{base_name}_transcript"
+    )
+
+    assert WebsiteContent.objects.filter(pk=video.pk).exists()
+    assert WebsiteContent.objects.filter(pk=caption.pk).exists()
+    assert WebsiteContent.objects.filter(pk=transcript.pk).exists()
+
+    delete_related_captions_and_transcript(video)
+    delete_resource(video)
+
+    assert not WebsiteContent.objects.filter(pk=video.pk).exists()
+    assert not WebsiteContent.objects.filter(pk=caption.pk).exists()
+    assert not WebsiteContent.objects.filter(pk=transcript.pk).exists()

--- a/websites/deletion_utils_test.py
+++ b/websites/deletion_utils_test.py
@@ -14,7 +14,7 @@ from websites.factories import WebsiteContentFactory, WebsiteFactory
 from websites.models import WebsiteContent
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_delete_pre_existing_video(mocker):
     """
     Deleting a pre-existing video should also delete its associated caption and transcript.
@@ -63,7 +63,7 @@ def test_delete_pre_existing_video(mocker):
     assert not WebsiteContent.objects.filter(pk=transcript.pk).exists()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_delete_video_with_drive_files_comprehensive(mocker):
     """
     Deleting a video with associated drive files should:
@@ -170,7 +170,7 @@ def test_delete_video_with_drive_files_comprehensive(mocker):
         assert key in s3_keys
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_delete_video_mixed_scenario(mocker):
     """
     Test mixed scenario: Video has drive file, but caption/transcript don't.

--- a/websites/deletion_utils_test.py
+++ b/websites/deletion_utils_test.py
@@ -14,7 +14,7 @@ from websites.factories import WebsiteContentFactory, WebsiteFactory
 from websites.models import WebsiteContent
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db()
 def test_delete_pre_existing_video(mocker):
     """
     Deleting a pre-existing video should also delete its associated caption and transcript.
@@ -63,7 +63,7 @@ def test_delete_pre_existing_video(mocker):
     assert not WebsiteContent.objects.filter(pk=transcript.pk).exists()
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db()
 def test_delete_video_with_drive_files_comprehensive(mocker):
     """
     Deleting a video with associated drive files should:
@@ -80,6 +80,7 @@ def test_delete_video_with_drive_files_comprehensive(mocker):
         "gdrive_sync.api.delete_drive_file", wraps=gdrive_api_module.delete_drive_file
     )
     mock_delete_s3_objects = mocker.patch("websites.deletion_utils.delete_s3_objects")
+    mocker.patch("gdrive_sync.signals.delete_s3_objects")
     mocker.patch.object(DriveFile, "get_content_dependencies", return_value=[])
 
     base_name = "E8uZtq_vOYM"
@@ -169,7 +170,7 @@ def test_delete_video_with_drive_files_comprehensive(mocker):
         assert key in s3_keys
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db()
 def test_delete_video_mixed_scenario(mocker):
     """
     Test mixed scenario: Video has drive file, but caption/transcript don't.
@@ -180,6 +181,7 @@ def test_delete_video_mixed_scenario(mocker):
     mock_get_drive_service = mocker.patch("websites.deletion_utils.get_drive_service")
     mock_drive_service = mock_get_drive_service.return_value
     mock_delete_s3_objects = mocker.patch("websites.deletion_utils.delete_s3_objects")
+    mocker.patch("gdrive_sync.signals.delete_s3_objects")
     mock_delete_drive_file.side_effect = (
         lambda drive_file, **kwargs: drive_file.delete()  # noqa: ARG005
     )

--- a/websites/deletion_utils_test.py
+++ b/websites/deletion_utils_test.py
@@ -11,7 +11,7 @@ from websites.factories import WebsiteContentFactory, WebsiteFactory
 from websites.models import WebsiteContent
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_delete_video_deletes_captions_and_transcripts(mocker):
     """
     Deleting a video should also delete its associated caption and transcript WebsiteContent

--- a/websites/deletion_utils_test.py
+++ b/websites/deletion_utils_test.py
@@ -2,6 +2,9 @@
 
 import pytest
 
+import gdrive_sync.api as gdrive_api_module
+from gdrive_sync.factories import DriveFileFactory
+from gdrive_sync.models import DriveFile
 from websites.constants import CONTENT_TYPE_RESOURCE, RESOURCE_TYPE_VIDEO
 from websites.deletion_utils import (
     delete_related_captions_and_transcript,
@@ -11,11 +14,10 @@ from websites.factories import WebsiteContentFactory, WebsiteFactory
 from websites.models import WebsiteContent
 
 
-@pytest.mark.django_db
-def test_delete_video_deletes_captions_and_transcripts(mocker):
+@pytest.mark.django_db()
+def test_delete_pre_existing_video(mocker):
     """
-    Deleting a video should also delete its associated caption and transcript WebsiteContent
-    objects.
+    Deleting a pre-existing video should also delete its associated caption and transcript.
     """
     website = WebsiteFactory.create()
 
@@ -59,3 +61,182 @@ def test_delete_video_deletes_captions_and_transcripts(mocker):
     assert not WebsiteContent.objects.filter(pk=video.pk).exists()
     assert not WebsiteContent.objects.filter(pk=caption.pk).exists()
     assert not WebsiteContent.objects.filter(pk=transcript.pk).exists()
+
+
+@pytest.mark.django_db()
+def test_delete_video_with_drive_files_comprehensive(mocker):
+    """
+    Deleting a video with associated drive files should:
+     - Delete the video WebsiteContent object
+     - Delete associated caption and transcript WebsiteContent objects
+     - Delete associated DriveFile objects
+     - Call external services for Google Drive and S3 cleanup
+    """
+    website = WebsiteFactory.create()
+
+    mock_get_drive_service = mocker.patch("websites.deletion_utils.get_drive_service")
+    mock_drive_service = mock_get_drive_service.return_value
+    mocker.patch(
+        "gdrive_sync.api.delete_drive_file", wraps=gdrive_api_module.delete_drive_file
+    )
+    mock_delete_s3_objects = mocker.patch("websites.deletion_utils.delete_s3_objects")
+    mocker.patch.object(DriveFile, "get_content_dependencies", return_value=[])
+
+    base_name = "E8uZtq_vOYM"
+    course_path = f"/courses/{website.name}/"
+    caption_path = f"{course_path}{base_name}_captions.vtt"
+    transcript_path = f"{course_path}{base_name}_transcript.pdf"
+    video_path = f"{course_path}{base_name}.mp4"
+
+    video_metadata = {
+        "resourcetype": RESOURCE_TYPE_VIDEO,
+        "video_files": {
+            "video_captions_file": caption_path,
+            "video_transcript_file": transcript_path,
+        },
+    }
+
+    video = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        metadata=video_metadata,
+        file=video_path,
+    )
+    caption = WebsiteContentFactory.create(
+        website=website, file=caption_path, filename=f"{base_name}_captions"
+    )
+    transcript = WebsiteContentFactory.create(
+        website=website, file=transcript_path, filename=f"{base_name}_transcript"
+    )
+
+    video_drive_file = DriveFileFactory.create(
+        resource=video,
+        website=website,
+        file_id="video_drive_file_id",
+        s3_key=f"s3/{video_path}",
+    )
+    caption_drive_file = DriveFileFactory.create(
+        resource=caption,
+        website=website,
+        file_id="caption_drive_file_id",
+        s3_key=f"s3/{caption_path}",
+    )
+    transcript_drive_file = DriveFileFactory.create(
+        resource=transcript,
+        website=website,
+        file_id="transcript_drive_file_id",
+        s3_key=f"s3/{transcript_path}",
+    )
+
+    # Assert objects exist
+    assert WebsiteContent.objects.filter(pk=video.pk).exists()
+    assert WebsiteContent.objects.filter(pk=caption.pk).exists()
+    assert WebsiteContent.objects.filter(pk=transcript.pk).exists()
+    assert DriveFile.objects.filter(pk=video_drive_file.pk).exists()
+    assert DriveFile.objects.filter(pk=caption_drive_file.pk).exists()
+    assert DriveFile.objects.filter(pk=transcript_drive_file.pk).exists()
+
+    # Trigger deletion
+    delete_related_captions_and_transcript(video)
+    delete_resource(video)
+
+    # Assert objects are gone
+    assert not WebsiteContent.objects.filter(pk=video.pk).exists()
+    assert not WebsiteContent.objects.filter(pk=caption.pk).exists()
+    assert not WebsiteContent.objects.filter(pk=transcript.pk).exists()
+    assert not DriveFile.objects.filter(pk=video_drive_file.pk).exists()
+    assert not DriveFile.objects.filter(pk=caption_drive_file.pk).exists()
+    assert not DriveFile.objects.filter(pk=transcript_drive_file.pk).exists()
+
+    # Verify external deletions
+    assert mock_drive_service.files().delete.call_count == 3
+    drive_ids = [
+        call.kwargs["fileId"]
+        for call in mock_drive_service.files().delete.call_args_list
+    ]
+    for fid in (
+        "video_drive_file_id",
+        "caption_drive_file_id",
+        "transcript_drive_file_id",
+    ):
+        assert fid in drive_ids
+
+    assert mock_delete_s3_objects.delay.call_count == 3
+    s3_keys = [
+        call.kwargs["key"] for call in mock_delete_s3_objects.delay.call_args_list
+    ]
+    for key in (f"s3/{video_path}", f"s3/{caption_path}", f"s3/{transcript_path}"):
+        assert key in s3_keys
+
+
+@pytest.mark.django_db()
+def test_delete_video_mixed_scenario(mocker):
+    """
+    Test mixed scenario: Video has drive file, but caption/transcript don't.
+    """
+    website = WebsiteFactory.create()
+
+    mock_delete_drive_file = mocker.patch("websites.deletion_utils.delete_drive_file")
+    mock_get_drive_service = mocker.patch("websites.deletion_utils.get_drive_service")
+    mock_drive_service = mock_get_drive_service.return_value
+    mock_delete_s3_objects = mocker.patch("websites.deletion_utils.delete_s3_objects")
+    mock_delete_drive_file.side_effect = (
+        lambda drive_file, **kwargs: drive_file.delete()  # noqa: ARG005
+    )
+
+    base_name = "E8uZtq_vOYM"
+    course_path = f"/courses/{website.name}/"
+
+    video_metadata = {
+        "resourcetype": RESOURCE_TYPE_VIDEO,
+        "video_files": {
+            "video_captions_file": f"{course_path}{base_name}_captions.vtt",
+            "video_transcript_file": f"{course_path}{base_name}_transcript.pdf",
+        },
+    }
+
+    video = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        metadata=video_metadata,
+        file=f"{course_path}{base_name}.mp4",
+    )
+    caption = WebsiteContentFactory.create(
+        website=website, file=f"{course_path}{base_name}_captions.vtt"
+    )
+    transcript = WebsiteContentFactory.create(
+        website=website, file=f"{course_path}{base_name}_transcript.pdf"
+    )
+
+    video_drive_file = DriveFileFactory.create(
+        resource=video,
+        website=website,
+        file_id="video_drive_file_id",
+        s3_key=f"s3/{course_path}{base_name}.mp4",
+    )
+
+    drive_file_id = video_drive_file.file_id
+
+    assert WebsiteContent.objects.filter(pk=video.pk).exists()
+    assert WebsiteContent.objects.filter(pk=caption.pk).exists()
+    assert WebsiteContent.objects.filter(pk=transcript.pk).exists()
+    assert DriveFile.objects.filter(file_id=drive_file_id).exists()
+
+    # Perform deletion
+    delete_related_captions_and_transcript(video)
+    delete_resource(video)
+
+    # Post-delete checks
+    assert not WebsiteContent.objects.filter(pk=video.pk).exists()
+    assert not WebsiteContent.objects.filter(pk=caption.pk).exists()
+    assert not WebsiteContent.objects.filter(pk=transcript.pk).exists()
+    assert not DriveFile.objects.filter(file_id=drive_file_id).exists()
+
+    # Assertions on mock calls
+    mock_delete_drive_file.assert_called_once()
+    mock_drive_service.files().delete.assert_called_once_with(
+        fileId=drive_file_id, supportsAllDrives=True
+    )
+    mock_delete_s3_objects.delay.assert_called_once_with(
+        key=f"s3/{course_path}{base_name}.mp4"
+    )

--- a/websites/deletion_utils_test.py
+++ b/websites/deletion_utils_test.py
@@ -14,7 +14,7 @@ from websites.factories import WebsiteContentFactory, WebsiteFactory
 from websites.models import WebsiteContent
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_delete_pre_existing_video(mocker):
     """
     Deleting a pre-existing video should also delete its associated caption and transcript.
@@ -63,7 +63,7 @@ def test_delete_pre_existing_video(mocker):
     assert not WebsiteContent.objects.filter(pk=transcript.pk).exists()
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_delete_video_with_drive_files_comprehensive(mocker):
     """
     Deleting a video with associated drive files should:
@@ -169,7 +169,7 @@ def test_delete_video_with_drive_files_comprehensive(mocker):
         assert key in s3_keys
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 def test_delete_video_mixed_scenario(mocker):
     """
     Test mixed scenario: Video has drive file, but caption/transcript don't.

--- a/websites/deletion_utils_test.py
+++ b/websites/deletion_utils_test.py
@@ -21,7 +21,7 @@ def test_delete_video_deletes_captions_and_transcripts(mocker):
 
     mocker.patch("websites.deletion_utils.delete_drive_file")
     mocker.patch("websites.deletion_utils.get_drive_service")
-    mocker.patch("websites.deletion_utils.delete_s3_objects.delay")
+    mocker.patch("websites.deletion_utils.delete_s3_objects")
 
     base_name = "E8uZtq_vOYM"
     course_path = f"/courses/{website.name}/"

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -33,6 +33,7 @@ from websites.constants import (
     CONTENT_TYPE_METADATA,
     CONTENT_TYPE_RESOURCE,
     PUBLISH_STATUS_NOT_STARTED,
+    RESOURCE_TYPE_VIDEO,
 )
 from websites.models import Website, WebsiteContent, WebsiteStarter
 from websites.permissions import is_global_admin, is_site_admin
@@ -490,12 +491,11 @@ class WebsiteContentSerializer(serializers.ModelSerializer):
         return True
 
     def get_is_deletable_by_resourcetype(self, obj):
-        # if not a resource, always OK, because we're using config var to
-        #  control deletable content types
+        # it will still use config var OCW_STUDIO_DELETABLE_CONTENT_TYPES
+        # to check for deletable content types
         if obj.type != CONTENT_TYPE_RESOURCE:
             return True
-        # for resources only, check metadata.resourcetype === "Video"
-        return (obj.metadata or {}).get("resourcetype") == "Video"
+        return (obj.metadata or {}).get("resourcetype") == RESOURCE_TYPE_VIDEO
 
     class Meta:
         model = WebsiteContent

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -476,6 +476,7 @@ class WebsiteContentSerializer(serializers.ModelSerializer):
 
     website_name = serializers.CharField(source="website.name")
     is_deletable = serializers.SerializerMethodField()
+    is_deletable_by_resourcetype = serializers.SerializerMethodField()
 
     def get_is_deletable(self, obj):
         request = self.context.get("request", None)
@@ -488,6 +489,14 @@ class WebsiteContentSerializer(serializers.ModelSerializer):
             return len(refs) == 0
         return True
 
+    def get_is_deletable_by_resourcetype(self, obj):
+        # if not a resource, always OK, because we're using config var to
+        #  control deletable content types
+        if obj.type != CONTENT_TYPE_RESOURCE:
+            return True
+        # for resources only, check metadata.resourcetype === "Video"
+        return (obj.metadata or {}).get("resourcetype") == "Video"
+
     class Meta:
         model = WebsiteContent
         read_only_fields = [
@@ -497,6 +506,7 @@ class WebsiteContentSerializer(serializers.ModelSerializer):
             "type",
             "updated_on",
             "is_deletable",
+            "is_deletable_by_resourcetype",
         ]
         # See WebsiteContentCreateSerializer below for creating new WebsiteContent objects  # noqa: E501
         fields = read_only_fields

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -630,6 +630,13 @@ class WebsiteContentDetailSerializer(
                 result[file_field["name"]] = instance.file.url
         return result
 
+    is_deletable_by_resourcetype = serializers.SerializerMethodField()
+
+    def get_is_deletable_by_resourcetype(self, obj):
+        if obj.type != CONTENT_TYPE_RESOURCE:
+            return True
+        return (obj.metadata or {}).get("resourcetype") == "Video"
+
     class Meta:
         model = WebsiteContent
         read_only_fields = [
@@ -638,6 +645,7 @@ class WebsiteContentDetailSerializer(
             "content_context",
             "url_path",
             "filename",
+            "is_deletable_by_resourcetype",
         ]
         fields = [
             *read_only_fields,

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -297,6 +297,23 @@ def test_website_content_serializer():
     assert "metadata" not in serialized_data
 
 
+@pytest.mark.parametrize(
+    ("type_", "resourcetype", "expected"),
+    [
+        (CONTENT_TYPE_RESOURCE, "video", True),
+        (CONTENT_TYPE_RESOURCE, "document", False),
+    ],
+)
+def test_serializer_is_deletable_by_resourcetype(type_, resourcetype, expected):
+    """
+    WebsiteContentSerializer should return correct is_deletable_by_resourcetype
+    """
+    metadata = {"resourcetype": resourcetype} if resourcetype else {}
+    content = WebsiteContentFactory.build(type=type_, metadata=metadata)
+    serializer = WebsiteContentSerializer(instance=content)
+    assert serializer.data["is_deletable_by_resourcetype"] is expected
+
+
 def test_website_content_detail_serializer():
     """WebsiteContentDetailSerializer should serialize all relevant fields to the frontend"""
     content = WebsiteContentFactory.create(

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -309,7 +309,7 @@ def test_serializer_is_deletable_by_resourcetype(type_, resourcetype, expected):
     WebsiteContentSerializer should return correct is_deletable_by_resourcetype
     """
     metadata = {"resourcetype": resourcetype} if resourcetype else {}
-    content = WebsiteContentFactory.build(type=type_, metadata=metadata)
+    content = WebsiteContentFactory.create(type=type_, metadata=metadata)
     serializer = WebsiteContentSerializer(instance=content)
     assert serializer.data["is_deletable_by_resourcetype"] is expected
 

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -18,6 +18,8 @@ from websites.constants import (
     CONTENT_TYPE_RESOURCE,
     PUBLISH_STATUS_NOT_STARTED,
     PUBLISH_STATUS_SUCCEEDED,
+    RESOURCE_TYPE_DOCUMENT,
+    RESOURCE_TYPE_VIDEO,
     ROLE_EDITOR,
     WEBSITE_CONFIG_ROOT_URL_PATH_KEY,
     WEBSITE_SOURCE_OCW_IMPORT,
@@ -300,8 +302,8 @@ def test_website_content_serializer():
 @pytest.mark.parametrize(
     ("type_", "resourcetype", "expected"),
     [
-        (CONTENT_TYPE_RESOURCE, "Video", True),
-        (CONTENT_TYPE_RESOURCE, "Document", False),
+        (CONTENT_TYPE_RESOURCE, RESOURCE_TYPE_VIDEO, True),
+        (CONTENT_TYPE_RESOURCE, RESOURCE_TYPE_DOCUMENT, False),
     ],
 )
 def test_serializer_is_deletable_by_resourcetype(type_, resourcetype, expected):

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -300,8 +300,8 @@ def test_website_content_serializer():
 @pytest.mark.parametrize(
     ("type_", "resourcetype", "expected"),
     [
-        (CONTENT_TYPE_RESOURCE, "video", True),
-        (CONTENT_TYPE_RESOURCE, "document", False),
+        (CONTENT_TYPE_RESOURCE, "Video", True),
+        (CONTENT_TYPE_RESOURCE, "Document", False),
     ],
 )
 def test_serializer_is_deletable_by_resourcetype(type_, resourcetype, expected):
@@ -310,8 +310,8 @@ def test_serializer_is_deletable_by_resourcetype(type_, resourcetype, expected):
     """
     metadata = {"resourcetype": resourcetype} if resourcetype else {}
     content = WebsiteContentFactory.create(type=type_, metadata=metadata)
-    serializer = WebsiteContentSerializer(instance=content)
-    assert serializer.data["is_deletable_by_resourcetype"] is expected
+    serializer = WebsiteContentSerializer(instance=content).data
+    assert serializer["is_deletable_by_resourcetype"] is expected
 
 
 def test_website_content_detail_serializer():

--- a/websites/views.py
+++ b/websites/views.py
@@ -27,16 +27,13 @@ from content_sync.api import (
 )
 from content_sync.constants import VERSION_DRAFT, VERSION_LIVE
 from content_sync.tasks import update_mass_build_pipelines_on_publish
-from gdrive_sync.api import delete_drive_file, get_drive_service
 from gdrive_sync.constants import WebsiteSyncStatus
-from gdrive_sync.models import DriveFile
 from gdrive_sync.tasks import import_website_files
 from main import features
 from main.permissions import ReadonlyPermission
 from main.utils import uuid_string, valid_key
 from main.views import DefaultPagination
 from users.models import User
-from videos.tasks import delete_s3_objects
 from websites import constants
 from websites.api import get_valid_new_filename, update_website_status
 from websites.constants import (
@@ -51,6 +48,10 @@ from websites.constants import (
     RESOURCE_TYPE_OTHER,
     RESOURCE_TYPE_VIDEO,
     WebsiteStarterStatus,
+)
+from websites.deletion_utils import (
+    delete_related_captions_and_transcript,
+    delete_resource,
 )
 from websites.models import Website, WebsiteContent, WebsiteStarter
 from websites.permissions import (
@@ -700,44 +701,13 @@ class WebsiteContentViewSet(
             content.type == "resource"
             and (content.metadata or {}).get("resourcetype") == RESOURCE_TYPE_VIDEO
         )
-        if not is_video:
-            return super().destroy(request, *args, **kwargs)
+        if is_video:
+            delete_related_captions_and_transcript(content)
+            delete_resource(content)
+            self.perform_destroy(content)
+            return Response(status=status.HTTP_204_NO_CONTENT)
 
-        drive_file = DriveFile.objects.filter(resource=content).first()
-        drive_file_id = drive_file.file_id if drive_file else None
-        video_files = content.metadata.get("video_files", {}) or {}
-        for attr in ("video_captions_file", "video_transcript_file"):
-            path = video_files.get(attr)
-            if not path:
-                continue
-            key = path
-            filename = key.split("/")[-1]
-            base_name = filename.rsplit(".", 1)[0]
-            qs = WebsiteContent.objects.filter(website=content.website)
-            related = qs.filter(
-                Q(file=key) | Q(file=key.strip("/")) | Q(filename=base_name)
-            ).first()
-            if related:
-                related_drive_file = DriveFile.objects.filter(resource=related).first()
-                related_drive_file_id = (
-                    related_drive_file.file_id if related_drive_file else None
-                )
-                if related_drive_file_id:
-                    delete_s3_objects.delay(key=related_drive_file.s3_key)
-                    delete_drive_file(related_drive_file, sync_datetime=now_in_utc())
-                    ds = get_drive_service()
-                    ds.files().delete(
-                        fileId=related_drive_file_id, supportsAllDrives=True
-                    ).execute()
-                related.delete()
-        if drive_file and drive_file_id:
-            delete_drive_file(drive_file, sync_datetime=now_in_utc())
-            ds = get_drive_service()
-            ds.files().delete(fileId=drive_file_id, supportsAllDrives=True).execute()
-        super().perform_destroy(content)
-        content.delete()
-        update_website_backend(content.website)
-        return Response(status=status.HTTP_204_NO_CONTENT)
+        return super().destroy(request, *args, **kwargs)
 
     def perform_destroy(self, instance: WebsiteContent):
         """(soft) deletes a WebsiteContent record"""

--- a/websites/views.py
+++ b/websites/views.py
@@ -40,6 +40,7 @@ from websites.constants import (
     CONTENT_TYPE_COURSE_LIST,
     CONTENT_TYPE_METADATA,
     CONTENT_TYPE_PAGE,
+    CONTENT_TYPE_RESOURCE,
     CONTENT_TYPE_RESOURCE_COLLECTION,
     PUBLISH_STATUS_NOT_STARTED,
     PUBLISH_STATUS_SUCCEEDED,
@@ -698,7 +699,7 @@ class WebsiteContentViewSet(
         content: WebsiteContent = self.get_object()
 
         is_video = (
-            content.type == "resource"
+            content.type == CONTENT_TYPE_RESOURCE
             and (content.metadata or {}).get("resourcetype") == RESOURCE_TYPE_VIDEO
         )
         if is_video:


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/2991

### Description (What does it do?)
Adds the ability to delete all kinds of video resources according to the plan specified in: https://github.com/mitodl/hq/issues/2991#issuecomment-2651158964

### How can this be tested?
Follow the video workflow. Make sure you got the env vars etc as defined here: https://github.com/mitodl/ocw-studio?tab=readme-ov-file#video-workflow

Note: You will need to use `DRIVE_SERVICE_ACCOUNT_CREDS` of ocw-studio-rc to actually enable files deletion in gdrive. Because I got the permissions set up there. I used RC environment for testing (so no minio).

Checkout to this branch. Add resource in your env var `OCW_STUDIO_DELETABLE_CONTENT_TYPES`:
`OCW_STUDIO_DELETABLE_CONTENT_TYPES=instructor,page,course-collection,resource`

To test pre-existing videos' deletion:
1. Click on Add New Resource and create a new video resource using `youtube_id`: `E8uZtq_vOYM`
  i. This will create the video resource with linked transcript and caption files.
2. Click on the 3 dots that appear on the right side of resource, for deletion. Confirm deletion.
3. Make sure all the 3 resources are fully deleted.

To test other videos (legacy or gdrive workflow):
1.  Add a video in videos_final and a `videoname_captions.vtt` file and a `videoname_transcript.pdf` file in `files_final` directory in gdrive.
2. Sync resources.
3. Under the normal flow, both the related files automatically get linked with video.. but this might not happen locally. So you can go to Django admin, the relevant WebsiteContent files, and from `File` field copy the relevant path of caption and transcript. And link them with the Video resource from OCW studio interface. Make sure there are no spaces in the start or end of the path!
4. Delete the video resource. Make sure all the 3 resources are fully deleted.

This can take a couple of seconds to delete. I'm going to create follow-up tickets for:
1. Video image_thumbnail process updating (right now it force-overwrites the thumbnail even when provided)
2. Closing off deletion dialog without waiting for deletion to complete
3. Updating READMEs