### PR TITLE
Add published URL to metadata for build

### DIFF
--- a/content_sync/serializers.py
+++ b/content_sync/serializers.py
@@ -144,7 +144,7 @@ class JsonFileSerializer(BaseContentFileSerializer):
         if website_content.type == CONTENT_TYPE_METADATA:
             metadata["site_uid"] = str(website_content.website.uuid)
             metadata["site_short_id"] = website_content.website.short_id
-            metadata["site_url_path"] = website_content.website.url_path
+            metadata["site_url_path"] = website_content.website.get_url_path()
 
         return json.dumps(
             self.serialize_contents(metadata, website_content.title),

--- a/content_sync/serializers.py
+++ b/content_sync/serializers.py
@@ -143,8 +143,8 @@ class JsonFileSerializer(BaseContentFileSerializer):
         metadata = website_content.metadata
         if website_content.type == CONTENT_TYPE_METADATA:
             metadata["site_uid"] = str(website_content.website.uuid)
-            metadata["site_short_id"] = str(website_content.website.short_id)
-            metadata["site_url_path"] = str(website_content.website.url_path)
+            metadata["site_short_id"] = website_content.website.short_id
+            metadata["site_url_path"] = website_content.website.url_path
 
         return json.dumps(
             self.serialize_contents(metadata, website_content.title),

--- a/content_sync/serializers.py
+++ b/content_sync/serializers.py
@@ -144,6 +144,7 @@ class JsonFileSerializer(BaseContentFileSerializer):
         if website_content.type == CONTENT_TYPE_METADATA:
             metadata["site_uid"] = str(website_content.website.uuid)
             metadata["site_short_id"] = str(website_content.website.short_id)
+            metadata["site_url_path"] = str(website_content.website.url_path)
 
         return json.dumps(
             self.serialize_contents(metadata, website_content.title),

--- a/content_sync/serializers_test.py
+++ b/content_sync/serializers_test.py
@@ -339,8 +339,8 @@ def test_metadata_file_serialize():
         **metadata,
         "site_uid": str(content.website.uuid),
         "title": "Content Title",
-        "site_short_id": str(content.website.short_id),
-        "site_url_path": str(content.website.url_path),
+        "site_short_id": content.website.short_id,
+        "site_url_path": content.website.url_path,
     }
 
 

--- a/content_sync/serializers_test.py
+++ b/content_sync/serializers_test.py
@@ -319,8 +319,13 @@ def test_data_file_serialize(serializer_cls):
 @pytest.mark.django_db
 def test_metadata_file_serialize():
     """JsonFileSerializer should create the expected data file contents for sitemetadata files"""
+    website = WebsiteFactory.create(
+        short_id="somecourse-f25",
+        url_path="courses/somecourse-fall-2025",
+    )
     metadata = {"metadata1": "dummy value 1", "metadata2": "dummy value 2"}
     content = WebsiteContentFactory.create(
+        website=website,
         text_id="abcdefg",
         title="Content Title",
         type="sitemetadata",
@@ -334,6 +339,8 @@ def test_metadata_file_serialize():
         **metadata,
         "site_uid": str(content.website.uuid),
         "title": "Content Title",
+        "site_short_id": str(content.website.short_id),
+        "site_url_path": str(content.website.url_path),
     }
 
 

--- a/content_sync/serializers_test.py
+++ b/content_sync/serializers_test.py
@@ -146,7 +146,7 @@ def test_hugo_file_serialize(settings, markdown, exp_sections):
         + [f"{k}: {v}" for k, v in metadata.items()]
     )
     assert (
-        f"image: /media/{content.website.url_path}/{content.file.name.split('/')[-1]}"
+        f"image: /media/{content.website.get_url_path()}/{content.file.name.split('/')[-1]}"
         in front_matter_lines
     )
     if exp_sections > 1:
@@ -340,7 +340,7 @@ def test_metadata_file_serialize():
         "site_uid": str(content.website.uuid),
         "title": "Content Title",
         "site_short_id": content.website.short_id,
-        "site_url_path": content.website.url_path,
+        "site_url_path": content.website.get_url_path(),
     }
 
 


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/7693.

### Description (What does it do?)
This PR adds `Website.url_path` to JSON files serialized through `content_sync.serializers.JsonFileSerializer` as `site_url_path`. This will be used to allow offline builds to access the published URL path, which can be used for setting the SEO tags for offline builds to the correct online location. Also, tests are added for both the `short_id` and `url_path` fields in the serialized object.

### How can this be tested?
Run the following for any course:

```
docker compose exec web ./manage.py backpopulate_pipelines --filter <course-id>
docker compose exec web ./manage.py reset_sync_states --filter <course-id> --skip_sync
docker compose exec web ./manage.py sync_website_to_backend --filter <course-id>
```

Publish the course, and verify that the content repo's `data/course.json` file contains `site_url_path` with the correct value for `url_path`.

### Additional Context
https://github.com/mitodl/ocw-studio/pull/1566 was a previous PR that added a similar field for a course's `short_id`.