### PR TITLE
Upgrade Concourse to 7.14 and remove Apple Silicon overrides

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -113,9 +113,9 @@
         "filename": "README.md",
         "hashed_secret": "be4fc4886bd949b369d5e092eb87494f12e57e5b",
         "is_verified": false,
-        "line_number": 247
+        "line_number": 246
       }
     ]
   },
-  "generated_at": "2024-09-04T01:40:31Z"
+  "generated_at": "2025-08-25T21:18:30Z"
 }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ OCW Studio manages deployments for OCW courses.
   - [Running a Local Concourse Docker Container](#running-a-local-concourse-docker-container)
   - [End to end testing of site pipelines](#end-to-end-testing-of-site-pipelines)
   - [Publish And Build Dates](#publish-and-build-dates)
-- [Running OCW Studio on Apple Silicon](#running-ocw-studio-on-apple-silicon)
 - [Video Workflow](#video-workflow)
 - [Enabling YouTube integration](#enabling-youtube-integration)
 - [Enabling Google Drive integration](#enabling-google-drive-integration)
@@ -414,14 +413,6 @@ You should now have a pipeline in Concourse called `e2e-test-pipeline`. Run this
 
 - Publishing the site from Studio for live and draft versions updates the website properties `(live_build_date, publish_date)` and `(draft_build_date, draft_publish_date)`, respectively.
 - Running the mass build for live and draft versions only updates the website properties `live_build_date` and `draft_build_date`, respectively.
-
-# Running OCW Studio on Apple Silicon
-
-Currently, the default Docker image for Concourse is not compatible with Apple Silicon. Therefore, run the following command prior to running `docker-compose up`:
-
-```
-cp docker-compose-arm64.yml docker-compose.override.yml
-```
 
 # Video Workflow
 

--- a/docker-compose-arm64.yml
+++ b/docker-compose-arm64.yml
@@ -1,6 +1,0 @@
----
-version: "3.7"
-
-services:
-  concourse-worker:
-    image: concourse/dev:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,7 +168,7 @@ services:
     - concourse-keys:/concourse-keys
 
   concourse:
-    image: concourse/concourse:7.13
+    image: concourse/concourse:7.14
     command: web
     privileged: true
     depends_on:
@@ -217,7 +217,7 @@ services:
         ipv4_address: 10.1.0.101
 
   concourse-worker:
-    image: concourse/concourse:7.13
+    image: concourse/concourse:7.14
     command: worker
     privileged: true
     depends_on:


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
In https://github.com/mitodl/ocw-studio/pull/1572, a workaround for using Concourse on Apple Silicon was added and subsequently updated in https://github.com/mitodl/ocw-studio/pull/2023. In the latest release of Concourse (7.14), there is official support for ARM, allowing for the official image to be used for all architectures. This removes the need for separate treatment of Apple Silicon.

### How can this be tested?
Run `docker compose pull concourse` and `docker compose up --build` and then verify that various Concourse-related tasks (publishing for both online and offline builds, theme assets build, etc.) work as expected.
