### PR TITLE
fix: asterisks in math formulas being interpreted as em tags in ckeditor

### DIFF
--- a/static/js/lib/ckeditor/plugins/MathSyntax.test.ts
+++ b/static/js/lib/ckeditor/plugins/MathSyntax.test.ts
@@ -77,6 +77,14 @@ describe.each(modes)("MathSyntax converstion to/from $name", (mode) => {
     await htmlConvertContainsTest(editor, md, html)
   })
 
+  test("a complex expression involving asterisks and subscripts", async () => {
+    const editor = await getEditor()
+    const math = String.raw`\\Vert 1\_X^{\*2} \\Vert\_{\\ell\_{\\infty}} + \\Vert 1\_X^{\*2} \\Vert\_{\\ell\_{\\infty}}`
+    const md = mode.start + math + mode.end
+    const html = `<p>${scriptify(mode, math.replace(/\\\\/g, "\\").replace(/\\_/g, "_").replace(/\\\*/g, "*"))}</p>`
+    await htmlConvertContainsTest(editor, md, html)
+  })
+
   test("a complex expression involving subscripts", async () => {
     const editor = await getEditor()
     const math = String.raw`\\mathbb{F}\_q^2 + \\mathbb{N}\_q^2 + |\\pi\_{t\_1 + t\_2} (X)| \\le K^C |X|^{1/2}`

--- a/static/js/lib/ckeditor/plugins/MathSyntax.ts
+++ b/static/js/lib/ckeditor/plugins/MathSyntax.ts
@@ -36,6 +36,14 @@ const prepareTexForMarkdown = (s: string) => {
        *  So we replace any "_" by "\_".
        */
       .replace(/_/g, String.raw`\_`)
+      /**
+       * Markdown uses "*" to represent emphasis.
+       * It may happen that when interpreting markdown in ckeditor, the "*" is interpreted as <em>
+       * tags in the html, mangling part of our math.
+       *
+       *  So we escape asterisks by replacing any "*" by "\*".
+       */
+      .replace(/\*/g, String.raw`\*`)
   )
 }
 


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7966

### Description (What does it do?)
This is a followup on https://github.com/mitodl/ocw-studio/pull/2664. In https://github.com/mitodl/ocw-studio/pull/2664, we escaped underscores in math expressions to prevent them from being interpreted as `<em>` tags. However, we can also have asterisks in math expressions (which are also used to represent emphasis in markdown) that may be converted by ckeditor (while converting markdown to html) to `<em>` tags.

To better understand what the issue here, try to enter the following math in ckeditor, save the page and then reopen the page. You will observe that the math has been polluted with `<em>` tags

`\Vert 1_X^{*2} \Vert_{\ell_{\infty}} + \Vert 1_X^{*2} \Vert_{\ell_{\infty}}`


To fix this, while converting math expressions into markdown (from ckeditor), we "escape" asterisks inside math expressions.

### How can this be tested?

1. Copy the markdown for [this](https://ocw-studio.odl.mit.edu/sites/projection-theory/type/page/edit/d64eb800-3a7f-4f7a-a1d9-a59d8b682fb9/) page from the [admin](https://ocw-studio.odl.mit.edu/admin/websites/websitecontent/529397/change/) into some page on your local.
2. Fix the mistakenly converted `em` tags by converting them to `*` in the math expressions
3. Verify that the math is rendered correctly in ckeditor.
4. Save the page.
5. Now make some minor changes to the page and save it again.
6. Open the page again and verify that the math renders correctly even after saving.
7. Now publish the page and verify that hugo renders it correctly as well i.e all the math expressions are correctly displayed

If you have existing pages with math formulas/content, repeat steps 1-7 for them and verify that there are no issues.
