### PR TITLE
Remove Lecture Videos LRT from non-video resources

### DIFF
--- a/websites/migrations/0072_remove_lecture_videos_lrt_from_non_video_resources.py
+++ b/websites/migrations/0072_remove_lecture_videos_lrt_from_non_video_resources.py
@@ -1,0 +1,42 @@
+"""
+Remove `Lecture Videos` Learning Resource Type from non-video resource
+content. Since this is a data fix, there is no reverse migration implemented.
+"""
+
+from django.db import migrations
+
+from websites.constants import CONTENT_TYPE_RESOURCE, RESOURCE_TYPE_VIDEO
+
+LECTURE_VIDEOS_LRT = "Lecture Videos"
+
+
+def remove_lecture_videos_lrt_from_non_video_resources(apps, schema_editor):
+    """Remove 'Lecture Videos' from learning_resource_types for non-video resources."""
+    WebsiteContent = apps.get_model("websites", "WebsiteContent")
+
+    resources = WebsiteContent.objects.filter(
+        type=CONTENT_TYPE_RESOURCE,
+        metadata__learning_resource_types__contains=LECTURE_VIDEOS_LRT,
+    ).exclude(metadata__resourcetype=RESOURCE_TYPE_VIDEO)
+
+    for resource in resources.iterator():
+        resource.metadata["learning_resource_types"] = [
+            v for v in resource.metadata["learning_resource_types"]
+            if v != LECTURE_VIDEOS_LRT
+        ]
+        resource.save(update_fields=["metadata"])
+
+
+class Migration(migrations.Migration):
+    """Remove Lecture Videos LRT from non-video resources."""
+
+    dependencies = [
+        ("websites", "0071_remove_buy_at_amazon_links"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            remove_lecture_videos_lrt_from_non_video_resources,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/websites/migrations/0072_remove_lecture_videos_lrt_from_non_video_resources.py
+++ b/websites/migrations/0072_remove_lecture_videos_lrt_from_non_video_resources.py
@@ -5,8 +5,8 @@ content. Since this is a data fix, there is no reverse migration implemented.
 
 from django.db import migrations
 
-from websites.constants import CONTENT_TYPE_RESOURCE, RESOURCE_TYPE_VIDEO
-
+CONTENT_TYPE_RESOURCE = "resource"
+RESOURCE_TYPE_VIDEO = "Video"
 LECTURE_VIDEOS_LRT = "Lecture Videos"
 
 

--- a/websites/migrations/0072_remove_lecture_videos_lrt_from_non_video_resources.py
+++ b/websites/migrations/0072_remove_lecture_videos_lrt_from_non_video_resources.py
@@ -13,18 +13,25 @@ LECTURE_VIDEOS_LRT = "Lecture Videos"
 def remove_lecture_videos_lrt_from_non_video_resources(apps, schema_editor):
     """Remove 'Lecture Videos' from learning_resource_types for non-video resources."""
     WebsiteContent = apps.get_model("websites", "WebsiteContent")
+    Website = apps.get_model("websites", "Website")
 
-    resources = WebsiteContent.objects.filter(
-        type=CONTENT_TYPE_RESOURCE,
-        metadata__learning_resource_types__contains=LECTURE_VIDEOS_LRT,
-    ).exclude(metadata__resourcetype=RESOURCE_TYPE_VIDEO)
+    resources = list(
+        WebsiteContent.objects.filter(
+            type=CONTENT_TYPE_RESOURCE,
+            metadata__learning_resource_types__contains=LECTURE_VIDEOS_LRT,
+        ).exclude(metadata__resourcetype=RESOURCE_TYPE_VIDEO)
+    )
 
-    for resource in resources.iterator():
+    for resource in resources:
         resource.metadata["learning_resource_types"] = [
             v for v in resource.metadata["learning_resource_types"]
             if v != LECTURE_VIDEOS_LRT
         ]
-        resource.save(update_fields=["metadata"])
+
+    WebsiteContent.objects.bulk_update(resources, ["metadata"])
+    Website.objects.filter(
+        uuid__in={r.website_id for r in resources}
+    ).update(has_unpublished_live=True, has_unpublished_draft=True)
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
### What are the relevant tickets?
Closes https://github.com/mitodl/hq/issues/11085.

### Description (What does it do?)
This PR is relevant to the integration with MIT Learn, where anything tagged with the `Lecture Videos` tag is assumed to be a video. 

This PR adds a data migration that removes the `Lecture Videos` learning resource type from OCW resource content records that are not videos. This is a data cleanup fix, since some non-video resources were incorrectly tagged with `Lecture Videos` in their `learning_resource_types` metadata field.

The migration targets `WebsiteContent` records where:
- `type` is `resource`
- `metadata.learning_resource_types` contains `"Lecture Videos"`
- `metadata.resourcetype` is **not** `"Video"`

514 resources are updated by this migration. Since this is a data fix removing an incorrect LRT tag, there is no reverse migration.

### How can this be tested?
Make sure that this is applied to a recent copy of production data. See the [Production to Local Data Cloning Guide](https://github.com/mitodl/ocw-studio/blob/master/docs/production-to-local-data-cloning.md) for guidance on doing this. Then, restart OCW Studio containers. After the migrations have been applied automatically, verify that there are 0 resources with this data issue by running

```
from websites.models import WebsiteContent

WebsiteContent.objects.filter(
    type="resource",
    website__site_type="ocw",
    metadata__learning_resource_types__contains="Lecture Videos",
).exclude(metadata__resourcetype="Video").count()
```
in a Django shell.