### PR TITLE
fix: git author attribution for django admin edits and gdrive sync

### DIFF
--- a/gdrive_sync/tasks.py
+++ b/gdrive_sync/tasks.py
@@ -57,7 +57,9 @@ def process_drive_file(self, drive_file_id: str):
 
 
 @app.task()
-def create_gdrive_resource_content_batch(drive_file_ids: list[str | None]):
+def create_gdrive_resource_content_batch(
+    drive_file_ids: list[str | None], user_pk=None
+):
     """
     Creates WebsiteContent resources from a Google Drive files identified by `drive_file_ids`.
 
@@ -76,18 +78,43 @@ def create_gdrive_resource_content_batch(drive_file_ids: list[str | None]):
                 exc_info=exc,
             )
         else:
-            api.create_gdrive_resource_content(drive_file)
+            api.create_gdrive_resource_content(drive_file, user_pk=user_pk)
 
 
 @app.task()
-def delete_drive_file(drive_file_id: str, sync_datetime: datetime):
+def update_updated_by_field_on_deleted_resources(
+    drive_file_ids: list[str | None], user_pk=None
+):
+    """
+    Updates the `updated_by` field on WebsiteContent resources deleted by a gdrive sync
+
+    `drive_file_ids` are expected to be results from `process_drive_file` tasks.
+    """  # noqa: D401
+    for drive_file_id in drive_file_ids:
+        if drive_file_id is None:
+            continue
+
+        try:
+            drive_file = DriveFile.objects.get(file_id=drive_file_id)
+        except DriveFile.DoesNotExist as exc:
+            log.exception(
+                "Attempted to create resource for drive file %s which does not exist.",
+                drive_file_id,
+                exc_info=exc,
+            )
+        else:
+            api.create_gdrive_resource_content(drive_file, user_pk=user_pk)
+
+
+@app.task()
+def delete_drive_file(drive_file_id: str, sync_datetime: datetime, user_pk=None):
     """
     Delete the DriveFile if it is not being used in website page content.
     See api.delete_drive_file for details.
     """
     drive_file = DriveFile.objects.filter(file_id=drive_file_id).first()
     if drive_file:
-        api.delete_drive_file(drive_file, sync_datetime=sync_datetime)
+        api.delete_drive_file(drive_file, sync_datetime=sync_datetime, user_pk=user_pk)
 
 
 def _get_gdrive_files(website: Website) -> tuple[dict[str, list[dict]], list[str]]:
@@ -129,7 +156,7 @@ def _get_gdrive_files(website: Website) -> tuple[dict[str, list[dict]], list[str
 
 @app.task(bind=True, acks_late=True, autoretry_for=(BlockingIOError,), retry_backoff=30)
 @single_task(30)
-def import_website_files(self, name: str):
+def import_website_files(self, name: str, user_pk=None):
     """Query the Drive API for all children of a website folder and import the files"""
     if not api.is_gdrive_enabled():
         return None
@@ -145,7 +172,7 @@ def import_website_files(self, name: str):
         website,
     )
     delete_file_tasks = [
-        delete_drive_file.si(drive_file.file_id, website.synced_on)
+        delete_drive_file.si(drive_file.file_id, website.synced_on, user_pk=user_pk)
         for drive_file in deleted_drive_files
     ]
 
@@ -176,7 +203,8 @@ def import_website_files(self, name: str):
 
     if file_tasks:
         step = chord(
-            celery.group(*file_tasks), create_gdrive_resource_content_batch.s()
+            celery.group(*file_tasks),
+            create_gdrive_resource_content_batch.s(user_pk=user_pk),
         )
         workflow_steps.append(step)
 

--- a/websites/admin.py
+++ b/websites/admin.py
@@ -89,6 +89,16 @@ class WebsiteContentAdmin(TimestampedModelAdmin, SafeDeleteAdmin):
                 kwargs["queryset"] = WebsiteContent.objects.none()
         return super().formfield_for_manytomany(db_field, request, **kwargs)
 
+    def save_model(self, request, obj, form, change):
+        """
+        Set the updated_by and owner fields when modifying objects
+        from the django admin.
+        """
+        obj.updated_by = request.user
+        if not change:
+            obj.owner = request.user
+        super().save_model(request, obj, form, change)
+
 
 class WebsiteStarterForm(forms.ModelForm):
     """Custom form for the WebsiteStarter model"""

--- a/websites/views.py
+++ b/websites/views.py
@@ -776,12 +776,12 @@ class WebsiteContentViewSet(
     )
     def gdrive_sync(
         self,
-        request,  # noqa: ARG002
+        request,
         **kwargs,  # noqa: ARG002
     ):  # pylint:disable=unused-argument
         """Trigger a task to sync all non-video Google Drive files"""
         website = Website.objects.get(name=self.kwargs.get("parent_lookup_website"))
         website.sync_status = WebsiteSyncStatus.PENDING
         website.save()
-        import_website_files.delay(website.name)
+        import_website_files.delay(website.name, user_pk=request.user.pk)
         return Response(status=200)


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/2753

### Description (What does it do?)
Git author attribution is [determined](https://github.com/mitodl/ocw-studio/blob/968e8de22c61ba3e73551742be9a151a89227870/content_sync/apis/github.py#L337-L347) through the `updated_by` field on WebsiteContent objects. This field is set properly for edits made through studio, but is not set while making edits to a WebsiteContent object from admin, or when resources are synced through the gdrive workflow.

In this PR, we make changes to ensure that the `updated_by` field is properly set when making edits through django admin. Similarly, during gdrive sync, the `updated_by` field for any created/updated 
### How can this be tested?
