### PR TITLE
Configure bumpver for Concourse release pipeline

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -26,7 +26,7 @@ from main.sentry import init_sentry
 
 # pylint: disable=too-many-lines
 
-VERSION = "0.184.0"
+VERSION = "2026.04.16.1"
 
 SITE_ID = get_int(
     name="OCW_STUDIO_SITE_ID",

--- a/main/settings_test.py
+++ b/main/settings_test.py
@@ -8,7 +8,6 @@ import sys
 from unittest import mock
 
 import pytest
-import semantic_version
 from django.conf import settings
 from django.core import mail
 from django.core.exceptions import ImproperlyConfigured
@@ -159,13 +158,6 @@ class TestSettings(TestCase):
                     ),
                 }
             )
-
-    @staticmethod
-    def test_semantic_version():
-        """
-        Verify that we have a semantic compatible version.
-        """
-        semantic_version.Version(settings.VERSION)
 
     def test_server_side_cursors_disabled(self):
         """DISABLE_SERVER_SIDE_CURSORS should be true by default"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -190,3 +190,13 @@ inline-quotes = "double"
 "**/migrations/**" = ["ARG001"]
 "**/apps.py" = ["PLC0415"]
 "repl.py" = ["S603"]
+
+[tool.bumpver]
+current_version = "2026.04.16.1"
+version_pattern = "YYYY.0M.0D.INC1"
+commit = false
+tag = false
+push = false
+
+[tool.bumpver.file_patterns]
+"main/settings.py" = ['VERSION = "{version}"']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ocw-studio"
-version = "0.0.0"
+version = "2026.04.16.1"
 description = "OCW Studio manages deployments for OCW courses"
 authors = [{ name = "MITODL" }]
 requires-python = ">=3.13,<3.14"
@@ -200,3 +200,4 @@ push = false
 
 [tool.bumpver.file_patterns]
 "main/settings.py" = ['VERSION = "{version}"']
+"pyproject.toml" = ['version = "{version}"']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ocw-studio"
-version = "0.0.0"
+version = "0.188.0"
 description = "OCW Studio manages deployments for OCW courses"
 authors = [{ name = "MITODL" }]
 requires-python = ">=3.13,<3.14"
@@ -229,3 +229,36 @@ env = [
     "OCW_IMPORT_STARTER_SLUG=course",
     "OCW_COURSE_STARTER_SLUG=course",
 ]
+
+[tool.bumpversion]
+commit = false
+tag = false
+parse = "(?P<release>(?:[1-9][0-9]{3})\\.(?:1[0-2]|[1-9])\\.(?:3[0-1]|[12][0-9]|[1-9]))\\.(?P<build>\\d+)"
+serialize = ["{release}.{build}"]
+
+[tool.bumpversion.parts.release]
+calver_format = "{YYYY}.{MM}.{DD}"
+
+[tool.bumpversion.parts.build]
+first_value = "1"
+
+[[tool.bumpversion.files]]
+filename = "main/settings.py"
+search = 'VERSION = "{current_version}"'
+replace = 'VERSION = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "pyproject.toml"
+search = 'version = "{current_version}"'
+replace = 'version = "{new_version}"'
+
+[[tool.bumpversion.files]]
+filename = "uv.lock"
+search = """
+name = "ocw-studio"
+version = "{current_version}"
+source = {{ virtual = "." }}"""
+replace = """
+name = "ocw-studio"
+version = "{new_version}"
+source = {{ virtual = "." }}"""

--- a/uv.lock
+++ b/uv.lock
@@ -1324,7 +1324,7 @@ wheels = [
 
 [[package]]
 name = "ocw-studio"
-version = "0.0.0"
+version = "0.188.0"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Adds `[tool.bumpver]` configuration to `pyproject.toml` so the Concourse
release pipeline can update the application version automatically on each
release.

The new version format is `YYYY.MM.DD.N` (e.g., `2026.04.16.1`), which
replaces the previous semver-style version strings. This is required by the
Concourse `release` resource workflow being rolled out in
mitodl/ol-infrastructure#4506.

The `VERSION` constant in Django settings is updated to the initial release
format version as part of this change.

### How can this be tested?
1. With `bumpver` installed (`pip install bumpver`), run `bumpver update --dry` from the repo root and confirm it shows the expected diff with no errors.
2. Check that `VERSION` in Django settings matches `current_version` in `pyproject.toml`.

### Additional Context
Part of the Concourse release pipeline modernization — migrating from the Doof
Slack bot to a Concourse-native release workflow using GitHub Issues as
production gates.