### PR TITLE
make Github API timeout configurable

### DIFF
--- a/app.json
+++ b/app.json
@@ -214,6 +214,10 @@
       "description": "Minimum time to sleep between when throttling github calls",
       "required": false
     },
+    "GITHUB_TIMEOUT": {
+      "description": "Timeout in seconds for Github API requests",
+      "required": false
+    },
     "GITHUB_WEBHOOK_BRANCH": {
       "description": "Github branch to filter webhook requests against",
       "required": false
@@ -479,6 +483,10 @@
       "description": "API token for communicating with PostHog",
       "required": false
     },
+    "POST_TRANSCODE_ACTIONS": {
+      "description": "Actions to perform before publish",
+      "required": false
+    },
     "PREPUBLISH_ACTIONS": {
       "description": "Actions to perform before publish",
       "required": false
@@ -644,6 +652,10 @@
       "description": "3play project id",
       "required": false
     },
+    "TRANSCODE_JOB_TEMPLATE": {
+      "description": "Path to the transcoding job template",
+      "required": false
+    },
     "UPDATE_MISSING_TRANSCRIPT_FREQUENCY": {
       "description": "The frequency to check for transcripts for published videos with blank transcripts",
       "required": false
@@ -664,12 +676,28 @@
       "description": "Use the PORT from original url accessed by user",
       "required": false
     },
+    "VIDEO_S3_THUMBNAIL_BUCKET": {
+      "description": "Bucket to be used for thumbnail generation",
+      "required": false
+    },
+    "VIDEO_S3_THUMBNAIL_PREFIX": {
+      "description": "Prefix for the thumbnail video",
+      "required": false
+    },
+    "VIDEO_S3_TRANSCODE_BUCKET": {
+      "description": "Bucket to be used for transcoding",
+      "required": false
+    },
     "VIDEO_S3_TRANSCODE_ENDPOINT": {
       "description": "Endpoint to be used for AWS MediaConvert",
       "required": false
     },
     "VIDEO_S3_TRANSCODE_PREFIX": {
-      "description": "Prefix to be used for S3 keys of files transcoded from AWS MediaConvert",
+      "description": "Prefix for the transcoded video",
+      "required": false
+    },
+    "VIDEO_S3_UPLOAD_PREFIX": {
+      "description": "Prefix for the source video",
       "required": false
     },
     "VIDEO_TRANSCODE_QUEUE": {

--- a/content_sync/apis/github.py
+++ b/content_sync/apis/github.py
@@ -76,7 +76,7 @@ def sync_starter_configs(  # pylint:disable=too-many-locals
     """  # noqa: E501
     repo_path = urlparse(repo_url).path.lstrip("/")
     org_name, repo_name = repo_path.split("/", 1)
-    git = Github()
+    git = Github(timeout=settings.GITHUB_TIMEOUT)
     org = git.get_organization(org_name)
     repo = org.get_repo(repo_name)
 

--- a/main/settings.py
+++ b/main/settings.py
@@ -974,6 +974,12 @@ GITHUB_APP_PRIVATE_KEY = (
     .decode("unicode_escape")
     .encode()
 )
+GITHUB_TIMEOUT = get_int(
+    name="GITHUB_TIMEOUT",
+    default=15,
+    description="Timeout in seconds for Github API requests",
+    required=False,
+)
 GIT_ORGANIZATION = get_string(
     name="GIT_ORGANIZATION",
     default=None,


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7861

### Description (What does it do?)
This PR adds a new setting (`GITHUB_TIMEOUT`) and utilizes it when initializing the Github backend.

### How can this be tested?
 - Put `GITHUB_TIMEOUT=1` in your `.env` file
 - Try and publish a site, and the status should just hang at "not started"
 - Change it to `GITHUB_TIMEOUT=60` and restart your containers
 - Try publishing the site again and it should succeed
