### PR TITLE
Skip recursion by using skip_sync flag variable for Add Video Resource

### DIFF
--- a/videos/signals.py
+++ b/videos/signals.py
@@ -76,5 +76,6 @@ def sync_missing_caption(
             )
             instance.metadata = metadata
             metadata["file_size"] = None
+            instance.skip_sync = True
             instance.save(update_fields=["metadata"])
         sync_video_captions_and_transcripts(instance)

--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -583,4 +583,4 @@ def populate_video_file_size(video_content_id: int):
     if response.status_code == HTTP_200_OK and "Content-Length" in response.headers:
         video.metadata["file_size"] = int(response.headers["Content-Length"])
         video.skip_sync = True
-        video.save()
+        video.save(update_fields=["metadata"])

--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -582,4 +582,5 @@ def populate_video_file_size(video_content_id: int):
     )
     if response.status_code == HTTP_200_OK and "Content-Length" in response.headers:
         video.metadata["file_size"] = int(response.headers["Content-Length"])
+        video.skip_sync = True
         video.save()


### PR DESCRIPTION
### What are the relevant tickets?
None

### Description (What does it do?)
Fixes a bug in RC introduced as side effect of https://github.com/mitodl/ocw-studio/pull/2618. If you create a video resource using Add Video Resource functionality without `archive_url`, it goes into an infinite loop.


### How can this be tested?
Checkout to this branch.
Use the Add Video Resource functionality using youtube_id `E8uZtq_vOYM`. In one test, don't use an archive_url. In another test, use this archive_url: `https://dn720405.ca.archive.org/0/items/mit-2020-vision/MIT_2020_Vision_Part_6_300k.mp4`. Make sure it's properly created with transcript and captions. (For single youtube_id in a course, transcript/captions will only be created once -- but they will be linked regardless).