### PR TITLE
Update URLs only for pages when title changes

### DIFF
--- a/websites/signals.py
+++ b/websites/signals.py
@@ -8,6 +8,7 @@ from django.utils.text import slugify
 from main.posthog import is_feature_enabled
 from websites.constants import (
     CONTENT_TYPE_NAVMENU,
+    CONTENT_TYPE_PAGE,
     POSTHOG_ENABLE_EDITABLE_PAGE_URLS,
     WEBSITE_CONTENT_LEFTNAV,
     WEBSITE_PAGES_PATH,
@@ -50,7 +51,7 @@ def update_page_url_on_title_change(
     if not is_feature_enabled(POSTHOG_ENABLE_EDITABLE_PAGE_URLS):
         return
 
-    if instance.is_page_content and instance.title:
+    if instance.type == CONTENT_TYPE_PAGE and instance.title:
         new_filename = slugify(instance.title)
         if instance.filename == new_filename:
             return
@@ -58,7 +59,7 @@ def update_page_url_on_title_change(
             website=instance.website,
             dirpath=instance.dirpath,
             filename=new_filename,
-            is_page_content=True,
+            type=CONTENT_TYPE_PAGE,
         ).exclude(pk=instance.pk)
 
         if not cur_filename.exists():

--- a/websites/signals_test.py
+++ b/websites/signals_test.py
@@ -5,6 +5,7 @@ from django.utils.text import slugify
 
 from users.factories import UserFactory
 from websites import constants
+from websites.constants import CONTENT_TYPE_INSTRUCTOR, CONTENT_TYPE_PAGE
 from websites.factories import WebsiteContentFactory, WebsiteFactory
 
 
@@ -20,7 +21,7 @@ def test_handle_website_save():
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     (
-        "is_page_content",
+        "is_page",
         "feature_flag",
         "initial_title",
         "new_title",
@@ -32,7 +33,7 @@ def test_handle_website_save():
         (True, False, "Original Title", "New Title", False, "original-title"),
         # conflict with existing slugified title; no URL change
         (True, True, "Original Title", "Some Existing Title", True, "original-title"),
-        # non-page content; no URL change
+        # non-page; no URL change
         (False, True, "Original Title", "New Title", False, "original-title"),
         # slugified title matches existing filename; no URL change
         (True, True, "Test Page", "test page", False, "test-page"),
@@ -42,7 +43,7 @@ def test_handle_website_save():
 )
 def test_update_page_url_on_title_change_parametrized(  # noqa: PLR0913
     mocker,
-    is_page_content,
+    is_page,
     feature_flag,
     initial_title,
     new_title,
@@ -56,7 +57,7 @@ def test_update_page_url_on_title_change_parametrized(  # noqa: PLR0913
     if existing_conflict:
         WebsiteContentFactory.create(
             website=website,
-            is_page_content=True,
+            type=CONTENT_TYPE_PAGE,
             dirpath="",
             title=new_title,
             filename=slugify(new_title),
@@ -64,7 +65,7 @@ def test_update_page_url_on_title_change_parametrized(  # noqa: PLR0913
 
     page = WebsiteContentFactory.create(
         website=website,
-        is_page_content=is_page_content,
+        type=CONTENT_TYPE_PAGE if is_page else CONTENT_TYPE_INSTRUCTOR,
         dirpath="",
         title=initial_title,
         filename=slugify(initial_title),
@@ -83,7 +84,7 @@ def test_navmenu_updated_on_page_title_change(mocker):
 
     page = WebsiteContentFactory.create(
         website=website,
-        is_page_content=True,
+        type=CONTENT_TYPE_PAGE,
         dirpath="",
         title="Original Title",
         filename="original-title",

--- a/websites/signals_test.py
+++ b/websites/signals_test.py
@@ -5,7 +5,6 @@ from django.utils.text import slugify
 
 from users.factories import UserFactory
 from websites import constants
-from websites.constants import CONTENT_TYPE_INSTRUCTOR, CONTENT_TYPE_PAGE
 from websites.factories import WebsiteContentFactory, WebsiteFactory
 
 
@@ -57,7 +56,7 @@ def test_update_page_url_on_title_change_parametrized(  # noqa: PLR0913
     if existing_conflict:
         WebsiteContentFactory.create(
             website=website,
-            type=CONTENT_TYPE_PAGE,
+            type=constants.CONTENT_TYPE_PAGE,
             dirpath="",
             title=new_title,
             filename=slugify(new_title),
@@ -65,7 +64,9 @@ def test_update_page_url_on_title_change_parametrized(  # noqa: PLR0913
 
     page = WebsiteContentFactory.create(
         website=website,
-        type=CONTENT_TYPE_PAGE if is_page else CONTENT_TYPE_INSTRUCTOR,
+        type=constants.CONTENT_TYPE_PAGE
+        if is_page
+        else constants.CONTENT_TYPE_INSTRUCTOR,
         dirpath="",
         title=initial_title,
         filename=slugify(initial_title),
@@ -84,7 +85,7 @@ def test_navmenu_updated_on_page_title_change(mocker):
 
     page = WebsiteContentFactory.create(
         website=website,
-        type=CONTENT_TYPE_PAGE,
+        type=constants.CONTENT_TYPE_PAGE,
         dirpath="",
         title="Original Title",
         filename="original-title",


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/5357. Follow-up to https://github.com/mitodl/ocw-studio/pull/2601 and https://github.com/mitodl/ocw-studio/pull/2611.

### Description (What does it do?)
The page URL editing feature added in https://github.com/mitodl/ocw-studio/pull/2601 also updated the URLs for instructors, which are classified in OCW Studio as "page content" despite not being actual pages. This was causing an issue where the URL of the instructor was not what was expected by the publishing pipeline, resulting in publishing failures such as:
`
ERROR Failed to fetch instructors from https://((redacted)).((redacted))/instructors/bd8a2538-4087-4389-961e-2ee648f97d53/index.json
`

### How can this be tested?
Set the `OCW_STUDIO_EDITABLE_PAGE_URLS` feature flag to on in PostHog. Open up `ocw-www` in OCW Studio, and add a new instructor or make any change to an existing instructor and then save the changes. The URL of the `Edit Instructor` drawer will be `localhost:8043/sites/ocw-www/type/instructor/edit/<uuid>`. Navigate to Django Admin and search for that UUID in `Website contents`. Verify that the `Filename` of the object is the UUID and not the title.

Then, test the entire publishing workflow. Add a new instructor, publish `ocw-www`, and then add that new instructor to a new or existing course. Publishing the course should work successfully.