### PR TITLE
feat: handled refrencing_content for captions/transcripts

### DIFF
--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -57,7 +57,11 @@ from videos.youtube import (
     mail_youtube_upload_failure,
     mail_youtube_upload_success,
 )
-from websites.api import is_ocw_site, videos_missing_captions
+from websites.api import (
+    is_ocw_site,
+    sync_website_content_references,
+    videos_missing_captions,
+)
 from websites.constants import RESOURCE_TYPE_VIDEO
 from websites.messages import VideoTranscriptingCompleteMessage
 from websites.models import Website, WebsiteContent
@@ -519,6 +523,7 @@ def update_transcript_and_captions(resource, new_transcript_file, new_captions_f
     )
 
     resource.save()
+    sync_website_content_references(resource)
 
 
 def create_drivefile(gdrive_file_id, new_resource, destination_course, files_or_videos):

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -967,6 +967,7 @@ def test_update_transcript_and_captions(mocker):
     new_transcript_file = "/path/to/new_transcript_file"
     new_captions_file = "/path/to/new_captions_file"
     mocker.spy(test_resource, "save")
+    sync_refs_mock = mocker.patch("videos.tasks.sync_website_content_references")
 
     update_transcript_and_captions(
         test_resource, new_transcript_file, new_captions_file
@@ -981,6 +982,7 @@ def test_update_transcript_and_captions(mocker):
         == new_captions_file
     )
     test_resource.save.assert_called_once()
+    sync_refs_mock.assert_called_once_with(test_resource)
 
 
 def test_create_drivefile(mocker):

--- a/videos/threeplay_sync.py
+++ b/videos/threeplay_sync.py
@@ -10,6 +10,7 @@ from main.utils import get_dirpath_and_filename, get_file_extension
 from videos.constants import PDF_FORMAT_ID, WEBVTT_FORMAT_ID
 from videos.threeplay_api import fetch_file, threeplay_transcript_api_request
 from videos.utils import generate_s3_path, get_content_dirpath
+from websites.api import sync_website_content_references
 from websites.models import WebsiteContent
 
 log = logging.getLogger()
