### PR TITLE
fix: do not change url for section pages

### DIFF
--- a/drf_lint_baseline.json
+++ b/drf_lint_baseline.json
@@ -1,7 +1,5 @@
 [
   "content_sync/serializers.py:133:21:ORM001",
   "content_sync/serializers.py:54:21:ORM001",
-  "websites/serializers.py:257:23:ORM001",
-  "websites/serializers.py:683:16:ORM001",
-  "websites/serializers.py:700:20:ORM002"
+  "websites/serializers.py:257:23:ORM001"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,6 +177,7 @@ ignore = [
     "RUF012",
     "UP007"
 ]
+external = ["ORM001", "ORM002"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "pep257"

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -684,7 +684,7 @@ class WebsiteContentDetailSerializer(
         contents = []
         for website_id, text_ids in lookup.items():
             contents.extend(
-                WebsiteContent.objects.filter( # noqa: ORM001
+                WebsiteContent.objects.filter(  # noqa: ORM001
                     (Q(website__url_path=website_id) | Q(website__name=website_id)),
                     text_id__in=text_ids,
                 )
@@ -701,7 +701,7 @@ class WebsiteContentDetailSerializer(
             if file_field:
                 result[file_field["name"]] = instance.file.url
 
-        drivefile = instance.drivefile_set.first() # noqa: ORM002
+        drivefile = instance.drivefile_set.first()  # noqa: ORM002
         if drivefile:
             result["gdrive_url"] = DRIVE_FILE_VIEW_URL.format(file_id=drivefile.file_id)
 

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -571,7 +571,11 @@ class WebsiteContentDetailSerializer(
     def update(self, instance, validated_data):
         """Update WebsiteContent, handling filename and metadata."""
         title = validated_data.get("title", instance.title)
-        if instance.type == CONTENT_TYPE_PAGE and title:
+        if (
+            instance.type == CONTENT_TYPE_PAGE
+            and title
+            and instance.filename != "_index"
+        ):
             new_filename = slugify(title)
             if instance.filename != new_filename:
                 cur_filename = WebsiteContent.objects.filter(

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -574,7 +574,7 @@ class WebsiteContentDetailSerializer(
         if (
             instance.type == CONTENT_TYPE_PAGE
             and title
-            and instance.filename != "_index"
+            and instance.filename not in constants.CONTENT_FILENAMES_FORBIDDEN
         ):
             new_filename = slugify(title)
             if instance.filename != new_filename:

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -684,7 +684,7 @@ class WebsiteContentDetailSerializer(
         contents = []
         for website_id, text_ids in lookup.items():
             contents.extend(
-                WebsiteContent.objects.filter(
+                WebsiteContent.objects.filter( # noqa: ORM001
                     (Q(website__url_path=website_id) | Q(website__name=website_id)),
                     text_id__in=text_ids,
                 )
@@ -701,7 +701,7 @@ class WebsiteContentDetailSerializer(
             if file_field:
                 result[file_field["name"]] = instance.file.url
 
-        drivefile = instance.drivefile_set.first()
+        drivefile = instance.drivefile_set.first() # noqa: ORM002
         if drivefile:
             result["gdrive_url"] = DRIVE_FILE_VIEW_URL.format(file_id=drivefile.file_id)
 

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -905,6 +905,39 @@ def test_update_page_url_on_title_change_parametrized(  # noqa: PLR0913
         assert page.filename == expected_filename
 
 
+@pytest.mark.parametrize(
+    ("initial_filename", "expected_filename"),
+    [
+        ("_index", "_index"),
+        ("original-title", "new-title"),
+    ],
+)
+def test_update_page_url_on_title_change_legacy_index_behavior(
+    enable_websitecontent_signal,
+    initial_filename,
+    expected_filename,
+):
+    """Legacy _index pages skip page url updates; normal pages still proceed with them."""
+    website = WebsiteFactory.create(owner=UserFactory.create())
+    page = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_PAGE,
+        dirpath="",
+        title="Original Title",
+        filename=initial_filename,
+    )
+
+    serializer = WebsiteContentDetailSerializer(
+        instance=page, data={"title": "New Title"}, partial=True
+    )
+    assert serializer.is_valid(), serializer.errors
+    serializer.save()
+
+    page.refresh_from_db()
+    assert page.filename == expected_filename
+    assert page.title == "New Title"
+
+
 def test_website_content_detail_serializer_syncs_video_relation_files(
     mocker, mocked_website_funcs
 ):


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10832

### Description (What does it do?)
See [comment](https://github.com/mitodl/hq/issues/10832#issuecomment-4243181190)



### How can this be tested?
1. Create a section page in a site. This is a page with a filename of _index.md (like [this](https://ocw-studio-rc.odl.mit.edu/sites/pe-710-tennis-spring-2007/type/page/edit/de168d39-f840-f977-8435-fb3ef4fd9530/)) I don't think the studio interface supports building such pages and these are for legacy usage only.
2. Make some small edit to the page and save
3. Verify that the page url does not change.
4. Build the course and verify that the section page renders correctly.