### PR TITLE
Disable postinstall scripts [security fix]

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,8 @@
 ---
 yarnPath: ".yarn/releases/yarn-4.10.0.cjs"
+
+enableScripts: false
+
 nodeLinker: "node-modules"
 supportedArchitectures:
   os: [linux, darwin]


### PR DESCRIPTION
### What are the relevant tickets?
None, but in response to https://www.cisa.gov/news-events/alerts/2025/09/23/widespread-supply-chain-compromise-impacting-npm-ecosystem

### Description (What does it do?)
Disables postinstall scripts.

From [yarn docs](https://yarnpkg.com/advanced/lifecycle-scripts#postinstall):
> **warning**
> Postinstall scripts should be avoided at all cost, as they make installs slower and riskier. Many users will refuse to install dependencies that have postinstall scripts. Additionally, since the output isn't shown out of the box, using them to print a message to the user will not work as you expect.


### How can this be tested?
Check that the app still works. Remove node_modules via `rm -rf node_modules && rm -rf frontends/*/node_modules`, then restart the app.

If you want to check that this actually disables postinstall scripts, see https://github.com/mitodl/mit-learn/pull/2536