### PR TITLE
fix: Pin aws-cli image to AL2

### DIFF
--- a/content_sync/pipelines/definitions/concourse/common/image_resources.py
+++ b/content_sync/pipelines/definitions/concourse/common/image_resources.py
@@ -13,8 +13,7 @@ OCW_COURSE_PUBLISHER_REGISTRY_IMAGE = AnonymousResource(
 
 AWS_CLI_REGISTRY_IMAGE = AnonymousResource(
     type=REGISTRY_IMAGE,
-    source=RegistryImage(repository="amazon/aws-cli",
-    tag="2.27.50")
+    source=RegistryImage(repository="amazon/aws-cli", tag="2.27.50"),
 )
 
 BASH_REGISTRY_IMAGE = AnonymousResource(

--- a/content_sync/pipelines/definitions/concourse/common/image_resources.py
+++ b/content_sync/pipelines/definitions/concourse/common/image_resources.py
@@ -12,7 +12,9 @@ OCW_COURSE_PUBLISHER_REGISTRY_IMAGE = AnonymousResource(
 )
 
 AWS_CLI_REGISTRY_IMAGE = AnonymousResource(
-    type=REGISTRY_IMAGE, source=RegistryImage(repository="amazon/aws-cli", tag="latest")
+    type=REGISTRY_IMAGE,
+    source=RegistryImage(repository="amazon/aws-cli",
+    tag="2.27.50")
 )
 
 BASH_REGISTRY_IMAGE = AnonymousResource(


### PR DESCRIPTION
### What are the relevant tickets?
No ticket.

### Description (What does it do?)
The aws-cli docker image has been updated from AL2 to a more recent version which doesn't contain the packages we need.

