### PR TITLE
fixed regex for the embedded resources

### DIFF
--- a/websites/utils.py
+++ b/websites/utils.py
@@ -115,7 +115,7 @@ def get_metadata_content_key(content) -> list:
     return content_keys
 
 
-def parse_string(text: str) -> str:
+def parse_string(text: str) -> list[str]:
     """
     Parse the input text to extract UUIDs from resource links.
 
@@ -123,12 +123,41 @@ def parse_string(text: str) -> str:
         text (str): The input text containing resource links.
 
     Returns:
-        str: A list of extracted UUIDs.
+        list[str]: A list of extracted UUIDs.
     """
+
+    # This regex pattern matches two types of Hugo resource patterns:
+    # 1. Hugo shortcode syntax: {{% resource_link "uuid" "title" %}}
+    # 2. Hugo resource syntax: {{< resource uuid="uuid" >}}
+    #
+    # Pattern breakdown:
+    # - Pattern 1: \{\{%\s+resource_link\s+"([uuid])"\s+"([^"]+)"\s+%\}\}
+    #   - \{\{%     : Matches literal "{{%"
+    #   - \s+       : Matches one or more whitespace characters
+    #   - resource_link : Matches literal "resource_link"
+    #   - \s+       : Matches one or more whitespace characters
+    #   - "([uuid])" : Captures UUID in group 1 (full pattern below)
+    #   - \s+       : Matches one or more whitespace characters
+    #   - "([^"]+)" : Captures title text in group 2
+    #   - \s+       : Matches one or more whitespace characters
+    #   - %\}\}     : Matches literal "%}}"
+    #
+    # - Pattern 2: \{\{<\s+resource\s+uuid="([uuid])"\s*>\}\}
+    #   - \{\{<     : Matches literal "{{<"
+    #   - \s+       : Matches one or more whitespace characters
+    #   - resource  : Matches literal "resource"
+    #   - \s+       : Matches one or more whitespace characters
+    #   - uuid="([uuid])" : Captures UUID in group 3 (full pattern below)
+    #   - \s*       : Matches zero or more whitespace characters
+    #   - >\}\}     : Matches literal ">}}"
+    #
+    # UUID format: [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}
+    # Example: b02b216b-1e9e-4b5c-8b1b-9c275a834679
+
     pattern = r"""
-    \{\{%\s+resource_link\s+"([a-f0-9-]{36})"\s+"([^"]+)"\s+%\}\}
+    \{\{%\s+resource_link\s+"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"\s+"([^"]+)"\s+%\}\}
     |
-    \{\{<\s+resource\s+uuid="([a-f0-9-]{36})"\s*>\}\}
+    \{\{<\s+resource\s+uuid="([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"\s*>\}\}
     """
 
     regex = re.compile(pattern, re.VERBOSE)

--- a/websites/utils.py
+++ b/websites/utils.py
@@ -128,7 +128,7 @@ def parse_string(text: str) -> str:
     pattern = r"""
     \{\{%\s+resource_link\s+"([a-f0-9-]{36})"\s+"([^"]+)"\s+%\}\}
     |
-    \{\{<\s+resource\s+uuid="([a-f0-9-]{36})"\+s>\}\}
+    \{\{<\s+resource\s+uuid="([a-f0-9-]{36})"\s*>\}\}
     """
 
     regex = re.compile(pattern, re.VERBOSE)

--- a/websites/utils_test.py
+++ b/websites/utils_test.py
@@ -6,6 +6,7 @@ from websites import constants
 from websites.factories import WebsiteFactory
 from websites.utils import (
     get_dict_query_field,
+    parse_string,
     permissions_group_name_for_role,
     set_dict_field,
 )
@@ -80,3 +81,108 @@ def test_set_dict_field():
             "parameter_2": "value2",
         },
     }
