### PR TITLE
fix: added check for root site when checking hide_download setting

### DIFF
--- a/websites/views.py
+++ b/websites/views.py
@@ -332,10 +332,12 @@ class WebsiteViewSet(
     def hide_download(self, request, name=None):  # noqa: ARG002
         """Process webhook requests from concourse pipeline runs"""
         website = get_object_or_404(Website, name=name)
-        content = WebsiteContent.objects.get(
-            website=website, type=CONTENT_TYPE_METADATA
-        )
-        hide_download = content and content.metadata.get("hide_download")
+        hide_download = False
+        if website.name != settings.ROOT_WEBSITE_NAME:
+            content = WebsiteContent.objects.get(
+                website=website, type=CONTENT_TYPE_METADATA
+            )
+            hide_download = content and content.metadata.get("hide_download")
         return Response(
             status=200,
             data={} if hide_download else {"version": str(now_in_utc().timestamp())},


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7875

### Description (What does it do?)
We have been experiencing issues when checking for `hide_download` settings for the root site. Root site should not be hidden, and it doesn't have a `hide_download` setting. Thus, this pull request adds a check for the root site when checking for the `hide_download` setting.

### How can this be tested?
1. Switch to this branch and spin up containers
2. Publish the root site (e.g., `ocw-www`) in the studio
3. Log in to Concourse locally and verify that `offline-site-job` ran for the root site.