### PR TITLE
Update Playwright image with Apple Silicon support; ignore v3 offline tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ STATIC_API_BASE_URL_TEST=http://10.1.0.102:8046
 If you are running on Apple Silicon (arm64), you should also set:
 
 ```
-SYSTEM_ARCHITECTURE=arm64
+PLAYWRIGHT_IMAGE_ARCH=amd64
 ```
 
 This ensures the e2e test pipeline uses an explicit `amd64` Playwright image, which is required because `hugo-bin-extended` ships an `x86_64` binary.

--- a/README.md
+++ b/README.md
@@ -369,7 +369,15 @@ AWS_OFFLINE_TEST_BUCKET_NAME=ocw-content-offline-test
 STATIC_API_BASE_URL_TEST=http://10.1.0.102:8046
 ```
 
-There are fixtures for two test websites in the `test_site_fixtures` folder. These contain two sites; `ocw-ci-test-www` and `ocw-ci-test-course` along with test content. In `test_websites.json`, the ID's of the `ocw-www` and `ocw-course` starters are referenced. If these ID's are not correct on your system, you can get the ID's of your starters in Django admin and modify the fixture. They can be loaded into the database with the following commands:
+If you are running on Apple Silicon (arm64), you should also set:
+
+```
+SYSTEM_ARCHITECTURE=arm64
+```
+
+This ensures the e2e test pipeline uses an explicit `amd64` Playwright image, which is required because `hugo-bin-extended` ships an `x86_64` binary.
+
+There are fixtures for two test websites in the `test_site_fixtures` folder. These contain two sites; `ocw-ci-test-www` and `ocw-ci-test-course` along with test content. In `test_websites.json`, the IDs of the `ocw-www` and `ocw-course` starters are referenced. If these IDs are not correct on your system, you can get the IDs of your starters in Django admin and modify the fixture. They can be loaded into the database with the following commands:
 
 ```
 docker-compose exec web ./manage.py loaddata test_site_fixtures/test_websites.json

