### PR TITLE
fix: do not add incorrect source for gdrive videos

### DIFF
--- a/static/js/components/forms/SiteContentForm.test.tsx
+++ b/static/js/components/forms/SiteContentForm.test.tsx
@@ -156,7 +156,7 @@ test.each(EDITOR_STATES)(
   async (editorState) => {
     const data = setupData()
     data.content.type = "resource"
-    data.content.metadata.resourcetype = "Video"
+    data.content.metadata = { resourcetype: "Video" }
     const configItem = makeEditableConfigItem("resource")
     configItem.fields = resourceFields
 
@@ -177,7 +177,7 @@ test.each(EDITOR_STATES)(
       form.update()
     })
 
-    const expectedVideoMetadata = {
+    const expectedVideoMetadata: any = {
       youtube_id: "abcdefghij",
     }
 

--- a/static/js/components/forms/SiteContentForm.test.tsx
+++ b/static/js/components/forms/SiteContentForm.test.tsx
@@ -177,7 +177,7 @@ test.each(EDITOR_STATES)(
       form.update()
     })
 
-    let expectedVideoMetadata = {
+    const expectedVideoMetadata = {
       youtube_id: "abcdefghij",
     }
 

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -93,7 +93,7 @@ export default function SiteContentForm(props: FormProps): JSX.Element {
         if (!values.video_files.video_thumbnail_file) {
           values.video_files.video_thumbnail_file = `https://img.youtube.com/vi/${youtubeId}/default.jpg`
         }
-        if (!values.video_metadata.source) {
+        if (!values.video_metadata.source && editorState.adding()) {
           values.video_metadata.source = "youtube"
         }
       }

--- a/static/js/components/forms/SiteContentForm.tsx
+++ b/static/js/components/forms/SiteContentForm.tsx
@@ -84,7 +84,7 @@ export default function SiteContentForm(props: FormProps): JSX.Element {
     values: FormikValues,
     formikHelpers: FormikHelpers<any>,
   ) => {
-    if (values.resourcetype === "Video") {
+    if (values.resourcetype === "Video" && editorState.adding()) {
       const youtubeId = values?.video_metadata?.youtube_id
       if (youtubeId) {
         if (!values.video_files) {
@@ -93,7 +93,7 @@ export default function SiteContentForm(props: FormProps): JSX.Element {
         if (!values.video_files.video_thumbnail_file) {
           values.video_files.video_thumbnail_file = `https://img.youtube.com/vi/${youtubeId}/default.jpg`
         }
-        if (!values.video_metadata.source && editorState.adding()) {
+        if (!values.video_metadata.source) {
           values.video_metadata.source = "youtube"
         }
       }

--- a/static/js/util/factories/websites.ts
+++ b/static/js/util/factories/websites.ts
@@ -90,6 +90,27 @@ const exampleFields: ConfigField[] = [
   },
 ]
 
+export const resourceFields: ConfigField[] = [
+  ...exampleFields,
+  {
+    label: "Resource Type",
+    name: "resourcetype",
+    widget: WidgetVariant.Select,
+  },
+  {
+    label: "Video Metadata",
+    name: "video_metadata",
+    widget: WidgetVariant.Object,
+    fields: [
+      {
+        label: "YouTube ID",
+        name: "youtube_id",
+        widget: WidgetVariant.String,
+      },
+    ],
+  },
+]
+
 export const makeFileConfigItem = (name?: string): SingletonConfigItem => ({
   fields: cloneDeep(exampleFields),
   file: casual.word,

--- a/static/js/util/factories/websites.ts
+++ b/static/js/util/factories/websites.ts
@@ -96,6 +96,7 @@ export const resourceFields: ConfigField[] = [
     label: "Resource Type",
     name: "resourcetype",
     widget: WidgetVariant.Select,
+    options: ["Image", "Video"],
   },
   {
     label: "Video Metadata",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8354

### Description (What does it do?)
For videos added through the `Add Video Resource` button, we set their `metadata.video_metadata.source` to "youtube" if they have a youtube Id. However, this code also runs if you try **editing** a "conventional" gdrive video resource that has been published to youtube. Hence, that gdrive resource is incorrectly marked as being of source "youtube", and in a [post save signal](https://github.com/mitodl/ocw-studio/blob/master/videos/signals.py#L77-L78), its file size is set to None.

### How can this be tested?

1. Create a gdrive video resource and push it through the [video workflows](https://github.com/mitodl/ocw-studio/blob/master/videos/README.md) to ensure it is uploaded to youtube. 
2. Back in studio, verify that it has the correct file size.
3. Open the resource in studio, and save it again. 
4. The file size has been incorrectly set to None
5. Checkout this branch and repeat the above steps. The file size should be unaffected by saving the resource in studio.
