### PR TITLE
Warn and prevent save if new page title conflicts with existing URL

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -10,7 +10,7 @@ from django.db.models.signals import pre_save
 from fixtures.common import *  # pylint:disable=wildcard-import,unused-wildcard-import  # noqa: F403
 from websites.constants import OMNIBUS_STARTER_SLUG
 from websites.models import WebsiteContent, WebsiteStarter
-from websites.signals import update_page_url_on_title_change
+from websites.signals import update_navmenu_on_title_change
 from websites.site_config_api import SiteConfig
 
 
@@ -96,7 +96,7 @@ def disable_websitecontent_signal():
     """Disable page url update signal"""
 
     # Disconnect
-    pre_save.disconnect(update_page_url_on_title_change, sender=WebsiteContent)
+    pre_save.disconnect(update_navmenu_on_title_change, sender=WebsiteContent)
 
 
 @pytest.fixture
@@ -104,4 +104,4 @@ def enable_websitecontent_signal():
     """Enable page url update signal"""
 
     # Disconnect
-    pre_save.connect(update_page_url_on_title_change, sender=WebsiteContent)
+    pre_save.connect(update_navmenu_on_title_change, sender=WebsiteContent)

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -535,6 +535,7 @@ class WebsiteContentDetailSerializer(
     url_path = serializers.SerializerMethodField()
 
     def update(self, instance, validated_data):
+        """Update WebsiteContent, handling filename and metadata."""
         if is_feature_enabled(POSTHOG_ENABLE_EDITABLE_PAGE_URLS):
             title = validated_data.get("title", instance.title)
             if instance.type == CONTENT_TYPE_PAGE and title:
@@ -557,7 +558,6 @@ class WebsiteContentDetailSerializer(
                         )
                     else:
                         instance.filename = new_filename
-        """Add updated_by to the data"""
         if instance.type == CONTENT_TYPE_RESOURCE:
             update_youtube_thumbnail(
                 instance.website.uuid, validated_data.get("metadata"), overwrite=True

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -7,14 +7,18 @@ import pytest
 from dateutil.parser import parse as parse_date
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db.models import CharField, Value
+from django.utils.text import slugify
 from mitol.common.utils import now_in_utc
+from rest_framework.exceptions import ValidationError
 
 from main.constants import ISO_8601_FORMAT
 from users.factories import UserFactory
 from users.models import User
 from videos.constants import YT_THUMBNAIL_IMG
 from websites.constants import (
+    CONTENT_TYPE_INSTRUCTOR,
     CONTENT_TYPE_METADATA,
+    CONTENT_TYPE_PAGE,
     CONTENT_TYPE_RESOURCE,
     PUBLISH_STATUS_NOT_STARTED,
     PUBLISH_STATUS_SUCCEEDED,
@@ -807,3 +811,69 @@ def test_website_content_export_serializer(ocw_site):
     assert data["fields"]["owner"] is None
     assert data["fields"]["updated_by"] is None
     assert data["fields"]["file"] == str(Path(content.website.url_path) / "file.txt")
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    (
+        "is_page",
+        "feature_flag",
+        "initial_title",
+        "new_title",
+        "existing_conflict",
+        "expected_filename",
+    ),
+    [
+        # feature flag disabled; no URL change
+        (True, False, "Original Title", "New Title", False, "original-title"),
+        # conflict with existing slugified title; no URL change
+        (True, True, "Original Title", "Some Existing Title", True, "original-title"),
+        # non-page; no URL change
+        (False, True, "Original Title", "New Title", False, "original-title"),
+        # slugified title matches existing filename; no URL change
+        (True, True, "Test Page", "test page", False, "test-page"),
+        # URL should be updated
+        (True, True, "Test Page", "Some New Title", False, "some-new-title"),
+    ],
+)
+def test_update_page_url_on_title_change_parametrized(  # noqa: PLR0913
+    mocker,
+    enable_websitecontent_signal,
+    is_page,
+    feature_flag,
+    initial_title,
+    new_title,
+    existing_conflict,
+    expected_filename,
+):
+    """Page filename is updated correctly when page's title changes"""
+    website = WebsiteFactory.create(owner=UserFactory.create())
+    mocker.patch("websites.serializers.is_feature_enabled", return_value=feature_flag)
+
+    if existing_conflict:
+        WebsiteContentFactory.create(
+            website=website,
+            type=CONTENT_TYPE_PAGE,
+            dirpath="",
+            title=new_title,
+            filename=slugify(new_title),
+        )
+
+    page = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_PAGE if is_page else CONTENT_TYPE_INSTRUCTOR,
+        dirpath="",
+        title=initial_title,
+        filename=slugify(initial_title),
+    )
+    serializer = WebsiteContentDetailSerializer(
+        instance=page, data={"title": new_title}, partial=True
+    )
+    assert serializer.is_valid(), serializer.errors
+    if existing_conflict:
+        with pytest.raises(ValidationError):
+            serializer.save()
+    else:
+        serializer.save()
+        page.refresh_from_db()
+        assert page.filename == expected_filename

--- a/websites/signals.py
+++ b/websites/signals.py
@@ -8,6 +8,7 @@ from django.utils.text import slugify
 from main.posthog import is_feature_enabled
 from websites.constants import (
     CONTENT_TYPE_NAVMENU,
+    CONTENT_TYPE_PAGE,
     POSTHOG_ENABLE_EDITABLE_PAGE_URLS,
     WEBSITE_CONTENT_LEFTNAV,
     WEBSITE_PAGES_PATH,
@@ -48,6 +49,16 @@ def update_navmenu_on_title_change(
     """
 
     if not is_feature_enabled(POSTHOG_ENABLE_EDITABLE_PAGE_URLS):
+        return
+
+    if instance.type != CONTENT_TYPE_PAGE:
+        return
+
+    try:
+        prev_instance = WebsiteContent.objects.get(pk=instance.pk)
+        if prev_instance.title == instance.title:
+            return
+    except WebsiteContent.DoesNotExist:
         return
 
     new_filename = slugify(instance.title)

--- a/websites/signals.py
+++ b/websites/signals.py
@@ -8,7 +8,6 @@ from django.utils.text import slugify
 from main.posthog import is_feature_enabled
 from websites.constants import (
     CONTENT_TYPE_NAVMENU,
-    CONTENT_TYPE_PAGE,
     POSTHOG_ENABLE_EDITABLE_PAGE_URLS,
     WEBSITE_CONTENT_LEFTNAV,
     WEBSITE_PAGES_PATH,
@@ -37,13 +36,13 @@ def handle_website_save(
 
 
 @receiver(pre_save, sender=WebsiteContent)
-def update_page_url_on_title_change(
+def update_navmenu_on_title_change(
     sender,  # noqa: ARG001
     instance,
     **kwargs,  # noqa: ARG001
 ):
     """
-    Update page URL when title changes for page content.
+    Update navmenu when the title of a page changes.
     This is currently behind the PostHog feature flag
     OCW_STUDIO_EDITABLE_PAGE_URLS.
     """
@@ -51,34 +50,22 @@ def update_page_url_on_title_change(
     if not is_feature_enabled(POSTHOG_ENABLE_EDITABLE_PAGE_URLS):
         return
 
-    if instance.type == CONTENT_TYPE_PAGE and instance.title:
-        new_filename = slugify(instance.title)
-        if instance.filename == new_filename:
-            return
-        cur_filename = WebsiteContent.objects.filter(
-            website=instance.website,
-            dirpath=instance.dirpath,
-            filename=new_filename,
-            type=CONTENT_TYPE_PAGE,
-        ).exclude(pk=instance.pk)
-
-        if not cur_filename.exists():
-            instance.filename = new_filename
-
-            try:
-                navmenu = WebsiteContent.objects.get(
-                    website=instance.website,
-                    type=CONTENT_TYPE_NAVMENU,
-                )
-                menu_items = navmenu.metadata.get(WEBSITE_CONTENT_LEFTNAV, [])
-                navmenu_updated = False
-                for item in menu_items:
-                    if item.get("identifier") == instance.text_id:
-                        item["pageRef"] = f"/{WEBSITE_PAGES_PATH}/{new_filename}"
-                        item["name"] = instance.title
-                        navmenu_updated = True
-                if navmenu_updated:
-                    navmenu.metadata[WEBSITE_CONTENT_LEFTNAV] = menu_items
-                    navmenu.save(update_fields=["metadata"])
-            except WebsiteContent.DoesNotExist:
-                pass
+    new_filename = slugify(instance.title)
+    if instance.filename == new_filename:
+        try:
+            navmenu = WebsiteContent.objects.get(
+                website=instance.website,
+                type=CONTENT_TYPE_NAVMENU,
+            )
+            menu_items = navmenu.metadata.get(WEBSITE_CONTENT_LEFTNAV, [])
+            navmenu_updated = False
+            for item in menu_items:
+                if item.get("identifier") == instance.text_id:
+                    item["pageRef"] = f"/{WEBSITE_PAGES_PATH}/{new_filename}"
+                    item["name"] = instance.title
+                    navmenu_updated = True
+            if navmenu_updated:
+                navmenu.metadata[WEBSITE_CONTENT_LEFTNAV] = menu_items
+                navmenu.save(update_fields=["metadata"])
+        except WebsiteContent.DoesNotExist:
+            pass

--- a/websites/signals_test.py
+++ b/websites/signals_test.py
@@ -1,11 +1,11 @@
 """Tests for signals"""
 
 import pytest
-from django.utils.text import slugify
 
 from users.factories import UserFactory
 from websites import constants
 from websites.factories import WebsiteContentFactory, WebsiteFactory
+from websites.serializers import WebsiteContentDetailSerializer
 
 
 @pytest.mark.django_db
@@ -15,67 +15,6 @@ def test_handle_website_save():
     assert website.admin_group is not None
     assert website.editor_group is not None
     assert website.owner.has_perm(constants.PERMISSION_EDIT, website)
-
-
-@pytest.mark.django_db
-@pytest.mark.parametrize(
-    (
-        "is_page",
-        "feature_flag",
-        "initial_title",
-        "new_title",
-        "existing_conflict",
-        "expected_filename",
-    ),
-    [
-        # feature flag disabled; no URL change
-        (True, False, "Original Title", "New Title", False, "original-title"),
-        # conflict with existing slugified title; no URL change
-        (True, True, "Original Title", "Some Existing Title", True, "original-title"),
-        # non-page; no URL change
-        (False, True, "Original Title", "New Title", False, "original-title"),
-        # slugified title matches existing filename; no URL change
-        (True, True, "Test Page", "test page", False, "test-page"),
-        # URL should be updated
-        (True, True, "Test Page", "Some New Title", False, "some-new-title"),
-    ],
-)
-def test_update_page_url_on_title_change_parametrized(  # noqa: PLR0913
-    mocker,
-    enable_websitecontent_signal,
-    is_page,
-    feature_flag,
-    initial_title,
-    new_title,
-    existing_conflict,
-    expected_filename,
-):
-    """Page filename is updated correctly when page's title changes"""
-    website = WebsiteFactory.create(owner=UserFactory.create())
-    mocker.patch("websites.signals.is_feature_enabled", return_value=feature_flag)
-
-    if existing_conflict:
-        WebsiteContentFactory.create(
-            website=website,
-            type=constants.CONTENT_TYPE_PAGE,
-            dirpath="",
-            title=new_title,
-            filename=slugify(new_title),
-        )
-
-    page = WebsiteContentFactory.create(
-        website=website,
-        type=constants.CONTENT_TYPE_PAGE
-        if is_page
-        else constants.CONTENT_TYPE_INSTRUCTOR,
-        dirpath="",
-        title=initial_title,
-        filename=slugify(initial_title),
-    )
-    page.title = new_title
-    page.save()
-    page.refresh_from_db()
-    assert page.filename == expected_filename
 
 
 @pytest.mark.django_db
@@ -107,7 +46,11 @@ def test_navmenu_updated_on_page_title_change(mocker, enable_websitecontent_sign
     )
 
     page.title = "New Title"
-    page.save()
+    serializer = WebsiteContentDetailSerializer(
+        instance=page, data={"title": "New Title"}, partial=True
+    )
+    assert serializer.is_valid(), serializer.errors
+    serializer.save()
     navmenu.refresh_from_db()
     menu_item = navmenu.metadata[constants.WEBSITE_CONTENT_LEFTNAV][0]
     assert menu_item["pageRef"] == "/pages/new-title"

--- a/websites/signals_test.py
+++ b/websites/signals_test.py
@@ -21,6 +21,7 @@ def test_handle_website_save():
 def test_navmenu_updated_on_page_title_change(mocker, enable_websitecontent_signal):
     """Navmenu pageRef and name are updated when a page's title changes"""
     website = WebsiteFactory.create(owner=UserFactory.create())
+    mocker.patch("websites.serializers.is_feature_enabled", return_value=True)
     mocker.patch("websites.signals.is_feature_enabled", return_value=True)
 
     page = WebsiteContentFactory.create(


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/5357.

### Description (What does it do?)
This PR prevents saving a page title if there is an existing page URL in the same course that would conflict with that title. Note that this refers to the slugified title, so for example, `new title` and `New Title` would be considered conflicts since they resolve to the same URL.

It also refactors the URL updating logic (https://github.com/mitodl/ocw-studio/pull/2601), moving it to the `WebsiteContent` serializer while keeping the navmenu updates (added in https://github.com/mitodl/ocw-studio/pull/2611) as part of the pre-save signal. 

### How can this be tested?
Note: this is currently behind the PostHog feature flag `OCW_STUDIO_EDITABLE_PAGE_URLS`. Make sure that this feature flag is enabled for any testing.

Verify that changing the title of a page updates the page URL and any navmenus containing that page, as before. Now, try to enter a title that will conflict with another page URL for the course and verify that a warning is displayed and that it's not possible to save the page with that title.