### PR TITLE
fix: make video workflows more robust

### DIFF
--- a/videos/api.py
+++ b/videos/api.py
@@ -5,6 +5,7 @@ import os
 
 import botocore
 from django.conf import settings
+from django.db import transaction
 from mitol.transcoding.api import media_convert_job
 
 from content_sync.utils import move_s3_object
@@ -91,6 +92,7 @@ def process_video_outputs(video: Video, output_group_details: dict):
     prepare_video_download_file(video)
 
 
+@transaction.atomic
 def update_video_job(results: dict):
     """Update a VideoJob and associated Video, VideoFiles based on MediaConvert results"""  # noqa: E501
 

--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -125,7 +125,7 @@ def upload_youtube_videos():  # noqa: C901
                 set_dict_field(
                     video_resource.metadata, settings.YT_FIELD_TAGS, merged_tags
                 )
-                video_resource.save(update_fields=["metadata"])
+                video_resource.save(update_fields=["metadata", "updated_on"])
 
         # Always save video_file status
         video_file.save()

--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -125,7 +125,7 @@ def upload_youtube_videos():  # noqa: C901
                 set_dict_field(
                     video_resource.metadata, settings.YT_FIELD_TAGS, merged_tags
                 )
-                video_resource.save()
+                video_resource.save(update_fields=["metadata"])
 
         # Always save video_file status
         video_file.save()


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11212

### Description (What does it do?)

There is a race condition between the mediaconvert transcode job webhook and the upload to youtube task that can cause lost updates for the download url and file size on the video resource objects.
 
1. The MediaConvert transcode [webhook](https://github.com/mitodl/ocw-studio/blob/7cea4bbf4ed6ab3fd56b389752c6433a8b92a72b/videos/api.py#L94) executes and [creates](https://github.com/mitodl/ocw-studio/blob/7cea4bbf4ed6ab3fd56b389752c6433a8b92a72b/videos/api.py#L70) the relevant VideoFile objects.
2. The periodic “upload to YouTube” [task](https://github.com/mitodl/ocw-studio/blob/7cea4bbf4ed6ab3fd56b389752c6433a8b92a72b/videos/tasks.py#L79) is triggered and begins the upload process.
3. The upload task retains an in-memory [reference](https://github.com/mitodl/ocw-studio/blob/7cea4bbf4ed6ab3fd56b389752c6433a8b92a72b/videos/tasks.py#L100) to the VideoResource object.
4. The MediaConvert webhook [updates](https://github.com/mitodl/ocw-studio/blob/7cea4bbf4ed6ab3fd56b389752c6433a8b92a72b/videos/api.py#L48) the download link on the resource object in the database.
5. Meanwhile, the upload task still holds a stale in-memory version of the same resource object and [saves](https://github.com/mitodl/ocw-studio/blob/7cea4bbf4ed6ab3fd56b389752c6433a8b92a72b/videos/tasks.py#L124-L128) it while updating the YouTube tags.
6. As a result, the save operation in step 5 unintentionally overwrites the download link update made in step 4.


This PR wraps the MediaConvert webhook logic in a transaction to ensure atomicity so that the upload to youtube task effectively only runs when the transcode job endpoint has completed fully. The upload to youtube task is gated on the presence of youtube videofile objects, which as a result of the transaction should only be available when the whole update_video_job has completed. We also update the “upload to YouTube” task so that it only modifies the YouTube tags field, avoiding accidental overwrites of other fields from a stale in-memory resource object.

### How can this be tested?

Test the complete video workflows by following the instructions at https://github.com/mitodl/ocw-studio/tree/master/videos#testing-prs-with-transcoding. Ensure that the s3, transcoding, and youtube upload workflows have the expected results.
