### PR TITLE
Umar/8322 nested shortcode syntax in hugo

### DIFF
--- a/websites/management/commands/markdown_cleaning/cleaner.py
+++ b/websites/management/commands/markdown_cleaning/cleaner.py
@@ -144,12 +144,18 @@ class WebsiteContentMarkdownCleaner:
     def write_matches_to_csv(self, path: str, only_changes):
         """Write matches and replacements to csv."""
 
-        with open(path, "w", newline="") as csvfile:  # noqa: PTH123
+        with open(path, "w", newline="", encoding="utf-8") as csvfile:  # noqa: PTH123
             fieldnames = [
                 *self.csv_metadata_fieldnames,
                 *(f.name for f in fields(self.rule.ReplacementNotes)),
             ]
-            writer = csv.DictWriter(csvfile, fieldnames, quoting=csv.QUOTE_MINIMAL)
+            writer = csv.DictWriter(
+                csvfile,
+                fieldnames,
+                quoting=csv.QUOTE_MINIMAL,
+                escapechar="\\",
+                doublequote=False,
+            )
             writer.writeheader()
             for change in self.replacement_matches:
                 has_changed = change.original_text != change.replacement

--- a/websites/management/commands/markdown_cleaning/cleaner.py
+++ b/websites/management/commands/markdown_cleaning/cleaner.py
@@ -149,7 +149,7 @@ class WebsiteContentMarkdownCleaner:
                 *self.csv_metadata_fieldnames,
                 *(f.name for f in fields(self.rule.ReplacementNotes)),
             ]
-            writer = csv.DictWriter(csvfile, fieldnames, quoting=csv.QUOTE_ALL)
+            writer = csv.DictWriter(csvfile, fieldnames, quoting=csv.QUOTE_MINIMAL)
             writer.writeheader()
             for change in self.replacement_matches:
                 has_changed = change.original_text != change.replacement

--- a/websites/management/commands/markdown_cleaning/link_parser.py
+++ b/websites/management/commands/markdown_cleaning/link_parser.py
@@ -173,7 +173,18 @@ class LinkParser(WrappedParser):
                 ignoreExpr=ignore,
             )
         ).setResultsName("text")
-        text.addParseAction(lambda s, l, toks: toks[0][1:-1])  # noqa: ARG005, E741
+
+        def clean_text_parse_action(_s, _l, toks):
+            # Extract text without the outer brackets
+            raw_text = toks[0][1:-1]
+            # Clean up unnecessary escapes that come from Turndown conversion
+            # Remove escapes from backticks - they don't need to be escaped
+            cleaned = raw_text.replace("\\`", "`")
+            # Remove escapes from square brackets - they don't need to be escaped
+            return cleaned.replace("\\[", "[").replace("\\]", "]")
+            # Keep double quote escapes as they are necessary
+
+        text.addParseAction(clean_text_parse_action)
         return text
 
     @staticmethod

--- a/websites/management/commands/markdown_cleaning/link_parser.py
+++ b/websites/management/commands/markdown_cleaning/link_parser.py
@@ -165,7 +165,7 @@ class LinkParser(WrappedParser):
         # If this ever changes, we would need to change content to something
         # like Combine(OneOrMore(~ignore + content_character))
         content = content_character
