### PR TITLE
chore: update 3play sync for multi language

### DIFF
--- a/videos/threeplay_sync.py
+++ b/videos/threeplay_sync.py
@@ -39,6 +39,53 @@ extension_map = {
 }
 
 
+def _append_resource_to_video_files(
+    video: WebsiteContent,
+    resource_field: str,
+    file_field: str,
+    text_id: str,
+    filepath: str,
+) -> None:
+    """
+    Append a caption/transcript resource entry to video_files metadata.
+
+    Preserves any existing entries (e.g. other-language variants already
+    linked from GDrive) instead of overwriting them.
+    """
+    vf = video.metadata["video_files"]
+    existing_resources = vf.get(resource_field)
+    if isinstance(existing_resources, dict) and existing_resources.get("content"):
+        if text_id not in existing_resources["content"]:
+            existing_resources["content"] = [*existing_resources["content"], text_id]
+    else:
+        vf[resource_field] = {"content": [text_id], "website": video.website.name}
+    existing_files = vf.get(file_field)
+    new_file_entry = {"file": filepath, "language": "en"}
+    if isinstance(existing_files, list):
+        if not any(e.get("file") == filepath for e in existing_files):
+            vf[file_field] = [*existing_files, new_file_entry]
+    else:
+        vf[file_field] = [new_file_entry]
+
+
+def _threeplay_resource_already_linked(
+    video: WebsiteContent, resource_field: str, filename: str
+) -> bool:
+    """Return True if the 3Play-generated resource is already in the content list."""
+    existing_content = (
+        video.metadata["video_files"].get(resource_field, {}).get("content") or []
+    )
+    return bool(
+        isinstance(existing_content, list)
+        and existing_content
+        and WebsiteContent.objects.filter(
+            website=video.website,
+            text_id__in=existing_content,
+            filename=filename,
+        ).exists()
+    )
+
+
 def _attach_transcript_if_missing(
     video: WebsiteContent,
     base_url: str,
@@ -50,10 +97,8 @@ def _attach_transcript_if_missing(
     Attach transcript to video if it does not exist.
     Fetches from 3Play API and updates the video metadata.
     """
-    if (
-        video.metadata["video_files"]
-        .get("video_transcript_resources", {})
-        .get("content")
+    if _threeplay_resource_already_linked(
+        video, "video_transcript_resources", f"{youtube_id}_transcript"
     ):
         return
 
@@ -67,17 +112,15 @@ def _attach_transcript_if_missing(
         file_size = len(pdf_response.getvalue())
         pdf_file = File(pdf_response, name=f"{youtube_id}.pdf")
         filepath, text_id = _create_new_content(pdf_file, video, file_size=file_size)
-        video.metadata["video_files"]["video_transcript_resources"] = {
-            "content": [text_id],
-            "website": video.website.name,
-        }
-        video.metadata["video_files"]["video_transcript_file"] = [
-            {"file": filepath, "language": "en"}
-        ]
-
+        _append_resource_to_video_files(
+            video,
+            "video_transcript_resources",
+            "video_transcript_file",
+            text_id,
+            filepath,
+        )
         if summary:
             summary["transcripts"]["updated"] += 1
-
         write_output(
             "Transcript updated for video, %s and course %s",
             video.title,
@@ -101,7 +144,9 @@ def _attach_captions_if_missing(
     Attach captions to video if it does not exist.
     Fetches from 3Play API and updates the video metadata.
     """
-    if video.metadata["video_files"].get("video_captions_resources", {}).get("content"):
+    if _threeplay_resource_already_linked(
+        video, "video_captions_resources", f"{youtube_id}_captions"
+    ):
         return
 
     webvtt_url = base_url + f"&format_id={WEBVTT_FORMAT_ID}"
@@ -113,13 +158,13 @@ def _attach_captions_if_missing(
         file_size = len(webvtt_response.getvalue())
         vtt_file = File(webvtt_response, name=f"{youtube_id}.webvtt")
         filepath, text_id = _create_new_content(vtt_file, video, file_size)
-        video.metadata["video_files"]["video_captions_resources"] = {
-            "content": [text_id],
-            "website": video.website.name,
-        }
-        video.metadata["video_files"]["video_captions_file"] = [
-            {"file": filepath, "language": "en"}
-        ]
+        _append_resource_to_video_files(
+            video,
+            "video_captions_resources",
+            "video_captions_file",
+            text_id,
+            filepath,
+        )
         if summary:
             summary["captions"]["updated"] += 1
         write_output(

--- a/videos/threeplay_sync.py
+++ b/videos/threeplay_sync.py
@@ -50,7 +50,11 @@ def _attach_transcript_if_missing(
     Attach transcript to video if it does not exist.
     Fetches from 3Play API and updates the video metadata.
     """
-    if video.metadata["video_files"].get("video_transcript_file"):
+    if (
+        video.metadata["video_files"]
+        .get("video_transcript_resources", {})
+        .get("content")
+    ):
         return
 
     pdf_url = base_url + f"&format_id={PDF_FORMAT_ID}"
@@ -62,8 +66,14 @@ def _attach_transcript_if_missing(
     if pdf_response:
         file_size = len(pdf_response.getvalue())
         pdf_file = File(pdf_response, name=f"{youtube_id}.pdf")
-        filepath = _create_new_content(pdf_file, video, file_size=file_size)
-        video.metadata["video_files"]["video_transcript_file"] = filepath
+        filepath, text_id = _create_new_content(pdf_file, video, file_size=file_size)
+        video.metadata["video_files"]["video_transcript_resources"] = {
+            "content": [text_id],
+            "website": video.website.name,
+        }
+        video.metadata["video_files"]["video_transcript_file"] = [
+            {"file": filepath, "language": "en"}
+        ]
 
         if summary:
             summary["transcripts"]["updated"] += 1
@@ -91,7 +101,7 @@ def _attach_captions_if_missing(
     Attach captions to video if it does not exist.
     Fetches from 3Play API and updates the video metadata.
     """
-    if video.metadata["video_files"].get("video_captions_file"):
+    if video.metadata["video_files"].get("video_captions_resources", {}).get("content"):
         return
 
     webvtt_url = base_url + f"&format_id={WEBVTT_FORMAT_ID}"
@@ -102,8 +112,14 @@ def _attach_captions_if_missing(
     if webvtt_response:
         file_size = len(webvtt_response.getvalue())
         vtt_file = File(webvtt_response, name=f"{youtube_id}.webvtt")
-        filepath = _create_new_content(vtt_file, video, file_size)
-        video.metadata["video_files"]["video_captions_file"] = filepath
+        filepath, text_id = _create_new_content(vtt_file, video, file_size)
+        video.metadata["video_files"]["video_captions_resources"] = {
+            "content": [text_id],
+            "website": video.website.name,
+        }
+        video.metadata["video_files"]["video_captions_file"] = [
+            {"file": filepath, "language": "en"}
+        ]
         if summary:
             summary["captions"]["updated"] += 1
         write_output(
@@ -198,10 +214,11 @@ def generate_metadata(
 
 def _create_new_content(
     file_content: File, video: WebsiteContent, file_size: int | None = None
-) -> str:
+) -> tuple[str, str]:
     """
     Create and save a new WebsiteContent object
     for a caption or transcript file.
+    Returns a (s3_path, text_id) tuple.
     """
     new_text_id = str(uuid4())
     new_s3_loc = upload_to_s3(file_content, video)
@@ -228,4 +245,4 @@ def _create_new_content(
     obj.file = new_s3_loc
     obj.save()
 
-    return new_s3_loc
+    return new_s3_loc, str(obj.text_id)

--- a/videos/threeplay_sync_test.py
+++ b/videos/threeplay_sync_test.py
@@ -67,6 +67,16 @@ def test_sync_video_captions_and_transcripts_skips_if_resource_exists(mocker):
     """3Play sync skips captions/transcripts that already have _resource content set."""
     starter = WebsiteStarterFactory.create(slug="ocw-course-v2")
     website = WebsiteFactory.create(starter=starter)
+    # Create actual WebsiteContent objects with the 3Play-derived filenames so the
+    # DB guard in each _attach_*_if_missing function can find them.
+    transcript_resource = WebsiteContentFactory.create(
+        website=website,
+        filename="yt789_transcript",
+    )
+    captions_resource = WebsiteContentFactory.create(
+        website=website,
+        filename="yt789_captions",
+    )
     video = WebsiteContentFactory.create(
         website=website,
         type=CONTENT_TYPE_RESOURCE,
@@ -75,11 +85,11 @@ def test_sync_video_captions_and_transcripts_skips_if_resource_exists(mocker):
             "video_metadata": {"youtube_id": "yt789"},
             "video_files": {
                 "video_captions_resources": {
-                    "content": ["some-text-id"],
+                    "content": [str(captions_resource.text_id)],
                     "website": website.name,
                 },
                 "video_transcript_resources": {
-                    "content": ["some-other-id"],
+                    "content": [str(transcript_resource.text_id)],
                     "website": website.name,
                 },
             },
@@ -95,6 +105,89 @@ def test_sync_video_captions_and_transcripts_skips_if_resource_exists(mocker):
     sync_video_captions_and_transcripts(video)
 
     fetch_file_mock.assert_not_called()
+
+
+def test_sync_video_captions_and_transcripts_appends_english_when_other_languages_exist(
+    mocker,
+):
+    """3Play adds English even when other-language entries already exist from GDrive."""
+    starter = WebsiteStarterFactory.create(slug="ocw-course-v2")
+    website = WebsiteFactory.create(starter=starter)
+    # Simulate GDrive having already linked French caption/transcript resources.
+    # These use filenames that don't match the 3Play pattern, so the guard won't fire.
+    fr_caption = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_captions_fr_vtt",
+    )
+    fr_transcript = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_transcript_fr_pdf",
+    )
+    fr_caption_path = f"courses/{website.name}/lecture1_captions_fr.vtt"
+    fr_transcript_path = f"courses/{website.name}/lecture1_transcript_fr.pdf"
+    video = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        metadata={
+            "resourcetype": "Video",
+            "video_metadata": {"youtube_id": "yt789"},
+            "video_files": {
+                "video_captions_resources": {
+                    "content": [str(fr_caption.text_id)],
+                    "website": website.name,
+                },
+                "video_transcript_resources": {
+                    "content": [str(fr_transcript.text_id)],
+                    "website": website.name,
+                },
+                "video_captions_file": [{"file": fr_caption_path, "language": "fr"}],
+                "video_transcript_file": [
+                    {"file": fr_transcript_path, "language": "fr"}
+                ],
+            },
+        },
+    )
+
+    mocker.patch(
+        "videos.threeplay_sync.threeplay_transcript_api_request",
+        return_value={"data": [{"status": "complete", "id": 11, "media_file_id": 22}]},
+    )
+    mocker.patch(
+        "videos.threeplay_sync.fetch_file",
+        side_effect=[BytesIO(b"pdf"), BytesIO(b"webvtt")],
+    )
+    mocker.patch(
+        "videos.threeplay_sync.upload_to_s3",
+        side_effect=[
+            f"/courses/{website.name}/yt789_transcript.pdf",
+            f"/courses/{website.name}/yt789_captions.webvtt",
+        ],
+    )
+
+    sync_video_captions_and_transcripts(video)
+
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+
+    # French entries preserved; English appended
+    transcript_content = vf["video_transcript_resources"]["content"]
+    captions_content = vf["video_captions_resources"]["content"]
+    assert str(fr_transcript.text_id) in transcript_content
+    assert str(fr_caption.text_id) in captions_content
+    assert len(transcript_content) == 2
+    assert len(captions_content) == 2
+
+    # _file lists also have both entries
+    transcript_files = vf["video_transcript_file"]
+    captions_files = vf["video_captions_file"]
+    assert len(transcript_files) == 2
+    assert len(captions_files) == 2
+    transcript_languages = {e["language"] for e in transcript_files}
+    captions_languages = {e["language"] for e in captions_files}
+    assert "en" in transcript_languages
+    assert "fr" in transcript_languages
+    assert "en" in captions_languages
+    assert "fr" in captions_languages
 
 
 def test_sync_video_captions_and_transcripts_treats_empty_content_as_unset(mocker):

--- a/videos/threeplay_sync_test.py
+++ b/videos/threeplay_sync_test.py
@@ -16,7 +16,7 @@ pytestmark = pytest.mark.django_db
 
 
 def test_sync_video_captions_and_transcripts_sets_references(mocker):
-    """3Play sync should attach created caption/transcript resources as references."""
+    """3Play sync should create caption/transcript resources and set _resource fields."""
     starter = WebsiteStarterFactory.create(slug="ocw-course-v2")
     website = WebsiteFactory.create(starter=starter)
     video = WebsiteContentFactory.create(
@@ -48,7 +48,94 @@ def test_sync_video_captions_and_transcripts_sets_references(mocker):
     sync_video_captions_and_transcripts(video)
 
     video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    # _resource.content is a single-item list (array format post-10982)
+    transcript_content = vf["video_transcript_resources"]["content"]
+    captions_content = vf["video_captions_resources"]["content"]
+    assert isinstance(transcript_content, list)
+    assert len(transcript_content) == 1
+    assert isinstance(captions_content, list)
+    assert len(captions_content) == 1
+    # referenced_by tracks via file field on the created WebsiteContent objects
     assert set(video.referenced_by.values_list("file", flat=True)) == {
         f"/courses/{website.name}/yt789_transcript.pdf",
         f"/courses/{website.name}/yt789_captions.webvtt",
     }
+
+
+def test_sync_video_captions_and_transcripts_skips_if_resource_exists(mocker):
+    """3Play sync skips captions/transcripts that already have _resource content set."""
+    starter = WebsiteStarterFactory.create(slug="ocw-course-v2")
+    website = WebsiteFactory.create(starter=starter)
+    video = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        metadata={
+            "resourcetype": "Video",
+            "video_metadata": {"youtube_id": "yt789"},
+            "video_files": {
+                "video_captions_resources": {
+                    "content": ["some-text-id"],
+                    "website": website.name,
+                },
+                "video_transcript_resources": {
+                    "content": ["some-other-id"],
+                    "website": website.name,
+                },
+            },
+        },
+    )
+
+    mocker.patch(
+        "videos.threeplay_sync.threeplay_transcript_api_request",
+        return_value={"data": [{"status": "complete", "id": 11, "media_file_id": 22}]},
+    )
+    fetch_file_mock = mocker.patch("videos.threeplay_sync.fetch_file")
+
+    sync_video_captions_and_transcripts(video)
+
+    fetch_file_mock.assert_not_called()
+
+
+def test_sync_video_captions_and_transcripts_treats_empty_content_as_unset(mocker):
+    """Empty-string _resource.content is treated as unset; 3Play fetch proceeds."""
+    starter = WebsiteStarterFactory.create(slug="ocw-course-v2")
+    website = WebsiteFactory.create(starter=starter)
+    video = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        metadata={
+            "resourcetype": "Video",
+            "video_metadata": {"youtube_id": "yt789"},
+            "video_files": {
+                # Site-config initialises relation widgets with empty content
+                "video_captions_resources": {"content": "", "website": ""},
+                "video_transcript_resources": {"content": "", "website": ""},
+            },
+        },
+    )
+
+    mocker.patch(
+        "videos.threeplay_sync.threeplay_transcript_api_request",
+        return_value={"data": [{"status": "complete", "id": 11, "media_file_id": 22}]},
+    )
+    fetch_file_mock = mocker.patch(
+        "videos.threeplay_sync.fetch_file",
+        side_effect=[BytesIO(b"pdf"), BytesIO(b"webvtt")],
+    )
+    mocker.patch(
+        "videos.threeplay_sync.upload_to_s3",
+        side_effect=[
+            f"/courses/{website.name}/yt789_transcript.pdf",
+            f"/courses/{website.name}/yt789_captions.webvtt",
+        ],
+    )
+
+    sync_video_captions_and_transcripts(video)
+
+    # Both files were fetched (empty content treated as unset)
+    assert fetch_file_mock.call_count == 2
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    assert isinstance(vf["video_transcript_resources"]["content"], list)
+    assert isinstance(vf["video_captions_resources"]["content"], list)


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10984

### Description (What does it do?)

Fixes the 3Play sync path to write captions and transcripts using the post-10982 array format and to guard correctly against existing content.

### How can this be tested?
1. have working 3play locally, you can add a video resource with youtube_id: `E8uZtq_vOYM` and it'd pull the related transcript and captions.
2. Open the video resource in Studio, and confirm `video_captions_resource` now shows a single English caption resource and `video_transcript_resource` shows a transcript.