### PR TITLE
Update hover text for draft courses

### DIFF
--- a/static/js/pages/SitesDashboard.test.tsx
+++ b/static/js/pages/SitesDashboard.test.tsx
@@ -202,6 +202,22 @@ describe("StatusWithDateHover component", () => {
     expect(getByText(/Published on Jan 15, 2023/)).toBeInTheDocument()
   })
 
+  it("shows 'Staged on' for draft sites on hover", () => {
+    const { getByText, container } = render(
+      <StatusWithDateHover
+        statusText="Draft"
+        hoverText="Staged"
+        dateTime="2023-01-15T12:30:45Z"
+        className="text-info"
+      />,
+    )
+
+    const element = container.firstChild as HTMLElement
+    fireEvent.mouseEnter(element)
+
+    expect(getByText(/Staged on Jan 15, 2023/)).toBeInTheDocument()
+  })
+
   it("reverts to status text when mouse leaves", () => {
     const { getByText, container } = render(
       <StatusWithDateHover

--- a/static/js/pages/SitesDashboard.tsx
+++ b/static/js/pages/SitesDashboard.tsx
@@ -105,7 +105,7 @@ export const getMostRecentStatus = (
         site.draft_publish_status &&
         site.draft_publish_status === PublishStatus.Success,
       statusText: "Draft",
-      hoverText: "Draft updated",
+      hoverText: "Staged",
       className: "text-info",
       dateTime: site.draft_publish_date,
     },


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7821.

### Description (What does it do?)
This PR updates the hover text for Draft courses from `Draft updated on <date>` to `Staged on <date>`. It also adds a test verifying that this message is properly displayed.

### How can this be tested?
In the course listing at `http://localhost:8043/sites`, find a course that has been published to draft ("staged") but not published to live. Hover over the status and verify that it now reads `Staged on`.