@@ -157,6 +158,7 @@ def sync_video_captions_and_transcripts(
     _attach_captions_if_missing(video, base_url, youtube_id, summary, write_output)
     video.skip_sync = True
     video.save()
+    sync_website_content_references(video)
 
 
 def upload_to_s3(file_content: File, video: WebsiteContent) -> str:

--- a/videos/threeplay_sync_test.py
+++ b/videos/threeplay_sync_test.py
@@ -1,0 +1,54 @@
+"""Tests for videos.threeplay_sync."""
+
+from io import BytesIO
+
+import pytest
+
+from videos.threeplay_sync import sync_video_captions_and_transcripts
+from websites.constants import CONTENT_TYPE_RESOURCE
+from websites.factories import (
+    WebsiteContentFactory,
+    WebsiteFactory,
+    WebsiteStarterFactory,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def test_sync_video_captions_and_transcripts_sets_references(mocker):
+    """3Play sync should attach created caption/transcript resources as references."""
+    starter = WebsiteStarterFactory.create(slug="ocw-course-v2")
+    website = WebsiteFactory.create(starter=starter)
+    video = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        metadata={
+            "resourcetype": "Video",
+            "video_metadata": {"youtube_id": "yt789"},
+            "video_files": {},
+        },
+    )
+
+    mocker.patch(
+        "videos.threeplay_sync.threeplay_transcript_api_request",
+        return_value={"data": [{"status": "complete", "id": 11, "media_file_id": 22}]},
+    )
+    mocker.patch(
+        "videos.threeplay_sync.fetch_file",
+        side_effect=[BytesIO(b"pdf"), BytesIO(b"webvtt")],
+    )
+    mocker.patch(
+        "videos.threeplay_sync.upload_to_s3",
+        side_effect=[
+            f"/courses/{website.name}/yt789_transcript.pdf",
+            f"/courses/{website.name}/yt789_captions.webvtt",
+        ],
+    )
+
+    sync_video_captions_and_transcripts(video)
+
+    video.refresh_from_db()
+    assert set(video.referenced_by.values_list("file", flat=True)) == {
+        f"/courses/{website.name}/yt789_transcript.pdf",
+        f"/courses/{website.name}/yt789_captions.webvtt",
+    }

--- a/websites/api.py
+++ b/websites/api.py
@@ -35,7 +35,12 @@ from websites.messages import (
     PreviewOrPublishSuccessMessage,
 )
 from websites.models import Website, WebsiteContent, WebsiteStarter
-from websites.utils import get_dict_field, get_dict_query_field, set_dict_field
+from websites.utils import (
+    get_dict_field,
+    get_dict_query_field,
+    resolve_referenced_content_ids,
+    set_dict_field,
+)
 
 log = logging.getLogger(__name__)
 
@@ -204,6 +209,14 @@ def update_youtube_thumbnail(
                 settings.YT_FIELD_THUMBNAIL,
                 YT_THUMBNAIL_IMG.format(video_id=youtube_id),
             )
+
+
+def sync_website_content_references(content: WebsiteContent) -> None:
+    """Refresh reference tracking for a WebsiteContent record."""
+    referenced_content = WebsiteContent.objects.filter(
+        id__in=resolve_referenced_content_ids(content)
+    )
+    content.referenced_by.set(referenced_content)
 
 
 def videos_with_unassigned_youtube_ids(website: Website) -> list[WebsiteContent]:

--- a/websites/management/commands/backpopulate_referencing_content.py
+++ b/websites/management/commands/backpopulate_referencing_content.py
@@ -1,5 +1,6 @@
 """Backpopulate referencing content"""  # noqa: INP001
 
+from django.conf import settings
 from django.db import transaction
 from mitol.common.utils import now_in_utc
 
@@ -13,6 +14,15 @@ from websites.utils import (
 )
 
 BATCH_SIZE_DEFAULT = 500  # Default batch size for processing content
+
+# Top-level metadata keys under which video file paths are stored, derived from
+# settings so custom field paths are respected.
+_VIDEO_FILE_TOP_KEYS = frozenset(
+    {
+        settings.YT_FIELD_CAPTIONS.split(".")[0],
+        settings.YT_FIELD_TRANSCRIPT.split(".")[0],
+    }
+)
 
 
 class Command(WebsiteFilterCommand):
@@ -170,7 +180,7 @@ class Command(WebsiteFilterCommand):
             if (
                 content.type == constants.CONTENT_TYPE_RESOURCE
                 and content.metadata
-                and content.metadata.get("video_files")
+                and any(content.metadata.get(k) for k in _VIDEO_FILE_TOP_KEYS)
             ):
                 video_resource_ids.append(content.id)
 

--- a/websites/management/commands/backpopulate_referencing_content.py
+++ b/websites/management/commands/backpopulate_referencing_content.py
@@ -8,7 +8,7 @@ from websites import constants
 from websites.models import Website, WebsiteContent
 from websites.utils import (
     compile_referencing_content,
-    resolve_referenced_content_ids,
+    resolve_course_list_referenced_content_ids,
     resolve_video_file_referenced_content_ids,
 )
 
@@ -192,7 +192,8 @@ class Command(WebsiteFilterCommand):
         """Merge per-item video file path resolutions into content_references."""
         if not video_resource_ids:
             return
-        video_map = {c.id: c for c in content_batch if c.id in video_resource_ids}
+        video_resource_id_set = set(video_resource_ids)
+        video_map = {c.id: c for c in content_batch if c.id in video_resource_id_set}
         for content_id, content in video_map.items():
             extra_ids = resolve_video_file_referenced_content_ids(content)
             if extra_ids:
@@ -208,7 +209,7 @@ class Command(WebsiteFilterCommand):
             return
         course_list_map = {c.id: c for c in content_batch if c.id in course_list_ids}
         for content_id, content in course_list_map.items():
-            extra_ids = resolve_referenced_content_ids(content)
+            extra_ids = resolve_course_list_referenced_content_ids(content)
             if extra_ids:
                 content_references[content_id] = (
                     content_references.get(content_id, set()) | extra_ids

--- a/websites/management/commands/backpopulate_referencing_content.py
+++ b/websites/management/commands/backpopulate_referencing_content.py
@@ -9,6 +9,7 @@ from websites.models import Website, WebsiteContent
 from websites.utils import (
     compile_referencing_content,
     resolve_referenced_content_ids,
+    resolve_video_file_referenced_content_ids,
 )
 
 BATCH_SIZE_DEFAULT = 500  # Default batch size for processing content
@@ -126,7 +127,7 @@ class Command(WebsiteFilterCommand):
         is still per-item because it depends on website lookups that cannot
         easily be batched.
         """
-        per_content_text_ids, course_list_ids, all_text_ids = (
+        per_content_text_ids, course_list_ids, video_resource_ids, all_text_ids = (
             self._compile_batch_text_ids(content_batch)
         )
         text_id_to_ids = self._bulk_resolve_text_ids(all_text_ids)
@@ -140,6 +141,9 @@ class Command(WebsiteFilterCommand):
                 content_references[content_id] = resolved
 
         self._merge_course_list_ids(content_batch, course_list_ids, content_references)
+        self._merge_video_file_ids(
+            content_batch, video_resource_ids, content_references
+        )
 
         if verbosity >= 3:  # noqa: PLR2004
             for content_id, refs in content_references.items():
@@ -153,6 +157,7 @@ class Command(WebsiteFilterCommand):
         """Compile text_id references for each item without hitting the DB."""
         per_content_text_ids: dict[int, list[str]] = {}
         course_list_ids: list[int] = []
+        video_resource_ids: list[int] = []
         all_text_ids: set[str] = set()
 
         for content in content_batch:
@@ -162,8 +167,14 @@ class Command(WebsiteFilterCommand):
                 all_text_ids.update(text_ids)
             if content.type == constants.CONTENT_TYPE_COURSE_LIST and content.metadata:
                 course_list_ids.append(content.id)
+            if (
+                content.type == constants.CONTENT_TYPE_RESOURCE
+                and content.metadata
+                and content.metadata.get("video_files")
+            ):
+                video_resource_ids.append(content.id)
 
-        return per_content_text_ids, course_list_ids, all_text_ids
+        return per_content_text_ids, course_list_ids, video_resource_ids, all_text_ids
 
     def _bulk_resolve_text_ids(self, all_text_ids):
         """Return a mapping of text_id → set of WebsiteContent ids via one query."""
@@ -174,6 +185,20 @@ class Command(WebsiteFilterCommand):
             ).values_list("id", "text_id"):
                 text_id_to_ids.setdefault(wc_text_id, set()).add(wc_id)
         return text_id_to_ids
+
+    def _merge_video_file_ids(
+        self, content_batch, video_resource_ids, content_references
+    ):
+        """Merge per-item video file path resolutions into content_references."""
+        if not video_resource_ids:
+            return
+        video_map = {c.id: c for c in content_batch if c.id in video_resource_ids}
+        for content_id, content in video_map.items():
+            extra_ids = resolve_video_file_referenced_content_ids(content)
+            if extra_ids:
+                content_references[content_id] = (
+                    content_references.get(content_id, set()) | extra_ids
+                )
 
     def _merge_course_list_ids(
         self, content_batch, course_list_ids, content_references

--- a/websites/management/commands/backpopulate_referencing_content_test.py
+++ b/websites/management/commands/backpopulate_referencing_content_test.py
@@ -964,3 +964,41 @@ def test_video_resource_captions_only_reference_detected():
     referenced_content = list(video_resource.referenced_by.all())
     assert len(referenced_content) == 1
     assert captions_resource in referenced_content
+
+
+def test_video_resource_file_path_references_detected():
+    """Test that video_captions_file and video_transcript_file paths are resolved to referenced content"""
+    website = WebsiteFactory.create()
+    captions_content = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        filename="nXyqvKrQGZ8_captions",
+        file=f"courses/{website.name}/nXyqvKrQGZ8_captions.webvtt",
+    )
+    transcript_content = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        filename="pdf_testpage",
+        file=f"courses/{website.name}/pdf_testpage.pdf",
+    )
+    video_resource = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_file": f"/courses/{website.name}/nXyqvKrQGZ8_captions.webvtt",
+                "video_transcript_file": f"/courses/{website.name}/pdf_testpage.pdf",
+            },
+        },
+    )
+
+    assert video_resource.referenced_by.count() == 0
+
+    call_command("backpopulate_referencing_content", verbosity=0, stdout=StringIO())
+
+    video_resource.refresh_from_db()
+    referenced_content = list(video_resource.referenced_by.all())
+    assert len(referenced_content) == 2
+    assert captions_content in referenced_content
+    assert transcript_content in referenced_content

--- a/websites/management/commands/backpopulate_referencing_content_test.py
+++ b/websites/management/commands/backpopulate_referencing_content_test.py
@@ -11,6 +11,7 @@ from websites.constants import (
     CONTENT_TYPE_HOMEPAGE_SETTINGS,
     CONTENT_TYPE_INSTRUCTOR,
     CONTENT_TYPE_METADATA,
+    CONTENT_TYPE_NAVMENU,
     CONTENT_TYPE_PAGE,
     CONTENT_TYPE_PROMO,
     CONTENT_TYPE_RESOURCE,
@@ -18,6 +19,7 @@ from websites.constants import (
     CONTENT_TYPE_STORY,
     CONTENT_TYPE_TESTIMONIAL,
     CONTENT_TYPE_VIDEO_GALLERY,
+    WEBSITE_CONTENT_LEFTNAV,
 )
 from websites.factories import (
     WebsiteContentFactory,
@@ -850,3 +852,115 @@ def test_promo_no_image_field():
     promo.refresh_from_db()
     # Should still be 0 since there are no references
     assert promo.referenced_by.count() == 0
+
+
+def test_navmenu_references_detected():
+    """Test that navmenu leftnav identifiers are detected as references"""
+    website = WebsiteFactory.create()
+    page1 = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_PAGE,
+    )
+    page2 = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_PAGE,
+    )
+    navmenu = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_NAVMENU,
+        metadata={
+            WEBSITE_CONTENT_LEFTNAV: [
+                {"identifier": page1.text_id, "name": "Page 1"},
+                {"identifier": page2.text_id, "name": "Page 2"},
+            ]
+        },
+    )
+
+    assert navmenu.referenced_by.count() == 0
+
+    call_command("backpopulate_referencing_content", verbosity=0, stdout=StringIO())
+
+    navmenu.refresh_from_db()
+    referenced_content = list(navmenu.referenced_by.all())
+    assert len(referenced_content) == 2
+    assert page1 in referenced_content
+    assert page2 in referenced_content
+
+
+def test_navmenu_null_metadata_no_error():
+    """Test that navmenu with None metadata does not raise an error"""
+    website = WebsiteFactory.create()
+    navmenu = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_NAVMENU,
+        metadata=None,
+    )
+
+    assert navmenu.referenced_by.count() == 0
+
+    call_command("backpopulate_referencing_content", verbosity=0, stdout=StringIO())
+
+    navmenu.refresh_from_db()
+    assert navmenu.referenced_by.count() == 0
+
+
+def test_video_resource_captions_and_transcript_references_detected():
+    """Test that captions and transcript resource UUIDs in video metadata are detected"""
+    website = WebsiteFactory.create()
+    captions_resource = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+    )
+    transcript_resource = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+    )
+    video_resource = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_resource": {"content": captions_resource.text_id},
+                "video_transcript_resource": {"content": transcript_resource.text_id},
+            },
+        },
+    )
+
+    assert video_resource.referenced_by.count() == 0
+
+    call_command("backpopulate_referencing_content", verbosity=0, stdout=StringIO())
+
+    video_resource.refresh_from_db()
+    referenced_content = list(video_resource.referenced_by.all())
+    assert len(referenced_content) == 2
+    assert captions_resource in referenced_content
+    assert transcript_resource in referenced_content
+
+
+def test_video_resource_captions_only_reference_detected():
+    """Test that only captions resource UUID is detected when transcript is absent"""
+    website = WebsiteFactory.create()
+    captions_resource = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+    )
+    video_resource = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_resource": {"content": captions_resource.text_id},
+            },
+        },
+    )
+
+    assert video_resource.referenced_by.count() == 0
+
+    call_command("backpopulate_referencing_content", verbosity=0, stdout=StringIO())
+
+    video_resource.refresh_from_db()
+    referenced_content = list(video_resource.referenced_by.all())
+    assert len(referenced_content) == 1
+    assert captions_resource in referenced_content

--- a/websites/utils.py
+++ b/websites/utils.py
@@ -145,6 +145,8 @@ def get_metadata_content_key(content) -> list:
             content_keys = [
                 constants.METADATA_FIELD_IMAGE_CAPTION,
                 constants.METADATA_FIELD_IMAGE_CREDIT,
+                settings.YT_FIELD_CAPTIONS_RESOURCE + ".content",
+                settings.YT_FIELD_TRANSCRIPT_RESOURCE + ".content",
             ]
         case constants.CONTENT_TYPE_COURSE_COLLECTION:
             content_keys = [

--- a/websites/utils.py
+++ b/websites/utils.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+from pathlib import Path
 from typing import Any
 
 from django.apps import apps
@@ -46,6 +47,8 @@ def get_dict_field(obj: dict, field_path: str) -> Any:
     current_obj = obj
     for field in fields[:-1]:
         current_obj = current_obj.get(field, {})
+        if not isinstance(current_obj, dict):
+            return None
     return current_obj.get(fields[-1])
 
 
@@ -306,6 +309,26 @@ def _resolve_course_list_referenced_content_ids(content) -> set[int]:
     return referenced_content_ids
 
 
+def resolve_video_file_referenced_content_ids(content) -> set[int]:
+    """Resolve video_captions_file/video_transcript_file paths to WebsiteContent ids."""
+    WebsiteContent = apps.get_model("websites", "WebsiteContent")
+    referenced_ids = set()
+
+    for field_path in (settings.YT_FIELD_CAPTIONS, settings.YT_FIELD_TRANSCRIPT):
+        key = get_dict_field(content.metadata, field_path)
+        if not key:
+            continue
+        base_name = Path(key).stem
+        related_ids = (
+            WebsiteContent.objects.filter(website=content.website)
+            .filter(Q(file=key) | Q(file=key.strip("/")) | Q(filename=base_name))
+            .values_list("id", flat=True)
+        )
+        referenced_ids.update(related_ids)
+
+    return referenced_ids
+
+
 def compile_referencing_content(content) -> list[str]:
     """Compile referencing content for a website content instance."""
     references = []
@@ -361,6 +384,11 @@ def resolve_referenced_content_ids(content) -> set[int]:
     if content.type == constants.CONTENT_TYPE_COURSE_LIST and content.metadata:
         referenced_content_ids.update(
             _resolve_course_list_referenced_content_ids(content)
+        )
+
+    if content.type == constants.CONTENT_TYPE_RESOURCE and content.metadata:
+        referenced_content_ids.update(
+            resolve_video_file_referenced_content_ids(content)
         )
 
     return referenced_content_ids

--- a/websites/utils.py
+++ b/websites/utils.py
@@ -310,10 +310,11 @@ def compile_referencing_content(content) -> list[str]:
     """Compile referencing content for a website content instance."""
     references = []
 
-    if content.type == constants.CONTENT_TYPE_NAVMENU:
+    if content.type == constants.CONTENT_TYPE_NAVMENU and content.metadata:
         references = [
             item["identifier"]
             for item in content.metadata.get(constants.WEBSITE_CONTENT_LEFTNAV, [])
+            if item.get("identifier")
         ]
     else:
         if content.markdown:

--- a/websites/utils.py
+++ b/websites/utils.py
@@ -291,7 +291,7 @@ def _get_sitemetadata_for_course_path(course_id: str):
     return sitemetadata
 
 
-def _resolve_course_list_referenced_content_ids(content) -> set[int]:
+def resolve_course_list_referenced_content_ids(content) -> set[int]:
     """Resolve course-list course entries to concrete referenced content ids."""
     referenced_content_ids = set()
 
@@ -329,45 +329,55 @@ def resolve_video_file_referenced_content_ids(content) -> set[int]:
     return referenced_ids
 
 
+def _extract_references_from_metadata_key(content, content_key: str) -> list[str]:
+    """Extract text_id references from a single metadata key on a content item."""
+    resource_data = get_dict_field(content.metadata, content_key)
+    if not resource_data:
+        return []
+    if isinstance(resource_data, list):
+        return _extract_relation_text_ids(resource_data)
+    if isinstance(resource_data, str):
+        resource_data = resource_data.strip()
+        if re.fullmatch(UUID_REGEX_STR, resource_data):
+            return [resource_data]
+        return parse_resource_uuid(resource_data)
+    log.warning(
+        "Unexpected metadata type %s for key '%s' in content %s",
+        type(resource_data).__name__,
+        content_key,
+        content.text_id,
+    )
+    return []
+
+
 def compile_referencing_content(content) -> list[str]:
     """Compile referencing content for a website content instance."""
     references = []
 
-    if content.type == constants.CONTENT_TYPE_NAVMENU and content.metadata:
-        references = [
-            item["identifier"]
-            for item in content.metadata.get(constants.WEBSITE_CONTENT_LEFTNAV, [])
-            if item.get("identifier")
-        ]
-    else:
-        if content.markdown:
-            references += parse_resource_uuid(content.markdown)
-
+    if content.type == constants.CONTENT_TYPE_NAVMENU:
         if content.metadata:
-            content_keys = get_metadata_content_key(content)
-            if content.type == constants.CONTENT_TYPE_COURSE_LIST:
-                content_keys = [
-                    content_key
-                    for content_key in content_keys
-                    if content_key != constants.METADATA_FIELD_COURSE_LIST_COURSES
-                ]
-            for content_key in content_keys:
-                if resource_data := get_dict_field(content.metadata, content_key):
-                    if isinstance(resource_data, list):
-                        references.extend(_extract_relation_text_ids(resource_data))
-                    elif isinstance(resource_data, str):
-                        resource_data = resource_data.strip()
-                        if re.fullmatch(UUID_REGEX_STR, resource_data):
-                            references.append(resource_data)
-                        else:
-                            references.extend(parse_resource_uuid(resource_data))
-                    else:
-                        log.warning(
-                            "Unexpected metadata type %s for key '%s' in content %s",
-                            type(resource_data).__name__,
-                            content_key,
-                            content.text_id,
-                        )
+            references = [
+                item["identifier"]
+                for item in content.metadata.get(constants.WEBSITE_CONTENT_LEFTNAV, [])
+                if item.get("identifier")
+            ]
+        return references
+
+    if content.markdown:
+        references += parse_resource_uuid(content.markdown)
+
+    if content.metadata:
+        content_keys = get_metadata_content_key(content)
+        if content.type == constants.CONTENT_TYPE_COURSE_LIST:
+            content_keys = [
+                k
+                for k in content_keys
+                if k != constants.METADATA_FIELD_COURSE_LIST_COURSES
+            ]
+        for content_key in content_keys:
+            references.extend(
+                _extract_references_from_metadata_key(content, content_key)
+            )
     return references
 
 
@@ -383,7 +393,7 @@ def resolve_referenced_content_ids(content) -> set[int]:
 
     if content.type == constants.CONTENT_TYPE_COURSE_LIST and content.metadata:
         referenced_content_ids.update(
-            _resolve_course_list_referenced_content_ids(content)
+            resolve_course_list_referenced_content_ids(content)
         )
 
     if content.type == constants.CONTENT_TYPE_RESOURCE and content.metadata:

--- a/websites/utils_test.py
+++ b/websites/utils_test.py
@@ -391,6 +391,18 @@ def test_compile_referencing_content_navmenu_null_metadata():
     assert result == []
 
 
+def test_compile_referencing_content_navmenu_empty_metadata():
+    """compile_referencing_content with NAVMENU type and empty dict metadata returns empty list without scanning markdown."""
+    content = WebsiteContentFactory.build(
+        type=constants.CONTENT_TYPE_NAVMENU,
+        metadata={},
+        markdown='{{% resource_link "550e8400-e29b-41d4-a716-446655440001" "Should not appear" %}}',
+    )
+
+    result = compile_referencing_content(content)
+    assert result == []
+
+
 def test_compile_referencing_content_navmenu_skips_items_without_identifier():
     """compile_referencing_content with NAVMENU skips items that have no identifier (e.g. external links)."""
     content = WebsiteContentFactory.build(

--- a/websites/utils_test.py
+++ b/websites/utils_test.py
@@ -1213,3 +1213,61 @@ def test_resolve_referenced_content_ids_scopes_course_list_sitemetadata():
         sitemetadata_1.id,
         sitemetadata_2.id,
     }
+
+
+@pytest.mark.django_db
+def test_resolve_referenced_content_ids_video_file_paths():
+    """resolve_referenced_content_ids resolves video_captions_file and video_transcript_file by file path."""
+    website = WebsiteFactory.create()
+
+    captions_content = WebsiteContentFactory.create(
+        website=website,
+        type=constants.CONTENT_TYPE_RESOURCE,
+        filename="nXyqvKrQGZ8_captions",
+        file=f"courses/{website.name}/nXyqvKrQGZ8_captions.webvtt",
+    )
+    transcript_content = WebsiteContentFactory.create(
+        website=website,
+        type=constants.CONTENT_TYPE_RESOURCE,
+        filename="pdf_testpage",
+        file=f"courses/{website.name}/pdf_testpage.pdf",
+    )
+
+    video_resource = WebsiteContentFactory.create(
+        website=website,
+        type=constants.CONTENT_TYPE_RESOURCE,
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_file": f"/courses/{website.name}/nXyqvKrQGZ8_captions.webvtt",
+                "video_transcript_file": f"/courses/{website.name}/pdf_testpage.pdf",
+            },
+        },
+    )
+
+    result = resolve_referenced_content_ids(video_resource)
+    assert captions_content.id in result
+    assert transcript_content.id in result
+
+
+@pytest.mark.django_db
+def test_resolve_referenced_content_ids_video_file_empty_strings():
+    """resolve_referenced_content_ids handles empty-string video file paths gracefully."""
+    website = WebsiteFactory.create()
+
+    video_resource = WebsiteContentFactory.create(
+        website=website,
+        type=constants.CONTENT_TYPE_RESOURCE,
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_file": "",
+                "video_transcript_file": "",
+                "video_captions_resource": "",
+                "video_transcript_resource": "",
+            },
+        },
+    )
+
+    result = resolve_referenced_content_ids(video_resource)
+    assert result == set()

--- a/websites/utils_test.py
+++ b/websites/utils_test.py
@@ -3,6 +3,7 @@
 from typing import Any
 
 import pytest
+from django.conf import settings
 
 from websites import constants
 from websites.factories import (
@@ -378,6 +379,39 @@ def test_compile_referencing_content_navmenu_empty():
     assert result == []
 
 
+def test_compile_referencing_content_navmenu_null_metadata():
+    """compile_referencing_content with NAVMENU type and None metadata returns empty list."""
+    content = WebsiteContentFactory.build(
+        type=constants.CONTENT_TYPE_NAVMENU,
+        metadata=None,
+        markdown="This markdown should be ignored",
+    )
+
+    result = compile_referencing_content(content)
+    assert result == []
+
+
+def test_compile_referencing_content_navmenu_skips_items_without_identifier():
+    """compile_referencing_content with NAVMENU skips items that have no identifier (e.g. external links)."""
+    content = WebsiteContentFactory.build(
+        type=constants.CONTENT_TYPE_NAVMENU,
+        metadata={
+            constants.WEBSITE_CONTENT_LEFTNAV: [
+                {"identifier": "12345678-90ab-cdef-1234-567890abcdef"},
+                {"url": "https://example.com", "name": "External Link"},
+                {"identifier": "abcdef12-3456-789a-bcde-f1234567890a"},
+            ]
+        },
+        markdown="This markdown should be ignored",
+    )
+
+    result = compile_referencing_content(content)
+    assert result == [
+        "12345678-90ab-cdef-1234-567890abcdef",
+        "abcdef12-3456-789a-bcde-f1234567890a",
+    ]
+
+
 def test_compile_referencing_content_page_markdown():
     """compile_referencing_content with PAGE type containing markdown references."""
     markdown_content = (
@@ -729,6 +763,46 @@ def test_compile_referencing_content_resource_image_metadata(
     assert result == expected_uuids
 
 
+def test_compile_referencing_content_resource_captions_and_transcript():
+    """Test compile_referencing_content with RESOURCE type having captions/transcript resource references."""
+    captions_uuid = "aaaabbbb-cccc-dddd-eeee-ffff12345678"
+    transcript_uuid = "11223344-5566-7788-99aa-bbccddee1122"
+
+    content = WebsiteContentFactory.build(
+        type=constants.CONTENT_TYPE_RESOURCE,
+        markdown=None,
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_resource": {"content": captions_uuid},
+                "video_transcript_resource": {"content": transcript_uuid},
+            },
+        },
+    )
+
+    result = compile_referencing_content(content)
+    assert sorted(result) == sorted([captions_uuid, transcript_uuid])
+
+
+def test_compile_referencing_content_resource_captions_only():
+    """Test compile_referencing_content with RESOURCE type having only captions resource reference."""
+    captions_uuid = "aaaabbbb-cccc-dddd-eeee-ffff12345678"
+
+    content = WebsiteContentFactory.build(
+        type=constants.CONTENT_TYPE_RESOURCE,
+        markdown=None,
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_resource": {"content": captions_uuid},
+            },
+        },
+    )
+
+    result = compile_referencing_content(content)
+    assert result == [captions_uuid]
+
+
 def test_compile_referencing_content_empty_and_none():
     """Test compile_referencing_content with no/empty markdown and metadata"""
     # Test with None values
@@ -817,6 +891,8 @@ def test_get_metadata_content_key():
     assert get_metadata_content_key(content_resource) == [
         constants.METADATA_FIELD_IMAGE_CAPTION,
         constants.METADATA_FIELD_IMAGE_CREDIT,
+        settings.YT_FIELD_CAPTIONS_RESOURCE + ".content",
+        settings.YT_FIELD_TRANSCRIPT_RESOURCE + ".content",
     ]
 
     # Test unknown/unsupported type

--- a/websites/views.py
+++ b/websites/views.py
@@ -38,7 +38,11 @@ from main.utils import uuid_string, valid_key
 from main.views import DefaultPagination
 from users.models import User
 from websites import constants
-from websites.api import get_valid_new_filename, update_website_status
+from websites.api import (
+    get_valid_new_filename,
+    sync_website_content_references,
+    update_website_status,
+)
 from websites.constants import (
     CONTENT_TYPE_COURSE_LIST,
     CONTENT_TYPE_METADATA,
@@ -87,7 +91,6 @@ from websites.site_config_api import SiteConfig
 from websites.utils import (
     get_valid_base_filename,
     permissions_group_name_for_role,
-    resolve_referenced_content_ids,
 )
 
 log = logging.getLogger(__name__)
@@ -793,29 +796,22 @@ class WebsiteContentViewSet(
             if content:
                 # If the content already exists, return it instead of creating a new one
                 serializer = self.get_serializer(content)
-                self._referencing_content(content)
+                sync_website_content_references(content)
                 return Response(serializer.data, status=status.HTTP_200_OK)
 
         # Proceed with creation if no existing content is found
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
         instance = serializer.save(updated_by=self.request.user)
-        self._referencing_content(instance)
+        sync_website_content_references(instance)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
-
-    def _referencing_content(self, instance: WebsiteContent):
-        """Update instance.referenced_by based on the referencing content"""
-        content_refs = WebsiteContent.objects.filter(
-            id__in=resolve_referenced_content_ids(instance)
-        ).all()
-        instance.referenced_by.set(content_refs)
 
     def perform_update(self, serializer):
         """
         Override the update request for content
         """
         instance = serializer.save(updated_by=self.request.user)
-        self._referencing_content(instance)
+        sync_website_content_references(instance)
 
     @action(
         detail=False,

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -1132,6 +1132,58 @@ def test_websites_content_create_course_list_sets_references(
     }
 
 
+def test_websites_content_create_video_resource_sets_3play_references(
+    drf_client, global_admin_user
+):
+    """Creating a video resource should resolve caption/transcript file references."""
+    drf_client.force_login(global_admin_user)
+    website = WebsiteFactory.create()
+    captions = WebsiteContentFactory.create(
+        website=website,
+        type=constants.CONTENT_TYPE_RESOURCE,
+        filename="video-captions",
+        file=f"courses/{website.name}/video-captions.webvtt",
+    )
+    transcript = WebsiteContentFactory.create(
+        website=website,
+        type=constants.CONTENT_TYPE_RESOURCE,
+        filename="video-transcript",
+        file=f"courses/{website.name}/video-transcript.pdf",
+    )
+
+    payload = {
+        "type": constants.CONTENT_TYPE_RESOURCE,
+        "metadata": {
+            "resourcetype": "Video",
+            "video_metadata": {"youtube_id": "yt123"},
+            "video_files": {
+                "video_captions_file": f"/courses/{website.name}/video-captions.webvtt",
+                "video_transcript_file": (
+                    f"/courses/{website.name}/video-transcript.pdf"
+                ),
+            },
+        },
+    }
+    resp = drf_client.post(
+        reverse(
+            "websites_content_api-list",
+            kwargs={"parent_lookup_website": website.name},
+        ),
+        data=payload,
+        format="json",
+    )
+
+    assert resp.status_code == 201
+    content = WebsiteContent.objects.get(
+        website=website,
+        text_id=resp.data["text_id"],
+    )
+    assert set(content.referenced_by.values_list("id", flat=True)) == {
+        captions.id,
+        transcript.id,
+    }
+
+
 def test_websites_content_create_with_textid(drf_client, global_admin_user):
     """If a text_id is added when POSTing to the WebsiteContent, we should use that instead of creating a uuid"""
     drf_client.force_login(global_admin_user)
@@ -1632,3 +1684,62 @@ def test_referencing_content_clears_when_references_removed(
 
     page.refresh_from_db()
     assert page.referenced_by.count() == 0
+
+
+def test_websites_content_update_video_resource_sets_3play_references(
+    drf_client, global_admin_user
+):
+    """Updating a video resource should refresh caption/transcript file references."""
+    drf_client.force_login(global_admin_user)
+    website = WebsiteFactory.create()
+    captions = WebsiteContentFactory.create(
+        website=website,
+        type=constants.CONTENT_TYPE_RESOURCE,
+        filename="updated-captions",
+        file=f"courses/{website.name}/updated-captions.webvtt",
+    )
+    transcript = WebsiteContentFactory.create(
+        website=website,
+        type=constants.CONTENT_TYPE_RESOURCE,
+        filename="updated-transcript",
+        file=f"courses/{website.name}/updated-transcript.pdf",
+    )
+    video = WebsiteContentFactory.create(
+        website=website,
+        type=constants.CONTENT_TYPE_RESOURCE,
+        metadata={
+            "resourcetype": "Video",
+            "video_metadata": {"youtube_id": "yt456"},
+            "video_files": {},
+        },
+    )
+
+    resp = drf_client.patch(
+        reverse(
+            "websites_content_api-detail",
+            kwargs={
+                "parent_lookup_website": website.name,
+                "text_id": str(video.text_id),
+            },
+        ),
+        data={
+            "metadata": {
+                "video_files": {
+                    "video_captions_file": (
+                        f"/courses/{website.name}/updated-captions.webvtt"
+                    ),
+                    "video_transcript_file": (
+                        f"/courses/{website.name}/updated-transcript.pdf"
+                    ),
+                }
+            }
+        },
+        format="json",
+    )
+
+    assert resp.status_code == 200
+    video.refresh_from_db()
+    assert set(video.referenced_by.values_list("id", flat=True)) == {
+        captions.id,
+        transcript.id,
+    }


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10169

### Description (What does it do?)
Add missing referenced_by links for 3play transcripts/captions.

### How can this be tested?
1. Checkout to `master` branch
2. Set `THREEPLAY_API_KEY`, `THREEPLAY_CALLBACK_KEY`, `THREEPLAY_PROJECT_ID` in your .env and restart containers
3. Create a video resource from OCW Studio interface. and use this `youtube_id`: `E8uZtq_vOYM`
4. Click on Save. There should be immediately 2 more resources created, namely `<video_title>_captions`, and `<video_title>_transcript`. Relevant logs for it are also present in Web container in Docker.
5. switch to the branch and run:
```bash
./manage backpopulate_referencing_content
```
6. Verify that `referenicng_content` has been populated for the captions/transcript files.
7. Delete the video and re-add it.
8 Check if `referencing_content` is populated for transcript/captions when updating a content and also when running the backpopulate command:
