### PR TITLE
added migration and management to backpopulate referencing content

### DIFF
--- a/websites/management/commands/backpopulate_referencing_content.py
+++ b/websites/management/commands/backpopulate_referencing_content.py
@@ -1,0 +1,207 @@
+"""Backpopulate referencing content"""  # noqa: INP001
+
+from django.db import transaction
+from mitol.common.utils import now_in_utc
+
+from main.management.commands.filter import WebsiteFilterCommand
+from websites.models import Website, WebsiteContent
+from websites.utils import compile_referencing_content
+
+
+class Command(WebsiteFilterCommand):
+    """Backpopulate referencing content for existing resources"""
+
+    help = "Backpopulate referencing content for existing resources"
+
+    def add_arguments(self, parser):
+        """Add command arguments."""
+        super().add_arguments(parser)
+        parser.add_argument(
+            "--chunk-size",
+            type=int,
+            default=500,
+            help="Number of content items to process in each chunk (default: 500)",
+        )
+
+    def handle(self, *args, **options):
+        """Handle the management command execution."""
+        super().handle(*args, **options)
+
+        chunk_size = options["chunk_size"]
+        verbosity = options["verbosity"]
+
+        self.stdout.write("Backpopulating referencing content for existing resources")
+        start = now_in_utc()
+
+        website_qset = self.filter_websites(websites=Website.objects.all())
+
+        # Get total count for progress tracking
+        total_content = website_qset.count()
+        self.stdout.write(
+            f"Processing {total_content} content items in chunks of {chunk_size}..."
+        )
+
+        if verbosity >= 2:  # noqa: PLR2004
+            self.stdout.write(f"Verbosity level: {verbosity}")
+            self.stdout.write(
+                f"Website filter applied: {website_qset.count()} websites"
+            )
+
+        total_updated = 0
+        offset = 0
+
+        while offset < total_content:
+            if verbosity >= 1:
+                self.stdout.write(
+                    f"Processing chunk {offset // chunk_size + 1}: "
+                    f"items {offset + 1} to {min(offset + chunk_size, total_content)}"
+                )
+
+            chunk_updated = self._process_chunk(
+                website_qset, offset, chunk_size, verbosity
+            )
+            total_updated += chunk_updated
+            offset += chunk_size
+
+            # Progress update
+            processed = min(offset, total_content)
+            if verbosity >= 1:
+                self.stdout.write(
+                    f"Processed {processed}/{total_content} items "
+                    f"({processed/total_content*100:.1f}%) - "
+                    f"{chunk_updated} updated in this chunk"
+                )
+
+        total_seconds = (now_in_utc() - start).total_seconds()
+        self.stdout.write(
+            f"Backpopulate referencing content finished, "
+            f"took {total_seconds:.2f} seconds"
+        )
+        self.stdout.write(
+            f"{website_qset.count()} websites processed, "
+            f"{total_updated} content updated"
+        )
+
+    def _process_chunk(self, website_qset, offset, chunk_size, verbosity):
+        """Process a chunk of content items."""
+        # Fetch a chunk of content with optimized query
+        content_chunk = WebsiteContent.objects.filter(website__in=website_qset)[
+            offset : offset + chunk_size
+        ]
+
+        if verbosity >= 3:  # noqa: PLR2004
+            self.stdout.write(f"Fetched {len(content_chunk)} content items for chunk")
+
+        # Collect references for this chunk only
+        content_references, all_reference_uuids = self._collect_references(
+            content_chunk, verbosity
+        )
+
+        if not all_reference_uuids:
+            if verbosity >= 2:  # noqa: PLR2004
+                self.stdout.write("No references found in this chunk")
+            return 0
+
+        if verbosity >= 2:  # noqa: PLR2004
+            self.stdout.write(
+                f"Found {len(all_reference_uuids)} unique references in chunk"
+            )
+
+        # Bulk fetch all referenced content for this chunk
+        referenced_content_map = self._fetch_referenced_content(
+            all_reference_uuids, verbosity
+        )
+
+        # Update relationships for this chunk
+        chunk_updated = self._update_relationships(
+            content_references, referenced_content_map, verbosity
+        )
+
+        if verbosity >= 2:  # noqa: PLR2004
+            self.stdout.write(f"Updated {chunk_updated} content items in chunk")
+
+        return chunk_updated
+
+    def _collect_references(self, content_chunk, verbosity):
+        """Collect and flatten references from content chunk."""
+        content_references = {}
+        all_reference_uuids = set()
+
+        for content in content_chunk:
+            if references := compile_referencing_content(content):
+                # Flatten the references list in case it contains nested lists
+                flat_references = []
+                for ref in references:
+                    if isinstance(ref, list):
+                        flat_references.extend(ref)
+                    else:
+                        flat_references.append(ref)
+
+                content_references[content.id] = flat_references
+                all_reference_uuids.update(flat_references)
+
+                if verbosity >= 3:  # noqa: PLR2004
+                    self.stdout.write(
+                        f"Content {content.text_id} references "
+                        f"{len(flat_references)} items"
+                    )
+
+        return content_references, all_reference_uuids
+
+    def _fetch_referenced_content(self, all_reference_uuids, verbosity):
+        """Fetch referenced content in bulk."""
+        referenced_content_map = {
+            content.text_id: content
+            for content in WebsiteContent.objects.filter(
+                text_id__in=all_reference_uuids
+            ).only("id", "text_id")
+        }
+
+        if verbosity >= 2:  # noqa: PLR2004
+            self.stdout.write(
+                f"Resolved {len(referenced_content_map)} of "
+                f"{len(all_reference_uuids)} references"
+            )
+
+        return referenced_content_map
+
+    def _update_relationships(
+        self, content_references, referenced_content_map, verbosity
+    ):
+        """Update content relationships in a transaction."""
+        chunk_updated = 0
+        with transaction.atomic():
+            for content_id, reference_uuids in content_references.items():
+                try:
+                    content = WebsiteContent.objects.get(id=content_id)
+
+                    # Get valid referenced content objects
+                    referenced_content_ids = [
+                        referenced_content_map[ref_uuid].id
+                        for ref_uuid in reference_uuids
+                        if ref_uuid in referenced_content_map
+                    ]
+
+                    if referenced_content_ids:
+                        # Set new relationships (clears existing ones automatically)
+                        referenced_objects = WebsiteContent.objects.filter(
+                            id__in=referenced_content_ids
+                        )
+                        content.referenced_by.set(referenced_objects)
+                        chunk_updated += 1
+
+                        if verbosity >= 3:  # noqa: PLR2004
+                            self.stdout.write(
+                                f"Updated {content.text_id} with "
+                                f"{len(referenced_content_ids)} references"
+                            )
+
+                except WebsiteContent.DoesNotExist:
+                    # Content might have been deleted between queries
+                    if verbosity >= 2:  # noqa: PLR2004
+                        self.stdout.write(
+                            f"Content with id {content_id} not found, skipping"
+                        )
+                    continue
+
+        return chunk_updated

