### PR TITLE
feat: added handling for missing quotes in internal resource links

### DIFF
--- a/websites/utils.py
+++ b/websites/utils.py
@@ -130,27 +130,30 @@ def parse_resource_uuid(text: str) -> list[str]:
     """
 
     # This regex pattern matches two types of Hugo resource patterns:
-    # 1. Hugo shortcode syntax: {{% resource_link "uuid" "title" %}}
-    # 2. Hugo resource syntax: {{< resource uuid="uuid" >}}
+    # 1. Hugo shortcode syntax: {{% resource_link "uuid" "title" %}} or
+    #    {{% resource_link uuid "title" %}}
+    # 2. Hugo resource syntax: {{< resource uuid="uuid" >}} or
+    #    {{< resource uuid=uuid >}}
     #
     # Pattern breakdown:
-    # - Pattern 1: \{\{%\s+resource_link\s+"([uuid])"\s+"([^"]+)"\s+%\}\}
+    # - Pattern 1: \{\{%\s+resource_link\s+"?([uuid])"?\s+"([^"]+)"\s+%\}\}
     #   - \{\{%     : Matches literal "{{%"
     #   - \s+       : Matches one or more whitespace characters
     #   - resource_link : Matches literal "resource_link"
     #   - \s+       : Matches one or more whitespace characters
-    #   - "([uuid])" : Captures UUID in group 1 (full pattern below)
+    #   - "?([uuid])"? : Captures UUID in group 1 with optional quotes
+    #                    (full pattern below)
     #   - \s+       : Matches one or more whitespace characters
     #   - "([^"]+)" : Captures title text in group 2
     #   - \s+       : Matches one or more whitespace characters
     #   - %\}\}     : Matches literal "%}}"
     #
-    # - Pattern 2: \{\{<\s+resource\s+uuid="([uuid])"\s*>\}\}
+    # - Pattern 2: \{\{<\s+resource\s+uuid="?([uuid])"?\s*>\}\}
     #   - \{\{<     : Matches literal "{{<"
     #   - \s+       : Matches one or more whitespace characters
     #   - resource  : Matches literal "resource"
     #   - \s+       : Matches one or more whitespace characters
-    #   - uuid="([uuid])" : Captures UUID in group 3 (full pattern below)
+    #   - uuid="?([uuid])"? : Captures UUID in group 3 with optional quotes
     #   - \s*       : Matches zero or more whitespace characters
     #   - >\}\}     : Matches literal ">}}"
     #
@@ -158,9 +161,9 @@ def parse_resource_uuid(text: str) -> list[str]:
     # Example: b02b216b-1e9e-4b5c-8b1b-9c275a834679
 
     pattern = r"""
-    \{\{%\s+resource_link\s+"([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"\s+"([^"]+)"\s+%\}\}
+    \{\{%\s+resource_link\s+"?([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"?\s+"([^"]+)"\s+%\}\}
     |
