### PR TITLE
Properly filter websites for backpopulate_video_downloads command

### DIFF
--- a/videos/management/commands/backpopulate_video_downloads.py
+++ b/videos/management/commands/backpopulate_video_downloads.py
@@ -1,9 +1,7 @@
 """
-Move 16:9 transcoded videos into the correct S3 paths for syncing, and update the resource
-metadata to point to that path for downloads.
-"""  # noqa: E501
-
-from pathlib import Path
+Move 16:9 transcoded videos into the correct S3 paths for syncing,
+and update the resource metadata to point to that path for downloads.
+"""
 
 from django.conf import settings
 from django.core.management import CommandParser
@@ -13,8 +11,6 @@ from content_sync.tasks import sync_unsynced_websites
 from main.management.commands.filter import WebsiteFilterCommand
 from videos.api import prepare_video_download_file
 from videos.models import Video
-
-script_path = Path(__file__).parent
 
 
 class Command(WebsiteFilterCommand):


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/8255.

### Description (What does it do?)
This PR fixes a bug in the `backpopulate_video_downloads` management command, where the `--filter` argument is ignored and the command runs over all websites even when the argument is specified.

### How can this be tested?
Run `docker compose exec web ./manage.py backpopulate_video_downloads --filter <course-id>` for any course with videos, and confirm that the command only runs for the videos in that particular course.