### PR TITLE
fix: use iterator instead of loadig all records in memory

### DIFF
--- a/websites/migrations/0060_add_referencing_content_for_existing_resources.py
+++ b/websites/migrations/0060_add_referencing_content_for_existing_resources.py
@@ -15,7 +15,7 @@ def migrate_metadata_forward(apps, schema_editor):
     """
     WebsiteContent = apps.get_model("websites", "WebsiteContent")
 
-    # Use iterator to process records one at a time without loading all into memory
+    # Process records in batches without loading all into memory
     for content in WebsiteContent.objects.iterator(chunk_size=1000):
         if references := compile_referencing_content(content):
             referenced_objects = WebsiteContent.objects.filter(text_id__in=references)

--- a/websites/migrations/0060_add_referncing_content_for_existing_resources.py
+++ b/websites/migrations/0060_add_referncing_content_for_existing_resources.py
@@ -1,4 +1,4 @@
-# Data migration to add referencing content for existing resources
+"""Data migration to add referencing content for existing resources."""
 
 import logging
 
@@ -14,13 +14,12 @@ def migrate_metadata_forward(apps, schema_editor):
     Forward migration to add referencing content for existing resources.
     """
     WebsiteContent = apps.get_model("websites", "WebsiteContent")
-    website_content = WebsiteContent.objects.all()
 
-    for content in website_content:
+    # Use iterator to process records one at a time without loading all into memory
+    for content in WebsiteContent.objects.iterator(chunk_size=1000):
         if references := compile_referencing_content(content):
-            references = WebsiteContent.objects.filter(text_id__in=references)
-            content.referenced_by.set(references)
-            content.save()
+            referenced_objects = WebsiteContent.objects.filter(text_id__in=references)
+            content.referenced_by.set(referenced_objects)
 
 
 def migrate_metadata_backward(apps, schema_editor):


### PR DESCRIPTION
### What are the relevant tickets?
follow up to https://github.com/mitodl/hq/issues/7681

### Description (What does it do?)
This PR optimizes the Django migration `0060_add_referencing_content_for_existing_resources.py` to resolve memory quota exceeded errors in CI. The migration was failing because it was loading all WebsiteContent records into memory at once.

- Replaced `WebsiteContent.objects.all()` with `WebsiteContent.objects.iterator(chunk_size=1000)` to process records in memory-efficient chunks
- Maintained the same functionality while drastically reducing memory usage

### How can this be tested?
1. Switch to this branch and spin up containers
2. Create a test environment with a substantial number of WebsiteContent records
3. Run the migration: `python manage.py migrate websites 0060`
4. Verify that `referencing_content` relationships are correctly populated after migration
5. Check migration logs for progress tracking