### PR TITLE
Add help text to Page URL field in Edit Page drawer

### DIFF
--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -178,6 +178,9 @@ export function FormFields(props: InnerFormProps): JSX.Element {
                   {content?.type === "page" ? (
                     <div>
                       <label htmlFor="page-url">Page URL</label>
+                      <div className="help-text">
+                        This is auto-generated from the title field
+                      </div>
                       <Label
                         value={`/pages/${content.filename}`}
                         name="page-url"


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/5185 (relevant comment: https://github.com/mitodl/hq/issues/5185#issuecomment-3050023485).

### Description (What does it do?)
This PR adds the help text `This is auto-generated from the title field` to the Page URL field. This can be considered a follow-up to https://github.com/mitodl/ocw-studio/pull/2610.

### How can this be tested?
Open the Edit Page drawer, and confirm that the help text looks correct.

### Additional Context
An alternative approach to this PR would have been to expose the components of the Page URL field to the API and then use a new widget type for that component, with an appropriate definition in the `ocw-hugo-projects` course YAML for that field. The approach taken in this PR is substantially simpler, but the alternative approach could be considered if further modifications are needed or greater flexibility is desired.