-        text = originalTextFor(
+        return originalTextFor(
             nestedExpr(
                 opener="[",
                 closer="]",
@@ -173,19 +173,6 @@ class LinkParser(WrappedParser):
                 ignoreExpr=ignore,
             )
         ).setResultsName("text")
-
-        def clean_text_parse_action(_s, _l, toks):
-            # Extract text without the outer brackets
-            raw_text = toks[0][1:-1]
-            # Clean up unnecessary escapes that come from Turndown conversion
-            # Remove escapes from backticks - they don't need to be escaped
-            cleaned = raw_text.replace("\\`", "`")
-            # Remove escapes from square brackets - they don't need to be escaped
-            return cleaned.replace("\\[", "[").replace("\\]", "]")
-            # Keep double quote escapes as they are necessary
-
-        text.addParseAction(clean_text_parse_action)
-        return text
 
     @staticmethod
     def _parser_piece_destination_and_title():

--- a/websites/management/commands/markdown_cleaning/link_parser.py
+++ b/websites/management/commands/markdown_cleaning/link_parser.py
@@ -165,7 +165,7 @@ class LinkParser(WrappedParser):
         # If this ever changes, we would need to change content to something
         # like Combine(OneOrMore(~ignore + content_character))
         content = content_character
-        return originalTextFor(
+        text = originalTextFor(
             nestedExpr(
                 opener="[",
                 closer="]",
@@ -173,6 +173,10 @@ class LinkParser(WrappedParser):
                 ignoreExpr=ignore,
             )
         ).setResultsName("text")
+
+        text.addParseAction(lambda s, l, toks: toks[0][1:-1])  # noqa: ARG005, E741
+
+        return text
 
     @staticmethod
     def _parser_piece_destination_and_title():

--- a/websites/management/commands/markdown_cleaning/link_parser_test.py
+++ b/websites/management/commands/markdown_cleaning/link_parser_test.py
@@ -68,11 +68,8 @@ def test_link_parser_parses_good_links(title, dest, text, is_image):
     parsed = parser.parse_string(markdown)
     assert parsed.original_text == markdown
 
-    # Our escape prevention should clean unnecessary escapes
-    expected_text = text.replace("\\]", "]").replace("\\[", "[")
-
     expected_link = MarkdownLink(
-        text=expected_text,
+        text=text,
         destination=dest,
         title=title,
         is_image=is_image,

--- a/websites/management/commands/markdown_cleaning/link_parser_test.py
+++ b/websites/management/commands/markdown_cleaning/link_parser_test.py
@@ -68,8 +68,11 @@ def test_link_parser_parses_good_links(title, dest, text, is_image):
     parsed = parser.parse_string(markdown)
     assert parsed.original_text == markdown
 
+    # Our escape prevention should clean unnecessary escapes
+    expected_text = text.replace("\\]", "]").replace("\\[", "[")
+
     expected_link = MarkdownLink(
-        text=text,
+        text=expected_text,
         destination=dest,
         title=title,
         is_image=is_image,

--- a/websites/management/commands/markdown_cleaning/parsing_utils.py
+++ b/websites/management/commands/markdown_cleaning/parsing_utils.py
@@ -157,7 +157,7 @@ class ShortcodeParam:
         >>> ShortcodeParam(name='dog', value='woof "woof" bark').to_hugo()
         'dog="woof \\"woof\\" bark"
         """
-        hugo_value = self.hugo_escape_param_value(self.value)
+        hugo_value = ShortcodeParam.hugo_escape_param_value(self.value)
 
         if self.name:
             return f"{self.name}={hugo_value}"
@@ -175,7 +175,9 @@ class ShortcodeParam:
             - encase in double quotes and escape any quotes in the arg
             - replace newlines with space
         """
+        # Replace newlines with spaces
         no_new_lines = s.replace("\n", " ")
+        # Escape double quotes and wrap in quotes
         return f'"{escape_double_quotes(no_new_lines)}"'
 
 

--- a/websites/management/commands/markdown_cleaning/rules/link_to_external_resource.py
+++ b/websites/management/commands/markdown_cleaning/rules/link_to_external_resource.py
@@ -164,6 +164,7 @@ class LinkToExternalResourceRule(PyparsingRule):
         url: str = ""
         external_resource: str = ""
         has_external_license_warning: bool = True
+        is_inside_shortcode_attribute: bool = False
 
     def __init__(self) -> None:
         super().__init__()
@@ -225,10 +226,6 @@ class LinkToExternalResourceRule(PyparsingRule):
     ):
         # Check if this link is inside a Hugo shortcode attribute
         link_end = l + len(toks.original_text)
-        if self._is_inside_shortcode_attribute(s, l, link_end):
-            return toks.original_text, self.ReplacementNotes(
-                note="inside shortcode attribute"
-            )
         is_inside_shortcode_attribute = self._is_inside_shortcode_attribute(
             s, l, link_end
         )

--- a/websites/management/commands/markdown_cleaning/rules/link_to_external_resource_test.py
+++ b/websites/management/commands/markdown_cleaning/rules/link_to_external_resource_test.py
@@ -997,6 +997,12 @@ def test_link_to_external_resource_skips_shortcode_attributes(settings):
             False,
             "multiple attributes",
         ),
+        # Multiple links inside same shortcode attribute should NOT be converted
+        (
+            '{{< image-gallery-item text="Check [link1](https://example.com) and [link2](https://google.com) both" >}}',
+            False,
+            "multiple links in single attribute",
+        ),
         # Link outside any shortcode should be converted
         ("Regular [link](https://example.com) in text", True, "outside shortcode"),
     ],
@@ -1031,16 +1037,18 @@ def test_shortcode_attribute_detection_edge_cases(
             assert "resource_link" in website_content.markdown, (
                 f"Failed: {description} - no resource_link found"
             )
-            assert "[link](https://example.com)" not in website_content.markdown, (
-                f"Failed: {description} - original link still present"
+            # Check that original markdown links are no longer present
+            assert "](https://" not in website_content.markdown, (
+                f"Failed: {description} - original links still present"
             )
         else:
             # Content should remain unchanged
             assert website_content.markdown == original_content, (
                 f"Failed: {description} - content was modified"
             )
-            assert "[link](https://example.com)" in website_content.markdown, (
-                f"Failed: {description} - original link missing"
+            # Check that original markdown links are still present
+            assert "](https://" in website_content.markdown, (
+                f"Failed: {description} - original links missing"
             )
             assert "resource_link" not in website_content.markdown, (
                 f"Failed: {description} - unexpected resource_link found"


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8322

### Description (What does it do?)
Adds guards to prevent nested shortcodes in Hugo builds by detecting when markdown links are inside existing Hugo shortcode attributes and skipping their conversion to `resource_link` shortcodes. This prevents invalid nested shortcode syntax like `{{< shortcode attr="{{< resource_link ... >}}" >}}` which would break Hugo builds.

The implementation adds a `_is_inside_shortcode_attribute()` method that uses regex patterns to detect if a markdown link is positioned within a Hugo shortcode's attribute value (between quotes), and if so, preserves the original markdown link instead of converting it.

This PR also includes fixes for markdown text cleaning that prevent over-escaping of backticks and brackets, ensuring clean Hugo shortcode parameter generation without unnecessary escape characters.

### How can this be tested?

## Testing
1. Add the following test data (or use your own test data) to an existing (or new) page using Django Admin.
```markdown
# Test Page with Shortcodes and Escaping Issues

Regular link that should be converted:
[MIT Website](https://mit.edu)

Image gallery with links in attributes (should NOT be converted):
{{< image-gallery >}}
{{< image-gallery-item href="test1.png" text="[OCW](https://ocw.mit.edu) - Educational content" >}}
{{< image-gallery-item href="test2.png" data-desc="Link to [GitHub](https://github.com) repository" >}}
{{< /image-gallery >}}

Links with problematic characters that need proper escaping:
[Download \`solution.py\` from \[Resources\]](resource:abc-123)  
[Code example with \`backticks\` and \[brackets\]](https://example.com/code)
[Math notation: \[A\] + \[B\] = \[C\]](https://example.com/math)

Another regular link that should be converted:
[Google](https://google.com)
```

2. ### Manual Testing
```bash
# Test the shortcode detection prevents nested shortcodes and escaping is fixed
docker-compose exec web ./manage.py markdown_cleanup link_to_external_resource --filter my_site

# Expected Results:
# - Regular links converted to resource_link shortcodes
# - Links inside shortcode attributes remain as markdown links  
# - Generated Hugo shortcodes have clean parameters without over-escaped backticks/brackets
# - Example: {{< resource_link "uuid" "Download `solution.py` from [Resources]" >}}
```