+
+
+@pytest.mark.parametrize(
+    ("input_text", "expected_uuids"),
+    [
+        # Test case 1: Empty string
+        ("", []),
+        # Test case 2: String with no resource patterns
+        ("This is just plain text with no resources", []),
+        # Test case 3: Single resource_link pattern
+        (
+            '{{% resource_link "b02b216b-1e9e-4b5c-8b1b-9c275a834679" "Some Title" %}}',
+            ["b02b216b-1e9e-4b5c-8b1b-9c275a834679"],
+        ),
+        # Test case 4: Single resource shortcode pattern
+        (
+            '{{< resource uuid="dbcd885b-f9a6-419d-8fd9-a7ddb67b94c5" >}}',
+            ["dbcd885b-f9a6-419d-8fd9-a7ddb67b94c5"],
+        ),
+        # Test case 5: Multiple resource shortcode patterns (your original example)
+        (
+            '{{< resource uuid="b02b216b-1e9e-4b5c-8b1b-9c275a834679" >}}\n{{< resource uuid="dbcd885b-f9a6-419d-8fd9-a7ddb67b94c5" >}}',
+            [
+                "b02b216b-1e9e-4b5c-8b1b-9c275a834679",
+                "dbcd885b-f9a6-419d-8fd9-a7ddb67b94c5",
+            ],
+        ),
+        # Test case 6: Mixed patterns
+        (
+            '{{% resource_link "a1b2c3d4-e5f6-7890-abcd-ef1234567890" "Title 1" %}}\n{{< resource uuid="f9e8d7c6-b5a4-3210-9876-543210fedcba" >}}',
+            [
+                "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                "f9e8d7c6-b5a4-3210-9876-543210fedcba",
+            ],
+        ),
+        # Test case 7: Resource shortcode with extra whitespace
+        (
+            '{{< resource uuid="12345678-1234-1234-1234-123456789012"   >}}',
+            ["12345678-1234-1234-1234-123456789012"],
+        ),
+        # Test case 8: Resource link with complex title
+        (
+            '{{% resource_link "87654321-4321-4321-4321-210987654321" "Complex Title with Numbers 123 and Symbols!" %}}',
+            ["87654321-4321-4321-4321-210987654321"],
+        ),
+        # Test case 9: Multiple resource_link patterns
+        (
+            '{{% resource_link "11111111-2222-3333-4444-555555555555" "First" %}}\n{{% resource_link "66666666-7777-8888-9999-000000000000" "Second" %}}',
+            [
+                "11111111-2222-3333-4444-555555555555",
+                "66666666-7777-8888-9999-000000000000",
+            ],
+        ),
+        # Test case 10: Text with invalid UUID format (should not match)
+        (
+            '{{< resource uuid="invalid-uuid-format" >}}',
+            [],
+        ),
+        # Test case 11: Partial matches that shouldn't work
+        (
+            "Some text with {{< resource uuid= and other incomplete patterns",
+            [],
+        ),
+    ],
+)
+def test_parse_string(input_text, expected_uuids):
+    """Test parse_string extracts UUIDs correctly from various resource patterns"""
+    result = parse_string(input_text)
+    assert result == expected_uuids
+
+
+def test_parse_string_with_surrounding_text():
+    """Test parse_string works correctly when resource patterns are embedded in other text"""
+    text = """
+    This is some markdown content before the resource.
+
+    {{< resource uuid="123e4567-e89b-12d3-a456-426614174000" >}}
+
+    Here is some content in between resources.
+
+    {{% resource_link "987fcdeb-ba01-2345-6789-abcdef012345" "My Resource Title" %}}
+
+    And here is some content after the resources.
+    """
+
+    result = parse_string(text)
+    expected = [
+        "123e4567-e89b-12d3-a456-426614174000",
+        "987fcdeb-ba01-2345-6789-abcdef012345",
+    ]
+    assert result == expected
+
+
+def test_parse_string_case_sensitivity():
+    """Test that parse_string is case sensitive for the pattern matching"""
+    # These should not match because of case differences
+    invalid_cases = [
+        '{{< Resource uuid="123e4567-e89b-12d3-a456-426614174000" >}}',  # Capital R
+        '{{< RESOURCE UUID="123e4567-e89b-12d3-a456-426614174000" >}}',  # All caps
+        '{{% RESOURCE_LINK "123e4567-e89b-12d3-a456-426614174000" "title" %}}',  # All caps
+    ]
+
+    for text in invalid_cases:
+        result = parse_string(text)
+        assert result == [], f"Expected no matches for: {text}"


### PR DESCRIPTION
### What are the relevant tickets?
closes https://github.com/mitodl/hq/issues/7675

### Description (What does it do?)
When we add a link or embed a resource in content, it should populate the references for the resource, which can be verified using the Django admin. But for the embedded resources, it's not populating due to an issue in parsing the text.

### Screenshots (if appropriate):
![Screenshot 2025-06-25 at 5 20 06 PM](https://github.com/user-attachments/assets/1439d3c4-4d98-4f5a-b500-f70db9fe111b)

### How can this be tested?
1. Switch to this branch and spin up containers
2. Embed a video/image resource in a page
3. Verify in Django admin that the image/video resource has `Referencing Content` populated with the page ID.