### PR TITLE
feat: ingest drive files for multi language

### DIFF
--- a/drf_lint_baseline.json
+++ b/drf_lint_baseline.json
@@ -1,5 +1,5 @@
 [
   "content_sync/serializers.py:139:21:ORM001",
   "content_sync/serializers.py:58:21:ORM001",
-  "websites/serializers.py:269:23:ORM001"
+  "websites/serializers.py:266:23:ORM001"
 ]

--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -42,7 +42,7 @@ from gdrive_sync.constants import (
 )
 from gdrive_sync.models import DriveFile
 from main.s3_utils import get_boto3_resource
-from main.utils import get_dirpath_and_filename
+from main.utils import get_base_filename, get_dirpath_and_filename
 from videos.api import create_media_convert_job
 from videos.constants import VideoJobStatus, VideoStatus
 from videos.models import Video, VideoJob
@@ -439,6 +439,140 @@ def get_pdf_title(drive_file: DriveFile) -> str:
         return drive_file.name
 
 
+def _link_video_caption_transcript_resources(
+    resource: WebsiteContent, website: Website
+) -> None:
+    """
+    Ensure ``video_captions_resources`` / ``video_transcript_resources`` relation
+    fields are kept in sync after a gdrive resource is created or updated.
+
+    - If *resource* is a Video, look for existing captions/transcript resources
+      in the same website by the ``{base}_captions_vtt`` / ``{base}_transcript_pdf``
+      filename convention and set the relation fields on the video (without
+      overwriting ones that are already present).
+    - If *resource* is a captions or transcript file, find the corresponding
+      video resource by the same convention and set the appropriate relation
+      field on that video.
+    """
+    resource_type = (resource.metadata or {}).get("resourcetype")
+    filename = resource.filename or ""
+
+    if resource_type == RESOURCE_TYPE_VIDEO:
+        _link_captions_transcript_to_video(resource, website)
+    elif "_captions" in filename:
+        video_base = filename.split("_captions")[0]
+        _link_resource_to_video(
+            resource, website, "video_captions_resources", video_base
+        )
+    elif "_transcript" in filename:
+        video_base = filename.split("_transcript")[0]
+        _link_resource_to_video(
+            resource, website, "video_transcript_resources", video_base
+        )
+
+
+def _link_captions_transcript_to_video(
+    video_resource: WebsiteContent, website: Website
+) -> None:
+    """Set _resource relation fields on a video from existing captions/transcript."""
+    video_base = get_base_filename(video_resource.filename or "")
+    if not video_base:
+        return
+    video_files = (
+        video_resource.metadata.get("video_files") if video_resource.metadata else None
+    )
+    if not isinstance(video_files, dict):
+        video_files = {}
+
+    changed = False
+    for resource_field, data_field, filename in [
+        (
+            "video_captions_resources",
+            "video_captions_file",
+            f"{video_base}_captions_vtt",
+        ),
+        (
+            "video_transcript_resources",
+            "video_transcript_file",
+            f"{video_base}_transcript_pdf",
+        ),
+    ]:
+        # Skip when content is already set — empty string/list is treated as unset.
+        existing = video_files.get(resource_field)
+        if isinstance(existing, dict) and existing.get("content"):
+            continue
+        related = WebsiteContent.objects.filter(
+            website=website, filename=filename
+        ).first()
+        if not related:
+            continue
+        video_files[resource_field] = {
+            "content": [str(related.text_id)],
+            "website": website.name,
+        }
+        if related.file and related.file.name:
+            video_files[data_field] = [
+                {"file": f"/{related.file.name.lstrip('/')}", "language": "en"}
+            ]
+        changed = True
+
+    if changed:
+        if not isinstance(video_resource.metadata, dict):
+            video_resource.metadata = {}
+        video_resource.metadata["video_files"] = video_files
+        video_resource.save()
+
+
+def _link_resource_to_video(
+    resource: WebsiteContent,
+    website: Website,
+    resource_field: str,
+    video_base: str,
+) -> None:
+    """Set a captions/transcript _resource field on the corresponding video resource."""
+    # Identify the video by filename convention: {base}_{ext} where base == video_base.
+    # Exclude known non-video filenames (captions and transcripts share the same base).
+    candidates = WebsiteContent.objects.filter(
+        website=website,
+        filename__startswith=f"{video_base}_",
+    ).exclude(Q(filename__contains="_captions") | Q(filename__contains="_transcript"))
+    video_resource = next(
+        (v for v in candidates if get_base_filename(v.filename or "") == video_base),
+        None,
+    )
+    if not video_resource:
+        return
+
+    video_files = (
+        video_resource.metadata.get("video_files")
+        if isinstance(video_resource.metadata, dict)
+        else None
+    )
+    if not isinstance(video_files, dict):
+        video_files = {}
+    existing = video_files.get(resource_field)
+    if isinstance(existing, dict) and existing.get("content"):
+        return
+
+    video_files[resource_field] = {
+        "content": [str(resource.text_id)],
+        "website": website.name,
+    }
+    data_field = (
+        "video_captions_file"
+        if "captions" in resource_field
+        else "video_transcript_file"
+    )
+    if resource.file and resource.file.name:
+        video_files[data_field] = [
+            {"file": f"/{resource.file.name.lstrip('/')}", "language": "en"}
+        ]
+    if not isinstance(video_resource.metadata, dict):
+        video_resource.metadata = {}
+    video_resource.metadata["video_files"] = video_files
+    video_resource.save()
+
+
 @transaction.atomic
 def create_gdrive_resource_content(drive_file: DriveFile, user_pk=None):
     """Create a WebsiteContent resource from a Google Drive file"""
@@ -511,6 +645,7 @@ def create_gdrive_resource_content(drive_file: DriveFile, user_pk=None):
             resource.save()
         drive_file.resource = resource
         drive_file.update_status(DriveFileStatus.COMPLETE)