--- a/websites/migrations/0060_add_referncing_content_for_existing_resources.py
+++ b/websites/migrations/0060_add_referncing_content_for_existing_resources.py
@@ -1,0 +1,47 @@
+# Data migration to add referencing content for existing resources
+
+import logging
+
+from django.db import migrations
+
+from websites.utils import compile_referencing_content
+
+logger = logging.getLogger(__name__)
+
+
+def migrate_metadata_forward(apps, schema_editor):
+    """
+    Forward migration remove the "name" field from the metadata
+    of existing stories
+    """
+    WebsiteContent = apps.get_model("websites", "WebsiteContent")
+    website_content = WebsiteContent.objects.all()
+
+    for content in website_content:
+        if references := compile_referencing_content(content):
+            references = WebsiteContent.objects.filter(text_id__in=references)
+            content.referenced_by.set(references)
+            content.save()
+
+
+def migrate_metadata_backward(apps, schema_editor):
+    """
+    Run migration in backward direction.
+    This will not return the DB to original state.
+    """
+    logger.warning(
+        "Backward migration for adding referencing content is not implemented. "
+        "This will not return the DB to original state."
+    )
+
+
+class Migration(migrations.Migration):
+    """Data migration to add referencing content for existing resources"""
+
+    dependencies = [
+        ("websites", "0059_remove_name_from_stories_websitecontent_metadata"),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_metadata_forward, migrate_metadata_backward),
+    ]