--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ If you are running on Apple Silicon (arm64), you should also set:
 PLAYWRIGHT_IMAGE_ARCH=amd64
 ```
 
-This ensures the e2e test pipeline uses an explicit `amd64` Playwright image, which is required because `hugo-bin-extended` ships an `x86_64` binary.
+This ensures the e2e test pipeline uses an explicit `amd64` Playwright image so it can run the `x86_64` `hugo-bin-extended` binary used in the end-to-end test.
 
 There are fixtures for two test websites in the `test_site_fixtures` folder. These contain two sites; `ocw-ci-test-www` and `ocw-ci-test-course` along with test content. In `test_websites.json`, the IDs of the `ocw-www` and `ocw-course` starters are referenced. If these IDs are not correct on your system, you can get the IDs of your starters in Django admin and modify the fixture. They can be loaded into the database with the following commands:
 

--- a/content_sync/pipelines/definitions/concourse/common/image_resources.py
+++ b/content_sync/pipelines/definitions/concourse/common/image_resources.py
@@ -27,8 +27,8 @@ CURL_REGISTRY_IMAGE = AnonymousResource(
 
 PLAYWRIGHT_VERSION = "v1.59.1"
 PLAYWRIGHT_TAG = (
-    f"{PLAYWRIGHT_VERSION}-jammy-amd64"
-    if settings.SYSTEM_ARCHITECTURE == "arm64"
+    f"{PLAYWRIGHT_VERSION}-jammy-{settings.PLAYWRIGHT_IMAGE_ARCH}"
+    if settings.PLAYWRIGHT_IMAGE_ARCH
     else f"{PLAYWRIGHT_VERSION}-jammy"
 )
 

--- a/content_sync/pipelines/definitions/concourse/common/image_resources.py
+++ b/content_sync/pipelines/definitions/concourse/common/image_resources.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from ol_concourse.lib.constants import REGISTRY_IMAGE
 from ol_concourse.lib.models.pipeline import AnonymousResource, RegistryImage
 
@@ -24,9 +25,14 @@ CURL_REGISTRY_IMAGE = AnonymousResource(
     type=REGISTRY_IMAGE, source=RegistryImage(repository="curlimages/curl")
 )
 
+PLAYWRIGHT_VERSION = "v1.59.1"
+PLAYWRIGHT_TAG = (
+    f"{PLAYWRIGHT_VERSION}-jammy-amd64"
+    if settings.SYSTEM_ARCHITECTURE == "arm64"
+    else f"{PLAYWRIGHT_VERSION}-jammy"
+)
+
 PLAYWRIGHT_REGISTRY_IMAGE = AnonymousResource(
     type=REGISTRY_IMAGE,
-    source=RegistryImage(
-        repository="mcr.microsoft.com/playwright", tag="v1.40.0-jammy"
-    ),
+    source=RegistryImage(repository="mcr.microsoft.com/playwright", tag=PLAYWRIGHT_TAG),
 )

--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
@@ -298,7 +298,10 @@ class EndToEndTestPipelineDefinition(Pipeline):
                     params={
                         "PLAYWRIGHT_BASE_URL": static_api_base_url,
                         "CI": "1",
-                        "TESTS_IGNORE": "**/ocw-ci-test-course-v3/**",
+                        "TESTS_IGNORE": (
+                            "**/ocw-ci-test-course-v3/**"
+                            ",**/ocw-ci-test-course-v3-offline/**"
+                        ),
                         "FEATURE_ENABLE_LEARN_INTEGRATION": "true",
                         "API_BEARER_TOKEN": settings.API_BEARER_TOKEN,
                         "GTM_ACCOUNT_ID": settings.OCW_GTM_ACCOUNT_ID,

--- a/main/settings.py
+++ b/main/settings.py
@@ -983,12 +983,17 @@ CONCOURSE_IS_PRIVATE_REPO = get_bool(
     description="True if a git repo requires authentication to retrieve",
     required=False,
 )
-SYSTEM_ARCHITECTURE = get_string(
-    name="SYSTEM_ARCHITECTURE",
-    default="x86_64",
-    description="System architecture for pipeline image selection",
+PLAYWRIGHT_IMAGE_ARCH = get_string(
+    name="PLAYWRIGHT_IMAGE_ARCH",
+    default="",
+    description=("Architecture suffix for the Playwright image tag (e.g., 'amd64')."),
     required=False,
 )
+if PLAYWRIGHT_IMAGE_ARCH not in {"", "amd64"}:
+    msg = (
+        f"PLAYWRIGHT_IMAGE_ARCH must be 'amd64' or unset, got {PLAYWRIGHT_IMAGE_ARCH!r}"
+    )
+    raise ImproperlyConfigured(msg)
 
 # Git backend settings
 GIT_TOKEN = get_string(

--- a/main/settings.py
+++ b/main/settings.py
@@ -983,6 +983,13 @@ CONCOURSE_IS_PRIVATE_REPO = get_bool(
     description="True if a git repo requires authentication to retrieve",
     required=False,
 )
+SYSTEM_ARCHITECTURE = get_string(
+    name="SYSTEM_ARCHITECTURE",
+    default="x86_64",
+    description="System architecture for pipeline image selection",
+    required=False,
+)
+
 # Git backend settings
 GIT_TOKEN = get_string(
     name="GIT_TOKEN",


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/10157.

### Description (What does it do?)
This PR fixes an issue with e2e test failures by ignoring the offline v3 tests while they are being developed (consistent with the current treatment of v3 online build tests). In addition, it updates the Playwright image tag and adds an optional `PLAYWRIGHT_IMAGE_ARCH` setting to allow the end-to-end testing pipeline to work correctly on Apple Silicon machines. 

### How can this be tested?
If running on Apple Silicon (or another ARM64 processor), add the variable `PLAYWRIGHT_IMAGE_ARCH=amd64` to the `.env` file and restart OCW Studio containers.

Run a theme assets build against the `pt/update_test_site_content` branch of `ocw-hugo-themes` by running `docker-compose exec web ./manage.py upsert_theme_assets_pipeline --themes-branch pt/update_test_site_content`, unpausing the pipeline in Concourse and triggering a build. Once this completes successfully, follow the instructions at https://github.com/mitodl/ocw-studio?tab=readme-ov-file#end-to-end-testing-of-site-pipelines. In particular, upsert the end-to-end testing pipeline by running `docker compose exec web ./manage.py upsert_e2e_test_pipeline --themes-branch pt/update_test_site_content --projects-branch main`, unpause that pipeline, and trigger a build. Verify that it completes successfully.


