### PR TITLE
chore: add missing vars to e2e pipeline

### DIFF
--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
@@ -322,6 +322,8 @@ class EndToEndTestPipelineDefinition(Pipeline):
                         "WEBPACK_WATCH_MODE": "false",
                         "WWW_CONTENT_PATH": f"../{www_content_git_identifier}",
                         "WWW_HUGO_CONFIG_PATH": f"../{OCW_HUGO_PROJECTS_GIT_IDENTIFIER}/ocw-www/config.yaml",  # noqa: E501
+                        "MIT_LEARN_BASE_URL": settings.MIT_LEARN_BASE_URL,
+                        "MIT_LEARN_API_BASE_URL": settings.MIT_LEARN_API_BASE_URL,
                     },
                     run=Command(
                         path="sh",


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8360

### Description (What does it do?)
Adds missing env vars to an e2e pipeline step. Currently, the [pipeline is failing](https://cicd-qa.odl.mit.edu/teams/ocw/pipelines/e2e-test-pipeline/jobs/e2e-test-job/builds/285) while trying to find these.

### How can this be tested?
Run the e2e pipeline. It will fail complaining about missing variables. Pull this branch and run it again. It should pass.
I was unable to perform this test myself :-) because of some issues installing hugo-bin-extended that I am unable to resolve so far.

I did test this by pushing [another pipeline](https://cicd-qa.odl.mit.edu/teams/ocw/pipelines/e2e-test-ali/jobs/e2e-test-job/builds/1) with these vars to RC and it gets past the error, and runs into other errors :-)