-    \{\{<\s+resource\s+uuid="([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"\s*>\}\}
+    \{\{<\s+resource\s+uuid="?([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})"?\s*>\}\}
     """
 
     regex = re.compile(pattern, re.VERBOSE)

--- a/websites/utils_test.py
+++ b/websites/utils_test.py
@@ -172,6 +172,92 @@ def test_set_dict_field():
             "Some text with {{< resource uuid= and other incomplete patterns",
             [],
         ),
+        # Test case 12: Unquoted UUID in resource_link (user's failing case)
+        (
+            'asdhgfhgf  {{% resource_link 5e104a4b-ffe0-67b3-5506-f301bef2d39f "PDF" %}}',
+            ["5e104a4b-ffe0-67b3-5506-f301bef2d39f"],
+        ),
+        # Test case 13: Mixed quoted and unquoted UUIDs
+        (
+            '{{% resource_link abcd1234-5678-90ef-abcd-123456789012 "Unquoted" %}} and {{% resource_link "efab5678-90ab-cdef-1234-567890abcdef" "Quoted" %}}',
+            [
+                "abcd1234-5678-90ef-abcd-123456789012",
+                "efab5678-90ab-cdef-1234-567890abcdef",
+            ],
+        ),
+        # Test case 14: Extra whitespace variations with unquoted UUID
+        (
+            '{{%  resource_link   1234abcd-ef56-7890-abcd-123456789012   "Title"   %}}',
+            ["1234abcd-ef56-7890-abcd-123456789012"],
+        ),
+        # Test case 15: Unquoted UUID with complex title
+        (
+            '{{% resource_link fedcba98-7654-3210-fedc-ba9876543210 "Complex Title with 123 Numbers & Symbols!" %}}',
+            ["fedcba98-7654-3210-fedc-ba9876543210"],
+        ),
+        # Test case 16: Unquoted UUID in resource shortcode
+        (
+            "{{< resource uuid=abcdef01-2345-6789-abcd-ef0123456789 >}}",
+            ["abcdef01-2345-6789-abcd-ef0123456789"],
+        ),
+        # Test case 17: Mixed quoted resource_link and unquoted resource shortcode
+        (
+            '{{% resource_link "11111111-2222-3333-4444-555555555555" "Link" %}} and {{< resource uuid=66666666-7777-8888-9999-000000000000 >}}',
+            [
+                "11111111-2222-3333-4444-555555555555",
+                "66666666-7777-8888-9999-000000000000",
+            ],
+        ),
+        # Test case 18: Unquoted resource shortcode with extra whitespace
+        (
+            "{{<  resource  uuid=fedcba98-7654-3210-fedc-ba9876543210  >}}",
+            ["fedcba98-7654-3210-fedc-ba9876543210"],
+        ),
+        # Edge cases: Malformed patterns
+        # Missing closing
+        (
+            '{{% resource_link "123e4567-e89b-12d3-a456-426614174000" "title"',
+            [],
+        ),
+        # Missing closing
+        (
+            '{{< resource uuid="123e4567-e89b-12d3-a456-426614174000"',
+            [],
+        ),
+        # Invalid UUID
+        (
+            '{{% resource_link "123e4567-e89b-12d3-a456-426614174000x" "title" %}}',
+            [],
+        ),
+        # Invalid UUID
+        (
+            '{{< resource uuid="123e4567-e89b-12d3-a456-426614174000extra" >}}',
+            [],
+        ),
+        # Missing title
+        (
+            '{{% resource_link "123e4567-e89b-12d3-a456-426614174000" %}}',
+            [],
+        ),
+        # Wrong UUID format
+        (
+            '{{% resource_link "123e4567-e89b-12d3-a456-42661417400" "title" %}}',
+            [],
+        ),
+        # Extra dash
+        (
+            '{{% resource_link "123e4567-e89b-12d3-a456-426614174000-extra" "title" %}}',
+            [],
+        ),
+        # Edge cases: Extreme whitespace (valid patterns)
+        (
+            '   {{% resource_link    12345678-abcd-1234-5678-123456789012    "title"    %}}   ',
+            ["12345678-abcd-1234-5678-123456789012"],
+        ),
+        (
+            '{{<    resource    uuid="87654321-dcba-4321-8765-210987654321"    >}}',
+            ["87654321-dcba-4321-8765-210987654321"],
+        ),
     ],
 )
 def test_parse_resource_uuid(input_text, expected_uuids):


### PR DESCRIPTION
### What are the relevant tickets?

Part of https://github.com/mitodl/hq/issues/8042

### Description (What does it do?)
The previous management and migration used the regex to parse resource IDs from the content. The regex, however, required quotes around the UUID in `{{% resource_link "5e104a4b-ffe0-67b3-5506-f301bef2d39f" "PDF" %}}`. It was identified that the data for the concerned course, which was migrated from Plone, does not have the quotes around the UUID. Thus, no matching text was parsed from the content, making the referencing content field for all the resources empty.

### How can this be tested?
Add resource links with the `Add Link` button in the editor, before running this command. From the Django admin, remove the `referencing content` for the resource.

1. Switch to this branch and restart containers: `docker compose up -d`
2. Run `docker compose exec web ./manage.py backpopulate_referencing_content --help` to verify that command exists
3. Now run the following command:
```
# Test it for your site
docker compose exec web ./manage.py backpopulate_referencing_content -filter <test-site>
```