### PR TITLE
Add captions/transcript resource variables to Heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -741,7 +741,7 @@
       "required": false
     },
     "YT_FIELD_CAPTIONS": {
-      "description": "The site config metadata field for the caption url",
+      "description": "The site config metadata field for the captions URL",
       "required": false
     },
     "YT_FIELD_CAPTIONS_RESOURCE": {
@@ -765,11 +765,11 @@
       "required": false
     },
     "YT_FIELD_THUMBNAIL": {
-      "description": "The site config metadata field for YouTube thumbnail url",
+      "description": "The site config metadata field for YouTube thumbnail URL",
       "required": false
     },
     "YT_FIELD_TRANSCRIPT": {
-      "description": "The site config metadata field for the transcript url",
+      "description": "The site config metadata field for the transcript URL",
       "required": false
     },
     "YT_FIELD_TRANSCRIPT_RESOURCE": {


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/6483.

### Description (What does it do?)
This PR adds the `YT_FIELD_CAPTIONS_RESOURCE` and `YT_FIELD_TRANSCRIPT_RESOURCE` to the Heroku config, as a follow-up to https://github.com/mitodl/ocw-studio/pull/2755.

### How can this be tested?
This can be tested by setting the appropriate values on Heroku when deployed to RC. Just verify that the variable names are correct.