### PR TITLE
Update Poetry to version 2.1.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
     - name: Install poetry
       uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
       with:
-        version: 2.1.1
+        version: 2.1.4
         virtualenvs-create: true
         virtualenvs-in-project: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13.7
+FROM python:3.12.11
 LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
 
 # Add package files, install updated node and pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12.11
+FROM python:3.13.7
 LABEL maintainer "ODL DevOps <mitx-devops@mit.edu>"
 
 # Add package files, install updated node and pip
@@ -20,7 +20,7 @@ RUN mkdir /var/media && chown -R mitodl:mitodl /var/media
 # Install Python packages
 ## Set some poetry config
 ENV  \
-  POETRY_VERSION=2.1.1 \
+  POETRY_VERSION=2.1.4 \
   POETRY_VIRTUALENVS_CREATE=false \
   POETRY_CACHE_DIR='/tmp/cache/poetry' \
   POETRY_HOME='/home/mitodl/.local' \
@@ -54,4 +54,3 @@ USER mitodl
 
 EXPOSE 8043
 ENV PORT 8043
-CMD uwsgi uwsgi.ini

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,3 +54,4 @@ USER mitodl
 
 EXPOSE 8043
 ENV PORT 8043
+CMD uwsgi uwsgi.ini


### PR DESCRIPTION
### What are the relevant tickets?
This is needed for https://github.com/mitodl/ocw-studio/issues/2650

### Description (What does it do?)
Of late, poetry has not been using the expected python version for its virtual environments in the CI. The expected python version is the one set up in the setup-python [step](https://github.com/mitodl/ocw-studio/blob/master/.github/workflows/ci.yml#L62-L66). What's happening is that poetry has been using the system python version for its environments (which is 3.12.3 on our runners). This can be verified by looking at the output of any recent CI run ([example](https://github.com/mitodl/ocw-studio/actions/runs/17013451368/job/48232531560)) Notice the python version set up in `Set up python` step (3.12.11) and the one being used in the `Tests` step (3.12.3)

This was reported as a [bug](https://github.com/python-poetry/poetry/issues/10490) in poetry and fixed in 2.1.4.


### How can this be tested?
1. Check out this branch
2. Rebuild the containers
3. Verify that studio loads correctly