### PR TITLE
fix: concourse issues while streaming volumes in the offline gate put step

### DIFF
--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -868,7 +868,7 @@ class SitePipelineDefinition(Pipeline):
             attempts=3,
             get_params={"strict": True},
             no_get=True,
-            inputs=[]
+            inputs=[],
         )
         # Add cleanup step to the inner put step.
         # This will trigger before TryStep suppresses the error

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -868,6 +868,7 @@ class SitePipelineDefinition(Pipeline):
             attempts=3,
             get_params={"strict": True},
             no_get=True,
+            inputs=[]
         )
         # Add cleanup step to the inner put step.
         # This will trigger before TryStep suppresses the error


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8354

### Description (What does it do?)
In the offline build gate step of the site pipeline, we often see failures that prevent the offline build from triggering. These failures look like

> selected worker: ip-10-1-3-50
streaming volume static-resources-s3 from ip-10-1-3-202
streaming volume site-content-git from ip-10-1-2-246
streaming volume ocw-hugo-themes-git from ip-10-1-2-246
find or create container on worker ip-10-1-3-50: Put "/volumes/7a148a01-b407-4716-b4a8-90c7bcb2c134/stream-in?limit=0.000000&path=.": context deadline exceeded, will retry ...

This is an attempt to fix this by explicitly setting the inputs to the put task to be an empty list, which should eliminate the need for concourse to stream these volumes at all.

### How can this be tested?
1. Pull this branch
2. Create a new course
3. Add some content and publish
4. In concourse, verify that the offline and online builds are both successful
5. Set `hide_download=True`
6. Publish again and verify that only the online build is successful, and the offline build has not run.
