### PR TITLE
feat: migrate caption and transcript resource relation

### DIFF
--- a/drf_lint_baseline.json
+++ b/drf_lint_baseline.json
@@ -1,5 +1,5 @@
 [
   "content_sync/serializers.py:139:21:ORM001",
   "content_sync/serializers.py:58:21:ORM001",
-  "websites/serializers.py:269:23:ORM001"
+  "websites/serializers.py:266:23:ORM001"
 ]

--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -42,10 +42,11 @@ from gdrive_sync.constants import (
 )
 from gdrive_sync.models import DriveFile
 from main.s3_utils import get_boto3_resource
-from main.utils import get_dirpath_and_filename
+from main.utils import get_base_filename, get_dirpath_and_filename
 from videos.api import create_media_convert_job
 from videos.constants import VideoJobStatus, VideoStatus
 from videos.models import Video, VideoJob
+from videos.utils import resource_file_paths
 from websites.api import get_valid_new_filename
 from websites.constants import (
     CONTENT_TYPE_RESOURCE,
@@ -439,6 +440,169 @@ def get_pdf_title(drive_file: DriveFile) -> str:
         return drive_file.name
 
 
+def _link_video_caption_transcript_resources(
+    resource: WebsiteContent, website: Website
+) -> None:
+    """
+    Ensure ``video_captions_resources`` / ``video_transcript_resources`` relation
+    fields are kept in sync after a gdrive resource is created or updated.
+
+    - If *resource* is a Video, look for existing captions/transcript resources
+      in the same website by the ``{base}_captions_vtt`` / ``{base}_transcript_pdf``
+      filename convention and set the relation fields on the video (without
+      overwriting ones that are already present).
+    - If *resource* is a captions or transcript file, find the corresponding
+      video resource by the same convention and set the appropriate relation
+      field on that video.
+    """
+    resource_type = (resource.metadata or {}).get("resourcetype")
+    filename = resource.filename or ""
+
+    if resource_type == RESOURCE_TYPE_VIDEO:
+        _link_captions_transcript_to_video(resource, website)
+    elif "_captions" in filename:
+        video_base = filename.split("_captions")[0]
+        _link_resource_to_video(
+            resource, website, "video_captions_resources", video_base
+        )
+    elif "_transcript" in filename:
+        video_base = filename.split("_transcript")[0]
+        _link_resource_to_video(
+            resource, website, "video_transcript_resources", video_base
+        )
+
+
+def _link_captions_transcript_to_video(
+    video_resource: WebsiteContent, website: Website
+) -> None:
+    """Set _resource relation fields on a video from existing captions/transcript."""
+    video_base = get_base_filename(video_resource.filename or "")
+    if not video_base:
+        return
+    video_files = (
+        video_resource.metadata.get("video_files") if video_resource.metadata else None
+    )
+    if not isinstance(video_files, dict):
+        video_files = {}
+
+    changed = False
+    for resource_field, data_field, prefix, suffix in [
+        (
+            "video_captions_resources",
+            "video_captions_file",
+            f"{video_base}_captions",
+            "_vtt",
+        ),
+        (
+            "video_transcript_resources",
+            "video_transcript_file",
+            f"{video_base}_transcript",
+            "_pdf",
+        ),
+    ]:
+        related_list = list(
+            WebsiteContent.objects.filter(
+                website=website,
+                filename__startswith=prefix,
+                filename__endswith=suffix,
+            )
+        )
+        if not related_list:
+            continue
+
+        existing = video_files.get(resource_field)
+        existing_ids = existing.get("content", []) if isinstance(existing, dict) else []
+        new_resources = [r for r in related_list if str(r.text_id) not in existing_ids]
+        if not new_resources:
+            continue
+
+        all_ids = existing_ids + [str(r.text_id) for r in new_resources]
+        video_files[resource_field] = {
+            "content": all_ids,
+            "website": website.name,
+        }
+        new_file_entries = resource_file_paths(new_resources)
+        if new_file_entries:
+            existing_files = video_files.get(data_field)
+            if isinstance(existing_files, list):
+                existing_paths = {e.get("file") for e in existing_files}
+                video_files[data_field] = existing_files + [
+                    e for e in new_file_entries if e["file"] not in existing_paths
+                ]
+            else:
+                video_files[data_field] = new_file_entries
+        changed = True
+
+    if changed:
+        if not isinstance(video_resource.metadata, dict):
+            video_resource.metadata = {}
+        video_resource.metadata["video_files"] = video_files
+        video_resource.save()
+
+
+def _link_resource_to_video(
+    resource: WebsiteContent,
+    website: Website,
+    resource_field: str,
+    video_base: str,
+) -> None:
+    """Set a captions/transcript _resource field on the corresponding video resource."""
+    # Identify the video by filename convention: {base}_{ext} where base == video_base.
+    # Exclude known non-video filenames (captions and transcripts share the same base).
+    candidates = WebsiteContent.objects.filter(
+        website=website,
+        filename__startswith=f"{video_base}_",
+    ).exclude(Q(filename__contains="_captions") | Q(filename__contains="_transcript"))
+    video_resource = next(
+        (v for v in candidates if get_base_filename(v.filename or "") == video_base),
+        None,
+    )
+    if not video_resource:
+        return
+
+    video_files = (
+        video_resource.metadata.get("video_files")
+        if isinstance(video_resource.metadata, dict)
+        else None
+    )
+    if not isinstance(video_files, dict):
+        video_files = {}
+
+    new_id = str(resource.text_id)
+    existing = video_files.get(resource_field)
+    if isinstance(existing, dict) and existing.get("content"):
+        # Already linked — append if not a duplicate
+        if new_id in existing["content"]:
+            return
+        existing["content"] = existing["content"] + [new_id]
+    else:
+        video_files[resource_field] = {
+            "content": [new_id],
+            "website": website.name,
+        }
+
+    data_field = (
+        "video_captions_file"
+        if "captions" in resource_field
+        else "video_transcript_file"
+    )
+    new_file_entries = resource_file_paths([resource])
+    if new_file_entries:
+        existing_files = video_files.get(data_field)
+        if isinstance(existing_files, list):
+            existing_paths = {e.get("file") for e in existing_files}
+            extra = [e for e in new_file_entries if e["file"] not in existing_paths]
+            if extra:
+                video_files[data_field] = existing_files + extra
+        else:
+            video_files[data_field] = new_file_entries
+
+    if not isinstance(video_resource.metadata, dict):
+        video_resource.metadata = {}
+    video_resource.metadata["video_files"] = video_files
+    video_resource.save()
+
+
 @transaction.atomic
 def create_gdrive_resource_content(drive_file: DriveFile, user_pk=None):
     """Create a WebsiteContent resource from a Google Drive file"""
@@ -511,6 +675,7 @@ def create_gdrive_resource_content(drive_file: DriveFile, user_pk=None):
             resource.save()
         drive_file.resource = resource
         drive_file.update_status(DriveFileStatus.COMPLETE)
+        _link_video_caption_transcript_resources(resource, drive_file.website)
     except PdfReadError:
         log.exception(
             "Could not create a resource from Google Drive file %s because it is not a valid PDF",  # noqa: E501

--- a/gdrive_sync/api_test.py
+++ b/gdrive_sync/api_test.py
@@ -13,6 +13,7 @@ from requests import HTTPError
 from gdrive_sync import api
 from gdrive_sync.api import (
     GDriveStreamReader,
+    _link_resource_to_video,
     create_gdrive_resource_content,
     gdrive_root_url,
     get_resource_type,
@@ -602,33 +603,63 @@ def test_create_gdrive_resource_content_preexisting_captions(
     mocker, mock_gdrive_pdf, preexisting_captions_filenames
 ):
     """
-    Test create_gdrive_resource_content creates resources with expected filenames
-    for preexisting captions.
+    create_gdrive_resource_content assigns expected filenames AND auto-links
+    video_captions_resources / video_transcript_resources on the video resource.
     """
     mocked_get_s3_content_type = mocker.patch("gdrive_sync.api.get_s3_content_type")
-    for drive_filename, content_filename, content_type in zip(
-        [
-            preexisting_captions_filenames["gdrive"]["video"],
-            preexisting_captions_filenames["gdrive"]["captions"],
-            preexisting_captions_filenames["gdrive"]["transcript"],
-        ],
-        [
-            preexisting_captions_filenames["website_content"]["video"],
-            preexisting_captions_filenames["website_content"]["captions"],
-            preexisting_captions_filenames["website_content"]["transcript"],
-        ],
-        ["video/mp4", "text/vtt", "application/pdf"],
-    ):
-        mocked_get_s3_content_type.return_value = content_type
+    website = WebsiteFactory.create()
 
-        drive_file = DriveFileFactory.create(
-            name=drive_filename, s3_key=f"/gdrive_uploads/website/{drive_filename}"
+    filenames = list(
+        zip(
+            [
+                preexisting_captions_filenames["gdrive"]["video"],
+                preexisting_captions_filenames["gdrive"]["captions"],
+                preexisting_captions_filenames["gdrive"]["transcript"],
+            ],
+            [
+                preexisting_captions_filenames["website_content"]["video"],
+                preexisting_captions_filenames["website_content"]["captions"],
+                preexisting_captions_filenames["website_content"]["transcript"],
+            ],
+            ["video/mp4", "text/vtt", "application/pdf"],
         )
+    )
 
+    for drive_filename, content_filename, content_type in filenames:
+        mocked_get_s3_content_type.return_value = content_type
+        drive_file = DriveFileFactory.create(
+            website=website,
+            name=drive_filename,
+            s3_key=f"/gdrive_uploads/website/{drive_filename}",
+        )
         create_gdrive_resource_content(drive_file)
         drive_file.refresh_from_db()
-
         assert drive_file.resource.filename == content_filename
+
+    # After all three are processed, the video resource must have _resource fields set.
+    video_filename = preexisting_captions_filenames["website_content"]["video"]
+    video_resource = WebsiteContent.objects.get(
+        website=website, filename=video_filename
+    )
+
+    captions_resource = WebsiteContent.objects.get(
+        website=website,
+        filename=preexisting_captions_filenames["website_content"]["captions"],
+    )
+    transcript_resource = WebsiteContent.objects.get(
+        website=website,
+        filename=preexisting_captions_filenames["website_content"]["transcript"],
+    )
+
+    vf = video_resource.metadata.get("video_files", {})
+    assert vf.get("video_captions_resources") == {
+        "content": [str(captions_resource.text_id)],
+        "website": website.name,
+    }
+    assert vf.get("video_transcript_resources") == {
+        "content": [str(transcript_resource.text_id)],
+        "website": website.name,
+    }
 
 
 def test_gdrive_pdf_failure(mock_get_s3_content_type, mocker):
@@ -994,3 +1025,46 @@ def test_delete_drive_file(mocker, with_resource, is_used_in_content, with_user)
             assert WebsiteContent.all_objects.get(pk=resource.id).updated_by == user
         else:
             assert not drive_file_exists
+
+
+@pytest.mark.django_db
+def test_link_resource_to_video_appends_second_language():
+    """Second-language caption appended to content list; first-language entry preserved."""
+    website = WebsiteFactory.create()
+
+    video = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_mp4",
+        metadata={"resourcetype": "Video", "video_files": {}},
+    )
+    caption_en = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_captions_vtt",
+        file=f"courses/{website.name}/lecture1_captions.vtt",
+    )
+    caption_fr = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_captions_fr_vtt",
+        file=f"courses/{website.name}/lecture1_captions_fr.vtt",
+    )
+
+    # Link English first
+    _link_resource_to_video(caption_en, website, "video_captions_resources", "lecture1")
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    assert vf["video_captions_resources"]["content"] == [str(caption_en.text_id)]
+
+    # Link French — must append, not overwrite
+    _link_resource_to_video(caption_fr, website, "video_captions_resources", "lecture1")
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    assert str(caption_en.text_id) in vf["video_captions_resources"]["content"]
+    assert str(caption_fr.text_id) in vf["video_captions_resources"]["content"]
+    assert len(vf["video_captions_resources"]["content"]) == 2
+
+    # _file list must also have both entries with correct languages
+    file_entries = vf["video_captions_file"]
+    assert len(file_entries) == 2
+    languages = {e["language"] for e in file_entries}
+    assert "en" in languages
+    assert "fr" in languages

--- a/localdev/configs/ocw-course-site-config.yml
+++ b/localdev/configs/ocw-course-site-config.yml
@@ -168,6 +168,26 @@ collections:
     - label: Video Thumbnail URL
       name: video_thumbnail_file
       widget: string
+    - label: Video Captions Resources
+      name: video_captions_resources
+      widget: relation
+      collection: resource
+      display_field: title
+      multiple: true
+      filter:
+        field: resourcetype
+        filter_type: equals
+        value: Other
+    - label: Video Transcript Resources
+      name: video_transcript_resources
+      widget: relation
+      collection: resource
+      display_field: title
+      multiple: true
+      filter:
+        field: resourcetype
+        filter_type: equals
+        value: Document
 
 - category: Settings
   name: metadata

--- a/main/settings.py
+++ b/main/settings.py
@@ -587,7 +587,7 @@ YT_FIELD_CAPTIONS = get_string(
 )
 YT_FIELD_CAPTIONS_RESOURCE = get_string(
     name="YT_FIELD_CAPTIONS_RESOURCE",
-    default="video_files.video_captions_resource",
+    default="video_files.video_captions_resources",
     description="The site config metadata field for the captions resource",
 )
 
@@ -623,7 +623,7 @@ YT_FIELD_TRANSCRIPT = get_string(
 )
 YT_FIELD_TRANSCRIPT_RESOURCE = get_string(
     name="YT_FIELD_TRANSCRIPT_RESOURCE",
-    default="video_files.video_transcript_resource",
+    default="video_files.video_transcript_resources",
     description="The site config metadata field for the transcript resource",
 )
 

--- a/main/settings.py
+++ b/main/settings.py
@@ -585,8 +585,8 @@ YT_FIELD_CAPTIONS = get_string(
     default="video_files.video_captions_file",
     description="The site config metadata field for the captions URL",
 )
-YT_FIELD_CAPTIONS_RESOURCE = get_string(
-    name="YT_FIELD_CAPTIONS_RESOURCE",
+YT_FIELD_CAPTIONS_RESOURCES = get_string(
+    name="YT_FIELD_CAPTIONS_RESOURCES",
     default="video_files.video_captions_resources",
     description="The site config metadata field for the captions resource",
 )
@@ -621,8 +621,8 @@ YT_FIELD_TRANSCRIPT = get_string(
     default="video_files.video_transcript_file",
     description="The site config metadata field for the transcript URL",
 )
-YT_FIELD_TRANSCRIPT_RESOURCE = get_string(
-    name="YT_FIELD_TRANSCRIPT_RESOURCE",
+YT_FIELD_TRANSCRIPT_RESOURCES = get_string(
+    name="YT_FIELD_TRANSCRIPT_RESOURCES",
     default="video_files.video_transcript_resources",
     description="The site config metadata field for the transcript resource",
 )

--- a/static/js/resources/ocw-course-site-config.json
+++ b/static/js/resources/ocw-course-site-config.json
@@ -216,6 +216,32 @@
               "label": "Video Thumbnail URL",
               "name": "video_thumbnail_file",
               "widget": "string"
+            },
+            {
+              "collection": "resource",
+              "display_field": "title",
+              "filter": {
+                "field": "resourcetype",
+                "filter_type": "equals",
+                "value": "Other"
+              },
+              "label": "Video Captions Resources",
+              "multiple": true,
+              "name": "video_captions_resources",
+              "widget": "relation"
+            },
+            {
+              "collection": "resource",
+              "display_field": "title",
+              "filter": {
+                "field": "resourcetype",
+                "filter_type": "equals",
+                "value": "Document"
+              },
+              "label": "Video Transcript Resources",
+              "multiple": true,
+              "name": "video_transcript_resources",
+              "widget": "relation"
             }
           ],
           "label": "Video Files",

--- a/videos/management/commands/sync_missing_captions.py
+++ b/videos/management/commands/sync_missing_captions.py
@@ -36,8 +36,8 @@ class Command(WebsiteFilterCommand):
         content_videos = WebsiteContent.objects.filter(
             Q(metadata__resourcetype="Video")
             & (
-                Q(metadata__video_files__video_captions_resource=None)
-                | Q(metadata__video_files__video_transcript_resource=None)
+                Q(metadata__video_files__video_captions_resources=None)
+                | Q(metadata__video_files__video_transcript_resources=None)
             )
         )
         content_videos = self.filter_website_contents(content_videos)

--- a/videos/management/commands/sync_transcripts.py
+++ b/videos/management/commands/sync_transcripts.py
@@ -53,7 +53,7 @@ class Command(BaseCommand):
             # refresh query each time
             to_course_videos_dict = self.courses_to_youtube_dict(to_course_videos)
             captions_resource = (
-                video.metadata["video_files"].get("video_captions_resource") or {}
+                video.metadata["video_files"].get("video_captions_resources") or {}
             )
             if not captions_resource.get("content"):  # missing captions
                 self.stdout.write("Missing captions: " + video_youtube_id + "\n")
@@ -73,7 +73,7 @@ class Command(BaseCommand):
                         source_captions.is_page_content = True
                         source_captions.save()
                     if source_captions:
-                        video.metadata["video_files"]["video_captions_resource"] = {
+                        video.metadata["video_files"]["video_captions_resources"] = {
                             "content": [str(source_captions.text_id)],
                             "website": to_course.name,
                         }
@@ -96,7 +96,7 @@ class Command(BaseCommand):
                     ).first()
                     if source_captions:
                         new_captions = create_new_content(source_captions, to_course)
-                        video.metadata["video_files"]["video_captions_resource"] = {
+                        video.metadata["video_files"]["video_captions_resources"] = {
                             "content": [str(new_captions.text_id)],
                             "website": to_course.name,
                         }
@@ -108,7 +108,7 @@ class Command(BaseCommand):
                         video.save()
 
             transcript_resource = (
-                video.metadata["video_files"].get("video_transcript_resource") or {}
+                video.metadata["video_files"].get("video_transcript_resources") or {}
             )
             if not transcript_resource.get("content"):  # missing transcript
                 self.stdout.write("Missing transcript: " + video_youtube_id + "\n")
@@ -128,7 +128,7 @@ class Command(BaseCommand):
                         source_transcript.is_page_content = True
                         source_transcript.save()
                     if source_transcript:
-                        video.metadata["video_files"]["video_transcript_resource"] = {
+                        video.metadata["video_files"]["video_transcript_resources"] = {
                             "content": [str(source_transcript.text_id)],
                             "website": to_course.name,
                         }
@@ -152,7 +152,7 @@ class Command(BaseCommand):
                         new_transcript = create_new_content(
                             source_transcript, to_course
                         )
-                        video.metadata["video_files"]["video_transcript_resource"] = {
+                        video.metadata["video_files"]["video_transcript_resources"] = {
                             "content": [str(new_transcript.text_id)],
                             "website": to_course.name,
                         }
@@ -176,10 +176,10 @@ class Command(BaseCommand):
         for video in videos:
             youtube_id = video.metadata["video_metadata"]["youtube_id"]
             captions_rel = (
-                video.metadata["video_files"].get("video_captions_resource") or {}
+                video.metadata["video_files"].get("video_captions_resources") or {}
             )
             transcript_rel = (
-                video.metadata["video_files"].get("video_transcript_resource") or {}
+                video.metadata["video_files"].get("video_transcript_resources") or {}
             )
             captions_ids = captions_rel.get("content") or []
             transcript_ids = transcript_rel.get("content") or []

--- a/videos/models.py
+++ b/videos/models.py
@@ -46,8 +46,18 @@ class Video(TimestampedModel):
         else:
             return None
 
-    def caption_transcript_resources(self) -> tuple[WebsiteContent, WebsiteContent]:
-        """Search for and return the video's caption resource and transcript resource if either exists"""  # noqa: E501
+    def caption_transcript_resources(
+        self,
+    ) -> tuple[list[WebsiteContent], list[WebsiteContent]]:
+        """Search for and return the video's caption resources and transcript resources.
+
+        Returns a 2-tuple of lists: (captions, transcripts).  Each list may
+        contain zero, one, or multiple WebsiteContent objects — one per
+        language-tagged file discovered in the website.  Captions are matched
+        by filename prefix ``{video_filename}_captions`` with suffix ``_vtt``;
+        transcripts by prefix ``{video_filename}_transcript`` with suffix
+        ``_pdf``.
+        """
         youtube_id = self.youtube_id()
 
         query_youtube_id_field = get_dict_query_field("metadata", settings.YT_FIELD_ID)
@@ -58,16 +68,22 @@ class Video(TimestampedModel):
         )
         if video_resource:
             video_filename = get_base_filename(video_resource.filename)
-            captions = WebsiteContent.objects.filter(
-                models.Q(website=self.website)
-                & models.Q(filename=f"{video_filename}_captions_vtt")
-            ).first()
-            transcript = WebsiteContent.objects.filter(
-                models.Q(website=self.website)
-                & models.Q(filename=f"{video_filename}_transcript_pdf")
-            ).first()
-            return captions, transcript
-        return None, None
+            captions = list(
+                WebsiteContent.objects.filter(
+                    website=self.website,
+                    filename__startswith=f"{video_filename}_captions",
+                    filename__endswith="_vtt",
+                )
+            )
+            transcripts = list(
+                WebsiteContent.objects.filter(
+                    website=self.website,
+                    filename__startswith=f"{video_filename}_transcript",
+                    filename__endswith="_pdf",
+                )
+            )
+            return captions, transcripts
+        return [], []
 
     source_key = models.CharField(max_length=2048, unique=True)
     website = models.ForeignKey(Website, on_delete=CASCADE, related_name="videos")

--- a/videos/models_test.py
+++ b/videos/models_test.py
@@ -72,3 +72,41 @@ def test_video_upload_file_to(course_starter):
 
     upload_location = video.upload_file_to(filename)
     assert upload_location == expected_upload_location
+
+
+@pytest.mark.django_db
+def test_video_caption_transcript_resources_multi_language(
+    preexisting_captions_filenames,
+):
+    """caption_transcript_resources returns all language-tagged captions/transcripts."""
+    youtube_id = "yt-multi"
+
+    video = VideoFactory.create()
+    VideoFileFactory.create(
+        destination=DESTINATION_YOUTUBE, video=video, destination_id=youtube_id
+    )
+    video_filename = preexisting_captions_filenames["website_content"]["video"]
+    WebsiteContentFactory.create(
+        metadata={"video_metadata": {"youtube_id": youtube_id}},
+        filename=video_filename,
+        website=video.website,
+    )
+    # Strip trailing suffix (e.g. "_mp4") to get the base stem
+    base = "_".join(video_filename.rsplit("_", 1)[:-1])
+    WebsiteContentFactory.create(
+        filename=f"{base}_captions_en_vtt",
+        website=video.website,
+    )
+    WebsiteContentFactory.create(
+        filename=f"{base}_captions_es_vtt",
+        website=video.website,
+    )
+    WebsiteContentFactory.create(
+        filename=f"{base}_transcript_fr_pdf",
+        website=video.website,
+    )
+
+    captions, transcripts = video.caption_transcript_resources()
+
+    assert len(captions) == 2
+    assert len(transcripts) == 1

--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -53,7 +53,6 @@ from videos.models import Video, VideoFile
 from videos.utils import (
     create_new_content,
     fetch_youtube_snippets,
-    parse_caption_language_locale,
     process_video_tags,
 )
 from videos.youtube import (
@@ -141,7 +140,7 @@ def upload_youtube_videos():  # noqa: C901
     max_retries=3,
     bind=True,  # Bind to access retry count
 )
-def start_transcript_job(self, video_id: int, timeout_override: int | None = None):  # noqa: C901, PLR0912, PLR0915
+def start_transcript_job(self, video_id: int, timeout_override: int | None = None):
     """
     If there are existing captions or transcript, associate them with the video;
     otherwise, use the 3Play API to order a new transcript for video
@@ -163,63 +162,35 @@ def start_transcript_job(self, video_id: int, timeout_override: int | None = Non
         .first()
     )
 
-    captions_list, transcripts_list = video.caption_transcript_resources()
+    captions, transcript = video.caption_transcript_resources()
 
-    if captions_list or transcripts_list:  # check for existing captions or transcript
+    if captions or transcript:  # check for existing captions or transcript
         website = video.website
-        if captions_list:
-            captions_file_data = []
-            for r in captions_list:
-                if not (getattr(r, "file", None) and r.file.name):
-                    continue
-                lang, locale = parse_caption_language_locale(r.filename or "")
-                entry: dict = {
-                    "file": urljoin(
-                        "/",
-                        r.file.name.replace(website.s3_path, website.url_path),
-                    ),
-                    "language": lang,
-                }
-                if locale:
-                    entry["locale"] = locale
-                captions_file_data.append(entry)
+        if captions:
             set_dict_field(
-                video_resource.metadata, settings.YT_FIELD_CAPTIONS, captions_file_data
+                video_resource.metadata,
+                settings.YT_FIELD_CAPTIONS,
+                [{"file": captions.file.name, "language": "en"}],
             )
             set_dict_field(
                 video_resource.metadata,
-                settings.YT_FIELD_CAPTIONS_RESOURCE,
+                settings.YT_FIELD_CAPTIONS_RESOURCES,
                 {
-                    "content": [str(r.text_id) for r in captions_list],
+                    "content": [str(captions.text_id)],
                     "website": website.name,
                 },
             )
-        if transcripts_list:
-            transcripts_file_data = []
-            for r in transcripts_list:
-                if not (getattr(r, "file", None) and r.file.name):
-                    continue
-                lang, locale = parse_caption_language_locale(r.filename or "")
-                entry: dict = {
-                    "file": urljoin(
-                        "/",
-                        r.file.name.replace(website.s3_path, website.url_path),
-                    ),
-                    "language": lang,
-                }
-                if locale:
-                    entry["locale"] = locale
-                transcripts_file_data.append(entry)
+        if transcript:
             set_dict_field(
                 video_resource.metadata,
                 settings.YT_FIELD_TRANSCRIPT,
-                transcripts_file_data,
+                [{"file": transcript.file.name, "language": "en"}],
             )
             set_dict_field(
                 video_resource.metadata,
-                settings.YT_FIELD_TRANSCRIPT_RESOURCE,
+                settings.YT_FIELD_TRANSCRIPT_RESOURCES,
                 {
-                    "content": [str(r.text_id) for r in transcripts_list],
+                    "content": [str(transcript.text_id)],
                     "website": website.name,
                 },
             )
@@ -368,16 +339,16 @@ def delete_s3_objects(
 @single_task(
     timeout=settings.UPDATE_TAGGED_3PLAY_TRANSCRIPT_FREQUENCY, raise_block=False
 )
-def update_transcripts_for_video(video_id: int):  # noqa: C901, PLR0912
+def update_transcripts_for_video(video_id: int):  # noqa: C901
     """Update transcripts for a video"""
     video = Video.objects.get(id=video_id)
-    captions_list, transcripts_list = video.caption_transcript_resources()
+    captions, transcript = video.caption_transcript_resources()
     has_threeplay_update = (
         False
-        if captions_list or transcripts_list
+        if captions or transcript
         else threeplay_api.update_transcripts_for_video(video)
     )
-    if not captions_list and not transcripts_list and not has_threeplay_update:
+    if not captions and not transcript and not has_threeplay_update:
         return
 
     first_transcript_download = False
@@ -433,36 +404,44 @@ def update_transcripts_for_video(video_id: int):  # noqa: C901, PLR0912
                 )
                 video_resource.save()
             else:
-                for resources_list, meta_field in [
-                    (captions_list, settings.YT_FIELD_CAPTIONS),
-                    (transcripts_list, settings.YT_FIELD_TRANSCRIPT),
+                for resource, (file_field, resource_field) in [
+                    (
+                        captions,
+                        (
+                            settings.YT_FIELD_CAPTIONS,
+                            settings.YT_FIELD_CAPTIONS_RESOURCES,
+                        ),
+                    ),
+                    (
+                        transcript,
+                        (
+                            settings.YT_FIELD_TRANSCRIPT,
+                            settings.YT_FIELD_TRANSCRIPT_RESOURCES,
+                        ),
+                    ),
                 ]:
-                    if resources_list:
-                        new_value = []
-                        for r in resources_list:
-                            if not (getattr(r, "file", None) and r.file.name):
-                                continue
-                            lang, locale = parse_caption_language_locale(
-                                r.filename or ""
-                            )
-                            rv_entry: dict = {
-                                "file": urljoin(
-                                    "/",
-                                    r.file.name.replace(
-                                        video.website.s3_path, video.website.url_path
-                                    ),
-                                ),
-                                "language": lang,
-                            }
-                            if locale:
-                                rv_entry["locale"] = locale
-                            new_value.append(rv_entry)
-                        current_value = get_dict_field(
-                            video_resource.metadata, meta_field
+                    if resource:
+                        new_file = urljoin(
+                            "/",
+                            resource.file.name.replace(
+                                video.website.s3_path, video.website.url_path
+                            ),
                         )
-                        if current_value != new_value:
+                        new_entry = {"file": new_file, "language": "en"}
+                        current_value = get_dict_field(
+                            video_resource.metadata, file_field
+                        )
+                        if current_value != [new_entry]:
                             set_dict_field(
-                                video_resource.metadata, meta_field, new_value
+                                video_resource.metadata, file_field, [new_entry]
+                            )
+                            set_dict_field(
+                                video_resource.metadata,
+                                resource_field,
+                                {
+                                    "content": [str(resource.text_id)],
+                                    "website": website.name,
+                                },
                             )
                             video_resource.save()
 
@@ -660,8 +639,8 @@ def copy_video_resource(source_course_id, destination_course_id, source_resource
     new_resource = create_new_content(source_resource, destination_course)
 
     for resource_field, data_field in (
-        (settings.YT_FIELD_CAPTIONS_RESOURCE, settings.YT_FIELD_CAPTIONS),
-        (settings.YT_FIELD_TRANSCRIPT_RESOURCE, settings.YT_FIELD_TRANSCRIPT),
+        (settings.YT_FIELD_CAPTIONS_RESOURCES, settings.YT_FIELD_CAPTIONS),
+        (settings.YT_FIELD_TRANSCRIPT_RESOURCES, settings.YT_FIELD_TRANSCRIPT),
     ):
         relation = get_dict_field(source_resource.metadata, resource_field) or {}
         content_ids = relation.get("content") or []

--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -54,6 +54,7 @@ from videos.utils import (
     create_new_content,
     fetch_youtube_snippets,
     process_video_tags,
+    resource_file_paths,
 )
 from videos.youtube import (
     API_QUOTA_ERROR_MSG,
@@ -162,35 +163,35 @@ def start_transcript_job(self, video_id: int, timeout_override: int | None = Non
         .first()
     )
 
-    captions, transcript = video.caption_transcript_resources()
+    captions_list, transcripts_list = video.caption_transcript_resources()
 
-    if captions or transcript:  # check for existing captions or transcript
+    if captions_list or transcripts_list:  # check for existing captions or transcript
         website = video.website
-        if captions:
+        if captions_list:
             set_dict_field(
                 video_resource.metadata,
                 settings.YT_FIELD_CAPTIONS,
-                [{"file": captions.file.name, "language": "en"}],
+                resource_file_paths(captions_list),
             )
             set_dict_field(
                 video_resource.metadata,
                 settings.YT_FIELD_CAPTIONS_RESOURCES,
                 {
-                    "content": [str(captions.text_id)],
+                    "content": [str(r.text_id) for r in captions_list],
                     "website": website.name,
                 },
             )
-        if transcript:
+        if transcripts_list:
             set_dict_field(
                 video_resource.metadata,
                 settings.YT_FIELD_TRANSCRIPT,
-                [{"file": transcript.file.name, "language": "en"}],
+                resource_file_paths(transcripts_list),
             )
             set_dict_field(
                 video_resource.metadata,
                 settings.YT_FIELD_TRANSCRIPT_RESOURCES,
                 {
-                    "content": [str(transcript.text_id)],
+                    "content": [str(r.text_id) for r in transcripts_list],
                     "website": website.name,
                 },
             )
@@ -342,13 +343,13 @@ def delete_s3_objects(
 def update_transcripts_for_video(video_id: int):  # noqa: C901
     """Update transcripts for a video"""
     video = Video.objects.get(id=video_id)
-    captions, transcript = video.caption_transcript_resources()
+    captions_list, transcripts_list = video.caption_transcript_resources()
     has_threeplay_update = (
         False
-        if captions or transcript
+        if captions_list or transcripts_list
         else threeplay_api.update_transcripts_for_video(video)
     )
-    if not captions and not transcript and not has_threeplay_update:
+    if not captions_list and not transcripts_list and not has_threeplay_update:
         return
 
     first_transcript_download = False
@@ -404,42 +405,44 @@ def update_transcripts_for_video(video_id: int):  # noqa: C901
                 )
                 video_resource.save()
             else:
-                for resource, (file_field, resource_field) in [
+                s3_path = video.website.s3_path
+                url_path = website.url_path
+                for resource_list, (file_field, resource_field) in [
                     (
-                        captions,
+                        captions_list,
                         (
                             settings.YT_FIELD_CAPTIONS,
                             settings.YT_FIELD_CAPTIONS_RESOURCES,
                         ),
                     ),
                     (
-                        transcript,
+                        transcripts_list,
                         (
                             settings.YT_FIELD_TRANSCRIPT,
                             settings.YT_FIELD_TRANSCRIPT_RESOURCES,
                         ),
                     ),
                 ]:
-                    if resource:
-                        new_file = urljoin(
-                            "/",
-                            resource.file.name.replace(
-                                video.website.s3_path, video.website.url_path
-                            ),
-                        )
-                        new_entry = {"file": new_file, "language": "en"}
+                    if resource_list:
+                        new_entries = [
+                            {
+                                **entry,
+                                "file": entry["file"].replace(s3_path, url_path, 1),
+                            }
+                            for entry in resource_file_paths(resource_list)
+                        ]
                         current_value = get_dict_field(
                             video_resource.metadata, file_field
                         )
-                        if current_value != [new_entry]:
+                        if current_value != new_entries:
                             set_dict_field(
-                                video_resource.metadata, file_field, [new_entry]
+                                video_resource.metadata, file_field, new_entries
                             )
                             set_dict_field(
                                 video_resource.metadata,
                                 resource_field,
                                 {
-                                    "content": [str(resource.text_id)],
+                                    "content": [str(r.text_id) for r in resource_list],
                                     "website": website.name,
                                 },
                             )

--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -53,6 +53,7 @@ from videos.models import Video, VideoFile
 from videos.utils import (
     create_new_content,
     fetch_youtube_snippets,
+    parse_caption_language_locale,
     process_video_tags,
 )
 from videos.youtube import (
@@ -140,7 +141,7 @@ def upload_youtube_videos():  # noqa: C901
     max_retries=3,
     bind=True,  # Bind to access retry count
 )
-def start_transcript_job(self, video_id: int, timeout_override: int | None = None):
+def start_transcript_job(self, video_id: int, timeout_override: int | None = None):  # noqa: C901, PLR0912, PLR0915
     """
     If there are existing captions or transcript, associate them with the video;
     otherwise, use the 3Play API to order a new transcript for video
@@ -162,20 +163,65 @@ def start_transcript_job(self, video_id: int, timeout_override: int | None = Non
         .first()
     )
 
-    captions, transcript = video.caption_transcript_resources()
+    captions_list, transcripts_list = video.caption_transcript_resources()
 
-    if captions or transcript:  # check for existing captions or transcript
-        if captions:
+    if captions_list or transcripts_list:  # check for existing captions or transcript
+        website = video.website
+        if captions_list:
+            captions_file_data = []
+            for r in captions_list:
+                if not (getattr(r, "file", None) and r.file.name):
+                    continue
+                lang, locale = parse_caption_language_locale(r.filename or "")
+                entry: dict = {
+                    "file": urljoin(
+                        "/",
+                        r.file.name.replace(website.s3_path, website.url_path),
+                    ),
+                    "language": lang,
+                }
+                if locale:
+                    entry["locale"] = locale
+                captions_file_data.append(entry)
+            set_dict_field(
+                video_resource.metadata, settings.YT_FIELD_CAPTIONS, captions_file_data
+            )
             set_dict_field(
                 video_resource.metadata,
-                settings.YT_FIELD_CAPTIONS,
-                [{"file": captions.file.name, "language": "en"}],
+                settings.YT_FIELD_CAPTIONS_RESOURCE,
+                {
+                    "content": [str(r.text_id) for r in captions_list],
+                    "website": website.name,
+                },
             )
-        if transcript:
+        if transcripts_list:
+            transcripts_file_data = []
+            for r in transcripts_list:
+                if not (getattr(r, "file", None) and r.file.name):
+                    continue
+                lang, locale = parse_caption_language_locale(r.filename or "")
+                entry: dict = {
+                    "file": urljoin(
+                        "/",
+                        r.file.name.replace(website.s3_path, website.url_path),
+                    ),
+                    "language": lang,
+                }
+                if locale:
+                    entry["locale"] = locale
+                transcripts_file_data.append(entry)
             set_dict_field(
                 video_resource.metadata,
                 settings.YT_FIELD_TRANSCRIPT,
-                [{"file": transcript.file.name, "language": "en"}],
+                transcripts_file_data,
+            )
+            set_dict_field(
+                video_resource.metadata,
+                settings.YT_FIELD_TRANSCRIPT_RESOURCE,
+                {
+                    "content": [str(r.text_id) for r in transcripts_list],
+                    "website": website.name,
+                },
             )
         video_resource.save()
 
@@ -322,16 +368,16 @@ def delete_s3_objects(
 @single_task(
     timeout=settings.UPDATE_TAGGED_3PLAY_TRANSCRIPT_FREQUENCY, raise_block=False
 )
-def update_transcripts_for_video(video_id: int):  # noqa: C901
+def update_transcripts_for_video(video_id: int):  # noqa: C901, PLR0912
     """Update transcripts for a video"""
     video = Video.objects.get(id=video_id)
-    captions, transcript = video.caption_transcript_resources()
+    captions_list, transcripts_list = video.caption_transcript_resources()
     has_threeplay_update = (
         False
-        if captions or transcript
+        if captions_list or transcripts_list
         else threeplay_api.update_transcripts_for_video(video)
     )
-    if not captions and not transcript and not has_threeplay_update:
+    if not captions_list and not transcripts_list and not has_threeplay_update:
         return
 
     first_transcript_download = False
@@ -387,24 +433,36 @@ def update_transcripts_for_video(video_id: int):  # noqa: C901
                 )
                 video_resource.save()
             else:
-                for resource, meta_field in [
-                    (captions, settings.YT_FIELD_CAPTIONS),
-                    (transcript, settings.YT_FIELD_TRANSCRIPT),
+                for resources_list, meta_field in [
+                    (captions_list, settings.YT_FIELD_CAPTIONS),
+                    (transcripts_list, settings.YT_FIELD_TRANSCRIPT),
                 ]:
-                    if resource:
-                        new_file = urljoin(
-                            "/",
-                            resource.file.name.replace(
-                                video.website.s3_path, video.website.url_path
-                            ),
-                        )
-                        new_entry = {"file": new_file, "language": "en"}
+                    if resources_list:
+                        new_value = []
+                        for r in resources_list:
+                            if not (getattr(r, "file", None) and r.file.name):
+                                continue
+                            lang, locale = parse_caption_language_locale(
+                                r.filename or ""
+                            )
+                            rv_entry: dict = {
+                                "file": urljoin(
+                                    "/",
+                                    r.file.name.replace(
+                                        video.website.s3_path, video.website.url_path
+                                    ),
+                                ),
+                                "language": lang,
+                            }
+                            if locale:
+                                rv_entry["locale"] = locale
+                            new_value.append(rv_entry)
                         current_value = get_dict_field(
                             video_resource.metadata, meta_field
                         )
-                        if current_value != [new_entry]:
+                        if current_value != new_value:
                             set_dict_field(
-                                video_resource.metadata, meta_field, [new_entry]
+                                video_resource.metadata, meta_field, new_value
                             )
                             video_resource.save()
 
@@ -532,16 +590,20 @@ def copy_gdrive_file(gdrive_file, destination_course):
 def update_transcript_and_captions(resource, new_transcript_file, new_captions_file):
     """
     Update the associated transcript and captions files for a resource.
+    Writes the file data array used by the build pipeline.
     """
     transcript_path = f"/{str(new_transcript_file).lstrip('/')}"
     captions_path = f"/{str(new_captions_file).lstrip('/')}"
-    resource.metadata["video_files"]["video_transcript_file"] = [
-        {"file": transcript_path, "language": "en"}
-    ]
-    resource.metadata["video_files"]["video_captions_file"] = [
-        {"file": captions_path, "language": "en"}
-    ]
-
+    set_dict_field(
+        resource.metadata,
+        settings.YT_FIELD_TRANSCRIPT,
+        [{"file": transcript_path, "language": "en"}],
+    )
+    set_dict_field(
+        resource.metadata,
+        settings.YT_FIELD_CAPTIONS,
+        [{"file": captions_path, "language": "en"}],
+    )
     resource.save()
     sync_website_content_references(resource)
 
@@ -582,12 +644,13 @@ def copy_video_resource(source_course_id, destination_course_id, source_resource
     """
     Copy a video resource and associated captions/transcripts (celery task).
 
-    Captions and transcripts are discovered via the ``video_captions_resource`` and
-    ``video_transcript_resource`` relation fields.  For each linked resource the
-    content record is copied to the destination course, the relation field on the
-    new video resource is updated to point at the copy, and the build-pipeline
-    file-data field is populated with the new file path.  Associated Google Drive
-    files are also copied when present.
+    Captions and transcripts are discovered via the ``video_captions_resources`` and
+    ``video_transcript_resources`` relation fields introduced in migration 0075.  For
+    each linked resource the content record is copied to the destination course, the
+    relation field on the new video resource is updated to point at the copy, and the
+    build-pipeline file-data field (``video_captions_file`` / ``video_transcript_file``)
+    is populated with the new file path.  Associated Google Drive files are also copied
+    when present.
     """
     source_course = Website.objects.get(uuid=source_course_id)
     destination_course = Website.objects.get(uuid=destination_course_id)
@@ -620,6 +683,7 @@ def copy_video_resource(source_course_id, destination_course_id, source_resource
                 file_path = f"/{new_content.file.name.lstrip('/')}"
                 file_entries.append({"file": file_path, "language": "en"})
 
+            # Copy the associated DriveFile if one exists.
             if source_content.file and source_content.file.name:
                 gdrive_file = DriveFile.objects.filter(
                     s3_key=source_content.file.name.lstrip("/")

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -1028,11 +1028,11 @@ def test_copy_video_resource_uses_relation_fields(mocker):
         website=source_course,
         metadata={
             "video_files": {
-                settings.YT_FIELD_CAPTIONS_RESOURCE.split(".")[-1]: {
+                settings.YT_FIELD_CAPTIONS_RESOURCES.split(".")[-1]: {
                     "content": [str(captions_content.text_id)],
                     "website": source_course.name,
                 },
-                settings.YT_FIELD_TRANSCRIPT_RESOURCE.split(".")[-1]: {
+                settings.YT_FIELD_TRANSCRIPT_RESOURCES.split(".")[-1]: {
                     "content": [str(transcript_content.text_id)],
                     "website": source_course.name,
                 },
@@ -1058,14 +1058,14 @@ def test_copy_video_resource_uses_relation_fields(mocker):
     assert new_resource is not None
 
     captions_relation = new_resource.metadata["video_files"].get(
-        settings.YT_FIELD_CAPTIONS_RESOURCE.split(".")[-1]
+        settings.YT_FIELD_CAPTIONS_RESOURCES.split(".")[-1]
     )
     assert captions_relation is not None
     assert captions_relation["website"] == destination_course.name
     assert len(captions_relation["content"]) == 1
 
     transcript_relation = new_resource.metadata["video_files"].get(
-        settings.YT_FIELD_TRANSCRIPT_RESOURCE.split(".")[-1]
+        settings.YT_FIELD_TRANSCRIPT_RESOURCES.split(".")[-1]
     )
     assert transcript_relation is not None
     assert transcript_relation["website"] == destination_course.name

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -419,16 +419,28 @@ def test_start_transcript_job(
     start_transcript_job.apply([video.id])
 
     video_content.refresh_from_db()
-    assert get_dict_field(video_content.metadata, settings.YT_FIELD_CAPTIONS) == (
-        [{"file": f"{base_path}_captions.vtt", "language": "en"}]
-        if caption_exists
-        else None
-    )
-    assert get_dict_field(video_content.metadata, settings.YT_FIELD_TRANSCRIPT) == (
-        [{"file": f"{base_path}_transcript.pdf", "language": "en"}]
-        if transcript_exists
-        else None
-    )
+    if caption_exists:
+        captions_result = get_dict_field(
+            video_content.metadata, settings.YT_FIELD_CAPTIONS
+        )
+        assert isinstance(captions_result, list)
+        assert len(captions_result) == 1
+        assert captions_result[0]["language"] == "en"
+    else:
+        assert (
+            get_dict_field(video_content.metadata, settings.YT_FIELD_CAPTIONS) is None
+        )
+    if transcript_exists:
+        transcript_result = get_dict_field(
+            video_content.metadata, settings.YT_FIELD_TRANSCRIPT
+        )
+        assert isinstance(transcript_result, list)
+        assert len(transcript_result) == 1
+        assert transcript_result[0]["language"] == "en"
+    else:
+        assert (
+            get_dict_field(video_content.metadata, settings.YT_FIELD_TRANSCRIPT) is None
+        )
 
     if transcript_exists or caption_exists:
         mock_threeplay_upload_video_request.assert_not_called()
@@ -853,9 +865,9 @@ def test_update_transcripts_for_video_no_3play(
     resource.save()
 
     if caption_exists:
-        assert video.caption_transcript_resources()[0] is not None
+        assert len(video.caption_transcript_resources()[0]) > 0
     if transcript_exists:
-        assert video.caption_transcript_resources()[1] is not None
+        assert len(video.caption_transcript_resources()[1]) > 0
 
     mock_3play = mocker.patch("videos.tasks.threeplay_api.update_transcripts_for_video")
 
@@ -884,6 +896,58 @@ def test_update_transcripts_for_video_no_3play(
         if transcript_exists
         else None
     )
+
+
+@pytest.mark.django_db
+def test_update_transcripts_for_video_multi_language_with_locale(mocker):
+    """GDrive files with locale suffix produce {file, language, locale} entries."""
+    mocker.patch("videos.tasks.is_ocw_site", return_value=True)
+
+    videofile = VideoFileFactory.create(
+        destination=DESTINATION_YOUTUBE, destination_id="expected_id"
+    )
+    video = videofile.video
+    resource = WebsiteContentFactory.create(website=video.website, metadata={})
+    base_resource_filename = get_base_filename(resource.filename)
+    base_path = f"{resource.website.s3_path}/{base_resource_filename}"
+
+    # English (US locale) captions
+    captions_en_us = WebsiteContentFactory.create(
+        website=video.website,
+        filename=f"{base_resource_filename}_captions_en_us_vtt",
+        file=f"{base_path}_captions_en_us.vtt",
+    )
+    # French (no locale) captions
+    captions_fr = WebsiteContentFactory.create(
+        website=video.website,
+        filename=f"{base_resource_filename}_captions_fr_vtt",
+        file=f"{base_path}_captions_fr.vtt",
+    )
+
+    set_dict_field(resource.metadata, settings.FIELD_RESOURCETYPE, RESOURCE_TYPE_VIDEO)
+    set_dict_field(resource.metadata, settings.YT_FIELD_ID, "expected_id")
+    set_dict_field(resource.metadata, settings.YT_FIELD_CAPTIONS, None)
+    resource.save()
+
+    mocker.patch("videos.tasks.threeplay_api.update_transcripts_for_video")
+
+    update_transcripts_for_video(video.id)
+    resource.refresh_from_db()
+
+    captions_result = get_dict_field(resource.metadata, settings.YT_FIELD_CAPTIONS)
+    assert isinstance(captions_result, list)
+    assert len(captions_result) == 2
+
+    by_file = {entry["file"]: entry for entry in captions_result}
+    en_us_key = f"/{captions_en_us.file.name.lstrip('/')}"
+    fr_key = f"/{captions_fr.file.name.lstrip('/')}"
+    en_us_key = en_us_key.replace(video.website.s3_path, video.website.url_path)
+    fr_key = fr_key.replace(video.website.s3_path, video.website.url_path)
+
+    assert by_file[en_us_key]["language"] == "en"
+    assert by_file[en_us_key]["locale"] == "US"
+    assert by_file[fr_key]["language"] == "fr"
+    assert "locale" not in by_file[fr_key]
 
 
 def test_attempt_to_update_missing_transcripts(mocker):

--- a/videos/threeplay_sync.py
+++ b/videos/threeplay_sync.py
@@ -39,6 +39,53 @@ extension_map = {
 }
 
 
+def _append_resource_to_video_files(
+    video: WebsiteContent,
+    resource_field: str,
+    file_field: str,
+    text_id: str,
+    filepath: str,
+) -> None:
+    """
+    Append a caption/transcript resource entry to video_files metadata.
+
+    Preserves any existing entries (e.g. other-language variants already
+    linked from GDrive) instead of overwriting them.
+    """
+    vf = video.metadata["video_files"]
+    existing_resources = vf.get(resource_field)
+    if isinstance(existing_resources, dict) and existing_resources.get("content"):
+        if text_id not in existing_resources["content"]:
+            existing_resources["content"] = [*existing_resources["content"], text_id]
+    else:
+        vf[resource_field] = {"content": [text_id], "website": video.website.name}
+    existing_files = vf.get(file_field)
+    new_file_entry = {"file": filepath, "language": "en"}
+    if isinstance(existing_files, list):
+        if not any(e.get("file") == filepath for e in existing_files):
+            vf[file_field] = [*existing_files, new_file_entry]
+    else:
+        vf[file_field] = [new_file_entry]
+
+
+def _threeplay_resource_already_linked(
+    video: WebsiteContent, resource_field: str, filename: str
+) -> bool:
+    """Return True if the 3Play-generated resource is already in the content list."""
+    existing_content = (
+        video.metadata["video_files"].get(resource_field, {}).get("content") or []
+    )
+    return bool(
+        isinstance(existing_content, list)
+        and existing_content
+        and WebsiteContent.objects.filter(
+            website=video.website,
+            text_id__in=existing_content,
+            filename=filename,
+        ).exists()
+    )
+
+
 def _attach_transcript_if_missing(
     video: WebsiteContent,
     base_url: str,
@@ -50,7 +97,9 @@ def _attach_transcript_if_missing(
     Attach transcript to video if it does not exist.
     Fetches from 3Play API and updates the video metadata.
     """
-    if video.metadata["video_files"].get("video_transcript_file"):
+    if _threeplay_resource_already_linked(
+        video, "video_transcript_resources", f"{youtube_id}_transcript"
+    ):
         return
 
     pdf_url = base_url + f"&format_id={PDF_FORMAT_ID}"
@@ -62,12 +111,16 @@ def _attach_transcript_if_missing(
     if pdf_response:
         file_size = len(pdf_response.getvalue())
         pdf_file = File(pdf_response, name=f"{youtube_id}.pdf")
-        filepath = _create_new_content(pdf_file, video, file_size=file_size)
-        video.metadata["video_files"]["video_transcript_file"] = filepath
-
+        filepath, text_id = _create_new_content(pdf_file, video, file_size=file_size)
+        _append_resource_to_video_files(
+            video,
+            "video_transcript_resources",
+            "video_transcript_file",
+            text_id,
+            filepath,
+        )
         if summary:
             summary["transcripts"]["updated"] += 1
-
         write_output(
             "Transcript updated for video, %s and course %s",
             video.title,
@@ -91,7 +144,9 @@ def _attach_captions_if_missing(
     Attach captions to video if it does not exist.
     Fetches from 3Play API and updates the video metadata.
     """
-    if video.metadata["video_files"].get("video_captions_file"):
+    if _threeplay_resource_already_linked(
+        video, "video_captions_resources", f"{youtube_id}_captions"
+    ):
         return
 
     webvtt_url = base_url + f"&format_id={WEBVTT_FORMAT_ID}"
@@ -102,8 +157,14 @@ def _attach_captions_if_missing(
     if webvtt_response:
         file_size = len(webvtt_response.getvalue())
         vtt_file = File(webvtt_response, name=f"{youtube_id}.webvtt")
-        filepath = _create_new_content(vtt_file, video, file_size)
-        video.metadata["video_files"]["video_captions_file"] = filepath
+        filepath, text_id = _create_new_content(vtt_file, video, file_size)
+        _append_resource_to_video_files(
+            video,
+            "video_captions_resources",
+            "video_captions_file",
+            text_id,
+            filepath,
+        )
         if summary:
             summary["captions"]["updated"] += 1
         write_output(
@@ -198,10 +259,11 @@ def generate_metadata(
 
 def _create_new_content(
     file_content: File, video: WebsiteContent, file_size: int | None = None
-) -> str:
+) -> tuple[str, str]:
     """
     Create and save a new WebsiteContent object
     for a caption or transcript file.
+    Returns a (s3_path, text_id) tuple.
     """
     new_text_id = str(uuid4())
     new_s3_loc = upload_to_s3(file_content, video)
@@ -228,4 +290,4 @@ def _create_new_content(
     obj.file = new_s3_loc
     obj.save()
 
-    return new_s3_loc
+    return new_s3_loc, str(obj.text_id)

--- a/videos/threeplay_sync_test.py
+++ b/videos/threeplay_sync_test.py
@@ -16,7 +16,7 @@ pytestmark = pytest.mark.django_db
 
 
 def test_sync_video_captions_and_transcripts_sets_references(mocker):
-    """3Play sync should attach created caption/transcript resources as references."""
+    """3Play sync should create caption/transcript resources and set _resource fields."""
     starter = WebsiteStarterFactory.create(slug="ocw-course-v2")
     website = WebsiteFactory.create(starter=starter)
     video = WebsiteContentFactory.create(
@@ -48,7 +48,187 @@ def test_sync_video_captions_and_transcripts_sets_references(mocker):
     sync_video_captions_and_transcripts(video)
 
     video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    # _resource.content is a single-item list (array format post-10982)
+    transcript_content = vf["video_transcript_resources"]["content"]
+    captions_content = vf["video_captions_resources"]["content"]
+    assert isinstance(transcript_content, list)
+    assert len(transcript_content) == 1
+    assert isinstance(captions_content, list)
+    assert len(captions_content) == 1
+    # referenced_by tracks via file field on the created WebsiteContent objects
     assert set(video.referenced_by.values_list("file", flat=True)) == {
         f"/courses/{website.name}/yt789_transcript.pdf",
         f"/courses/{website.name}/yt789_captions.webvtt",
     }
+
+
+def test_sync_video_captions_and_transcripts_skips_if_resource_exists(mocker):
+    """3Play sync skips captions/transcripts that already have _resource content set."""
+    starter = WebsiteStarterFactory.create(slug="ocw-course-v2")
+    website = WebsiteFactory.create(starter=starter)
+    # Create actual WebsiteContent objects with the 3Play-derived filenames so the
+    # DB guard in each _attach_*_if_missing function can find them.
+    transcript_resource = WebsiteContentFactory.create(
+        website=website,
+        filename="yt789_transcript",
+    )
+    captions_resource = WebsiteContentFactory.create(
+        website=website,
+        filename="yt789_captions",
+    )
+    video = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        metadata={
+            "resourcetype": "Video",
+            "video_metadata": {"youtube_id": "yt789"},
+            "video_files": {
+                "video_captions_resources": {
+                    "content": [str(captions_resource.text_id)],
+                    "website": website.name,
+                },
+                "video_transcript_resources": {
+                    "content": [str(transcript_resource.text_id)],
+                    "website": website.name,
+                },
+            },
+        },
+    )
+
+    mocker.patch(
+        "videos.threeplay_sync.threeplay_transcript_api_request",
+        return_value={"data": [{"status": "complete", "id": 11, "media_file_id": 22}]},
+    )
+    fetch_file_mock = mocker.patch("videos.threeplay_sync.fetch_file")
+
+    sync_video_captions_and_transcripts(video)
+
+    fetch_file_mock.assert_not_called()
+
+
+def test_sync_video_captions_and_transcripts_appends_english_when_other_languages_exist(
+    mocker,
+):
+    """3Play adds English even when other-language entries already exist from GDrive."""
+    starter = WebsiteStarterFactory.create(slug="ocw-course-v2")
+    website = WebsiteFactory.create(starter=starter)
+    # Simulate GDrive having already linked French caption/transcript resources.
+    # These use filenames that don't match the 3Play pattern, so the guard won't fire.
+    fr_caption = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_captions_fr_vtt",
+    )
+    fr_transcript = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_transcript_fr_pdf",
+    )
+    fr_caption_path = f"courses/{website.name}/lecture1_captions_fr.vtt"
+    fr_transcript_path = f"courses/{website.name}/lecture1_transcript_fr.pdf"
+    video = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        metadata={
+            "resourcetype": "Video",
+            "video_metadata": {"youtube_id": "yt789"},
+            "video_files": {
+                "video_captions_resources": {
+                    "content": [str(fr_caption.text_id)],
+                    "website": website.name,
+                },
+                "video_transcript_resources": {
+                    "content": [str(fr_transcript.text_id)],
+                    "website": website.name,
+                },
+                "video_captions_file": [{"file": fr_caption_path, "language": "fr"}],
+                "video_transcript_file": [
+                    {"file": fr_transcript_path, "language": "fr"}
+                ],
+            },
+        },
+    )
+
+    mocker.patch(
+        "videos.threeplay_sync.threeplay_transcript_api_request",
+        return_value={"data": [{"status": "complete", "id": 11, "media_file_id": 22}]},
+    )
+    mocker.patch(
+        "videos.threeplay_sync.fetch_file",
+        side_effect=[BytesIO(b"pdf"), BytesIO(b"webvtt")],
+    )
+    mocker.patch(
+        "videos.threeplay_sync.upload_to_s3",
+        side_effect=[
+            f"/courses/{website.name}/yt789_transcript.pdf",
+            f"/courses/{website.name}/yt789_captions.webvtt",
+        ],
+    )
+
+    sync_video_captions_and_transcripts(video)
+
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+
+    # French entries preserved; English appended
+    transcript_content = vf["video_transcript_resources"]["content"]
+    captions_content = vf["video_captions_resources"]["content"]
+    assert str(fr_transcript.text_id) in transcript_content
+    assert str(fr_caption.text_id) in captions_content
+    assert len(transcript_content) == 2
+    assert len(captions_content) == 2
+
+    # _file lists also have both entries
+    transcript_files = vf["video_transcript_file"]
+    captions_files = vf["video_captions_file"]
+    assert len(transcript_files) == 2
+    assert len(captions_files) == 2
+    transcript_languages = {e["language"] for e in transcript_files}
+    captions_languages = {e["language"] for e in captions_files}
+    assert "en" in transcript_languages
+    assert "fr" in transcript_languages
+    assert "en" in captions_languages
+    assert "fr" in captions_languages
+
+
+def test_sync_video_captions_and_transcripts_treats_empty_content_as_unset(mocker):
+    """Empty-string _resource.content is treated as unset; 3Play fetch proceeds."""
+    starter = WebsiteStarterFactory.create(slug="ocw-course-v2")
+    website = WebsiteFactory.create(starter=starter)
+    video = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        metadata={
+            "resourcetype": "Video",
+            "video_metadata": {"youtube_id": "yt789"},
+            "video_files": {
+                # Site-config initialises relation widgets with empty content
+                "video_captions_resources": {"content": "", "website": ""},
+                "video_transcript_resources": {"content": "", "website": ""},
+            },
+        },
+    )
+
+    mocker.patch(
+        "videos.threeplay_sync.threeplay_transcript_api_request",
+        return_value={"data": [{"status": "complete", "id": 11, "media_file_id": 22}]},
+    )
+    fetch_file_mock = mocker.patch(
+        "videos.threeplay_sync.fetch_file",
+        side_effect=[BytesIO(b"pdf"), BytesIO(b"webvtt")],
+    )
+    mocker.patch(
+        "videos.threeplay_sync.upload_to_s3",
+        side_effect=[
+            f"/courses/{website.name}/yt789_transcript.pdf",
+            f"/courses/{website.name}/yt789_captions.webvtt",
+        ],
+    )
+
+    sync_video_captions_and_transcripts(video)
+
+    # Both files were fetched (empty content treated as unset)
+    assert fetch_file_mock.call_count == 2
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    assert isinstance(vf["video_transcript_resources"]["content"], list)
+    assert isinstance(vf["video_captions_resources"]["content"], list)

--- a/videos/utils.py
+++ b/videos/utils.py
@@ -273,12 +273,54 @@ def process_video_tags(video_resource, snippet, youtube, *, add_course_tag):
     return "success" if tags_changed else "skip"
 
 
+# Regex that matches ``_captions_{lang}_vtt``, ``_transcript_{lang}_pdf``,
+# or ``_captions_{lang}_{locale}_vtt`` at the end of a slugified filename.
+# GDrive files follow the pattern ``<title>_<lang>_<locale>.<ext>`` where
+# the locale is an ISO 3166-1 alpha-2 region code (e.g. ``us``, ``gb``).
+_LANG_LOCALE_RE = re.compile(
+    r"(?:_captions|_transcript)_([a-z]{2,3})_(?:([a-z]{2,3})_)?(?:vtt|webvtt|pdf)$"
+)
+
+
+def parse_caption_language_locale(filename: str) -> tuple[str, str | None]:
+    """Return ``(language_code, locale_code)`` embedded in a caption/transcript
+    filename.
+
+    The filename is expected to be the slugified ``WebsiteContent.filename``.  GDrive
+    files follow the pattern ``<title>_captions_<lang>_<locale>_vtt`` where ``<lang>``
+    is an ISO 639-1 code (e.g. ``en``, ``fr``) and ``<locale>`` is an ISO 3166-1
+    alpha-2 region code (e.g. ``us``, ``gb``).  ``locale`` is returned uppercase
+    (e.g. ``"US"``) or ``None`` when absent.
+
+    Legacy single-language filenames without a language suffix
+    (e.g. ``lecture1_captions_vtt``) return ``("en", None)``.
+    """
+    match = _LANG_LOCALE_RE.search(filename)
+    if match:
+        lang = match.group(1)
+        locale = match.group(2).upper() if match.group(2) else None
+        return lang, locale
+    return "en", None
+
+
 def resource_file_paths(resources: list) -> list:
-    """Return {file, language} dicts for caption/transcript WebsiteContent objects."""
+    """Return a list of ``{file, language[, locale]}`` dicts for caption/transcript
+    resources.
+
+    Language and optional locale are parsed from each resource's ``filename`` using
+    :func:`parse_caption_language_locale`.  Resources without a resolvable file are
+    omitted.  ``locale`` is only included in the dict when present in the filename.
+    """
     result = []
     for resource in resources:
-        file_field = getattr(resource, "file", None)
-        file_name = getattr(file_field, "name", None) if file_field else None
+        file_name = getattr(getattr(resource, "file", None), "name", None)
         if file_name:
-            result.append({"file": f"/{file_name.lstrip('/')}", "language": "en"})
+            lang, locale = parse_caption_language_locale(resource.filename or "")
+            entry: dict = {
+                "file": f"/{file_name.lstrip('/')}",
+                "language": lang,
+            }
+            if locale:
+                entry["locale"] = locale
+            result.append(entry)
     return result

--- a/videos/utils.py
+++ b/videos/utils.py
@@ -273,38 +273,12 @@ def process_video_tags(video_resource, snippet, youtube, *, add_course_tag):
     return "success" if tags_changed else "skip"
 
 
-def parse_caption_language_locale(filename: str) -> tuple[str, str | None]:
-    """
-    Extract language code and optional locale from a slugified
-    caption/transcript filename.
-
-    The slugified naming convention is:
-        {base}_{captions|transcript}[_{lang}[_{locale}]]_{ext}
-
-    The last underscore-separated segment is the file extension slug (e.g. ``vtt``,
-    ``pdf``).  Segments between the type marker and the extension are interpreted as
-    ``[lang]`` or ``[lang, locale]``.  Defaults to ``("en", None)`` when no language
-    segment is present so existing content is unaffected.
-
-    Examples::
-
-        lecture1_captions_vtt         → ("en", None)
-        lecture1_captions_en_vtt      → ("en", None)
-        lecture1_captions_fr_vtt      → ("fr", None)
-        lecture1_captions_fr_ca_vtt   → ("fr", "CA")
-        lecture1_transcript_en_pdf    → ("en", None)
-    """
-    for marker in ("_captions_", "_transcript_"):
-        idx = filename.find(marker)
-        if idx != -1:
-            suffix = filename[idx + len(marker) :]
-            parts = suffix.split("_")
-            # parts[-1] is always the extension slug; before it: [lang, locale?]
-            lang_parts = parts[:-1]
-            _LANG_AND_LOCALE = 2
-            if len(lang_parts) >= _LANG_AND_LOCALE:
-                return lang_parts[0], lang_parts[1].upper()
-            if len(lang_parts) == 1:
-                return lang_parts[0], None
-            break
-    return "en", None
+def resource_file_paths(resources: list) -> list:
+    """Return {file, language} dicts for caption/transcript WebsiteContent objects."""
+    result = []
+    for resource in resources:
+        file_field = getattr(resource, "file", None)
+        file_name = getattr(file_field, "name", None) if file_field else None
+        if file_name:
+            result.append({"file": f"/{file_name.lstrip('/')}", "language": "en"})
+    return result

--- a/videos/utils_test.py
+++ b/videos/utils_test.py
@@ -11,6 +11,7 @@ from videos.utils import (
     generate_s3_path,
     get_content_dirpath,
     get_tags_with_course,
+    parse_caption_language_locale,
     update_metadata,
 )
 from websites.factories import (
@@ -170,3 +171,35 @@ def test_get_tags_with_course_whitespace_handling():
 
     # Whitespace stripped from tags, then sorted
     assert result == "ai, django, my-course, python"
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected"),
+    [
+        # Legacy single-language convention — defaults to English, no locale
+        ("lecture1_captions_vtt", ("en", None)),
+        ("lecture1_transcript_pdf", ("en", None)),
+        # Multi-language captions — language only, no locale
+        ("lecture1_captions_es_vtt", ("es", None)),
+        ("lecture1_captions_fr_vtt", ("fr", None)),
+        ("lecture1_captions_zh_vtt", ("zh", None)),
+        ("lecture1_captions_ar_vtt", ("ar", None)),
+        # Multi-language transcripts — language only, no locale
+        ("lecture1_transcript_es_pdf", ("es", None)),
+        ("lecture1_transcript_zh_pdf", ("zh", None)),
+        # GDrive pattern: <title>_<lang>_<locale>.<ext> — locale returned uppercase
+        ("lecture1_captions_en_us_vtt", ("en", "US")),
+        ("lecture1_captions_fr_en_vtt", ("fr", "EN")),
+        ("lecture1_transcript_en_us_pdf", ("en", "US")),
+        ("lecture1_transcript_fr_gb_pdf", ("fr", "GB")),
+        # Longer filename still parsed correctly
+        ("my_long_course_lecture_03_captions_pt_vtt", ("pt", None)),
+        ("my_long_course_lecture_03_captions_pt_br_vtt", ("pt", "BR")),
+        # No recognised suffix -> defaults to English, no locale
+        ("some_random_file_pdf", ("en", None)),
+        ("lecture1_vtt", ("en", None)),
+    ],
+)
+def test_parse_caption_language_locale(filename, expected):
+    """parse_caption_language_locale returns (language, locale) from slugified filename."""
+    assert parse_caption_language_locale(filename) == expected

--- a/websites/config_schema/site-config-schema.yml
+++ b/websites/config_schema/site-config-schema.yml
@@ -55,7 +55,7 @@ field_condition:
 ---
 relation_filter:
   field: str()
-  filter_type: enum('equals', 'not_equals')
+  filter_type: enum('equals')
   value: any()
 ---
 level:

--- a/websites/config_schema/site-config-schema.yml
+++ b/websites/config_schema/site-config-schema.yml
@@ -55,7 +55,7 @@ field_condition:
 ---
 relation_filter:
   field: str()
-  filter_type: enum('equals')
+  filter_type: enum('equals', 'not_equals')
   value: any()
 ---
 level:

--- a/websites/deletion_utils.py
+++ b/websites/deletion_utils.py
@@ -44,7 +44,7 @@ def delete_resource(content: WebsiteContent):
 def delete_related_captions_and_transcript(content: WebsiteContent):
     """Delete related captions and transcript resources for a video."""
     video_files = content.metadata.get("video_files", {})
-    for resource_field in ("video_captions_resource", "video_transcript_resource"):
+    for resource_field in ("video_captions_resources", "video_transcript_resources"):
         relation = video_files.get(resource_field)
         if not isinstance(relation, dict):
             continue

--- a/websites/deletion_utils_test.py
+++ b/websites/deletion_utils_test.py
@@ -41,11 +41,11 @@ def test_delete_pre_existing_video(mocker):
     video_metadata = {
         "resourcetype": RESOURCE_TYPE_VIDEO,
         "video_files": {
-            "video_captions_resource": {
+            "video_captions_resources": {
                 "content": [str(caption.text_id)],
                 "website": website.name,
             },
-            "video_transcript_resource": {
+            "video_transcript_resources": {
                 "content": [str(transcript.text_id)],
                 "website": website.name,
             },
@@ -106,11 +106,11 @@ def test_delete_video_with_drive_files_comprehensive(mocker):
     video_metadata = {
         "resourcetype": RESOURCE_TYPE_VIDEO,
         "video_files": {
-            "video_captions_resource": {
+            "video_captions_resources": {
                 "content": [str(caption.text_id)],
                 "website": website.name,
             },
-            "video_transcript_resource": {
+            "video_transcript_resources": {
                 "content": [str(transcript.text_id)],
                 "website": website.name,
             },
@@ -213,11 +213,11 @@ def test_delete_video_mixed_scenario(mocker):
     video_metadata = {
         "resourcetype": RESOURCE_TYPE_VIDEO,
         "video_files": {
-            "video_captions_resource": {
+            "video_captions_resources": {
                 "content": [str(caption.text_id)],
                 "website": website.name,
             },
-            "video_transcript_resource": {
+            "video_transcript_resources": {
                 "content": [str(transcript.text_id)],
                 "website": website.name,
             },

--- a/websites/management/commands/backpopulate_referencing_content_test.py
+++ b/websites/management/commands/backpopulate_referencing_content_test.py
@@ -921,8 +921,8 @@ def test_video_resource_captions_and_transcript_references_detected():
         metadata={
             "resourcetype": "Video",
             "video_files": {
-                "video_captions_resource": {"content": captions_resource.text_id},
-                "video_transcript_resource": {"content": transcript_resource.text_id},
+                "video_captions_resources": {"content": captions_resource.text_id},
+                "video_transcript_resources": {"content": transcript_resource.text_id},
             },
         },
     )
@@ -951,7 +951,7 @@ def test_video_resource_captions_only_reference_detected():
         metadata={
             "resourcetype": "Video",
             "video_files": {
-                "video_captions_resource": {"content": captions_resource.text_id},
+                "video_captions_resources": {"content": captions_resource.text_id},
             },
         },
     )

--- a/websites/migration_0075_test.py
+++ b/websites/migration_0075_test.py
@@ -1,0 +1,120 @@
+"""Tests for website migration 0075 — convert scalar _resource to list and rename to plural."""
+
+import importlib
+
+import pytest
+from django.apps import apps
+
+from websites.factories import WebsiteContentFactory, WebsiteFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def migration_module():
+    """Import the migration module (names with leading digits need importlib)."""
+    return importlib.import_module(
+        "websites.migrations.0075_remove_video_file_path_fields"
+    )
+
+
+def test_migration_0075_converts_scalar_and_renames_to_plural(migration_module):
+    """Scalar _resource content is converted to list and field is renamed to _resources."""
+    website = WebsiteFactory.create()
+    content = WebsiteContentFactory.create(
+        website=website,
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_resource": {
+                    "content": "caption-uuid-123",
+                    "website": website.name,
+                },
+                "video_transcript_resource": {
+                    "content": "transcript-uuid-456",
+                    "website": website.name,
+                },
+            },
+        },
+    )
+
+    migration_module._convert_and_rename(apps, None)  # noqa: SLF001
+
+    content.refresh_from_db()
+    vf = content.metadata["video_files"]
+
+    # Old singular fields removed
+    assert "video_captions_resource" not in vf
+    assert "video_transcript_resource" not in vf
+
+    # New plural fields with list content
+    assert vf["video_captions_resources"]["content"] == ["caption-uuid-123"]
+    assert vf["video_captions_resources"]["website"] == website.name
+    assert vf["video_transcript_resources"]["content"] == ["transcript-uuid-456"]
+    assert vf["video_transcript_resources"]["website"] == website.name
+
+
+def test_migration_0075_renames_already_list_fields(migration_module):
+    """Fields already in list format are renamed without content modification."""
+    website = WebsiteFactory.create()
+    content = WebsiteContentFactory.create(
+        website=website,
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_resource": {
+                    "content": ["uuid-1", "uuid-2"],
+                    "website": website.name,
+                },
+            },
+        },
+    )
+
+    migration_module._convert_and_rename(apps, None)  # noqa: SLF001
+
+    content.refresh_from_db()
+    vf = content.metadata["video_files"]
+
+    assert "video_captions_resource" not in vf
+    assert vf["video_captions_resources"]["content"] == ["uuid-1", "uuid-2"]
+
+
+def test_migration_0075_reverse_renames_to_singular_and_converts_to_scalar(
+    migration_module,
+):
+    """Reverse migration renames _resources back to _resource and collapses list to scalar."""
+    website = WebsiteFactory.create()
+    content = WebsiteContentFactory.create(
+        website=website,
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_resources": {
+                    "content": ["uuid-1", "uuid-2"],
+                    "website": website.name,
+                },
+                "video_transcript_resources": {
+                    "content": ["uuid-3"],
+                    "website": website.name,
+                },
+            },
+        },
+    )
+
+    migration_module._reverse_rename_and_convert(apps, None)  # noqa: SLF001
+
+    content.refresh_from_db()
+    vf = content.metadata["video_files"]
+
+    assert "video_captions_resources" not in vf
+    assert "video_transcript_resources" not in vf
+    # First element only
+    assert vf["video_captions_resource"]["content"] == "uuid-1"
+    assert vf["video_transcript_resource"]["content"] == "uuid-3"
+
+
+def test_migration_0075_skips_content_without_video_files(migration_module):
+    """Content without video_files metadata is silently skipped."""
+    WebsiteContentFactory.create(metadata={"resourcetype": "Page"})
+    # Should not raise
+    migration_module._convert_and_rename(apps, None)  # noqa: SLF001

--- a/websites/migrations/0075_remove_video_file_path_fields.py
+++ b/websites/migrations/0075_remove_video_file_path_fields.py
@@ -1,0 +1,112 @@
+"""
+Data migration: convert scalar video_captions_resource and video_transcript_resource
+metadata values from single-select to multi-select format, then rename them to
+video_captions_resources and video_transcript_resources (plural) to reflect that they
+now hold multiple values.
+
+Old (single-select) format written by migration 0074:
+  video_files.video_captions_resource   = {"content": "<text_id>", "website": "<name>"}
+  video_files.video_transcript_resource = {"content": "<text_id>", "website": "<name>"}
+
+New (multi-select, renamed) format:
+  video_files.video_captions_resources  = {"content": ["<text_id>"], "website": "<name>"}
+  video_files.video_transcript_resources = {"content": ["<text_id>"], "website": "<name>"}
+
+Records already in list format (content is already a list) are renamed without conversion.
+
+The reverse migration converts lists back to scalars (first element) and renames back
+to the singular form. Multi-language content is reduced to its first entry.
+"""
+
+from django.db import migrations
+
+
+_OLD_FIELDS = ("video_captions_resource", "video_transcript_resource")
+_NEW_FIELDS = ("video_captions_resources", "video_transcript_resources")
+
+
+def _convert_and_rename(apps, schema_editor):
+    """Convert scalar _resource content to lists and rename fields to plural form."""
+    WebsiteContent = apps.get_model("websites", "WebsiteContent")
+    Website = apps.get_model("websites", "Website")
+
+    updated_website_ids = set()
+
+    for content in (
+        WebsiteContent.objects.filter(metadata__video_files__isnull=False)
+        .only("id", "metadata", "website_id")
+        .iterator()
+    ):
+        video_files = content.metadata.get("video_files")
+        if not isinstance(video_files, dict):
+            continue
+
+        changed = False
+
+        for old_field, new_field in zip(_OLD_FIELDS, _NEW_FIELDS):
+            value = video_files.get(old_field)
+            if value is None:
+                continue
+            if isinstance(value, dict):
+                content_val = value.get("content")
+                if isinstance(content_val, str) and content_val:
+                    value["content"] = [content_val]
+            # Rename: move to plural field, remove old key
+            video_files[new_field] = value
+            del video_files[old_field]
+            changed = True
+
+        if changed:
+            content.save(update_fields=["metadata"])
+            updated_website_ids.add(content.website_id)
+
+    if updated_website_ids:
+        Website.objects.filter(pk__in=updated_website_ids).update(
+            has_unpublished_draft=True,
+            has_unpublished_live=True,
+        )
+
+
+def _reverse_rename_and_convert(apps, schema_editor):
+    """Reverse: rename _resources back to _resource and convert lists to scalars."""
+    WebsiteContent = apps.get_model("websites", "WebsiteContent")
+
+    for content in (
+        WebsiteContent.objects.filter(metadata__video_files__isnull=False)
+        .only("id", "metadata")
+        .iterator()
+    ):
+        video_files = content.metadata.get("video_files")
+        if not isinstance(video_files, dict):
+            continue
+
+        changed = False
+
+        for old_field, new_field in zip(_OLD_FIELDS, _NEW_FIELDS):
+            value = video_files.get(new_field)
+            if value is None:
+                continue
+            if isinstance(value, dict):
+                content_val = value.get("content")
+                if isinstance(content_val, list) and content_val:
+                    value["content"] = content_val[0]
+            # Rename back: move to singular field, remove plural key
+            video_files[old_field] = value
+            del video_files[new_field]
+            changed = True
+
+        if changed:
+            content.save(update_fields=["metadata"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("websites", "0074_video_caption_transcript_files_to_resources"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            _convert_and_rename,
+            reverse_code=_reverse_rename_and_convert,
+        ),
+    ]

--- a/websites/models.py
+++ b/websites/models.py
@@ -26,7 +26,12 @@ from safedelete.models import SafeDeleteModel
 from safedelete.queryset import SafeDeleteQueryset
 
 from content_sync.constants import VERSION_LIVE
-from main.settings import YT_FIELD_CAPTIONS, YT_FIELD_TRANSCRIPT
+from main.settings import (
+    YT_FIELD_CAPTIONS,
+    YT_FIELD_CAPTIONS_RESOURCE,
+    YT_FIELD_TRANSCRIPT,
+    YT_FIELD_TRANSCRIPT_RESOURCE,
+)
 from main.utils import uuid_string
 from users.models import User
 from websites import constants
@@ -412,7 +417,7 @@ class WebsiteContent(TimestampedModel, SafeDeleteModel):
         ).hexdigest()
 
     @property
-    def full_metadata(self) -> dict:
+    def full_metadata(self) -> dict:  # noqa: C901, PLR0912
         """Return the metadata field with file upload included"""
         file_field = self.get_config_file_field()
         s3_path = self.website.s3_path
@@ -430,31 +435,67 @@ class WebsiteContent(TimestampedModel, SafeDeleteModel):
             else:
                 full_metadata[file_field["name"]] = None
             modified = True
-        # Update video transcript/caption paths if they exist
+        if full_metadata:
+            # Resolve _resources relation fields to [{file, language}] for Hugo.
+            # video_captions_resources and video_transcript_resources are stored as
+            # {"content": [text_id, ...], "website": name} in the DB but Hugo needs
+            # resolved file paths.  Resolution happens at git-sync time here.
+            from videos.utils import (  # noqa: PLC0415
+                resource_file_paths,
+            )
+
+            for resource_field in (
+                YT_FIELD_CAPTIONS_RESOURCE,
+                YT_FIELD_TRANSCRIPT_RESOURCE,
+            ):
+                resource_data = get_dict_field(full_metadata, resource_field)
+                if not resource_data or not isinstance(resource_data, dict):
+                    continue
+                text_ids = resource_data.get("content", [])
+                if not text_ids:
+                    continue
+                # self.__class__ is WebsiteContent — no circular import needed
+                related_contents = list(
+                    self.__class__.objects.filter(
+                        website=self.website,
+                        text_id__in=text_ids,
+                    )
+                )
+                resolved = resource_file_paths(related_contents)
+                # Apply URL path substitution if s3 and url paths differ
+                if resolved and url_path and s3_path != url_path:
+                    resolved = [
+                        {**entry, "file": entry["file"].replace(s3_path, url_path, 1)}
+                        for entry in resolved
+                    ]
+                if resolved:
+                    set_dict_field(full_metadata, resource_field, resolved)
+                    modified = True
+
+        # Update video transcript/caption paths in _file fields if they exist.
+        # Handles both the legacy scalar string format and the new
+        # multi-language array-of-objects format.
         if full_metadata:
             for field in (YT_FIELD_TRANSCRIPT, YT_FIELD_CAPTIONS):
                 value = get_dict_field(full_metadata, field)
                 if not value or not url_path:
                     continue
-                if isinstance(value, list):
-                    set_dict_field(
-                        full_metadata,
-                        field,
-                        [
-                            {
-                                **entry,
-                                "file": entry["file"].replace(s3_path, url_path, 1),
-                            }
-                            if isinstance(entry, dict) and entry.get("file")
-                            else entry
-                            for entry in value
-                        ],
-                    )
-                elif isinstance(value, str):
+                if isinstance(value, str):
+                    # Legacy scalar — a single URL path string.
                     set_dict_field(
                         full_metadata, field, value.replace(s3_path, url_path, 1)
                     )
-                modified = True
+                    modified = True
+                elif isinstance(value, list):
+                    # Multi-language format — list of {"file": ..., "language": ...}.
+                    updated = [
+                        {**entry, "file": entry["file"].replace(s3_path, url_path, 1)}
+                        if isinstance(entry, dict) and entry.get("file")
+                        else entry
+                        for entry in value
+                    ]
+                    set_dict_field(full_metadata, field, updated)
+                    modified = True
         return full_metadata if modified else self.metadata
 
     def get_config_file_field(self) -> dict:

--- a/websites/models.py
+++ b/websites/models.py
@@ -28,9 +28,9 @@ from safedelete.queryset import SafeDeleteQueryset
 from content_sync.constants import VERSION_LIVE
 from main.settings import (
     YT_FIELD_CAPTIONS,
-    YT_FIELD_CAPTIONS_RESOURCE,
+    YT_FIELD_CAPTIONS_RESOURCES,
     YT_FIELD_TRANSCRIPT,
-    YT_FIELD_TRANSCRIPT_RESOURCE,
+    YT_FIELD_TRANSCRIPT_RESOURCES,
 )
 from main.utils import uuid_string
 from users.models import User
@@ -445,8 +445,8 @@ class WebsiteContent(TimestampedModel, SafeDeleteModel):
             )
 
             for resource_field in (
-                YT_FIELD_CAPTIONS_RESOURCE,
-                YT_FIELD_TRANSCRIPT_RESOURCE,
+                YT_FIELD_CAPTIONS_RESOURCES,
+                YT_FIELD_TRANSCRIPT_RESOURCES,
             ):
                 resource_data = get_dict_field(full_metadata, resource_field)
                 if not resource_data or not isinstance(resource_data, dict):

--- a/websites/models_test.py
+++ b/websites/models_test.py
@@ -611,11 +611,13 @@ def test_websitecontent_full_metadata_resolves_resources_relation():
     assert isinstance(resolved, list)
     assert len(resolved) == 2
     # s3_path ("sites/mysite") must be replaced by url_path ("sites/mysite-fall-2008")
+    # parse_caption_language_locale extracts "en" for the legacy no-suffix filename
     assert {
         "file": "/sites/mysite-fall-2008/lecture1_captions.vtt",
         "language": "en",
     } in resolved
+    # and "es" for the _es suffix — language detection added in this branch
     assert {
         "file": "/sites/mysite-fall-2008/lecture1_captions_es.vtt",
-        "language": "en",
+        "language": "es",
     } in resolved

--- a/websites/models_test.py
+++ b/websites/models_test.py
@@ -617,5 +617,5 @@ def test_websitecontent_full_metadata_resolves_resources_relation():
     } in resolved
     assert {
         "file": "/sites/mysite-fall-2008/lecture1_captions_es.vtt",
-        "language": "es",
+        "language": "en",
     } in resolved

--- a/websites/models_test.py
+++ b/websites/models_test.py
@@ -476,3 +476,146 @@ def test_website_collaborators_with_missing_groups():
     collaborators = website.collaborators
     assert len(collaborators) == 1
     assert owner in collaborators
+
+
+@pytest.mark.django_db
+def test_websitecontent_full_metadata_array_captions():
+    """full_metadata applies s3_path->url_path substitution on multi-language array _file values."""
+    content = WebsiteContentFactory.build(
+        type="resource",
+        metadata={
+            "video_files": {
+                "video_captions_file": [
+                    {"file": "/sites/mysite/lecture1_captions.vtt", "language": "en"},
+                    {
+                        "file": "/sites/mysite/lecture1_captions_es.vtt",
+                        "language": "es",
+                    },
+                ],
+                "video_transcript_file": [
+                    {
+                        "file": "/sites/mysite/lecture1_transcript.pdf",
+                        "language": "en",
+                    },
+                ],
+            }
+        },
+        file=None,
+        website=WebsiteFactory(
+            starter=WebsiteStarterFactory.create(
+                config={
+                    "content-dir": "content",
+                    "root-url-path": "sites",
+                    "collections": [
+                        {
+                            "name": "resource",
+                            "label": "Resource",
+                            "category": "Content",
+                            "folder": "content/resource",
+                            "fields": [
+                                {"label": "Title", "name": "title", "widget": "string"}
+                            ],
+                        }
+                    ],
+                }
+            ),
+            url_path="sites/mysite-fall-2008",
+            name="mysite",
+        ),
+    )
+
+    full = content.full_metadata
+
+    captions = full["video_files"]["video_captions_file"]
+    assert isinstance(captions, list)
+    assert len(captions) == 2
+    assert captions[0] == {
+        "file": "/sites/mysite-fall-2008/lecture1_captions.vtt",
+        "language": "en",
+    }
+    assert captions[1] == {
+        "file": "/sites/mysite-fall-2008/lecture1_captions_es.vtt",
+        "language": "es",
+    }
+
+    transcripts = full["video_files"]["video_transcript_file"]
+    assert isinstance(transcripts, list)
+    assert len(transcripts) == 1
+    assert transcripts[0] == {
+        "file": "/sites/mysite-fall-2008/lecture1_transcript.pdf",
+        "language": "en",
+    }
+
+
+def test_websitecontent_full_metadata_resolves_resources_relation():
+    """full_metadata resolves video_captions_resources/_resources dicts to [{file, language}] arrays.
+
+    The _resources relation field (stored as {"content": [text_id, ...], "website": name})
+    must be resolved at git-sync time by full_metadata() into a list of {file, language}
+    dicts, with s3_path replaced by url_path in each file path.
+    """
+    website = WebsiteFactory.create(
+        starter=WebsiteStarterFactory.create(
+            config={
+                "content-dir": "content",
+                "root-url-path": "sites",
+                "collections": [
+                    {
+                        "name": "resource",
+                        "label": "Resource",
+                        "category": "Content",
+                        "folder": "content/resource",
+                        "fields": [
+                            {"label": "Title", "name": "title", "widget": "string"}
+                        ],
+                    }
+                ],
+            }
+        ),
+        url_path="sites/mysite-fall-2008",
+        name="mysite",
+    )
+
+    # Create two caption resources — English (legacy no-lang suffix) and Spanish
+    captions_en = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_captions_vtt",
+        file="sites/mysite/lecture1_captions.vtt",
+        type="resource",
+    )
+    captions_es = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_captions_es_vtt",
+        file="sites/mysite/lecture1_captions_es.vtt",
+        type="resource",
+    )
+
+    video = WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        metadata={
+            "video_files": {
+                "video_captions_resources": {
+                    "content": [str(captions_en.text_id), str(captions_es.text_id)],
+                    "website": website.name,
+                },
+            }
+        },
+        file=None,
+    )
+
+    full = video.full_metadata
+
+    # _resources dict must be replaced by the resolved [{file, language}] list
+    resolved = full["video_files"]["video_captions_resources"]
+    assert isinstance(resolved, list)
+    assert len(resolved) == 2
+    # s3_path ("sites/mysite") must be replaced by url_path ("sites/mysite-fall-2008")
+    assert {
+        "file": "/sites/mysite-fall-2008/lecture1_captions.vtt",
+        "language": "en",
+    } in resolved
+    assert {
+        "file": "/sites/mysite-fall-2008/lecture1_captions_es.vtt",
+        "language": "es",
+    } in resolved

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -24,6 +24,7 @@ from gdrive_sync.tasks import create_gdrive_folders
 from main.posthog import is_feature_enabled
 from main.serializers import RequestUserSerializerMixin
 from users.models import User
+from videos.utils import resource_file_paths
 from websites import constants
 from websites.api import (
     detect_mime_type,
@@ -86,11 +87,7 @@ def sync_video_relation_urls(metadata: dict) -> None:
             if content_ids
             else []
         )
-        file_entries = [
-            {"file": f"/{r.file.name.lstrip('/')}", "language": "en"}
-            for r in resources
-            if getattr(r, "file", None) and r.file.name
-        ]
+        file_entries = resource_file_paths(resources)
         set_dict_field(metadata, target_field, file_entries or None)
 
 
@@ -762,6 +759,9 @@ class WebsiteContentCreateSerializer(
             validated_data["metadata"]["file_type"] = detect_mime_type(
                 validated_data["file"]
             )
+
+        if validated_data.get("metadata"):
+            sync_video_relation_urls(validated_data["metadata"])
 
         instance = super().create(
             {

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -54,8 +54,8 @@ ROLE_ERROR_MESSAGES = {"invalid_choice": "Invalid role", "required": "Role is re
 
 
 RELATION_URL_FIELDS = (
-    (settings.YT_FIELD_CAPTIONS_RESOURCE, settings.YT_FIELD_CAPTIONS),
-    (settings.YT_FIELD_TRANSCRIPT_RESOURCE, settings.YT_FIELD_TRANSCRIPT),
+    (settings.YT_FIELD_CAPTIONS_RESOURCES, settings.YT_FIELD_CAPTIONS),
+    (settings.YT_FIELD_TRANSCRIPT_RESOURCES, settings.YT_FIELD_TRANSCRIPT),
 )
 
 

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -1066,3 +1066,87 @@ def test_website_content_detail_serializer_syncs_video_relation_files_partial(
             get_dict_field(video.metadata, settings.YT_FIELD_CAPTIONS)
             == "/old/captions.vtt"
         )
+
+
+@pytest.mark.django_db
+def test_website_content_detail_serializer_syncs_video_relation_files_multi_language(
+    mocker, mocked_website_funcs
+):
+    """Updating video with multiple language resources stores list of {file, language}."""
+    mocker.patch("websites.serializers.update_youtube_thumbnail")
+    video_metadata = {
+        settings.FIELD_RESOURCETYPE: RESOURCE_TYPE_VIDEO,
+        "video_files": {},
+    }
+    set_dict_field(video_metadata, settings.YT_FIELD_CAPTIONS, [])
+    set_dict_field(video_metadata, settings.YT_FIELD_TRANSCRIPT, [])
+
+    video = WebsiteContentFactory.create(
+        type=CONTENT_TYPE_RESOURCE,
+        metadata=video_metadata,
+    )
+
+    caption_en = WebsiteContentFactory.create(
+        type=CONTENT_TYPE_RESOURCE,
+        is_page_content=True,
+        filename="lecture1_captions_vtt",
+        website=video.website,
+    )
+    caption_en.file = SimpleUploadedFile("lecture1_captions.vtt", b"en captions")
+    caption_en.save()
+
+    caption_es = WebsiteContentFactory.create(
+        type=CONTENT_TYPE_RESOURCE,
+        is_page_content=True,
+        filename="lecture1_captions_es_vtt",
+        website=video.website,
+    )
+    caption_es.file = SimpleUploadedFile("lecture1_captions_es.vtt", b"es captions")
+    caption_es.save()
+
+    transcript_en = WebsiteContentFactory.create(
+        type=CONTENT_TYPE_RESOURCE,
+        is_page_content=True,
+        filename="lecture1_transcript_pdf",
+        website=video.website,
+    )
+    transcript_en.file = SimpleUploadedFile("lecture1_transcript.pdf", b"en transcript")
+    transcript_en.save()
+
+    metadata_patch = {"video_files": {}}
+    set_dict_field(
+        metadata_patch,
+        settings.YT_FIELD_CAPTIONS_RESOURCE,
+        {
+            "content": [str(caption_en.text_id), str(caption_es.text_id)],
+            "website": video.website.name,
+        },
+    )
+    set_dict_field(
+        metadata_patch,
+        settings.YT_FIELD_TRANSCRIPT_RESOURCE,
+        {"content": [str(transcript_en.text_id)], "website": video.website.name},
+    )
+
+    serializer = WebsiteContentDetailSerializer(
+        instance=video,
+        data={"metadata": metadata_patch},
+        partial=True,
+        context={"request": mocker.Mock(user=UserFactory.create())},
+    )
+    serializer.is_valid(raise_exception=True)
+    serializer.save()
+    video.refresh_from_db()
+
+    captions_result = get_dict_field(video.metadata, settings.YT_FIELD_CAPTIONS)
+    assert isinstance(captions_result, list)
+    assert len(captions_result) == 2
+    # Language detection is not asserted here; all entries default to "en".
+    files = {entry["file"] for entry in captions_result}
+    assert f"/{caption_en.file.name.lstrip('/')}" in files
+    assert f"/{caption_es.file.name.lstrip('/')}" in files
+
+    transcript_result = get_dict_field(video.metadata, settings.YT_FIELD_TRANSCRIPT)
+    assert isinstance(transcript_result, list)
+    assert len(transcript_result) == 1
+    assert transcript_result[0]["file"] == f"/{transcript_en.file.name.lstrip('/')}"

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -968,12 +968,12 @@ def test_website_content_detail_serializer_syncs_video_relation_files(
     metadata_patch = {"video_files": {}}
     set_dict_field(
         metadata_patch,
-        settings.YT_FIELD_CAPTIONS_RESOURCE,
+        settings.YT_FIELD_CAPTIONS_RESOURCES,
         {"content": str(caption.text_id)},
     )
     set_dict_field(
         metadata_patch,
-        settings.YT_FIELD_TRANSCRIPT_RESOURCE,
+        settings.YT_FIELD_TRANSCRIPT_RESOURCES,
         {"content": str(transcript.text_id)},
     )
 
@@ -1028,9 +1028,9 @@ def test_website_content_detail_serializer_syncs_video_relation_files_partial(
     metadata_patch = {"video_files": video.metadata["video_files"].copy()}
 
     relation_field = (
-        settings.YT_FIELD_CAPTIONS_RESOURCE
+        settings.YT_FIELD_CAPTIONS_RESOURCES
         if update_field == "captions"
-        else settings.YT_FIELD_TRANSCRIPT_RESOURCE
+        else settings.YT_FIELD_TRANSCRIPT_RESOURCES
     )
     set_dict_field(
         metadata_patch,
@@ -1116,7 +1116,7 @@ def test_website_content_detail_serializer_syncs_video_relation_files_multi_lang
     metadata_patch = {"video_files": {}}
     set_dict_field(
         metadata_patch,
-        settings.YT_FIELD_CAPTIONS_RESOURCE,
+        settings.YT_FIELD_CAPTIONS_RESOURCES,
         {
             "content": [str(caption_en.text_id), str(caption_es.text_id)],
             "website": video.website.name,
@@ -1124,7 +1124,7 @@ def test_website_content_detail_serializer_syncs_video_relation_files_multi_lang
     )
     set_dict_field(
         metadata_patch,
-        settings.YT_FIELD_TRANSCRIPT_RESOURCE,
+        settings.YT_FIELD_TRANSCRIPT_RESOURCES,
         {"content": [str(transcript_en.text_id)], "website": video.website.name},
     )
 

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -1141,7 +1141,9 @@ def test_website_content_detail_serializer_syncs_video_relation_files_multi_lang
     captions_result = get_dict_field(video.metadata, settings.YT_FIELD_CAPTIONS)
     assert isinstance(captions_result, list)
     assert len(captions_result) == 2
-    # Language detection is not asserted here; all entries default to "en".
+    # Language detection via parse_caption_language: en (no suffix) and es
+    languages = {entry["language"] for entry in captions_result}
+    assert languages == {"en", "es"}
     files = {entry["file"] for entry in captions_result}
     assert f"/{caption_en.file.name.lstrip('/')}" in files
     assert f"/{caption_es.file.name.lstrip('/')}" in files
@@ -1149,4 +1151,77 @@ def test_website_content_detail_serializer_syncs_video_relation_files_multi_lang
     transcript_result = get_dict_field(video.metadata, settings.YT_FIELD_TRANSCRIPT)
     assert isinstance(transcript_result, list)
     assert len(transcript_result) == 1
+    assert transcript_result[0]["language"] == "en"
     assert transcript_result[0]["file"] == f"/{transcript_en.file.name.lstrip('/')}"
+
+
+@pytest.mark.django_db
+def test_website_content_detail_serializer_syncs_video_relation_files_with_locale(
+    mocker, mocked_website_funcs
+):
+    """Caption resources with locale suffix in filename produce {file, language, locale} entries."""
+    mocker.patch("websites.serializers.update_youtube_thumbnail")
+    video_metadata = {
+        settings.FIELD_RESOURCETYPE: RESOURCE_TYPE_VIDEO,
+        "video_files": {},
+    }
+    set_dict_field(video_metadata, settings.YT_FIELD_CAPTIONS, [])
+    video = WebsiteContentFactory.create(
+        type=CONTENT_TYPE_RESOURCE,
+        metadata=video_metadata,
+    )
+
+    # English (US locale) — filename carries locale suffix
+    caption_en_us = WebsiteContentFactory.create(
+        type=CONTENT_TYPE_RESOURCE,
+        is_page_content=True,
+        filename="lecture1_captions_en_us_vtt",
+        website=video.website,
+    )
+    caption_en_us.file = SimpleUploadedFile(
+        "lecture1_captions_en_us.vtt", b"en-US captions"
+    )
+    caption_en_us.save()
+
+    # French — no locale
+    caption_fr = WebsiteContentFactory.create(
+        type=CONTENT_TYPE_RESOURCE,
+        is_page_content=True,
+        filename="lecture1_captions_fr_vtt",
+        website=video.website,
+    )
+    caption_fr.file = SimpleUploadedFile("lecture1_captions_fr.vtt", b"fr captions")
+    caption_fr.save()
+
+    metadata_patch = {"video_files": {}}
+    set_dict_field(
+        metadata_patch,
+        settings.YT_FIELD_CAPTIONS_RESOURCES,
+        {
+            "content": [str(caption_en_us.text_id), str(caption_fr.text_id)],
+            "website": video.website.name,
+        },
+    )
+
+    serializer = WebsiteContentDetailSerializer(
+        instance=video,
+        data={"metadata": metadata_patch},
+        partial=True,
+        context={"request": mocker.Mock(user=UserFactory.create())},
+    )
+    serializer.is_valid(raise_exception=True)
+    serializer.save()
+    video.refresh_from_db()
+
+    captions_result = get_dict_field(video.metadata, settings.YT_FIELD_CAPTIONS)
+    assert isinstance(captions_result, list)
+    assert len(captions_result) == 2
+
+    by_file = {entry["file"]: entry for entry in captions_result}
+    en_us_key = f"/{caption_en_us.file.name.lstrip('/')}"
+    fr_key = f"/{caption_fr.file.name.lstrip('/')}"
+
+    assert by_file[en_us_key]["language"] == "en"
+    assert by_file[en_us_key]["locale"] == "US"
+    assert by_file[fr_key]["language"] == "fr"
+    assert "locale" not in by_file[fr_key]

--- a/websites/site_config_api_test.py
+++ b/websites/site_config_api_test.py
@@ -185,6 +185,8 @@ def test_generate_item_metadata(  # pylint: disable=too-many-arguments  # noqa: 
         "video_metadata": {"youtube_id": "", "video_speakers": "", "video_tags": ""},
         "video_files": {
             "video_thumbnail_file": "",
+            "video_captions_resources": [],
+            "video_transcript_resources": [],
         },
         **class_data,
     }

--- a/websites/utils.py
+++ b/websites/utils.py
@@ -148,8 +148,8 @@ def get_metadata_content_key(content) -> list:
             content_keys = [
                 constants.METADATA_FIELD_IMAGE_CAPTION,
                 constants.METADATA_FIELD_IMAGE_CREDIT,
-                settings.YT_FIELD_CAPTIONS_RESOURCE + ".content",
-                settings.YT_FIELD_TRANSCRIPT_RESOURCE + ".content",
+                settings.YT_FIELD_CAPTIONS_RESOURCES + ".content",
+                settings.YT_FIELD_TRANSCRIPT_RESOURCES + ".content",
             ]
         case constants.CONTENT_TYPE_COURSE_COLLECTION:
             content_keys = [

--- a/websites/utils.py
+++ b/websites/utils.py
@@ -310,7 +310,11 @@ def resolve_course_list_referenced_content_ids(content) -> set[int]:
 
 
 def resolve_video_file_referenced_content_ids(content) -> set[int]:
-    """Resolve video_captions_file/video_transcript_file paths to WebsiteContent ids."""
+    """Resolve video_captions_file/video_transcript_file paths to WebsiteContent ids.
+
+    Handles both the legacy scalar string format and the new multi-language
+    array-of-objects format (``[{"file": "/path/...", "language": "en"}, ...]``).
+    """
     WebsiteContent = apps.get_model("websites", "WebsiteContent")
     referenced_ids = set()
 
@@ -318,17 +322,20 @@ def resolve_video_file_referenced_content_ids(content) -> set[int]:
         value = get_dict_field(content.metadata, field_path)
         if not value:
             continue
-        # New array format: [{"file": "...", "language": "en"}]
-        if isinstance(value, list):
+
+        if isinstance(value, str):
+            # Legacy scalar format — a single URL path string.
+            keys = [value]
+        elif isinstance(value, list):
+            # Multi-language format — list of {"file": ..., "language": ...}.
             keys = [
                 entry["file"]
                 for entry in value
                 if isinstance(entry, dict) and entry.get("file")
             ]
-        elif isinstance(value, str):
-            keys = [value]
         else:
             continue
+
         for key in keys:
             base_name = Path(key).stem
             related_ids = (

--- a/websites/utils_test.py
+++ b/websites/utils_test.py
@@ -903,8 +903,8 @@ def test_get_metadata_content_key():
     assert get_metadata_content_key(content_resource) == [
         constants.METADATA_FIELD_IMAGE_CAPTION,
         constants.METADATA_FIELD_IMAGE_CREDIT,
-        settings.YT_FIELD_CAPTIONS_RESOURCE + ".content",
-        settings.YT_FIELD_TRANSCRIPT_RESOURCE + ".content",
+        settings.YT_FIELD_CAPTIONS_RESOURCES + ".content",
+        settings.YT_FIELD_TRANSCRIPT_RESOURCES + ".content",
     ]
 
     # Test unknown/unsupported type

--- a/websites/utils_test.py
+++ b/websites/utils_test.py
@@ -786,8 +786,8 @@ def test_compile_referencing_content_resource_captions_and_transcript():
         metadata={
             "resourcetype": "Video",
             "video_files": {
-                "video_captions_resource": {"content": captions_uuid},
-                "video_transcript_resource": {"content": transcript_uuid},
+                "video_captions_resources": {"content": captions_uuid},
+                "video_transcript_resources": {"content": transcript_uuid},
             },
         },
     )
@@ -806,7 +806,7 @@ def test_compile_referencing_content_resource_captions_only():
         metadata={
             "resourcetype": "Video",
             "video_files": {
-                "video_captions_resource": {"content": captions_uuid},
+                "video_captions_resources": {"content": captions_uuid},
             },
         },
     )
@@ -1275,11 +1275,67 @@ def test_resolve_referenced_content_ids_video_file_empty_strings():
             "video_files": {
                 "video_captions_file": "",
                 "video_transcript_file": "",
-                "video_captions_resource": "",
-                "video_transcript_resource": "",
+                "video_captions_resources": "",
+                "video_transcript_resources": "",
             },
         },
     )
 
     result = resolve_referenced_content_ids(video_resource)
     assert result == set()
+
+
+@pytest.mark.django_db
+def test_resolve_referenced_content_ids_video_file_paths_array_format():
+    """resolve_referenced_content_ids resolves multi-language array-of-objects _file format."""
+    website = WebsiteFactory.create()
+
+    captions_en = WebsiteContentFactory.create(
+        website=website,
+        type=constants.CONTENT_TYPE_RESOURCE,
+        filename="lecture1_captions_vtt",
+        file=f"courses/{website.name}/lecture1_captions.vtt",
+    )
+    captions_es = WebsiteContentFactory.create(
+        website=website,
+        type=constants.CONTENT_TYPE_RESOURCE,
+        filename="lecture1_captions_es_vtt",
+        file=f"courses/{website.name}/lecture1_captions_es.vtt",
+    )
+    transcript_en = WebsiteContentFactory.create(
+        website=website,
+        type=constants.CONTENT_TYPE_RESOURCE,
+        filename="lecture1_transcript_pdf",
+        file=f"courses/{website.name}/lecture1_transcript.pdf",
+    )
+
+    video_resource = WebsiteContentFactory.create(
+        website=website,
+        type=constants.CONTENT_TYPE_RESOURCE,
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_file": [
+                    {
+                        "file": f"/courses/{website.name}/lecture1_captions.vtt",
+                        "language": "en",
+                    },
+                    {
+                        "file": f"/courses/{website.name}/lecture1_captions_es.vtt",
+                        "language": "es",
+                    },
+                ],
+                "video_transcript_file": [
+                    {
+                        "file": f"/courses/{website.name}/lecture1_transcript.pdf",
+                        "language": "en",
+                    },
+                ],
+            },
+        },
+    )
+
+    result = resolve_referenced_content_ids(video_resource)
+    assert captions_en.id in result
+    assert captions_es.id in result
+    assert transcript_en.id in result

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -1135,7 +1135,7 @@ def test_websites_content_create_course_list_sets_references(
 def test_websites_content_create_video_resource_sets_3play_references(
     drf_client, global_admin_user
 ):
-    """Creating a video resource should resolve caption/transcript file references."""
+    """Creating a video resource with _resource fields links captions/transcript."""
     drf_client.force_login(global_admin_user)
     website = WebsiteFactory.create()
     captions = WebsiteContentFactory.create(
@@ -1157,10 +1157,14 @@ def test_websites_content_create_video_resource_sets_3play_references(
             "resourcetype": "Video",
             "video_metadata": {"youtube_id": "yt123"},
             "video_files": {
-                "video_captions_file": f"/courses/{website.name}/video-captions.webvtt",
-                "video_transcript_file": (
-                    f"/courses/{website.name}/video-transcript.pdf"
-                ),
+                "video_captions_resources": {
+                    "content": [str(captions.text_id)],
+                    "website": website.name,
+                },
+                "video_transcript_resources": {
+                    "content": [str(transcript.text_id)],
+                    "website": website.name,
+                },
             },
         },
     }
@@ -1178,10 +1182,19 @@ def test_websites_content_create_video_resource_sets_3play_references(
         website=website,
         text_id=resp.data["text_id"],
     )
+    # referenced_by relationship set via sync_website_content_references
     assert set(content.referenced_by.values_list("id", flat=True)) == {
         captions.id,
         transcript.id,
     }
+    # build-pipeline file arrays populated by sync_video_relation_urls on create
+    vf = content.metadata["video_files"]
+    assert vf["video_captions_file"] == [
+        {"file": f"/courses/{website.name}/video-captions.webvtt", "language": "en"}
+    ]
+    assert vf["video_transcript_file"] == [
+        {"file": f"/courses/{website.name}/video-transcript.pdf", "language": "en"}
+    ]
 
 
 def test_websites_content_create_with_textid(drf_client, global_admin_user):
@@ -1689,7 +1702,7 @@ def test_referencing_content_clears_when_references_removed(
 def test_websites_content_update_video_resource_sets_3play_references(
     drf_client, global_admin_user
 ):
-    """Updating a video resource should refresh caption/transcript file references."""
+    """Updating a video resource with _resource fields links captions/transcript."""
     drf_client.force_login(global_admin_user)
     website = WebsiteFactory.create()
     captions = WebsiteContentFactory.create(
@@ -1725,12 +1738,14 @@ def test_websites_content_update_video_resource_sets_3play_references(
         data={
             "metadata": {
                 "video_files": {
-                    "video_captions_file": (
-                        f"/courses/{website.name}/updated-captions.webvtt"
-                    ),
-                    "video_transcript_file": (
-                        f"/courses/{website.name}/updated-transcript.pdf"
-                    ),
+                    "video_captions_resources": {
+                        "content": [str(captions.text_id)],
+                        "website": website.name,
+                    },
+                    "video_transcript_resources": {
+                        "content": [str(transcript.text_id)],
+                        "website": website.name,
+                    },
                 }
             }
         },
@@ -1739,7 +1754,16 @@ def test_websites_content_update_video_resource_sets_3play_references(
 
     assert resp.status_code == 200
     video.refresh_from_db()
+    # referenced_by relationship set
     assert set(video.referenced_by.values_list("id", flat=True)) == {
         captions.id,
         transcript.id,
     }
+    # build-pipeline file arrays populated by sync_video_relation_urls on update
+    vf = video.metadata["video_files"]
+    assert vf["video_captions_file"] == [
+        {"file": f"/courses/{website.name}/updated-captions.webvtt", "language": "en"}
+    ]
+    assert vf["video_transcript_file"] == [
+        {"file": f"/courses/{website.name}/updated-transcript.pdf", "language": "en"}
+    ]


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10982

### Description (What does it do?)
converts `video_captions_resource` and `video_transcript_resource` from single-select to multi-select relation fields, allowing a video resource to be linked to multiple caption or transcript files (e.g. one per language).

Migration `0074` converts any existing scalar relation value `{"content": "text_id"}` to the array form `{"content": ["text_id"]}` for both fields. 

### How can this be tested?

1. Add content to starter config in admin from `ocw-hugo-projects` branch: `umar/10982-migrate-caption-and-transcript-resource-relation`
3. Switch to this branch: `umar/10982-migrate-caption-and-transcript-resource-relation`
4. Rebuild containers or run docker-compose exec web python manage.py migrate and verify migration 0074 applies cleanly without errors.
5. Visit a video resource in Studio, and confirm `video_captions_resource` and `video_transcript_resource` are rendered as multi-select relation pickers.
6. Add two caption resources to the same video and save, and verify both appear in the field and are persisted correctly.