### PR TITLE
Display read-only page URL in Edit Page drawer

### DIFF
--- a/static/js/components/forms/SiteContentForm.test.tsx
+++ b/static/js/components/forms/SiteContentForm.test.tsx
@@ -247,7 +247,7 @@ test.each`
 
 test.each`
   isGdriveEnabled | isResource | willRender | filename
-  ${true}         | ${true}    | ${true}    | ${"courses/file.pdf"}
+  ${true}         | ${true}    | ${true}    | ${"file.pdf"}
   ${false}        | ${true}    | ${false}   | ${null}
   ${true}         | ${false}   | ${false}   | ${null}
   ${false}        | ${false}   | ${false}   | ${null}
@@ -297,4 +297,23 @@ test("SiteContentField uses existing values when editing", () => {
   expect(form.find(FormFields).prop("values")).toEqual(
     contentInitialValues(data.content, data.configItem.fields, data.website),
   )
+})
+
+test("renders Page URL field for page content", () => {
+  const data = setupData()
+  data.content.type = "page"
+  data.content.filename = "test-page"
+  const configItem = makeEditableConfigItem("page")
+  configItem.fields = [
+    makeWebsiteConfigField({ name: "title", widget: WidgetVariant.String }),
+  ]
+  const { form } = setupInnerForm({
+    ...data,
+    configItem,
+    values: { title: "Test Page" },
+  })
+  const label = form
+    .find(Label)
+    .filterWhere((node) => node.prop("value") === "/pages/test-page")
+  expect(label.exists()).toBe(true)
 })

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -33,6 +33,7 @@ import {
 import { SiteFormValues } from "../../types/forms"
 import { getContentSchema } from "./validation"
 import { useWebsite } from "../../context/Website"
+import { filenameFromPath } from "../../lib/util"
 
 export interface FormProps {
   onSubmit: (
@@ -175,15 +176,9 @@ export function FormFields(props: InnerFormProps): JSX.Element {
                     onChange={handleChange}
                   />
                   {content?.type === "page" ? (
-                    <div className="form-group mt-2">
+                    <div>
                       <label>Page URL</label>
-                      <input
-                        className="form-control"
-                        value={`/pages/${content.filename}`}
-                        type="text"
-                        readOnly
-                        style={{ cursor: "not-allowed" }}
-                      />
+                      <Label value={`/pages/${content.filename}`} />
                     </div>
                   ) : null}
                 </React.Fragment>
@@ -205,6 +200,7 @@ export function FormFields(props: InnerFormProps): JSX.Element {
                 <Field
                   as={Label}
                   name={field.name}
+                  value={filenameFromPath(values[field.name])}
                   className="form-control"
                   onChange={handleChange}
                 />

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -177,8 +177,11 @@ export function FormFields(props: InnerFormProps): JSX.Element {
                   />
                   {content?.type === "page" ? (
                     <div>
-                      <label>Page URL</label>
-                      <Label value={`/pages/${content.filename}`} />
+                      <label htmlFor="page-url">Page URL</label>
+                      <Label
+                        value={`/pages/${content.filename}`}
+                        name="page-url"
+                      />
                     </div>
                   ) : null}
                 </React.Fragment>

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -200,7 +200,7 @@ export function FormFields(props: InnerFormProps): JSX.Element {
                 <Field
                   as={Label}
                   name={field.name}
-                  value={filenameFromPath(values[field.name])}
+                  value={filenameFromPath(values[field.name] as string)}
                   className="form-control"
                   onChange={handleChange}
                 />

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -166,6 +166,29 @@ export function FormFields(props: InnerFormProps): JSX.Element {
             ) {
               return null
             }
+            if (field.name === "title") {
+              return (
+                <React.Fragment key={field.name}>
+                  <SiteContentField
+                    field={field}
+                    contentContext={contentContext}
+                    onChange={handleChange}
+                  />
+                  {content?.type === "page" ? (
+                    <div className="form-group mt-2">
+                      <label>Page URL</label>
+                      <input
+                        className="form-control"
+                        value={`/pages/${content.filename}`}
+                        type="text"
+                        readOnly
+                        style={{ cursor: "not-allowed" }}
+                      />
+                    </div>
+                  ) : null}
+                </React.Fragment>
+              )
+            }
             return field.widget === WidgetVariant.Object ? (
               <ObjectField
                 field={field}

--- a/static/js/components/widgets/Label.tsx
+++ b/static/js/components/widgets/Label.tsx
@@ -14,6 +14,7 @@ const Label: React.FC<Props> = (props) => {
     <div className="form-group">
       {value && !(value instanceof File) ? (
         <input
+          id={props.name}
           className="form-control"
           value={value}
           type="text"

--- a/static/js/components/widgets/Label.tsx
+++ b/static/js/components/widgets/Label.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-import { filenameFromPath } from "../../lib/util"
 
 export interface Props {
   name?: string
@@ -16,7 +15,7 @@ const Label: React.FC<Props> = (props) => {
       {value && !(value instanceof File) ? (
         <input
           className="form-control"
-          value={filenameFromPath(value)}
+          value={value}
           type="text"
           readOnly
           style={{ cursor: "not-allowed" }}

--- a/static/js/types/websites.ts
+++ b/static/js/types/websites.ts
@@ -296,6 +296,7 @@ export interface WebsiteContent extends WebsiteContentListItem {
   markdown: string | null
   metadata: null | Record<string, SiteFormValue>
   content_context: WebsiteContent[] | null
+  filename: string
   file?: string
   url_path?: string
 }

--- a/static/js/util/factories/websites.ts
+++ b/static/js/util/factories/websites.ts
@@ -314,4 +314,5 @@ export const makeWebsiteContentDetail = (): WebsiteContent => ({
   },
   content_context: [],
   url_path: casual.text,
+  filename: casual.word,
 })

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -622,7 +622,13 @@ class WebsiteContentDetailSerializer(
 
     class Meta:
         model = WebsiteContent
-        read_only_fields = ["text_id", "type", "content_context", "url_path"]
+        read_only_fields = [
+            "text_id",
+            "type",
+            "content_context",
+            "url_path",
+            "filename",
+        ]
         fields = [
             *read_only_fields,
             "title",


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/5357.

### Description (What does it do?)
This PR adds a new read-only field to the `Edit Page` drawer where the page URL is displayed. This is part of making page URL editing easy-to-use and transparent. 

### How can this be tested?
In OCW Studio, verify that the Page URL field is displayed and looks correct in the `Edit Page` drawer.

Also, after following the testing instructions in https://github.com/mitodl/ocw-studio/pull/2601, verify that changing the Page Title also changes the displayed page URL after saving and re-opening the drawer. Note that this is currently behind a PostHog feature flag.
