### PR TITLE
Add v3 offline var to e2e test pipeline definition

### DIFF
--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
@@ -311,6 +311,7 @@ class EndToEndTestPipelineDefinition(Pipeline):
                         "COURSE_CONTENT_PATH": "../",
                         "COURSE_HUGO_CONFIG_PATH": f"../{OCW_HUGO_PROJECTS_GIT_IDENTIFIER}/ocw-course-v2/config.yaml",  # noqa: E501
                         "COURSE_V3_HUGO_CONFIG_PATH": f"../{OCW_HUGO_PROJECTS_GIT_IDENTIFIER}/ocw-course-v3/config.yaml",  # noqa: E501
+                        "COURSE_V3_OFFLINE_HUGO_CONFIG_PATH": f"../{OCW_HUGO_PROJECTS_GIT_IDENTIFIER}/ocw-course-v3/config-offline.yaml",  # noqa: E501
                         "GIT_CONTENT_SOURCE": "git@github.mit.edu:ocw-content-rc",
                         "OCW_TEST_COURSE": course_content_git_identifier,
                         "POSTHOG_ENV": "development",

--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline_test.py
@@ -255,3 +255,6 @@ def test_generate_e2e_test_site_pipeline_definition(  # noqa: PLR0913 PLR0915
     assert (
         playwright_task_params["WWW_CONTENT_PATH"] == f"../{www_content_git_identifier}"
     )
+    assert playwright_task_params["COURSE_V3_OFFLINE_HUGO_CONFIG_PATH"] == (
+        f"../{OCW_HUGO_PROJECTS_GIT_IDENTIFIER}/ocw-course-v3/config-offline.yaml"
+    )


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/10157.

### Description (What does it do?)
Currently, end-to-end tests fail (on RC/production) with
```
Environment variable validation error.
NODE_ENV is: undefined
If NODE_ENV is undefined or 'production', fewer default environment values are used.
Missing environment variables:
COURSE_V3_OFFLINE_HUGO_CONFIG_PATH: Path to the offline ocw-course-v3 Hugo configuration file
```
This PR adds the missing env variable to the e2e pipeline definition.

### How can this be tested?
The error here wouldn't happen locally because `ocw-hugo-themes` supplies a `devDefault` for `COURSE_V3_OFFLINE_HUGO_CONFIG_PATH` locally. The same testing instructions as for https://github.com/mitodl/ocw-studio/pull/2929 can be followed (now using the `main` branch of `ocw-hugo-themes`) just to verify that e2e test pipelines are still working.