### PR TITLE
Add migration to remove Course Introduction LRT from course metadata

### DIFF
--- a/websites/migrations/0062_remove_course_introduction_lrt.py
+++ b/websites/migrations/0062_remove_course_introduction_lrt.py
@@ -40,9 +40,7 @@ def restore_course_intro_lrt(apps, schema_editor):
             metadata__learning_resource_types__contains=COURSE_INTRODUCTION_LRT
         )
         contents = (
-            WebsiteContent.objects.filter(
-                website_id__in=[w.pk for w in websites_to_update]
-            )
+            WebsiteContent.objects.filter(website__in=websites_to_update)
             .filter(Q(type=CONTENT_TYPE_METADATA) | Q(type=CONTENT_TYPE_WEBSITE))
             .exclude(
                 metadata__learning_resource_types__contains=COURSE_INTRODUCTION_LRT


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7297.

### Description (What does it do?)
This PR adds a migration to remove the `Course Introduction` learning resource type from course metadata.

### How can this be tested?
Find a course that still has Course Introduction in the course metadata, e.g., `Freshman Seminar: The Nature of Engineering`. Apply the new migration by running `docker compose exec web ./manage.py migrate websites`, and verify that the course no longer has `Course Introduction` in its metadata. One source for such courses are the current results at `https://discussions-rc.odl.mit.edu/learn/search?f=Course%20Introduction`.