### PR TITLE
chore: set number of attempts for the offline build gate step to three

### DIFF
--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -864,7 +864,7 @@ class SitePipelineDefinition(Pipeline):
             try_=PutStep(
                 put=self._offline_build_gate_identifier,
                 timeout="1m",
-                attempts=1,
+                attempts=3,
                 get_params={"strict": True},
                 no_get=True,
             )


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7898

### Description (What does it do?)
This branch sets the number of attempts for the offline build gate step in the site pipeline, from one to three.

### How can this be tested?
1. Switch to the branch and spin up containers
2. update pipeline definition with the following command and verify that the offline build gate step has three attempts:
`docker compose exec web ./manage.py backpopulate_pipelines`