+        _link_video_caption_transcript_resources(resource, drive_file.website)
     except PdfReadError:
         log.exception(
             "Could not create a resource from Google Drive file %s because it is not a valid PDF",  # noqa: E501

--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -46,6 +46,7 @@ from main.utils import get_base_filename, get_dirpath_and_filename
 from videos.api import create_media_convert_job
 from videos.constants import VideoJobStatus, VideoStatus
 from videos.models import Video, VideoJob
+from videos.utils import resource_file_paths
 from websites.api import get_valid_new_filename
 from websites.constants import (
     CONTENT_TYPE_RESOURCE,
@@ -485,35 +486,51 @@ def _link_captions_transcript_to_video(
         video_files = {}
 
     changed = False
-    for resource_field, data_field, filename in [
+    for resource_field, data_field, prefix, suffix in [
         (
             "video_captions_resources",
             "video_captions_file",
-            f"{video_base}_captions_vtt",
+            f"{video_base}_captions",
+            "_vtt",
         ),
         (
             "video_transcript_resources",
             "video_transcript_file",
-            f"{video_base}_transcript_pdf",
+            f"{video_base}_transcript",
+            "_pdf",
         ),
     ]:
-        # Skip when content is already set — empty string/list is treated as unset.
+        related_list = list(
+            WebsiteContent.objects.filter(
+                website=website,
+                filename__startswith=prefix,
+                filename__endswith=suffix,
+            )
+        )
+        if not related_list:
+            continue
+
         existing = video_files.get(resource_field)
-        if isinstance(existing, dict) and existing.get("content"):
+        existing_ids = existing.get("content", []) if isinstance(existing, dict) else []
+        new_resources = [r for r in related_list if str(r.text_id) not in existing_ids]
+        if not new_resources:
             continue
-        related = WebsiteContent.objects.filter(
-            website=website, filename=filename
-        ).first()
-        if not related:
-            continue
+
+        all_ids = existing_ids + [str(r.text_id) for r in new_resources]
         video_files[resource_field] = {
-            "content": [str(related.text_id)],
+            "content": all_ids,
             "website": website.name,
         }
-        if related.file and related.file.name:
-            video_files[data_field] = [
-                {"file": f"/{related.file.name.lstrip('/')}", "language": "en"}
-            ]
+        new_file_entries = resource_file_paths(new_resources)
+        if new_file_entries:
+            existing_files = video_files.get(data_field)
+            if isinstance(existing_files, list):
+                existing_paths = {e.get("file") for e in existing_files}
+                video_files[data_field] = existing_files + [
+                    e for e in new_file_entries if e["file"] not in existing_paths
+                ]
+            else:
+                video_files[data_field] = new_file_entries
         changed = True
 
     if changed:
@@ -550,23 +567,36 @@ def _link_resource_to_video(
     )
     if not isinstance(video_files, dict):
         video_files = {}
+
+    new_id = str(resource.text_id)
     existing = video_files.get(resource_field)
     if isinstance(existing, dict) and existing.get("content"):
-        return
+        # Already linked — append if not a duplicate
+        if new_id in existing["content"]:
+            return
+        existing["content"] = existing["content"] + [new_id]
+    else:
+        video_files[resource_field] = {
+            "content": [new_id],
+            "website": website.name,
+        }
 
-    video_files[resource_field] = {
-        "content": [str(resource.text_id)],
-        "website": website.name,
-    }
     data_field = (
         "video_captions_file"
         if "captions" in resource_field
         else "video_transcript_file"
     )
-    if resource.file and resource.file.name:
-        video_files[data_field] = [
-            {"file": f"/{resource.file.name.lstrip('/')}", "language": "en"}
-        ]
+    new_file_entries = resource_file_paths([resource])
+    if new_file_entries:
+        existing_files = video_files.get(data_field)
+        if isinstance(existing_files, list):
+            existing_paths = {e.get("file") for e in existing_files}
+            extra = [e for e in new_file_entries if e["file"] not in existing_paths]
+            if extra:
+                video_files[data_field] = existing_files + extra
+        else:
+            video_files[data_field] = new_file_entries
+
     if not isinstance(video_resource.metadata, dict):
         video_resource.metadata = {}
     video_resource.metadata["video_files"] = video_files

--- a/gdrive_sync/api_test.py
+++ b/gdrive_sync/api_test.py
@@ -13,6 +13,7 @@ from requests import HTTPError
 from gdrive_sync import api
 from gdrive_sync.api import (
     GDriveStreamReader,
+    _link_resource_to_video,
     create_gdrive_resource_content,
     gdrive_root_url,
     get_resource_type,
@@ -1024,3 +1025,46 @@ def test_delete_drive_file(mocker, with_resource, is_used_in_content, with_user)
             assert WebsiteContent.all_objects.get(pk=resource.id).updated_by == user
         else:
             assert not drive_file_exists
+
+
+@pytest.mark.django_db
+def test_link_resource_to_video_appends_second_language():
+    """Second-language caption appended to content list; first-language entry preserved."""
+    website = WebsiteFactory.create()
+
+    video = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_mp4",
+        metadata={"resourcetype": "Video", "video_files": {}},
+    )
+    caption_en = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_captions_vtt",
+        file=f"courses/{website.name}/lecture1_captions.vtt",
+    )
+    caption_fr = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_captions_fr_vtt",
+        file=f"courses/{website.name}/lecture1_captions_fr.vtt",
+    )
+
+    # Link English first
+    _link_resource_to_video(caption_en, website, "video_captions_resources", "lecture1")
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    assert vf["video_captions_resources"]["content"] == [str(caption_en.text_id)]
+
+    # Link French — must append, not overwrite
+    _link_resource_to_video(caption_fr, website, "video_captions_resources", "lecture1")
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    assert str(caption_en.text_id) in vf["video_captions_resources"]["content"]
+    assert str(caption_fr.text_id) in vf["video_captions_resources"]["content"]
+    assert len(vf["video_captions_resources"]["content"]) == 2
+
+    # _file list must also have both entries with correct languages
+    file_entries = vf["video_captions_file"]
+    assert len(file_entries) == 2
+    languages = {e["language"] for e in file_entries}
+    assert "en" in languages
+    assert "fr" in languages

--- a/gdrive_sync/api_test.py
+++ b/gdrive_sync/api_test.py
@@ -602,33 +602,63 @@ def test_create_gdrive_resource_content_preexisting_captions(
     mocker, mock_gdrive_pdf, preexisting_captions_filenames
 ):
     """
-    Test create_gdrive_resource_content creates resources with expected filenames
-    for preexisting captions.
+    create_gdrive_resource_content assigns expected filenames AND auto-links
+    video_captions_resources / video_transcript_resources on the video resource.
     """
     mocked_get_s3_content_type = mocker.patch("gdrive_sync.api.get_s3_content_type")
-    for drive_filename, content_filename, content_type in zip(
-        [
-            preexisting_captions_filenames["gdrive"]["video"],
-            preexisting_captions_filenames["gdrive"]["captions"],
-            preexisting_captions_filenames["gdrive"]["transcript"],
-        ],
-        [
-            preexisting_captions_filenames["website_content"]["video"],
-            preexisting_captions_filenames["website_content"]["captions"],
-            preexisting_captions_filenames["website_content"]["transcript"],
-        ],
-        ["video/mp4", "text/vtt", "application/pdf"],
-    ):
-        mocked_get_s3_content_type.return_value = content_type
+    website = WebsiteFactory.create()
 
-        drive_file = DriveFileFactory.create(
-            name=drive_filename, s3_key=f"/gdrive_uploads/website/{drive_filename}"
+    filenames = list(
+        zip(
+            [
+                preexisting_captions_filenames["gdrive"]["video"],
+                preexisting_captions_filenames["gdrive"]["captions"],
+                preexisting_captions_filenames["gdrive"]["transcript"],
+            ],
+            [
+                preexisting_captions_filenames["website_content"]["video"],
+                preexisting_captions_filenames["website_content"]["captions"],
+                preexisting_captions_filenames["website_content"]["transcript"],
+            ],
+            ["video/mp4", "text/vtt", "application/pdf"],
         )
+    )
 
+    for drive_filename, content_filename, content_type in filenames:
+        mocked_get_s3_content_type.return_value = content_type
+        drive_file = DriveFileFactory.create(
+            website=website,
+            name=drive_filename,
+            s3_key=f"/gdrive_uploads/website/{drive_filename}",
+        )
         create_gdrive_resource_content(drive_file)
         drive_file.refresh_from_db()
-
         assert drive_file.resource.filename == content_filename
+
+    # After all three are processed, the video resource must have _resource fields set.
+    video_filename = preexisting_captions_filenames["website_content"]["video"]
+    video_resource = WebsiteContent.objects.get(
+        website=website, filename=video_filename
+    )
+
+    captions_resource = WebsiteContent.objects.get(
+        website=website,
+        filename=preexisting_captions_filenames["website_content"]["captions"],
+    )
+    transcript_resource = WebsiteContent.objects.get(
+        website=website,
+        filename=preexisting_captions_filenames["website_content"]["transcript"],
+    )
+
+    vf = video_resource.metadata.get("video_files", {})
+    assert vf.get("video_captions_resources") == {
+        "content": [str(captions_resource.text_id)],
+        "website": website.name,
+    }
+    assert vf.get("video_transcript_resources") == {
+        "content": [str(transcript_resource.text_id)],
+        "website": website.name,
+    }
 
 
 def test_gdrive_pdf_failure(mock_get_s3_content_type, mocker):

--- a/videos/models.py
+++ b/videos/models.py
@@ -46,8 +46,18 @@ class Video(TimestampedModel):
         else:
             return None
 
-    def caption_transcript_resources(self) -> tuple[WebsiteContent, WebsiteContent]:
-        """Search for and return the video's caption resource and transcript resource if either exists"""  # noqa: E501
+    def caption_transcript_resources(
+        self,
+    ) -> tuple[list[WebsiteContent], list[WebsiteContent]]:
+        """Search for and return the video's caption resources and transcript resources.
+
+        Returns a 2-tuple of lists: (captions, transcripts).  Each list may
+        contain zero, one, or multiple WebsiteContent objects — one per
+        language-tagged file discovered in the website.  Captions are matched
+        by filename prefix ``{video_filename}_captions`` with suffix ``_vtt``;
+        transcripts by prefix ``{video_filename}_transcript`` with suffix
+        ``_pdf``.
+        """
         youtube_id = self.youtube_id()
 
         query_youtube_id_field = get_dict_query_field("metadata", settings.YT_FIELD_ID)
@@ -58,16 +68,22 @@ class Video(TimestampedModel):
         )
         if video_resource:
             video_filename = get_base_filename(video_resource.filename)
-            captions = WebsiteContent.objects.filter(
-                models.Q(website=self.website)
-                & models.Q(filename=f"{video_filename}_captions_vtt")
-            ).first()
-            transcript = WebsiteContent.objects.filter(
-                models.Q(website=self.website)
-                & models.Q(filename=f"{video_filename}_transcript_pdf")
-            ).first()
-            return captions, transcript
-        return None, None
+            captions = list(
+                WebsiteContent.objects.filter(
+                    website=self.website,
+                    filename__startswith=f"{video_filename}_captions",
+                    filename__endswith="_vtt",
+                )
+            )
+            transcripts = list(
+                WebsiteContent.objects.filter(
+                    website=self.website,
+                    filename__startswith=f"{video_filename}_transcript",
+                    filename__endswith="_pdf",
+                )
+            )
+            return captions, transcripts
+        return [], []
 
     source_key = models.CharField(max_length=2048, unique=True)
     website = models.ForeignKey(Website, on_delete=CASCADE, related_name="videos")

--- a/videos/models_test.py
+++ b/videos/models_test.py
@@ -72,3 +72,41 @@ def test_video_upload_file_to(course_starter):
 
     upload_location = video.upload_file_to(filename)
     assert upload_location == expected_upload_location
+
+
+@pytest.mark.django_db
+def test_video_caption_transcript_resources_multi_language(
+    preexisting_captions_filenames,
+):
+    """caption_transcript_resources returns all language-tagged captions/transcripts."""
+    youtube_id = "yt-multi"
+
+    video = VideoFactory.create()
+    VideoFileFactory.create(
+        destination=DESTINATION_YOUTUBE, video=video, destination_id=youtube_id
+    )
+    video_filename = preexisting_captions_filenames["website_content"]["video"]
+    WebsiteContentFactory.create(
+        metadata={"video_metadata": {"youtube_id": youtube_id}},
+        filename=video_filename,
+        website=video.website,
+    )
+    # Strip trailing suffix (e.g. "_mp4") to get the base stem
+    base = "_".join(video_filename.rsplit("_", 1)[:-1])
+    WebsiteContentFactory.create(
+        filename=f"{base}_captions_en_vtt",
+        website=video.website,
+    )
+    WebsiteContentFactory.create(
+        filename=f"{base}_captions_es_vtt",
+        website=video.website,
+    )
+    WebsiteContentFactory.create(
+        filename=f"{base}_transcript_fr_pdf",
+        website=video.website,
+    )
+
+    captions, transcripts = video.caption_transcript_resources()
+
+    assert len(captions) == 2
+    assert len(transcripts) == 1

--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -54,6 +54,7 @@ from videos.utils import (
     create_new_content,
     fetch_youtube_snippets,
     process_video_tags,
+    resource_file_paths,
 )
 from videos.youtube import (
     API_QUOTA_ERROR_MSG,
@@ -162,35 +163,35 @@ def start_transcript_job(self, video_id: int, timeout_override: int | None = Non
         .first()
     )
 
-    captions, transcript = video.caption_transcript_resources()
+    captions_list, transcripts_list = video.caption_transcript_resources()
 
-    if captions or transcript:  # check for existing captions or transcript
+    if captions_list or transcripts_list:  # check for existing captions or transcript
         website = video.website
-        if captions:
+        if captions_list:
             set_dict_field(
                 video_resource.metadata,
                 settings.YT_FIELD_CAPTIONS,
-                [{"file": captions.file.name, "language": "en"}],
+                resource_file_paths(captions_list),
             )
             set_dict_field(
                 video_resource.metadata,
                 settings.YT_FIELD_CAPTIONS_RESOURCES,
                 {
-                    "content": [str(captions.text_id)],
+                    "content": [str(r.text_id) for r in captions_list],
                     "website": website.name,
                 },
             )
-        if transcript:
+        if transcripts_list:
             set_dict_field(
                 video_resource.metadata,
                 settings.YT_FIELD_TRANSCRIPT,
-                [{"file": transcript.file.name, "language": "en"}],
+                resource_file_paths(transcripts_list),
             )
             set_dict_field(
                 video_resource.metadata,
                 settings.YT_FIELD_TRANSCRIPT_RESOURCES,
                 {
-                    "content": [str(transcript.text_id)],
+                    "content": [str(r.text_id) for r in transcripts_list],
                     "website": website.name,
                 },
             )
@@ -342,13 +343,13 @@ def delete_s3_objects(
 def update_transcripts_for_video(video_id: int):  # noqa: C901
     """Update transcripts for a video"""
     video = Video.objects.get(id=video_id)
-    captions, transcript = video.caption_transcript_resources()
+    captions_list, transcripts_list = video.caption_transcript_resources()
     has_threeplay_update = (
         False
-        if captions or transcript
+        if captions_list or transcripts_list
         else threeplay_api.update_transcripts_for_video(video)
     )
-    if not captions and not transcript and not has_threeplay_update:
+    if not captions_list and not transcripts_list and not has_threeplay_update:
         return
 
     first_transcript_download = False
@@ -404,42 +405,44 @@ def update_transcripts_for_video(video_id: int):  # noqa: C901
                 )
                 video_resource.save()
             else:
-                for resource, (file_field, resource_field) in [
+                s3_path = video.website.s3_path
+                url_path = website.url_path
+                for resource_list, (file_field, resource_field) in [
                     (
-                        captions,
+                        captions_list,
                         (
                             settings.YT_FIELD_CAPTIONS,
                             settings.YT_FIELD_CAPTIONS_RESOURCES,
                         ),
                     ),
                     (
-                        transcript,
+                        transcripts_list,
                         (
                             settings.YT_FIELD_TRANSCRIPT,
                             settings.YT_FIELD_TRANSCRIPT_RESOURCES,
                         ),
                     ),
                 ]:
-                    if resource:
-                        new_file = urljoin(
-                            "/",
-                            resource.file.name.replace(
-                                video.website.s3_path, video.website.url_path
-                            ),
-                        )
-                        new_entry = {"file": new_file, "language": "en"}
+                    if resource_list:
+                        new_entries = [
+                            {
+                                **entry,
+                                "file": entry["file"].replace(s3_path, url_path, 1),
+                            }
+                            for entry in resource_file_paths(resource_list)
+                        ]
                         current_value = get_dict_field(
                             video_resource.metadata, file_field
                         )
-                        if current_value != [new_entry]:
+                        if current_value != new_entries:
                             set_dict_field(
-                                video_resource.metadata, file_field, [new_entry]
+                                video_resource.metadata, file_field, new_entries
                             )
                             set_dict_field(
                                 video_resource.metadata,
                                 resource_field,
                                 {
-                                    "content": [str(resource.text_id)],
+                                    "content": [str(r.text_id) for r in resource_list],
                                     "website": website.name,
                                 },
                             )

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -419,16 +419,28 @@ def test_start_transcript_job(
     start_transcript_job.apply([video.id])
 
     video_content.refresh_from_db()
-    assert get_dict_field(video_content.metadata, settings.YT_FIELD_CAPTIONS) == (
-        [{"file": f"{base_path}_captions.vtt", "language": "en"}]
-        if caption_exists
-        else None
-    )
-    assert get_dict_field(video_content.metadata, settings.YT_FIELD_TRANSCRIPT) == (
-        [{"file": f"{base_path}_transcript.pdf", "language": "en"}]
-        if transcript_exists
-        else None
-    )
+    if caption_exists:
+        captions_result = get_dict_field(
+            video_content.metadata, settings.YT_FIELD_CAPTIONS
+        )
+        assert isinstance(captions_result, list)
+        assert len(captions_result) == 1
+        assert captions_result[0]["language"] == "en"
+    else:
+        assert (
+            get_dict_field(video_content.metadata, settings.YT_FIELD_CAPTIONS) is None
+        )
+    if transcript_exists:
+        transcript_result = get_dict_field(
+            video_content.metadata, settings.YT_FIELD_TRANSCRIPT
+        )
+        assert isinstance(transcript_result, list)
+        assert len(transcript_result) == 1
+        assert transcript_result[0]["language"] == "en"
+    else:
+        assert (
+            get_dict_field(video_content.metadata, settings.YT_FIELD_TRANSCRIPT) is None
+        )
 
     if transcript_exists or caption_exists:
         mock_threeplay_upload_video_request.assert_not_called()
@@ -853,9 +865,9 @@ def test_update_transcripts_for_video_no_3play(
     resource.save()
 
     if caption_exists:
-        assert video.caption_transcript_resources()[0] is not None
+        assert len(video.caption_transcript_resources()[0]) > 0
     if transcript_exists:
-        assert video.caption_transcript_resources()[1] is not None
+        assert len(video.caption_transcript_resources()[1]) > 0
 
     mock_3play = mocker.patch("videos.tasks.threeplay_api.update_transcripts_for_video")
 
@@ -884,6 +896,58 @@ def test_update_transcripts_for_video_no_3play(
         if transcript_exists
         else None
     )
+
+
+@pytest.mark.django_db
+def test_update_transcripts_for_video_multi_language_with_locale(mocker):
+    """GDrive files with locale suffix produce {file, language, locale} entries."""
+    mocker.patch("videos.tasks.is_ocw_site", return_value=True)
+
+    videofile = VideoFileFactory.create(
+        destination=DESTINATION_YOUTUBE, destination_id="expected_id"
+    )
+    video = videofile.video
+    resource = WebsiteContentFactory.create(website=video.website, metadata={})
+    base_resource_filename = get_base_filename(resource.filename)
+    base_path = f"{resource.website.s3_path}/{base_resource_filename}"
+
+    # English (US locale) captions
+    captions_en_us = WebsiteContentFactory.create(
+        website=video.website,
+        filename=f"{base_resource_filename}_captions_en_us_vtt",
+        file=f"{base_path}_captions_en_us.vtt",
+    )
+    # French (no locale) captions
+    captions_fr = WebsiteContentFactory.create(
+        website=video.website,
+        filename=f"{base_resource_filename}_captions_fr_vtt",
+        file=f"{base_path}_captions_fr.vtt",
+    )
+
+    set_dict_field(resource.metadata, settings.FIELD_RESOURCETYPE, RESOURCE_TYPE_VIDEO)
+    set_dict_field(resource.metadata, settings.YT_FIELD_ID, "expected_id")
+    set_dict_field(resource.metadata, settings.YT_FIELD_CAPTIONS, None)
+    resource.save()
+
+    mocker.patch("videos.tasks.threeplay_api.update_transcripts_for_video")
+
+    update_transcripts_for_video(video.id)
+    resource.refresh_from_db()
+
+    captions_result = get_dict_field(resource.metadata, settings.YT_FIELD_CAPTIONS)
+    assert isinstance(captions_result, list)
+    assert len(captions_result) == 2
+
+    by_file = {entry["file"]: entry for entry in captions_result}
+    en_us_key = f"/{captions_en_us.file.name.lstrip('/')}"
+    fr_key = f"/{captions_fr.file.name.lstrip('/')}"
+    en_us_key = en_us_key.replace(video.website.s3_path, video.website.url_path)
+    fr_key = fr_key.replace(video.website.s3_path, video.website.url_path)
+
+    assert by_file[en_us_key]["language"] == "en"
+    assert by_file[en_us_key]["locale"] == "US"
+    assert by_file[fr_key]["language"] == "fr"
+    assert "locale" not in by_file[fr_key]
 
 
 def test_attempt_to_update_missing_transcripts(mocker):

--- a/videos/threeplay_sync.py
+++ b/videos/threeplay_sync.py
@@ -39,6 +39,53 @@ extension_map = {
 }
 
 
+def _append_resource_to_video_files(
+    video: WebsiteContent,
+    resource_field: str,
+    file_field: str,
+    text_id: str,
+    filepath: str,
+) -> None:
+    """
+    Append a caption/transcript resource entry to video_files metadata.
+
+    Preserves any existing entries (e.g. other-language variants already
+    linked from GDrive) instead of overwriting them.
+    """
+    vf = video.metadata["video_files"]
+    existing_resources = vf.get(resource_field)
+    if isinstance(existing_resources, dict) and existing_resources.get("content"):
+        if text_id not in existing_resources["content"]:
+            existing_resources["content"] = [*existing_resources["content"], text_id]
+    else:
+        vf[resource_field] = {"content": [text_id], "website": video.website.name}
+    existing_files = vf.get(file_field)
+    new_file_entry = {"file": filepath, "language": "en"}
+    if isinstance(existing_files, list):
+        if not any(e.get("file") == filepath for e in existing_files):
+            vf[file_field] = [*existing_files, new_file_entry]
+    else:
+        vf[file_field] = [new_file_entry]
+
+
+def _threeplay_resource_already_linked(
+    video: WebsiteContent, resource_field: str, filename: str
+) -> bool:
+    """Return True if the 3Play-generated resource is already in the content list."""
+    existing_content = (
+        video.metadata["video_files"].get(resource_field, {}).get("content") or []
+    )
+    return bool(
+        isinstance(existing_content, list)
+        and existing_content
+        and WebsiteContent.objects.filter(
+            website=video.website,
+            text_id__in=existing_content,
+            filename=filename,
+        ).exists()
+    )
+
+
 def _attach_transcript_if_missing(
     video: WebsiteContent,
     base_url: str,
@@ -50,7 +97,9 @@ def _attach_transcript_if_missing(
     Attach transcript to video if it does not exist.
     Fetches from 3Play API and updates the video metadata.
     """
-    if video.metadata["video_files"].get("video_transcript_file"):
+    if _threeplay_resource_already_linked(
+        video, "video_transcript_resources", f"{youtube_id}_transcript"
+    ):
         return
 
     pdf_url = base_url + f"&format_id={PDF_FORMAT_ID}"
@@ -62,12 +111,16 @@ def _attach_transcript_if_missing(
     if pdf_response:
         file_size = len(pdf_response.getvalue())
         pdf_file = File(pdf_response, name=f"{youtube_id}.pdf")
-        filepath = _create_new_content(pdf_file, video, file_size=file_size)
-        video.metadata["video_files"]["video_transcript_file"] = filepath
-
+        filepath, text_id = _create_new_content(pdf_file, video, file_size=file_size)
+        _append_resource_to_video_files(
+            video,
+            "video_transcript_resources",
+            "video_transcript_file",
+            text_id,
+            filepath,
+        )
         if summary:
             summary["transcripts"]["updated"] += 1
-
         write_output(
             "Transcript updated for video, %s and course %s",
             video.title,
@@ -91,7 +144,9 @@ def _attach_captions_if_missing(
     Attach captions to video if it does not exist.
     Fetches from 3Play API and updates the video metadata.
     """
-    if video.metadata["video_files"].get("video_captions_file"):
+    if _threeplay_resource_already_linked(
+        video, "video_captions_resources", f"{youtube_id}_captions"
+    ):
         return
 
     webvtt_url = base_url + f"&format_id={WEBVTT_FORMAT_ID}"
@@ -102,8 +157,14 @@ def _attach_captions_if_missing(
     if webvtt_response:
         file_size = len(webvtt_response.getvalue())
         vtt_file = File(webvtt_response, name=f"{youtube_id}.webvtt")
-        filepath = _create_new_content(vtt_file, video, file_size)
-        video.metadata["video_files"]["video_captions_file"] = filepath
+        filepath, text_id = _create_new_content(vtt_file, video, file_size)
+        _append_resource_to_video_files(
+            video,
+            "video_captions_resources",
+            "video_captions_file",
+            text_id,
+            filepath,
+        )
         if summary:
             summary["captions"]["updated"] += 1
         write_output(
@@ -198,10 +259,11 @@ def generate_metadata(
 
 def _create_new_content(
     file_content: File, video: WebsiteContent, file_size: int | None = None
-) -> str:
+) -> tuple[str, str]:
     """
     Create and save a new WebsiteContent object
     for a caption or transcript file.
+    Returns a (s3_path, text_id) tuple.
     """
     new_text_id = str(uuid4())
     new_s3_loc = upload_to_s3(file_content, video)
@@ -228,4 +290,4 @@ def _create_new_content(
     obj.file = new_s3_loc
     obj.save()
 
-    return new_s3_loc
+    return new_s3_loc, str(obj.text_id)

--- a/videos/threeplay_sync_test.py
+++ b/videos/threeplay_sync_test.py
@@ -16,7 +16,7 @@ pytestmark = pytest.mark.django_db
 
 
 def test_sync_video_captions_and_transcripts_sets_references(mocker):
-    """3Play sync should attach created caption/transcript resources as references."""
+    """3Play sync should create caption/transcript resources and set _resource fields."""
     starter = WebsiteStarterFactory.create(slug="ocw-course-v2")
     website = WebsiteFactory.create(starter=starter)
     video = WebsiteContentFactory.create(
@@ -48,7 +48,187 @@ def test_sync_video_captions_and_transcripts_sets_references(mocker):
     sync_video_captions_and_transcripts(video)
 
     video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    # _resource.content is a single-item list (array format post-10982)
+    transcript_content = vf["video_transcript_resources"]["content"]
+    captions_content = vf["video_captions_resources"]["content"]
+    assert isinstance(transcript_content, list)
+    assert len(transcript_content) == 1
+    assert isinstance(captions_content, list)
+    assert len(captions_content) == 1
+    # referenced_by tracks via file field on the created WebsiteContent objects
     assert set(video.referenced_by.values_list("file", flat=True)) == {
         f"/courses/{website.name}/yt789_transcript.pdf",
         f"/courses/{website.name}/yt789_captions.webvtt",
     }
+
+
+def test_sync_video_captions_and_transcripts_skips_if_resource_exists(mocker):
+    """3Play sync skips captions/transcripts that already have _resource content set."""
+    starter = WebsiteStarterFactory.create(slug="ocw-course-v2")
+    website = WebsiteFactory.create(starter=starter)
+    # Create actual WebsiteContent objects with the 3Play-derived filenames so the
+    # DB guard in each _attach_*_if_missing function can find them.
+    transcript_resource = WebsiteContentFactory.create(
+        website=website,
+        filename="yt789_transcript",
+    )
+    captions_resource = WebsiteContentFactory.create(
+        website=website,
+        filename="yt789_captions",
+    )
+    video = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        metadata={
+            "resourcetype": "Video",
+            "video_metadata": {"youtube_id": "yt789"},
+            "video_files": {
+                "video_captions_resources": {
+                    "content": [str(captions_resource.text_id)],
+                    "website": website.name,
+                },
+                "video_transcript_resources": {
+                    "content": [str(transcript_resource.text_id)],
+                    "website": website.name,
+                },
+            },
+        },
+    )
+
+    mocker.patch(
+        "videos.threeplay_sync.threeplay_transcript_api_request",
+        return_value={"data": [{"status": "complete", "id": 11, "media_file_id": 22}]},
+    )
+    fetch_file_mock = mocker.patch("videos.threeplay_sync.fetch_file")
+
+    sync_video_captions_and_transcripts(video)
+
+    fetch_file_mock.assert_not_called()
+
+
+def test_sync_video_captions_and_transcripts_appends_english_when_other_languages_exist(
+    mocker,
+):
+    """3Play adds English even when other-language entries already exist from GDrive."""
+    starter = WebsiteStarterFactory.create(slug="ocw-course-v2")
+    website = WebsiteFactory.create(starter=starter)
+    # Simulate GDrive having already linked French caption/transcript resources.
+    # These use filenames that don't match the 3Play pattern, so the guard won't fire.
+    fr_caption = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_captions_fr_vtt",
+    )
+    fr_transcript = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_transcript_fr_pdf",
+    )
+    fr_caption_path = f"courses/{website.name}/lecture1_captions_fr.vtt"
+    fr_transcript_path = f"courses/{website.name}/lecture1_transcript_fr.pdf"
+    video = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        metadata={
+            "resourcetype": "Video",
+            "video_metadata": {"youtube_id": "yt789"},
+            "video_files": {
+                "video_captions_resources": {
+                    "content": [str(fr_caption.text_id)],
+                    "website": website.name,
+                },
+                "video_transcript_resources": {
+                    "content": [str(fr_transcript.text_id)],
+                    "website": website.name,
+                },
+                "video_captions_file": [{"file": fr_caption_path, "language": "fr"}],
+                "video_transcript_file": [
+                    {"file": fr_transcript_path, "language": "fr"}
+                ],
+            },
+        },
+    )
+
+    mocker.patch(
+        "videos.threeplay_sync.threeplay_transcript_api_request",
+        return_value={"data": [{"status": "complete", "id": 11, "media_file_id": 22}]},
+    )
+    mocker.patch(
+        "videos.threeplay_sync.fetch_file",
+        side_effect=[BytesIO(b"pdf"), BytesIO(b"webvtt")],
+    )
+    mocker.patch(
+        "videos.threeplay_sync.upload_to_s3",
+        side_effect=[
+            f"/courses/{website.name}/yt789_transcript.pdf",
+            f"/courses/{website.name}/yt789_captions.webvtt",
+        ],
+    )
+
+    sync_video_captions_and_transcripts(video)
+
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+
+    # French entries preserved; English appended
+    transcript_content = vf["video_transcript_resources"]["content"]
+    captions_content = vf["video_captions_resources"]["content"]
+    assert str(fr_transcript.text_id) in transcript_content
+    assert str(fr_caption.text_id) in captions_content
+    assert len(transcript_content) == 2
+    assert len(captions_content) == 2
+
+    # _file lists also have both entries
+    transcript_files = vf["video_transcript_file"]
+    captions_files = vf["video_captions_file"]
+    assert len(transcript_files) == 2
+    assert len(captions_files) == 2
+    transcript_languages = {e["language"] for e in transcript_files}
+    captions_languages = {e["language"] for e in captions_files}
+    assert "en" in transcript_languages
+    assert "fr" in transcript_languages
+    assert "en" in captions_languages
+    assert "fr" in captions_languages
+
+
+def test_sync_video_captions_and_transcripts_treats_empty_content_as_unset(mocker):
+    """Empty-string _resource.content is treated as unset; 3Play fetch proceeds."""
+    starter = WebsiteStarterFactory.create(slug="ocw-course-v2")
+    website = WebsiteFactory.create(starter=starter)
+    video = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        metadata={
+            "resourcetype": "Video",
+            "video_metadata": {"youtube_id": "yt789"},
+            "video_files": {
+                # Site-config initialises relation widgets with empty content
+                "video_captions_resources": {"content": "", "website": ""},
+                "video_transcript_resources": {"content": "", "website": ""},
+            },
+        },
+    )
+
+    mocker.patch(
+        "videos.threeplay_sync.threeplay_transcript_api_request",
+        return_value={"data": [{"status": "complete", "id": 11, "media_file_id": 22}]},
+    )
+    fetch_file_mock = mocker.patch(
+        "videos.threeplay_sync.fetch_file",
+        side_effect=[BytesIO(b"pdf"), BytesIO(b"webvtt")],
+    )
+    mocker.patch(
+        "videos.threeplay_sync.upload_to_s3",
+        side_effect=[
+            f"/courses/{website.name}/yt789_transcript.pdf",
+            f"/courses/{website.name}/yt789_captions.webvtt",
+        ],
+    )
+
+    sync_video_captions_and_transcripts(video)
+
+    # Both files were fetched (empty content treated as unset)
+    assert fetch_file_mock.call_count == 2
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    assert isinstance(vf["video_transcript_resources"]["content"], list)
+    assert isinstance(vf["video_captions_resources"]["content"], list)

--- a/videos/utils.py
+++ b/videos/utils.py
@@ -273,12 +273,54 @@ def process_video_tags(video_resource, snippet, youtube, *, add_course_tag):
     return "success" if tags_changed else "skip"
 
 
+# Regex that matches ``_captions_{lang}_vtt``, ``_transcript_{lang}_pdf``,
+# or ``_captions_{lang}_{locale}_vtt`` at the end of a slugified filename.
+# GDrive files follow the pattern ``<title>_<lang>_<locale>.<ext>`` where
+# the locale is an ISO 3166-1 alpha-2 region code (e.g. ``us``, ``gb``).
+_LANG_LOCALE_RE = re.compile(
+    r"(?:_captions|_transcript)_([a-z]{2,3})_(?:([a-z]{2,3})_)?(?:vtt|webvtt|pdf)$"
+)
+
+
+def parse_caption_language_locale(filename: str) -> tuple[str, str | None]:
+    """Return ``(language_code, locale_code)`` embedded in a caption/transcript
+    filename.
+
+    The filename is expected to be the slugified ``WebsiteContent.filename``.  GDrive
+    files follow the pattern ``<title>_captions_<lang>_<locale>_vtt`` where ``<lang>``
+    is an ISO 639-1 code (e.g. ``en``, ``fr``) and ``<locale>`` is an ISO 3166-1
+    alpha-2 region code (e.g. ``us``, ``gb``).  ``locale`` is returned uppercase
+    (e.g. ``"US"``) or ``None`` when absent.
+
+    Legacy single-language filenames without a language suffix
+    (e.g. ``lecture1_captions_vtt``) return ``("en", None)``.
+    """
+    match = _LANG_LOCALE_RE.search(filename)
+    if match:
+        lang = match.group(1)
+        locale = match.group(2).upper() if match.group(2) else None
+        return lang, locale
+    return "en", None
+
+
 def resource_file_paths(resources: list) -> list:
-    """Return {file, language} dicts for caption/transcript WebsiteContent objects."""
+    """Return a list of ``{file, language[, locale]}`` dicts for caption/transcript
+    resources.
+
+    Language and optional locale are parsed from each resource's ``filename`` using
+    :func:`parse_caption_language_locale`.  Resources without a resolvable file are
+    omitted.  ``locale`` is only included in the dict when present in the filename.
+    """
     result = []
     for resource in resources:
-        file_field = getattr(resource, "file", None)
-        file_name = getattr(file_field, "name", None) if file_field else None
+        file_name = getattr(getattr(resource, "file", None), "name", None)
         if file_name:
-            result.append({"file": f"/{file_name.lstrip('/')}", "language": "en"})
+            lang, locale = parse_caption_language_locale(resource.filename or "")
+            entry: dict = {
+                "file": f"/{file_name.lstrip('/')}",
+                "language": lang,
+            }
+            if locale:
+                entry["locale"] = locale
+            result.append(entry)
     return result

--- a/videos/utils_test.py
+++ b/videos/utils_test.py
@@ -11,6 +11,7 @@ from videos.utils import (
     generate_s3_path,
     get_content_dirpath,
     get_tags_with_course,
+    parse_caption_language_locale,
     update_metadata,
 )
 from websites.factories import (
@@ -170,3 +171,35 @@ def test_get_tags_with_course_whitespace_handling():
 
     # Whitespace stripped from tags, then sorted
     assert result == "ai, django, my-course, python"
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected"),
+    [
+        # Legacy single-language convention — defaults to English, no locale
+        ("lecture1_captions_vtt", ("en", None)),
+        ("lecture1_transcript_pdf", ("en", None)),
+        # Multi-language captions — language only, no locale
+        ("lecture1_captions_es_vtt", ("es", None)),
+        ("lecture1_captions_fr_vtt", ("fr", None)),
+        ("lecture1_captions_zh_vtt", ("zh", None)),
+        ("lecture1_captions_ar_vtt", ("ar", None)),
+        # Multi-language transcripts — language only, no locale
+        ("lecture1_transcript_es_pdf", ("es", None)),
+        ("lecture1_transcript_zh_pdf", ("zh", None)),
+        # GDrive pattern: <title>_<lang>_<locale>.<ext> — locale returned uppercase
+        ("lecture1_captions_en_us_vtt", ("en", "US")),
+        ("lecture1_captions_fr_en_vtt", ("fr", "EN")),
+        ("lecture1_transcript_en_us_pdf", ("en", "US")),
+        ("lecture1_transcript_fr_gb_pdf", ("fr", "GB")),
+        # Longer filename still parsed correctly
+        ("my_long_course_lecture_03_captions_pt_vtt", ("pt", None)),
+        ("my_long_course_lecture_03_captions_pt_br_vtt", ("pt", "BR")),
+        # No recognised suffix -> defaults to English, no locale
+        ("some_random_file_pdf", ("en", None)),
+        ("lecture1_vtt", ("en", None)),
+    ],
+)
+def test_parse_caption_language_locale(filename, expected):
+    """parse_caption_language_locale returns (language, locale) from slugified filename."""
+    assert parse_caption_language_locale(filename) == expected

--- a/websites/models_test.py
+++ b/websites/models_test.py
@@ -611,11 +611,13 @@ def test_websitecontent_full_metadata_resolves_resources_relation():
     assert isinstance(resolved, list)
     assert len(resolved) == 2
     # s3_path ("sites/mysite") must be replaced by url_path ("sites/mysite-fall-2008")
+    # parse_caption_language_locale extracts "en" for the legacy no-suffix filename
     assert {
         "file": "/sites/mysite-fall-2008/lecture1_captions.vtt",
         "language": "en",
     } in resolved
+    # and "es" for the _es suffix — language detection added in this branch
     assert {
         "file": "/sites/mysite-fall-2008/lecture1_captions_es.vtt",
-        "language": "en",
+        "language": "es",
     } in resolved

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -24,6 +24,7 @@ from gdrive_sync.tasks import create_gdrive_folders
 from main.posthog import is_feature_enabled
 from main.serializers import RequestUserSerializerMixin
 from users.models import User
+from videos.utils import resource_file_paths
 from websites import constants
 from websites.api import (
     detect_mime_type,
@@ -86,11 +87,7 @@ def sync_video_relation_urls(metadata: dict) -> None:
             if content_ids
             else []
         )
-        file_entries = [
-            {"file": f"/{r.file.name.lstrip('/')}", "language": "en"}
-            for r in resources
-            if getattr(r, "file", None) and r.file.name
-        ]
+        file_entries = resource_file_paths(resources)
         set_dict_field(metadata, target_field, file_entries or None)
 
 
@@ -762,6 +759,9 @@ class WebsiteContentCreateSerializer(
             validated_data["metadata"]["file_type"] = detect_mime_type(
                 validated_data["file"]
             )
+
+        if validated_data.get("metadata"):
+            sync_video_relation_urls(validated_data["metadata"])
 
         instance = super().create(
             {

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -1196,7 +1196,7 @@ def test_website_content_detail_serializer_syncs_video_relation_files_with_local
     metadata_patch = {"video_files": {}}
     set_dict_field(
         metadata_patch,
-        settings.YT_FIELD_CAPTIONS_RESOURCE,
+        settings.YT_FIELD_CAPTIONS_RESOURCES,
         {
             "content": [str(caption_en_us.text_id), str(caption_fr.text_id)],
             "website": video.website.name,

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -1141,7 +1141,9 @@ def test_website_content_detail_serializer_syncs_video_relation_files_multi_lang
     captions_result = get_dict_field(video.metadata, settings.YT_FIELD_CAPTIONS)
     assert isinstance(captions_result, list)
     assert len(captions_result) == 2
-    # Language detection is not asserted here; all entries default to "en".
+    # Language detection via parse_caption_language: en (no suffix) and es
+    languages = {entry["language"] for entry in captions_result}
+    assert languages == {"en", "es"}
     files = {entry["file"] for entry in captions_result}
     assert f"/{caption_en.file.name.lstrip('/')}" in files
     assert f"/{caption_es.file.name.lstrip('/')}" in files
@@ -1149,4 +1151,77 @@ def test_website_content_detail_serializer_syncs_video_relation_files_multi_lang
     transcript_result = get_dict_field(video.metadata, settings.YT_FIELD_TRANSCRIPT)
     assert isinstance(transcript_result, list)
     assert len(transcript_result) == 1
+    assert transcript_result[0]["language"] == "en"
     assert transcript_result[0]["file"] == f"/{transcript_en.file.name.lstrip('/')}"
+
+
+@pytest.mark.django_db
+def test_website_content_detail_serializer_syncs_video_relation_files_with_locale(
+    mocker, mocked_website_funcs
+):
+    """Caption resources with locale suffix in filename produce {file, language, locale} entries."""
+    mocker.patch("websites.serializers.update_youtube_thumbnail")
+    video_metadata = {
+        settings.FIELD_RESOURCETYPE: RESOURCE_TYPE_VIDEO,
+        "video_files": {},
+    }
+    set_dict_field(video_metadata, settings.YT_FIELD_CAPTIONS, [])
+    video = WebsiteContentFactory.create(
+        type=CONTENT_TYPE_RESOURCE,
+        metadata=video_metadata,
+    )
+
+    # English (US locale) — filename carries locale suffix
+    caption_en_us = WebsiteContentFactory.create(
+        type=CONTENT_TYPE_RESOURCE,
+        is_page_content=True,
+        filename="lecture1_captions_en_us_vtt",
+        website=video.website,
+    )
+    caption_en_us.file = SimpleUploadedFile(
+        "lecture1_captions_en_us.vtt", b"en-US captions"
+    )
+    caption_en_us.save()
+
+    # French — no locale
+    caption_fr = WebsiteContentFactory.create(
+        type=CONTENT_TYPE_RESOURCE,
+        is_page_content=True,
+        filename="lecture1_captions_fr_vtt",
+        website=video.website,
+    )
+    caption_fr.file = SimpleUploadedFile("lecture1_captions_fr.vtt", b"fr captions")
+    caption_fr.save()
+
+    metadata_patch = {"video_files": {}}
+    set_dict_field(
+        metadata_patch,
+        settings.YT_FIELD_CAPTIONS_RESOURCE,
+        {
+            "content": [str(caption_en_us.text_id), str(caption_fr.text_id)],
+            "website": video.website.name,
+        },
+    )
+
+    serializer = WebsiteContentDetailSerializer(
+        instance=video,
+        data={"metadata": metadata_patch},
+        partial=True,
+        context={"request": mocker.Mock(user=UserFactory.create())},
+    )
+    serializer.is_valid(raise_exception=True)
+    serializer.save()
+    video.refresh_from_db()
+
+    captions_result = get_dict_field(video.metadata, settings.YT_FIELD_CAPTIONS)
+    assert isinstance(captions_result, list)
+    assert len(captions_result) == 2
+
+    by_file = {entry["file"]: entry for entry in captions_result}
+    en_us_key = f"/{caption_en_us.file.name.lstrip('/')}"
+    fr_key = f"/{caption_fr.file.name.lstrip('/')}"
+
+    assert by_file[en_us_key]["language"] == "en"
+    assert by_file[en_us_key]["locale"] == "US"
+    assert by_file[fr_key]["language"] == "fr"
+    assert "locale" not in by_file[fr_key]

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -1135,7 +1135,7 @@ def test_websites_content_create_course_list_sets_references(
 def test_websites_content_create_video_resource_sets_3play_references(
     drf_client, global_admin_user
 ):
-    """Creating a video resource should resolve caption/transcript file references."""
+    """Creating a video resource with _resource fields links captions/transcript."""
     drf_client.force_login(global_admin_user)
     website = WebsiteFactory.create()
     captions = WebsiteContentFactory.create(
@@ -1157,10 +1157,14 @@ def test_websites_content_create_video_resource_sets_3play_references(
             "resourcetype": "Video",
             "video_metadata": {"youtube_id": "yt123"},
             "video_files": {
-                "video_captions_file": f"/courses/{website.name}/video-captions.webvtt",
-                "video_transcript_file": (
-                    f"/courses/{website.name}/video-transcript.pdf"
-                ),
+                "video_captions_resources": {
+                    "content": [str(captions.text_id)],
+                    "website": website.name,
+                },
+                "video_transcript_resources": {
+                    "content": [str(transcript.text_id)],
+                    "website": website.name,
+                },
             },
         },
     }
@@ -1178,10 +1182,19 @@ def test_websites_content_create_video_resource_sets_3play_references(
         website=website,
         text_id=resp.data["text_id"],
     )
+    # referenced_by relationship set via sync_website_content_references
     assert set(content.referenced_by.values_list("id", flat=True)) == {
         captions.id,
         transcript.id,
     }
+    # build-pipeline file arrays populated by sync_video_relation_urls on create
+    vf = content.metadata["video_files"]
+    assert vf["video_captions_file"] == [
+        {"file": f"/courses/{website.name}/video-captions.webvtt", "language": "en"}
+    ]
+    assert vf["video_transcript_file"] == [
+        {"file": f"/courses/{website.name}/video-transcript.pdf", "language": "en"}
+    ]
 
 
 def test_websites_content_create_with_textid(drf_client, global_admin_user):
@@ -1689,7 +1702,7 @@ def test_referencing_content_clears_when_references_removed(
 def test_websites_content_update_video_resource_sets_3play_references(
     drf_client, global_admin_user
 ):
-    """Updating a video resource should refresh caption/transcript file references."""
+    """Updating a video resource with _resource fields links captions/transcript."""
     drf_client.force_login(global_admin_user)
     website = WebsiteFactory.create()
     captions = WebsiteContentFactory.create(
@@ -1725,12 +1738,14 @@ def test_websites_content_update_video_resource_sets_3play_references(
         data={
             "metadata": {
                 "video_files": {
-                    "video_captions_file": (
-                        f"/courses/{website.name}/updated-captions.webvtt"
-                    ),
-                    "video_transcript_file": (
-                        f"/courses/{website.name}/updated-transcript.pdf"
-                    ),
+                    "video_captions_resources": {
+                        "content": [str(captions.text_id)],
+                        "website": website.name,
+                    },
+                    "video_transcript_resources": {
+                        "content": [str(transcript.text_id)],
+                        "website": website.name,
+                    },
                 }
             }
         },
@@ -1739,7 +1754,16 @@ def test_websites_content_update_video_resource_sets_3play_references(
 
     assert resp.status_code == 200
     video.refresh_from_db()
+    # referenced_by relationship set
     assert set(video.referenced_by.values_list("id", flat=True)) == {
         captions.id,
         transcript.id,
     }
+    # build-pipeline file arrays populated by sync_video_relation_urls on update
+    vf = video.metadata["video_files"]
+    assert vf["video_captions_file"] == [
+        {"file": f"/courses/{website.name}/updated-captions.webvtt", "language": "en"}
+    ]
+    assert vf["video_transcript_file"] == [
+        {"file": f"/courses/{website.name}/updated-transcript.pdf", "language": "en"}
+    ]


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10983

### Description (What does it do?)

Adds language and locale parsing for caption and transcript filenames ingested from Google Drive, and auto-links caption/transcript resources to their video during GDrive ingestion.

### How can this be tested?
1. In Google Drive, upload a caption file named `<video_title>_captions_en_US.vtt` and a French one named `<video_title>_captions_fr.vtt` for the same video. Trigger a GDrive sync.
2. Open the corresponding video resource in Studio. Confirm both captions appear in `video_captions_resource` as separate linked resources, each with correct language.
3. Publish the site (draft) and inspect the generated YAML front-matter for the video, and verify the English entry has `locale: US` and the French entry has no `locale` key.
4. Open a video resource that already had a single English caption before this change, and confirm the existing entry still renders correctly with `language: en` and no `locale`.
5. Trigger a GDrive sync for a site that has video files, and confirm that after ingestion, the video resource's `video_captions_resource` and `video_transcript_resource` fields are populated without any manual editor action.