--- a/websites/utils.py
+++ b/websites/utils.py
@@ -100,6 +100,7 @@ def is_test_site(site_name: str) -> bool:
 
 
 def get_metadata_content_key(content) -> list:
+    """Get the metadata content keys based on the content type."""
     content_type = content.type
     match content_type:
         case (
@@ -115,7 +116,7 @@ def get_metadata_content_key(content) -> list:
     return content_keys
 
 
-def parse_string(text: str) -> list[str]:
+def parse_resource_uuid(text: str) -> list[str]:
     """
     Parse the input text to extract UUIDs from resource links.
 
@@ -169,3 +170,26 @@ def parse_string(text: str) -> list[str]:
         or _match[2]  # match[0] for first group UUID, match[2] for second group UUID
         for _match in matches
     ]
+
+
+def compile_referencing_content(content) -> list[str]:
+    """Compile referencing content for a website content instance."""
+    references = []
+
+    if content.type == constants.CONTENT_TYPE_NAVMENU:
+        references = [
+            item["identifier"]
+            for item in content.metadata.get(constants.WEBSITE_CONTENT_LEFTNAV, [])
+        ]
+    else:
+        if content.markdown:
+            references += parse_resource_uuid(content.markdown)
+
+        if content.metadata:
+            content_keys = get_metadata_content_key(content)
+            for content_key in content_keys:
+                if content.metadata.get(content_key):
+                    references.extend(
+                        parse_resource_uuid(content.metadata[content_key])
+                    )
+    return references

--- a/websites/utils_test.py
+++ b/websites/utils_test.py
@@ -6,7 +6,7 @@ from websites import constants
 from websites.factories import WebsiteFactory
 from websites.utils import (
     get_dict_query_field,
-    parse_string,
+    parse_resource_uuid,
     permissions_group_name_for_role,
     set_dict_field,
 )
@@ -146,14 +146,14 @@ def test_set_dict_field():
         ),
     ],
 )
-def test_parse_string(input_text, expected_uuids):
-    """Test parse_string extracts UUIDs correctly from various resource patterns"""
-    result = parse_string(input_text)
+def test_parse_resource_uuid(input_text, expected_uuids):
+    """Test parse_resource_uuid extracts UUIDs correctly from various resource patterns"""
+    result = parse_resource_uuid(input_text)
     assert result == expected_uuids
 
 
-def test_parse_string_with_surrounding_text():
-    """Test parse_string works correctly when resource patterns are embedded in other text"""
+def test_parse_resource_uuid_with_surrounding_text():
+    """Test parse_resource_uuid works correctly when resource patterns are embedded in other text"""
     text = """
     This is some markdown content before the resource.
 
@@ -166,7 +166,7 @@ def test_parse_string_with_surrounding_text():
     And here is some content after the resources.
     """
 
-    result = parse_string(text)
+    result = parse_resource_uuid(text)
     expected = [
         "123e4567-e89b-12d3-a456-426614174000",
         "987fcdeb-ba01-2345-6789-abcdef012345",
@@ -174,8 +174,8 @@ def test_parse_string_with_surrounding_text():
     assert result == expected
 
 
-def test_parse_string_case_sensitivity():
-    """Test that parse_string is case sensitive for the pattern matching"""
+def test_parse_resource_uuid_case_sensitivity():
+    """Test that parse_resource_uuid is case sensitive for the pattern matching"""
     # These should not match because of case differences
     invalid_cases = [
         '{{< Resource uuid="123e4567-e89b-12d3-a456-426614174000" >}}',  # Capital R
@@ -184,5 +184,5 @@ def test_parse_string_case_sensitivity():
     ]
 
     for text in invalid_cases:
-        result = parse_string(text)
+        result = parse_resource_uuid(text)
         assert result == [], f"Expected no matches for: {text}"


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7681

### Description (What does it do?)
This PR adds a Django management command for backpopulating referencing content in the WebsiteContent model and refactors reference parsing utilities to centralize the logic.

It handles navigation menu references, markdown content parsing, and metadata field parsing based on content type.

### How can this be tested?
TBA