### PR TITLE
Remove 'Buy at Amazon' links

### DIFF
--- a/websites/migrations/0071_remove_buy_at_amazon_links.py
+++ b/websites/migrations/0071_remove_buy_at_amazon_links.py
@@ -1,0 +1,72 @@
+"""
+Remove Buy at Amazon links from markdown and
+hard-delete their associated external resources.
+"""
+
+import logging
+import re
+
+from django.db import migrations, transaction
+from safedelete.models import HARD_DELETE
+
+from websites.constants import CONTENT_TYPE_EXTERNAL_RESOURCE
+
+logger = logging.getLogger(__name__)
+
+AMAZON_BUTTON_IMAGE = "a_logo_17.gif"
+
+AMAZON_BUTTON_SHORTCODE_PATTERN = re.compile(
+    r'\{\{% resource_link "[^"]+" "!\[[^\]]*\]\(/images/a_logo_17\.gif\)" %\}\} ?'
+)
+AMAZON_BUTTON_IMAGE_PATTERN = re.compile(r'!\[[^\]]*\]\(/images/a_logo_17\.gif\) ?')
+AMAZON_BUTTON_TITLE_PATTERN = re.compile(r"^!\[[^\]]*\]\(/images/a_logo_17\.gif\)$")
+
+
+def remove_amazon_links(apps, schema_editor):  # noqa: ARG001
+    WebsiteContent = apps.get_model("websites", "WebsiteContent")
+
+    markdown_to_update = []
+    for content in WebsiteContent.objects.filter(markdown__icontains=AMAZON_BUTTON_IMAGE):
+        updated = AMAZON_BUTTON_SHORTCODE_PATTERN.sub("", content.markdown)
+        updated = AMAZON_BUTTON_IMAGE_PATTERN.sub("", updated)
+        if updated != content.markdown:
+            content.markdown = updated
+            markdown_to_update.append(content)
+
+    resources_to_delete = [
+        content
+        for content in WebsiteContent.objects.filter(
+            title__icontains=AMAZON_BUTTON_IMAGE,
+            type=CONTENT_TYPE_EXTERNAL_RESOURCE,
+        )
+        if AMAZON_BUTTON_TITLE_PATTERN.match(content.title)
+    ]
+
+    with transaction.atomic():
+        if markdown_to_update:
+            WebsiteContent.objects.bulk_update(markdown_to_update, ["markdown"])
+
+        for content in resources_to_delete:
+            content.delete(force_policy=HARD_DELETE)
+
+
+def reverse_remove_amazon_links(apps, schema_editor):  # noqa: ARG001
+    """
+    Run migration in backward direction.
+    This will not return the DB to original state.
+    """
+    logger.warning("Migration is not reversible; removed Amazon links cannot be restored.")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        (
+            "external_resources",
+            "0003_remove_externalresourcestate_backup_url_response_code_and_more",
+        ),
+        ("websites", "0070_website_site_type"),
+    ]
+
+    operations = [
+        migrations.RunPython(remove_amazon_links, reverse_remove_amazon_links),
+    ]

--- a/websites/migrations/0071_remove_buy_at_amazon_links.py
+++ b/websites/migrations/0071_remove_buy_at_amazon_links.py
@@ -7,7 +7,6 @@ import logging
 import re
 
 from django.db import migrations, transaction
-from safedelete.models import HARD_DELETE
 
 from websites.constants import CONTENT_TYPE_EXTERNAL_RESOURCE
 
@@ -24,30 +23,39 @@ AMAZON_BUTTON_TITLE_PATTERN = re.compile(r"^!\[[^\]]*\]\(/images/a_logo_17\.gif\
 
 def remove_amazon_links(apps, schema_editor):  # noqa: ARG001
     WebsiteContent = apps.get_model("websites", "WebsiteContent")
+    Website = apps.get_model("websites", "Website")
 
     markdown_to_update = []
+    website_ids = set()
     for content in WebsiteContent.objects.filter(markdown__icontains=AMAZON_BUTTON_IMAGE):
         updated = AMAZON_BUTTON_SHORTCODE_PATTERN.sub("", content.markdown)
         updated = AMAZON_BUTTON_IMAGE_PATTERN.sub("", updated)
         if updated != content.markdown:
             content.markdown = updated
             markdown_to_update.append(content)
+            website_ids.add(content.website_id)
 
-    resources_to_delete = [
-        content
-        for content in WebsiteContent.objects.filter(
-            title__icontains=AMAZON_BUTTON_IMAGE,
-            type=CONTENT_TYPE_EXTERNAL_RESOURCE,
-        )
-        if AMAZON_BUTTON_TITLE_PATTERN.match(content.title)
-    ]
+    resources_to_delete_ids = []
+    for content in WebsiteContent.objects.filter(
+        title__icontains=AMAZON_BUTTON_IMAGE,
+        type=CONTENT_TYPE_EXTERNAL_RESOURCE,
+    ):
+        if AMAZON_BUTTON_TITLE_PATTERN.match(content.title):
+            resources_to_delete_ids.append(content.pk)
+            website_ids.add(content.website_id)
 
     with transaction.atomic():
         if markdown_to_update:
             WebsiteContent.objects.bulk_update(markdown_to_update, ["markdown"])
 
-        for content in resources_to_delete:
-            content.delete(force_policy=HARD_DELETE)
+        if resources_to_delete_ids:
+            WebsiteContent.objects.filter(pk__in=resources_to_delete_ids).delete()
+
+        if website_ids:
+            Website.objects.filter(pk__in=website_ids).update(
+                has_unpublished_live=True,
+                has_unpublished_draft=True,
+            )
 
 
 def reverse_remove_amazon_links(apps, schema_editor):  # noqa: ARG001


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/10823.

### Description (What does it do?)
This PR adds a data migration that removes `Buy at Amazon` links and images from all OCW content, including deleting the associated external resources. This affects one page in production and 30 other pages.

### How can this be tested?
First, start OCW Studio containers by running `docker compose up`, which will apply the new migration. Then, run `docker compose exec web ./manage.py reset_sync_states --filter <course id> --skip_sync` and `docker compose exec web ./manage.py sync_website_to_backend --filter <course id>` for a course that has `Buy at Amazon` links, such as `res-6-001-continuum-electromechanics-spring-2009`. Then, publish the course and navigate to a page containing links. For the course in the example above, this is `http://localhost:8045/courses/res-6-001-continuum-electromechanics-spring-2009/pages/open-textbook/`. Confirm that the `Buy at Amazon` link has been deleted.
