### PR TITLE
fix: use correct base url for learn deployed v3 theme

### DIFF
--- a/content_sync/conftest.py
+++ b/content_sync/conftest.py
@@ -89,6 +89,7 @@ def required_concourse_settings(settings):
     settings.CONTENT_FILE_SEARCH_API_URL = "http://test.edu/api/v1/content_file_search"
     settings.OCW_GTM_ACCOUNT_ID = "abc123"
     settings.OCW_EXTRA_THEMES_GTM_IDS = {}
+    settings.OCW_EXTRA_THEMES_BASE_URLS = {}
     settings.TEST_ROOT_WEBSITE_NAME = "ocw-ci-test-www"
     settings.OCW_TEST_SITE_SLUGS = ["ocw-ci-test-www", "ocw-ci-test-course"]
     return settings

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -78,12 +78,6 @@ BUILD_OFFLINE_SITE_IDENTIFIER = Identifier("build-offline-site").root
 UPLOAD_OFFLINE_BUILD_IDENTIFIER = Identifier("upload-offline-build").root
 CLEAR_CDN_CACHE_IDENTIFIER = Identifier("clear-cdn-cache").root
 
-# Extra themes can be served under a different published base path than the
-# source site path used in Studio.
-EXTRA_THEME_BASE_URL_PREFIXES = {
-    "ocw-course-v3": "/courses/o",
-}
-
 
 def get_site_pipeline_definition_vars(namespace: str):
     return {
@@ -127,7 +121,7 @@ def get_base_url_path(
     is_root_website: bool,
 ) -> str:
     """Get the Hugo baseURL path for a site pipeline."""
-    extra_theme_base_url_prefix = EXTRA_THEME_BASE_URL_PREFIXES.get(prefix)
+    extra_theme_base_url_prefix = settings.OCW_EXTRA_THEMES_BASE_URLS.get(prefix)
     if is_extra_theme and not is_root_website and extra_theme_base_url_prefix:
         root_prefix = site_root_path.strip("/")
         course_path = base_url

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -216,6 +216,18 @@ class SitePipelineDefinitionConfig:
         base_url_path = (
             f"/{self.prefix}/{self.base_url}" if self.prefix else f"/{self.base_url}"
         )
+
+        # ocw-course-v3 extra-theme course pages are served on Learn under
+        # /courses/o/<course-path>, so generated Hugo URLs must use that path.
+        if (
+            self.prefix == "ocw-course-v3"
+            and self.is_extra_theme
+            and not self.is_root_website
+        ):
+            base_url_path = f"/courses/o/{
+                self.base_url.removeprefix('/courses/').removeprefix('courses/')
+            }"
+
         base_online_args.update(
             {
                 "--config": f"../{OCW_HUGO_PROJECTS_GIT_IDENTIFIER}/{starter_slug}/config.yaml",  # noqa: E501

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -213,20 +213,20 @@ class SitePipelineDefinitionConfig:
         starter_slug = theme_slug if theme_slug else site.starter.slug
         base_hugo_args = {"--themesDir": f"../{OCW_HUGO_THEMES_GIT_IDENTIFIER}/"}
         base_online_args = base_hugo_args.copy()
-        base_url_path = (
-            f"/{self.prefix}/{self.base_url}" if self.prefix else f"/{self.base_url}"
-        )
-
-        # ocw-course-v3 extra-theme course pages are served on Learn under
-        # /courses/o/<course-path>, so generated Hugo URLs must use that path.
         if (
             self.prefix == "ocw-course-v3"
             and self.is_extra_theme
             and not self.is_root_website
         ):
-            base_url_path = f"/courses/o/{
-                self.base_url.removeprefix('/courses/').removeprefix('courses/')
-            }"
+            # ocw-course-v3 extra-theme course pages are served on Learn under
+            # /courses/o/<course-path>, so generated Hugo URLs must use that path.
+            base_url_path = f"/courses/o/{self.base_url.removeprefix('courses/')}"
+        else:
+            base_url_path = (
+                f"/{self.prefix}/{self.base_url}"
+                if self.prefix
+                else f"/{self.base_url}"
+            )
 
         base_online_args.update(
             {

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -78,6 +78,12 @@ BUILD_OFFLINE_SITE_IDENTIFIER = Identifier("build-offline-site").root
 UPLOAD_OFFLINE_BUILD_IDENTIFIER = Identifier("upload-offline-build").root
 CLEAR_CDN_CACHE_IDENTIFIER = Identifier("clear-cdn-cache").root
 
+# Extra themes can be served under a different published base path than the
+# source site path used in Studio.
+EXTRA_THEME_BASE_URL_PREFIXES = {
+    "ocw-course-v3": "/courses/o",
+}
+
 
 def get_site_pipeline_definition_vars(namespace: str):
     return {
@@ -110,6 +116,26 @@ def get_site_pipeline_definition_vars(namespace: str):
         "theme_slug": f"(({namespace}theme_slug))",
         "gtm_account_id": f"(({namespace}gtm_account_id))",
     }
+
+
+def get_base_url_path(
+    prefix: str,
+    base_url: str,
+    site_root_path: str,
+    *,
+    is_extra_theme: bool,
+    is_root_website: bool,
+) -> str:
+    """Get the Hugo baseURL path for a site pipeline."""
+    extra_theme_base_url_prefix = EXTRA_THEME_BASE_URL_PREFIXES.get(prefix)
+    if is_extra_theme and not is_root_website and extra_theme_base_url_prefix:
+        root_prefix = site_root_path.strip("/")
+        course_path = base_url
+        if root_prefix:
+            course_path = base_url.removeprefix(f"{root_prefix}/")
+        return f"{extra_theme_base_url_prefix}/{course_path}"
+
+    return f"/{prefix}/{base_url}" if prefix else f"/{base_url}"
 
 
 class SitePipelineDefinitionConfig:
@@ -213,20 +239,13 @@ class SitePipelineDefinitionConfig:
         starter_slug = theme_slug if theme_slug else site.starter.slug
         base_hugo_args = {"--themesDir": f"../{OCW_HUGO_THEMES_GIT_IDENTIFIER}/"}
         base_online_args = base_hugo_args.copy()
-        if (
-            self.prefix == "ocw-course-v3"
-            and self.is_extra_theme
-            and not self.is_root_website
-        ):
-            # ocw-course-v3 extra-theme course pages are served on Learn under
-            # /courses/o/<course-path>, so generated Hugo URLs must use that path.
-            base_url_path = f"/courses/o/{self.base_url.removeprefix('courses/')}"
-        else:
-            base_url_path = (
-                f"/{self.prefix}/{self.base_url}"
-                if self.prefix
-                else f"/{self.base_url}"
-            )
+        base_url_path = get_base_url_path(
+            prefix=self.prefix,
+            base_url=self.base_url,
+            site_root_path=site.get_site_root_path() or "",
+            is_extra_theme=self.is_extra_theme,
+            is_root_website=self.is_root_website,
+        )
 
         base_online_args.update(
             {

--- a/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
@@ -1151,6 +1151,7 @@ def test_site_pipeline_definition_config_ocw_course_v3_baseurl(  # noqa: PLR0913
     unexpected_template,
 ):
     settings.OCW_EXTRA_COURSE_THEMES = ["ocw-course-v3"]
+    settings.OCW_EXTRA_THEMES_BASE_URLS = {"ocw-course-v3": "/courses/o"}
     mocker.patch(
         "content_sync.pipelines.definitions.concourse.site_pipeline.is_dev",
         return_value=False,

--- a/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
@@ -1127,6 +1127,72 @@ def test_site_pipeline_definition_config_gtm_account_id(settings, mocker, gtm_ca
 
 
 @pytest.mark.parametrize(
+    ("use_root_website", "expected_template", "unexpected_template"),
+    [
+        (
+            False,
+            "--baseURL /courses/o/my-course",
+            "--baseURL /ocw-course-v3/courses/my-course",
+        ),
+        (
+            True,
+            "--baseURL /ocw-course-v3/",
+            "--baseURL /courses/o/",
+        ),
+    ],
+    ids=["learn-site", "root-site"],
+)
+def test_site_pipeline_definition_config_ocw_course_v3_baseurl(  # noqa: PLR0913
+    settings,
+    mocker,
+    root_website,
+    use_root_website,
+    expected_template,
+    unexpected_template,
+):
+    settings.OCW_EXTRA_COURSE_THEMES = ["ocw-course-v3"]
+    mocker.patch(
+        "content_sync.pipelines.definitions.concourse.site_pipeline.is_dev",
+        return_value=False,
+    )
+
+    if use_root_website:
+        website = root_website
+    else:
+        hugo_projects_path = "https://github.com/org/repo"
+        starter = WebsiteStarterFactory.create(
+            source=STARTER_SOURCE_GITHUB,
+            path=f"{hugo_projects_path}/site",
+            slug="learn-baseurl-config-test",
+        )
+        starter.config["root-url-path"] = "courses"
+        website = WebsiteFactory.create(
+            starter=starter,
+            url_path="courses/my-course",
+        )
+
+    config = SitePipelineDefinitionConfig(
+        site=website,
+        pipeline_name=VERSION_LIVE,
+        instance_vars="?vars={}",
+        site_content_branch="release",
+        static_api_url="https://ocw.mit.edu/",
+        storage_bucket="test-bucket",
+        artifacts_bucket="test-artifacts",
+        web_bucket="test-web",
+        offline_bucket="test-offline",
+        resource_base_url="https://ocw.mit.edu/",
+        ocw_hugo_themes_branch="main",
+        ocw_hugo_projects_branch="main",
+        prefix="ocw-course-v3",
+        theme_slug="ocw-course-v3",
+    )
+
+    assert expected_template in config.hugo_args_online
+    assert unexpected_template not in config.hugo_args_online
+
+
+@pytest.mark.parametrize(
     ("theme_slug", "extra_themes", "expect_webhook_resource"),
     [
         (None, ["ocw-course-v3"], True),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,7 +170,7 @@ services:
     - concourse-keys:/concourse-keys
 
   concourse:
-    image: concourse/concourse:7.14
+    image: concourse/concourse:8.0
     command: web
     privileged: true
     depends_on:
@@ -219,7 +219,7 @@ services:
         ipv4_address: 10.1.0.101
 
   concourse-worker:
-    image: concourse/concourse:7.14
+    image: concourse/concourse:8.0
     command: worker
     privileged: true
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -170,7 +170,7 @@ services:
     - concourse-keys:/concourse-keys
 
   concourse:
-    image: concourse/concourse:8.0
+    image: concourse/concourse:7.14
     command: web
     privileged: true
     depends_on:
@@ -219,7 +219,7 @@ services:
         ipv4_address: 10.1.0.101
 
   concourse-worker:
-    image: concourse/concourse:8.0
+    image: concourse/concourse:7.14
     command: worker
     privileged: true
     depends_on:

--- a/main/settings.py
+++ b/main/settings.py
@@ -1297,6 +1297,10 @@ OCW_EXTRA_COURSE_THEMES = get_delimited_list(
     description="Additional Hugo themes to build for OCW course sites",
     required=False,
 )
+OCW_EXTRA_THEMES_BASE_URLS = get_dict_of_str(
+    name="OCW_EXTRA_THEMES_BASE_URLS",
+    default={},
+)
 OCW_EXTRA_THEMES_GTM_IDS = get_dict_of_str(
     name="OCW_EXTRA_THEMES_GTM_IDS",
     default={},


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11124

### Description (What does it do?)
ocw-course-v3 sites are currently built with a baseUrl like `/ocw-course-v3/courses/12-108-fall-2004`. However, in Learn, these courses are served under a different path `/courses/o/12-108-fall-2004`. Because of this mismatch, Hugo generates incorrect internal links. For example, navigation links resolve to `/ocw-course-v3/courses/12-108-fall-2004/pages/...` instead of the expected `/courses/o/12-108-fall-2004/pages/...`

This results in broken or incorrect navigation when users browse course pages on Learn. You can reproduce the issue at https://rc.learn.mit.edu/courses/o/7-016-introductory-biology-fall-2018 by clicking on any navigation link and observing the resulting urls in the browser bar (they'll include `ocw-course-v3`)

### How can this be tested?
1. Set OCW_EXTRA_COURSE_THEMES=ocw-course-v3 in your env file
2. Set OCW_EXTRA_THEMES_BASE_URLS={"ocw-course-v3": "/courses/o"} in your env file
2. Backpopulate pipelines `./manage.py backpopulate_pipelines`
3. Trigger a publish from studio
4. Verify that both the v3 and v2 pipelines in concourse run
5. Verify from the concourse task logs that baseURL passed to hugo for the v3 pipeline follows the `courses/o/<course_name>` format.
6. Verify that the baseURL passed to hugo is unaffected by these changes for the v2 site pipeline.
