### PR TITLE
Remove OCW_STUDIO_EDITABLE_PAGE_URLS PostHog feature flag

### DIFF
--- a/websites/constants.py
+++ b/websites/constants.py
@@ -58,8 +58,6 @@ PERMISSION_PUBLISH = "websites.publish_website"
 PERMISSION_EDIT_CONTENT = "websites.edit_content_website"
 PERMISSION_COLLABORATE = "websites.add_collaborators_website"
 
-POSTHOG_ENABLE_EDITABLE_PAGE_URLS = "OCW_STUDIO_EDITABLE_PAGE_URLS"
-
 ROLE_ADMINISTRATOR = "admin"
 ROLE_EDITOR = "editor"
 ROLE_GLOBAL = "global_admin"

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -817,30 +817,26 @@ def test_website_content_export_serializer(ocw_site):
 @pytest.mark.parametrize(
     (
         "is_page",
-        "feature_flag",
         "initial_title",
         "new_title",
         "existing_conflict",
         "expected_filename",
     ),
     [
-        # feature flag disabled; no URL change
-        (True, False, "Original Title", "New Title", False, "original-title"),
         # conflict with existing slugified title; no URL change
-        (True, True, "Original Title", "Some Existing Title", True, "original-title"),
+        (True, "Original Title", "Some Existing Title", True, "original-title"),
         # non-page; no URL change
-        (False, True, "Original Title", "New Title", False, "original-title"),
+        (False, "Original Title", "New Title", False, "original-title"),
         # slugified title matches existing filename; no URL change
-        (True, True, "Test Page", "test page", False, "test-page"),
+        (True, "Test Page", "test page", False, "test-page"),
         # URL should be updated
-        (True, True, "Test Page", "Some New Title", False, "some-new-title"),
+        (True, "Test Page", "Some New Title", False, "some-new-title"),
     ],
 )
 def test_update_page_url_on_title_change_parametrized(  # noqa: PLR0913
     mocker,
     enable_websitecontent_signal,
     is_page,
-    feature_flag,
     initial_title,
     new_title,
     existing_conflict,
@@ -848,7 +844,6 @@ def test_update_page_url_on_title_change_parametrized(  # noqa: PLR0913
 ):
     """Page filename is updated correctly when page's title changes"""
     website = WebsiteFactory.create(owner=UserFactory.create())
-    mocker.patch("websites.serializers.is_feature_enabled", return_value=feature_flag)
 
     if existing_conflict:
         WebsiteContentFactory.create(

--- a/websites/signals.py
+++ b/websites/signals.py
@@ -5,11 +5,9 @@ from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 from django.utils.text import slugify
 
-from main.posthog import is_feature_enabled
 from websites.constants import (
     CONTENT_TYPE_NAVMENU,
     CONTENT_TYPE_PAGE,
-    POSTHOG_ENABLE_EDITABLE_PAGE_URLS,
     WEBSITE_CONTENT_LEFTNAV,
     WEBSITE_PAGES_PATH,
 )
@@ -44,12 +42,7 @@ def update_navmenu_on_title_change(
 ):
     """
     Update navmenu when the title of a page changes.
-    This is currently behind the PostHog feature flag
-    OCW_STUDIO_EDITABLE_PAGE_URLS.
     """
-
-    if not is_feature_enabled(POSTHOG_ENABLE_EDITABLE_PAGE_URLS):
-        return
 
     if instance.type != CONTENT_TYPE_PAGE:
         return

--- a/websites/signals_test.py
+++ b/websites/signals_test.py
@@ -21,8 +21,6 @@ def test_handle_website_save():
 def test_navmenu_updated_on_page_title_change(mocker, enable_websitecontent_signal):
     """Navmenu pageRef and name are updated when a page's title changes"""
     website = WebsiteFactory.create(owner=UserFactory.create())
-    mocker.patch("websites.serializers.is_feature_enabled", return_value=True)
-    mocker.patch("websites.signals.is_feature_enabled", return_value=True)
 
     page = WebsiteContentFactory.create(
         website=website,


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/7967.

### Description (What does it do?)
This PR removes the `OCW_STUDIO_EDITABLE_PAGE_URLS` feature flag. This feature has already been successfully deployed to all users in production.

### How can this be tested?
Verify that editing page URLs by changing the title works as previously (as described in the testing instructions for https://github.com/mitodl/ocw-studio/pull/2601 and https://github.com/mitodl/ocw-studio/pull/2642). This feature is no longer behind a feature flag. 