### PR TITLE
chore: added de-duplication and pre-filtering for YT tags update

### DIFF
--- a/videos/constants.py
+++ b/videos/constants.py
@@ -23,6 +23,11 @@ ARCHIVE_URL_FILESIZE_TASK_RATE_LIMIT = "0.1/s"
 S3_FILESIZE_TASK_RATE_LIMIT = "5/s"
 
 
+# Lock TTL for the update_youtube_tags_batch single_task mutex.
+# Long enough for a full batch to complete; short enough to self-heal after a crash.
+YTAGS_BATCH_LOCK_TTL = 30 * 60  # 30 minutes
+
+
 class VideoStatus:
     """Simple class for possible Video statuses"""
 

--- a/videos/management/commands/update_youtube_tags.py
+++ b/videos/management/commands/update_youtube_tags.py
@@ -381,7 +381,32 @@ class Command(WebsiteFilterCommand):
             next_saturday += timedelta(days=7)
         return int((next_saturday - now).total_seconds())
 
-    def _schedule_celery_tasks(  # noqa: C901, PLR0912, PLR0913, PLR0915
+    def _prefilter_videos(self, all_youtube_ids, yt_id_to_resources, add_course_tag):
+        """
+        Fetch current YouTube tags and return only the IDs that need updating.
+
+        Calls videos.list in batches (~1 quota unit per 50 IDs) and excludes
+        videos whose merged tags would be identical to their current YouTube
+        tags.  Returns (filtered_ids, list_quota_used).
+        """
+        youtube = YouTubeApi()
+        snippets = fetch_youtube_snippets(youtube, all_youtube_ids)
+        list_quota_used = (
+            math.ceil(len(all_youtube_ids) / YT_LIST_BATCH_SIZE) * QUOTA_COST_VIDEO_LIST
+        )
+
+        filtered_ids = [
+            yt_id
+            for yt_id in all_youtube_ids
+            if (snippet := snippets.get(yt_id)) is not None
+            and any(
+                compute_merged_tags(vr, snippet, add_course_tag=add_course_tag)[2]
+                for vr in yt_id_to_resources[yt_id]
+            )
+        ]
+        return filtered_ids, list_quota_used
+
+    def _schedule_celery_tasks(  # noqa: C901, PLR0912, PLR0913
         self,
         video_resources,
         add_course_tag,
@@ -417,25 +442,9 @@ class Command(WebsiteFilterCommand):
 
         all_youtube_ids = list(yt_id_to_resources.keys())
 
-        # Pre-filter: fetch current YouTube tags now so we only schedule tasks
-        # for videos that will actually change.  The list calls cost ~1 quota
-        # unit per 50 IDs — far cheaper than running 50-unit update tasks on
-        # videos that are already correct.
-        youtube = YouTubeApi()
-        snippets = fetch_youtube_snippets(youtube, all_youtube_ids)
-        list_quota_used = (
-            math.ceil(len(all_youtube_ids) / YT_LIST_BATCH_SIZE) * QUOTA_COST_VIDEO_LIST
+        filtered_ids, list_quota_used = self._prefilter_videos(
+            all_youtube_ids, yt_id_to_resources, add_course_tag
         )
-
-        filtered_ids = [
-            yt_id
-            for yt_id in all_youtube_ids
-            if (snippet := snippets.get(yt_id)) is not None
-            and any(
-                compute_merged_tags(vr, snippet, add_course_tag=add_course_tag)[2]
-                for vr in yt_id_to_resources[yt_id]
-            )
-        ]
         prefiltered_count = len(all_youtube_ids) - len(filtered_ids)
 
         if prefiltered_count:

--- a/videos/management/commands/update_youtube_tags.py
+++ b/videos/management/commands/update_youtube_tags.py
@@ -19,6 +19,7 @@ from videos.constants import (
 )
 from videos.tasks import update_youtube_tags_batch
 from videos.utils import (
+    compute_merged_tags,
     fetch_youtube_snippets,
     get_course_tag,
     parse_tags,
@@ -380,7 +381,7 @@ class Command(WebsiteFilterCommand):
             next_saturday += timedelta(days=7)
         return int((next_saturday - now).total_seconds())
 
-    def _schedule_celery_tasks(  # noqa: C901, PLR0913
+    def _schedule_celery_tasks(  # noqa: C901, PLR0912, PLR0913, PLR0915
         self,
         video_resources,
         add_course_tag,
@@ -407,16 +408,52 @@ class Command(WebsiteFilterCommand):
             (daily_quota - 10) // QUOTA_COST_VIDEO_UPDATE,  # reserve 10 for list calls
         )
 
-        # Collect all YouTube IDs
-        all_youtube_ids = []
-        seen_ids = set()
+        # Collect all YouTube IDs, keeping the resource objects for pre-filtering.
+        yt_id_to_resources = {}
         for vr in video_resources:
             yt_id = get_dict_field(vr.metadata, settings.YT_FIELD_ID)
-            if yt_id and yt_id not in seen_ids:
-                all_youtube_ids.append(yt_id)
-                seen_ids.add(yt_id)
+            if yt_id:
+                yt_id_to_resources.setdefault(yt_id, []).append(vr)
 
+        all_youtube_ids = list(yt_id_to_resources.keys())
+
+        # Pre-filter: fetch current YouTube tags now so we only schedule tasks
+        # for videos that will actually change.  The list calls cost ~1 quota
+        # unit per 50 IDs — far cheaper than running 50-unit update tasks on
+        # videos that are already correct.
+        youtube = YouTubeApi()
+        snippets = fetch_youtube_snippets(youtube, all_youtube_ids)
+        list_quota_used = (
+            math.ceil(len(all_youtube_ids) / YT_LIST_BATCH_SIZE) * QUOTA_COST_VIDEO_LIST
+        )
+
+        filtered_ids = [
+            yt_id
+            for yt_id in all_youtube_ids
+            if (snippet := snippets.get(yt_id)) is not None
+            and any(
+                compute_merged_tags(vr, snippet, add_course_tag=add_course_tag)[2]
+                for vr in yt_id_to_resources[yt_id]
+            )
+        ]
+        prefiltered_count = len(all_youtube_ids) - len(filtered_ids)
+
+        if prefiltered_count:
+            self.stdout.write(
+                f"Pre-filtered {prefiltered_count} video(s) already up to date "
+                f"({list_quota_used} quota unit(s) used)."
+            )
+
+        all_youtube_ids = filtered_ids
         total_videos = len(all_youtube_ids)
+
+        if total_videos == 0:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    "All videos already have the correct tags. Nothing to schedule."
+                )
+            )
+            return
         total_chunks = math.ceil(total_videos / videos_per_day)
         seconds_per_day = 24 * 60 * 60
 

--- a/videos/management/commands/update_youtube_tags_test.py
+++ b/videos/management/commands/update_youtube_tags_test.py
@@ -1146,6 +1146,12 @@ def test_update_youtube_tags_schedule_dispatches_celery_tasks(mock_youtube_api, 
         "videos.management.commands.update_youtube_tags.update_youtube_tags_batch"
     )
 
+    # Pre-filter fetches current YouTube tags; return empty tags so all videos
+    # are detected as needing an update (DB has tags, YouTube has none).
+    mock_youtube_api.client.videos.return_value.list.return_value.execute.return_value = _make_batch_list_response(
+        {f"yt_sched_{i}": {"tags": []} for i in range(1, 6)}
+    )
+
     call_command(
         "update_youtube_tags",
         filter="test-course",
@@ -1164,9 +1170,6 @@ def test_update_youtube_tags_schedule_dispatches_celery_tasks(mock_youtube_api, 
     # Second task should be delayed by 24 hours
     second_call = mock_task.apply_async.call_args_list[1]
     assert second_call.kwargs["countdown"] == 86400
-
-    # YouTube API should NOT have been called directly (no immediate processing)
-    mock_youtube_api.client.videos.return_value.list.return_value.execute.assert_not_called()
 
 
 def test_update_youtube_tags_schedule_runs_immediately_below_threshold(
@@ -1287,6 +1290,12 @@ def test_update_youtube_tags_schedule_weekends_only(mock_youtube_api, mocker):
         "videos.management.commands.update_youtube_tags.update_youtube_tags_batch"
     )
 
+    # Pre-filter fetches current YouTube tags; return empty tags so all videos
+    # are detected as needing an update (DB has tags, YouTube has none).
+    mock_youtube_api.client.videos.return_value.list.return_value.execute.return_value = _make_batch_list_response(
+        {f"yt_wknd_{i}": {"tags": []} for i in range(1, 6)}
+    )
+
     call_command(
         "update_youtube_tags",
         filter="test-course",
@@ -1311,6 +1320,3 @@ def test_update_youtube_tags_schedule_weekends_only(mock_youtube_api, mocker):
     # Second task should be on Sunday (one day later)
     second_countdown = mock_task.apply_async.call_args_list[1].kwargs["countdown"]
     assert second_countdown == first_countdown + 86400
-
-    # YouTube API should NOT have been called directly
-    mock_youtube_api.client.videos.return_value.list.return_value.execute.assert_not_called()

--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -39,6 +39,7 @@ from videos.constants import (
     DESTINATION_YOUTUBE,
     S3_FILESIZE_TASK_RATE_LIMIT,
     YT_THUMBNAIL_IMG,
+    YTAGS_BATCH_LOCK_TTL,
     VideoFileStatus,
     VideoStatus,
     YouTubeStatus,
@@ -780,7 +781,8 @@ def _process_batch_videos(
     return success_count, skipped_count, error_count
 
 
-@app.task(bind=True, acks_late=True, max_retries=3)
+@app.task(bind=True, max_retries=3)
+@single_task(timeout=YTAGS_BATCH_LOCK_TTL, raise_block=False)
 def update_youtube_tags_batch(
     self,
     youtube_ids,
@@ -789,6 +791,13 @@ def update_youtube_tags_batch(
 ):
     """
     Update YouTube tags for a batch of videos identified by youtube_ids.
+
+    Only one instance runs at a time cluster-wide (enforced by the
+    @single_task Redis lock). Duplicate messages delivered by the broker
+    after a pod restart are silently dropped by the lock; if they fire
+    after the first copy has already completed, process_video_tags() detects
+    no tag changes and skips the videos.update call, spending only the
+    cheap videos.list quota.
 
     This task is designed to be scheduled with a countdown/eta so that
     large tag-update operations can be spread across multiple days

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -1131,266 +1131,252 @@ def test_start_transcript_job_no_retry_on_unexpected_error(mocker, settings):
     mock_retry.assert_not_called()
 
 
-class TestUpdateYoutubeTagsBatch:
-    """Tests for update_youtube_tags_batch Celery task"""
+def _mock_redis_lock(mocker, *, acquire_returns, locked_returns):
+    """Set up a mock Redis lock for the @single_task decorator."""
+    mock_lock = mocker.MagicMock()
+    mock_lock.acquire.return_value = acquire_returns
+    mock_lock.locked.return_value = locked_returns
+    mock_redis = mocker.MagicMock()
+    mock_redis.lock.return_value = mock_lock
+    mocker.patch(
+        "content_sync.decorators.get_redis_connection", return_value=mock_redis
+    )
+    return mock_lock
 
-    @pytest.fixture(autouse=True)
-    def allow_single_task_lock(self, mocker):
-        """
-        Mock the Redis lock used by @single_task so it always grants.
-        This keeps tests independent of real Redis state.
-        """
-        mock_lock = mocker.MagicMock()
-        mock_lock.acquire.return_value = True
-        mock_lock.locked.return_value = True
-        mock_redis = mocker.MagicMock()
-        mock_redis.lock.return_value = mock_lock
-        mocker.patch(
-            "content_sync.decorators.get_redis_connection", return_value=mock_redis
-        )
-        return mock_lock
 
-    def test_updates_tags_and_saves_to_db(self, mocker, settings):
-        """Test that the task updates YouTube tags and saves merged tags to DB"""
-        settings.YT_ACCESS_TOKEN = "token"  # noqa: S105
-        settings.YT_REFRESH_TOKEN = "refresh"  # noqa: S105
-        settings.YT_CLIENT_ID = "client_id"
-        settings.YT_CLIENT_SECRET = "secret"  # noqa: S105
-        settings.YT_PROJECT_ID = "project"
+@pytest.fixture(autouse=False)
+def allow_single_task_lock(mocker):
+    """Grant the @single_task Redis lock so tests run unimpeded."""
+    return _mock_redis_lock(mocker, acquire_returns=True, locked_returns=True)
 
-        website = WebsiteFactory.create(name="test-course")
-        video = VideoFactory.create(website=website)
-        VideoFileFactory.create(
-            video=video,
-            destination=DESTINATION_YOUTUBE,
-            destination_id="yt_batch_1",
-        )
-        content = WebsiteContentFactory.create(
-            website=website,
-            title="Test Video",
-            metadata={
-                "resourcetype": RESOURCE_TYPE_VIDEO,
-                "video_metadata": {
-                    "youtube_id": "yt_batch_1",
-                    "video_tags": "python, django",
-                },
+
+@pytest.mark.usefixtures("allow_single_task_lock")
+def test_ytags_batch_updates_tags_and_saves_to_db(mocker, settings):
+    """Task updates YouTube tags and saves merged tags to DB."""
+    settings.YT_ACCESS_TOKEN = "token"  # noqa: S105
+    settings.YT_REFRESH_TOKEN = "refresh"  # noqa: S105
+    settings.YT_CLIENT_ID = "client_id"
+    settings.YT_CLIENT_SECRET = "secret"  # noqa: S105
+    settings.YT_PROJECT_ID = "project"
+
+    website = WebsiteFactory.create(name="test-course")
+    video = VideoFactory.create(website=website)
+    VideoFileFactory.create(
+        video=video,
+        destination=DESTINATION_YOUTUBE,
+        destination_id="yt_batch_1",
+    )
+    content = WebsiteContentFactory.create(
+        website=website,
+        title="Test Video",
+        metadata={
+            "resourcetype": RESOURCE_TYPE_VIDEO,
+            "video_metadata": {
+                "youtube_id": "yt_batch_1",
+                "video_tags": "python, django",
             },
-        )
+        },
+    )
 
-        mock_api_cls = mocker.patch("videos.tasks.YouTubeApi")
-        mock_api = mock_api_cls.return_value
+    mock_api_cls = mocker.patch("videos.tasks.YouTubeApi")
+    mock_api = mock_api_cls.return_value
+    mock_api.client.videos.return_value.list.return_value.execute.return_value = {
+        "items": [{"id": "yt_batch_1", "snippet": {"tags": ["machine-learning"]}}]
+    }
 
-        # Mock batch list response
-        mock_api.client.videos.return_value.list.return_value.execute.return_value = {
-            "items": [{"id": "yt_batch_1", "snippet": {"tags": ["machine-learning"]}}]
-        }
+    update_youtube_tags_batch(["yt_batch_1"])
 
-        update_youtube_tags_batch(["yt_batch_1"])
+    mock_api.client.videos.return_value.update.return_value.execute.assert_called()
 
-        # Verify videos.update was called
-        mock_api.client.videos.return_value.update.return_value.execute.assert_called()
+    content.refresh_from_db()
+    tags = content.metadata["video_metadata"]["video_tags"]
+    assert "python" in tags
+    assert "django" in tags
+    assert "machine-learning" in tags
 
-        # Verify DB was updated with merged tags
-        content.refresh_from_db()
-        tags = content.metadata["video_metadata"]["video_tags"]
-        assert "python" in tags
-        assert "django" in tags
-        assert "machine-learning" in tags
 
-    def test_skips_when_no_tag_changes(self, mocker, settings):
-        """Test that the task skips YouTube update when tags are identical"""
-        settings.YT_ACCESS_TOKEN = "token"  # noqa: S105
-        settings.YT_REFRESH_TOKEN = "refresh"  # noqa: S105
-        settings.YT_CLIENT_ID = "client_id"
-        settings.YT_CLIENT_SECRET = "secret"  # noqa: S105
-        settings.YT_PROJECT_ID = "project"
+@pytest.mark.usefixtures("allow_single_task_lock")
+def test_ytags_batch_skips_when_no_tag_changes(mocker, settings):
+    """Task skips YouTube update when tags are already identical."""
+    settings.YT_ACCESS_TOKEN = "token"  # noqa: S105
+    settings.YT_REFRESH_TOKEN = "refresh"  # noqa: S105
+    settings.YT_CLIENT_ID = "client_id"
+    settings.YT_CLIENT_SECRET = "secret"  # noqa: S105
+    settings.YT_PROJECT_ID = "project"
 
-        website = WebsiteFactory.create(name="test-course")
-        video = VideoFactory.create(website=website)
-        VideoFileFactory.create(
-            video=video,
-            destination=DESTINATION_YOUTUBE,
-            destination_id="yt_skip",
-        )
-        WebsiteContentFactory.create(
-            website=website,
-            metadata={
-                "resourcetype": RESOURCE_TYPE_VIDEO,
-                "video_metadata": {
-                    "youtube_id": "yt_skip",
-                    "video_tags": "python, django",
-                },
+    website = WebsiteFactory.create(name="test-course")
+    video = VideoFactory.create(website=website)
+    VideoFileFactory.create(
+        video=video,
+        destination=DESTINATION_YOUTUBE,
+        destination_id="yt_skip",
+    )
+    WebsiteContentFactory.create(
+        website=website,
+        metadata={
+            "resourcetype": RESOURCE_TYPE_VIDEO,
+            "video_metadata": {
+                "youtube_id": "yt_skip",
+                "video_tags": "python, django",
             },
-        )
+        },
+    )
 
-        mock_api_cls = mocker.patch("videos.tasks.YouTubeApi")
-        mock_api = mock_api_cls.return_value
+    mock_api_cls = mocker.patch("videos.tasks.YouTubeApi")
+    mock_api = mock_api_cls.return_value
+    mock_api.client.videos.return_value.list.return_value.execute.return_value = {
+        "items": [{"id": "yt_skip", "snippet": {"tags": ["python", "django"]}}]
+    }
 
-        # YouTube already has same tags
-        mock_api.client.videos.return_value.list.return_value.execute.return_value = {
-            "items": [{"id": "yt_skip", "snippet": {"tags": ["python", "django"]}}]
-        }
+    update_youtube_tags_batch(["yt_skip"])
 
-        update_youtube_tags_batch(["yt_skip"])
+    mock_api.client.videos.return_value.update.return_value.execute.assert_not_called()
 
-        # Should not call update
-        mock_api.client.videos.return_value.update.return_value.execute.assert_not_called()
 
-    def test_skips_when_youtube_disabled(self, mocker, settings):
-        """Test that the task returns early when YouTube is disabled"""
-        settings.YT_ACCESS_TOKEN = ""
+@pytest.mark.usefixtures("allow_single_task_lock")
+def test_ytags_batch_skips_when_youtube_disabled(mocker, settings):
+    """Task returns early when YouTube integration is disabled."""
+    settings.YT_ACCESS_TOKEN = ""
 
-        mock_api_cls = mocker.patch("videos.tasks.YouTubeApi")
+    mock_api_cls = mocker.patch("videos.tasks.YouTubeApi")
 
-        update_youtube_tags_batch(["yt_1"])
+    update_youtube_tags_batch(["yt_1"])
 
-        mock_api_cls.assert_not_called()
+    mock_api_cls.assert_not_called()
 
-    def test_handles_missing_video_on_youtube(self, mocker, settings):
-        """Test that videos not found on YouTube are skipped gracefully"""
-        settings.YT_ACCESS_TOKEN = "token"  # noqa: S105
-        settings.YT_REFRESH_TOKEN = "refresh"  # noqa: S105
-        settings.YT_CLIENT_ID = "client_id"
-        settings.YT_CLIENT_SECRET = "secret"  # noqa: S105
-        settings.YT_PROJECT_ID = "project"
 
-        website = WebsiteFactory.create(name="test-course")
-        video = VideoFactory.create(website=website)
-        VideoFileFactory.create(
-            video=video,
-            destination=DESTINATION_YOUTUBE,
-            destination_id="yt_missing",
-        )
-        WebsiteContentFactory.create(
-            website=website,
-            metadata={
-                "resourcetype": RESOURCE_TYPE_VIDEO,
-                "video_metadata": {
-                    "youtube_id": "yt_missing",
-                    "video_tags": "tag1",
-                },
+@pytest.mark.usefixtures("allow_single_task_lock")
+def test_ytags_batch_handles_missing_video_on_youtube(mocker, settings):
+    """Videos not found on YouTube are skipped gracefully without raising."""
+    settings.YT_ACCESS_TOKEN = "token"  # noqa: S105
+    settings.YT_REFRESH_TOKEN = "refresh"  # noqa: S105
+    settings.YT_CLIENT_ID = "client_id"
+    settings.YT_CLIENT_SECRET = "secret"  # noqa: S105
+    settings.YT_PROJECT_ID = "project"
+
+    website = WebsiteFactory.create(name="test-course")
+    video = VideoFactory.create(website=website)
+    VideoFileFactory.create(
+        video=video,
+        destination=DESTINATION_YOUTUBE,
+        destination_id="yt_missing",
+    )
+    WebsiteContentFactory.create(
+        website=website,
+        metadata={
+            "resourcetype": RESOURCE_TYPE_VIDEO,
+            "video_metadata": {
+                "youtube_id": "yt_missing",
+                "video_tags": "tag1",
             },
-        )
+        },
+    )
 
-        mock_api_cls = mocker.patch("videos.tasks.YouTubeApi")
-        mock_api = mock_api_cls.return_value
+    mock_api_cls = mocker.patch("videos.tasks.YouTubeApi")
+    mock_api = mock_api_cls.return_value
+    mock_api.client.videos.return_value.list.return_value.execute.return_value = {
+        "items": []
+    }
 
-        # YouTube returns empty response (video not found)
-        mock_api.client.videos.return_value.list.return_value.execute.return_value = {
-            "items": []
-        }
+    update_youtube_tags_batch(["yt_missing"])
 
-        # Should not raise
-        update_youtube_tags_batch(["yt_missing"])
+    mock_api.client.videos.return_value.update.return_value.execute.assert_not_called()
 
-        mock_api.client.videos.return_value.update.return_value.execute.assert_not_called()
 
-    def test_add_course_tag(self, mocker, settings):
-        """Test that add_course_tag adds the course slug to tags"""
-        settings.YT_ACCESS_TOKEN = "token"  # noqa: S105
-        settings.YT_REFRESH_TOKEN = "refresh"  # noqa: S105
-        settings.YT_CLIENT_ID = "client_id"
-        settings.YT_CLIENT_SECRET = "secret"  # noqa: S105
-        settings.YT_PROJECT_ID = "project"
+@pytest.mark.usefixtures("allow_single_task_lock")
+def test_ytags_batch_add_course_tag(mocker, settings):
+    """add_course_tag=True adds the course slug to the merged tag set."""
+    settings.YT_ACCESS_TOKEN = "token"  # noqa: S105
+    settings.YT_REFRESH_TOKEN = "refresh"  # noqa: S105
+    settings.YT_CLIENT_ID = "client_id"
+    settings.YT_CLIENT_SECRET = "secret"  # noqa: S105
+    settings.YT_PROJECT_ID = "project"
 
-        website = WebsiteFactory.create(
-            name="test-course",
-            url_path="test-course",
-        )
-        video = VideoFactory.create(website=website)
-        VideoFileFactory.create(
-            video=video,
-            destination=DESTINATION_YOUTUBE,
-            destination_id="yt_course_tag",
-        )
-        content = WebsiteContentFactory.create(
-            website=website,
-            title="Course Tag Video",
-            metadata={
-                "resourcetype": RESOURCE_TYPE_VIDEO,
-                "video_metadata": {
-                    "youtube_id": "yt_course_tag",
-                    "video_tags": "python",
-                },
+    website = WebsiteFactory.create(name="test-course", url_path="test-course")
+    video = VideoFactory.create(website=website)
+    VideoFileFactory.create(
+        video=video,
+        destination=DESTINATION_YOUTUBE,
+        destination_id="yt_course_tag",
+    )
+    content = WebsiteContentFactory.create(
+        website=website,
+        title="Course Tag Video",
+        metadata={
+            "resourcetype": RESOURCE_TYPE_VIDEO,
+            "video_metadata": {
+                "youtube_id": "yt_course_tag",
+                "video_tags": "python",
             },
-        )
+        },
+    )
 
-        mock_api_cls = mocker.patch("videos.tasks.YouTubeApi")
-        mock_api = mock_api_cls.return_value
+    mock_api_cls = mocker.patch("videos.tasks.YouTubeApi")
+    mock_api = mock_api_cls.return_value
+    mock_api.client.videos.return_value.list.return_value.execute.return_value = {
+        "items": [{"id": "yt_course_tag", "snippet": {"tags": ["python"]}}]
+    }
 
-        mock_api.client.videos.return_value.list.return_value.execute.return_value = {
-            "items": [{"id": "yt_course_tag", "snippet": {"tags": ["python"]}}]
-        }
+    update_youtube_tags_batch(["yt_course_tag"], add_course_tag=True)
 
-        update_youtube_tags_batch(["yt_course_tag"], add_course_tag=True)
+    mock_api.client.videos.return_value.update.return_value.execute.assert_called()
 
-        # Verify videos.update was called (course tag is a new tag)
-        mock_api.client.videos.return_value.update.return_value.execute.assert_called()
+    content.refresh_from_db()
+    tags = content.metadata["video_metadata"]["video_tags"]
+    assert "python" in tags
+    assert "test-course" in tags
 
-        # Verify DB was updated with course slug tag
-        content.refresh_from_db()
-        tags = content.metadata["video_metadata"]["video_tags"]
-        assert "python" in tags
-        assert "test-course" in tags
 
-    def test_skips_when_lock_already_held(self, mocker, settings):
-        """When another instance holds the @single_task lock, the task exits silently."""
-        settings.YT_ACCESS_TOKEN = "token"  # noqa: S105
+def test_ytags_batch_skips_when_lock_already_held(mocker, settings):
+    """When another instance holds the @single_task lock, the task exits silently."""
+    settings.YT_ACCESS_TOKEN = "token"  # noqa: S105
 
-        # Override autouse fixture: lock not granted
-        mock_lock = mocker.MagicMock()
-        mock_lock.acquire.return_value = False
-        mock_lock.locked.return_value = False
-        mock_redis = mocker.MagicMock()
-        mock_redis.lock.return_value = mock_lock
-        mocker.patch(
-            "content_sync.decorators.get_redis_connection", return_value=mock_redis
-        )
+    _mock_redis_lock(mocker, acquire_returns=False, locked_returns=False)
 
-        mock_api_cls = mocker.patch("videos.tasks.YouTubeApi")
+    mock_api_cls = mocker.patch("videos.tasks.YouTubeApi")
 
-        update_youtube_tags_batch(["yt_concurrent"])
+    update_youtube_tags_batch(["yt_concurrent"])
 
-        mock_api_cls.assert_not_called()
+    mock_api_cls.assert_not_called()
 
-    def test_duplicate_batch_skips_yt_update(self, mocker, settings):
-        """
-        A duplicate delivery that fires after the original completes makes only
-        videos.list calls (process_video_tags detects no changes and skips update).
-        """
-        settings.YT_ACCESS_TOKEN = "token"  # noqa: S105
-        settings.YT_REFRESH_TOKEN = "refresh"  # noqa: S105
-        settings.YT_CLIENT_ID = "client_id"
-        settings.YT_CLIENT_SECRET = "secret"  # noqa: S105
-        settings.YT_PROJECT_ID = "project"
 
-        website = WebsiteFactory.create(name="test-course")
-        video = VideoFactory.create(website=website)
-        VideoFileFactory.create(
-            video=video,
-            destination=DESTINATION_YOUTUBE,
-            destination_id="yt_dup_2",
-        )
-        WebsiteContentFactory.create(
-            website=website,
-            metadata={
-                "resourcetype": RESOURCE_TYPE_VIDEO,
-                "video_metadata": {
-                    "youtube_id": "yt_dup_2",
-                    "video_tags": "python",
-                },
+@pytest.mark.usefixtures("allow_single_task_lock")
+def test_ytags_batch_duplicate_skips_yt_update(mocker, settings):
+    """
+    A duplicate delivery after the original completes makes videos.list calls
+    but not videos.update — process_video_tags detects no changes.
+    """
+    settings.YT_ACCESS_TOKEN = "token"  # noqa: S105
+    settings.YT_REFRESH_TOKEN = "refresh"  # noqa: S105
+    settings.YT_CLIENT_ID = "client_id"
+    settings.YT_CLIENT_SECRET = "secret"  # noqa: S105
+    settings.YT_PROJECT_ID = "project"
+
+    website = WebsiteFactory.create(name="test-course")
+    video = VideoFactory.create(website=website)
+    VideoFileFactory.create(
+        video=video,
+        destination=DESTINATION_YOUTUBE,
+        destination_id="yt_dup_2",
+    )
+    WebsiteContentFactory.create(
+        website=website,
+        metadata={
+            "resourcetype": RESOURCE_TYPE_VIDEO,
+            "video_metadata": {
+                "youtube_id": "yt_dup_2",
+                "video_tags": "python",
             },
-        )
+        },
+    )
 
-        mock_api_cls = mocker.patch("videos.tasks.YouTubeApi")
-        mock_api = mock_api_cls.return_value
-        # YouTube already has the same tags as DB — simulates state after first run
-        mock_api.client.videos.return_value.list.return_value.execute.return_value = {
-            "items": [{"id": "yt_dup_2", "snippet": {"tags": ["python"]}}]
-        }
+    mock_api_cls = mocker.patch("videos.tasks.YouTubeApi")
+    mock_api = mock_api_cls.return_value
+    mock_api.client.videos.return_value.list.return_value.execute.return_value = {
+        "items": [{"id": "yt_dup_2", "snippet": {"tags": ["python"]}}]
+    }
 
-        update_youtube_tags_batch(["yt_dup_2"])
+    update_youtube_tags_batch(["yt_dup_2"])
 
-        # videos.list was called (cheap) but videos.update was not (no change)
-        mock_api.client.videos.return_value.list.return_value.execute.assert_called()
-        mock_api.client.videos.return_value.update.return_value.execute.assert_not_called()
+    mock_api.client.videos.return_value.list.return_value.execute.assert_called()
+    mock_api.client.videos.return_value.update.return_value.execute.assert_not_called()

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -1134,6 +1134,22 @@ def test_start_transcript_job_no_retry_on_unexpected_error(mocker, settings):
 class TestUpdateYoutubeTagsBatch:
     """Tests for update_youtube_tags_batch Celery task"""
 
+    @pytest.fixture(autouse=True)
+    def allow_single_task_lock(self, mocker):
+        """
+        Mock the Redis lock used by @single_task so it always grants.
+        This keeps tests independent of real Redis state.
+        """
+        mock_lock = mocker.MagicMock()
+        mock_lock.acquire.return_value = True
+        mock_lock.locked.return_value = True
+        mock_redis = mocker.MagicMock()
+        mock_redis.lock.return_value = mock_lock
+        mocker.patch(
+            "content_sync.decorators.get_redis_connection", return_value=mock_redis
+        )
+        return mock_lock
+
     def test_updates_tags_and_saves_to_db(self, mocker, settings):
         """Test that the task updates YouTube tags and saves merged tags to DB"""
         settings.YT_ACCESS_TOKEN = "token"  # noqa: S105
@@ -1316,3 +1332,65 @@ class TestUpdateYoutubeTagsBatch:
         tags = content.metadata["video_metadata"]["video_tags"]
         assert "python" in tags
         assert "test-course" in tags
+
+    def test_skips_when_lock_already_held(self, mocker, settings):
+        """When another instance holds the @single_task lock, the task exits silently."""
+        settings.YT_ACCESS_TOKEN = "token"  # noqa: S105
+
+        # Override autouse fixture: lock not granted
+        mock_lock = mocker.MagicMock()
+        mock_lock.acquire.return_value = False
+        mock_lock.locked.return_value = False
+        mock_redis = mocker.MagicMock()
+        mock_redis.lock.return_value = mock_lock
+        mocker.patch(
+            "content_sync.decorators.get_redis_connection", return_value=mock_redis
+        )
+
+        mock_api_cls = mocker.patch("videos.tasks.YouTubeApi")
+
+        update_youtube_tags_batch(["yt_concurrent"])
+
+        mock_api_cls.assert_not_called()
+
+    def test_duplicate_batch_skips_yt_update(self, mocker, settings):
+        """
+        A duplicate delivery that fires after the original completes makes only
+        videos.list calls (process_video_tags detects no changes and skips update).
+        """
+        settings.YT_ACCESS_TOKEN = "token"  # noqa: S105
+        settings.YT_REFRESH_TOKEN = "refresh"  # noqa: S105
+        settings.YT_CLIENT_ID = "client_id"
+        settings.YT_CLIENT_SECRET = "secret"  # noqa: S105
+        settings.YT_PROJECT_ID = "project"
+
+        website = WebsiteFactory.create(name="test-course")
+        video = VideoFactory.create(website=website)
+        VideoFileFactory.create(
+            video=video,
+            destination=DESTINATION_YOUTUBE,
+            destination_id="yt_dup_2",
+        )
+        WebsiteContentFactory.create(
+            website=website,
+            metadata={
+                "resourcetype": RESOURCE_TYPE_VIDEO,
+                "video_metadata": {
+                    "youtube_id": "yt_dup_2",
+                    "video_tags": "python",
+                },
+            },
+        )
+
+        mock_api_cls = mocker.patch("videos.tasks.YouTubeApi")
+        mock_api = mock_api_cls.return_value
+        # YouTube already has the same tags as DB — simulates state after first run
+        mock_api.client.videos.return_value.list.return_value.execute.return_value = {
+            "items": [{"id": "yt_dup_2", "snippet": {"tags": ["python"]}}]
+        }
+
+        update_youtube_tags_batch(["yt_dup_2"])
+
+        # videos.list was called (cheap) but videos.update was not (no change)
+        mock_api.client.videos.return_value.list.return_value.execute.assert_called()
+        mock_api.client.videos.return_value.update.return_value.execute.assert_not_called()

--- a/videos/utils.py
+++ b/videos/utils.py
@@ -198,6 +198,44 @@ def fetch_youtube_snippets(youtube, youtube_ids):
     return snippets
 
 
+def compute_merged_tags(video_resource, snippet, *, add_course_tag):
+    """
+    Compute the merged tag state for a video resource without making any API
+    calls or DB writes.
+
+    Args:
+        video_resource: WebsiteContent instance
+        snippet: YouTube snippet dict (from the videos.list response)
+        add_course_tag: If True, include the course URL slug as a tag
+
+    Returns:
+        tuple[str, list[str], bool]:
+            - merged_str: comma-separated merged tag string
+            - merged_list: list of individual merged tags
+            - tags_changed: True if the merged set differs from the current
+              YouTube tags (or if current YouTube tags have formatting issues)
+    """
+    youtube_tags = snippet.get("tags", [])
+    db_tags_str = get_dict_field(video_resource.metadata, settings.YT_FIELD_TAGS)
+    db_tags = set(parse_tags(db_tags_str or ""))
+
+    yt_tags_normalized = (
+        set().union(*(parse_tags(t) for t in youtube_tags)) if youtube_tags else set()
+    )
+    merged = yt_tags_normalized | db_tags
+    if add_course_tag:
+        course_slug = get_course_tag(video_resource.website)
+        if course_slug and course_slug not in merged:
+            merged.add(course_slug)
+
+    merged_str = ", ".join(sorted(merged))
+    merged_list = parse_tags(merged_str)
+    has_formatting_issues = any("," in tag for tag in youtube_tags)
+    tags_changed = merged != yt_tags_normalized or has_formatting_issues
+
+    return merged_str, merged_list, tags_changed
+
+
 def process_video_tags(video_resource, snippet, youtube, *, add_course_tag):
     """
     Merge YouTube and DB tags for a single video resource then persist.
@@ -216,27 +254,11 @@ def process_video_tags(video_resource, snippet, youtube, *, add_course_tag):
     Returns:
         str: ``"success"`` if YouTube was updated, ``"skip"`` otherwise
     """
-
     yt_id = get_dict_field(video_resource.metadata, settings.YT_FIELD_ID)
-    course_slug = get_course_tag(video_resource.website)
 
-    youtube_tags = snippet.get("tags", [])
-    db_tags_str = get_dict_field(video_resource.metadata, settings.YT_FIELD_TAGS)
-    db_tags = set(parse_tags(db_tags_str or ""))
-
-    yt_tags_normalized = (
-        set().union(*(parse_tags(t) for t in youtube_tags)) if youtube_tags else set()
+    merged_str, merged_list, tags_changed = compute_merged_tags(
+        video_resource, snippet, add_course_tag=add_course_tag
     )
-    merged = yt_tags_normalized | db_tags
-    if add_course_tag and course_slug and course_slug not in merged:
-        merged.add(course_slug)
-
-    merged_str = ", ".join(sorted(merged))
-    merged_list = parse_tags(merged_str)
-
-    # Detect formatting issues (e.g., commas in a single YouTube tag like "a, b")
-    has_formatting_issues = any("," in tag for tag in youtube_tags)
-    tags_changed = merged != yt_tags_normalized or has_formatting_issues
 
     if tags_changed:
         snippet["tags"] = merged_list


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/8719

### Description (What does it do?)
Optimizes the `update_youtube_tags` management command to add pre-filtering and deduplicated tasks in Kubernetes due to POD restarts and releases.

**Automatic scheduling via Celery:** When `--schedule` is passed and the video count exceeds `--threshold` (default: 150), the command dispatches `update_youtube_tags_batch` Celery tasks with staggered `countdown` delays (24h apart) so work is spread across days automatically. A `--weekends-only` flag restricts scheduled tasks to Saturday/Sunday slots.

**Pre-filtering before scheduling:** Before dispatching any Celery tasks, the command fetches current YouTube tags for all candidate videos and uses `compute_merged_tags` to identify which videos actually need updating. Videos already up to date are excluded from the schedule entirely, saving both task slots and future execution quota. The cost is only ~1 quota unit per 50 videos at dispatch time.

**Celery task deduplication (`update_youtube_tags_batch`):**
- Removed `acks_late=True`: the root cause of duplicate task delivery in Kubernetes. Without it, the broker acknowledges the message on receipt so pod restarts no longer redeliver parked ETA tasks.
- Added `@single_task(timeout=30min, raise_block=False)`: enforces a cluster-wide Redis mutex so only one batch task runs at a time, even if duplicate messages do arrive simultaneously.

**Command-line options (no env vars needed):**
- `--schedule` — enable Celery dispatch when above threshold
- `--threshold N` — video count that triggers scheduling (default: 150)
- `--daily-quota N` — quota budget per day for scheduling math (default: 9000)
- `--weekends-only` — restrict tasks to weekends
- `--quota-limit N` — stop processing before exceeding this many units
- `--add-course-tag` — add course URL slug as a tag
- `--out FILE` — export results to CSV

### How can this be tested?
1. **Verify `@single_task` deduplication (Django shell):**

Dispatch the same batch task twice with a short ETA so both messages land before either runs. Only the first to acquire the Redis lock should execute; the second should log a skip and return immediately.

```python
# python manage.py shell
from videos.tasks import update_youtube_tags_batch

# Use a real YouTube ID that exists in your DB, or any string — the lock check
# happens before any API calls so a fake ID is fine for testing the mutex.
fake_ids = ["test-yt-id-1", "test-yt-id-2"]

# Dispatch two copies of the same batch with a 5-second delay
update_youtube_tags_batch.apply_async(args=[fake_ids], countdown=5)
update_youtube_tags_batch.apply_async(args=[fake_ids], countdown=5)

print("Two tasks dispatched. Watch the Celery worker logs.")
```

Expected worker logs (one worker, ~5 seconds later):
```
# First message — lock acquired, task runs:
[INFO] YouTube tag batch complete: 0 updated, 0 skipped, 0 errors

# Second message — lock already held by first:
[INFO] update_youtube_tags_batch skipped: another instance is already running ...
```
If both messages arrive after the first has already finished, the second will acquire the lock and run (correctly re-processing — tags unchanged → 0 updates, 0 quota wasted on `videos.update`). Either outcome confirms the mutex is working.
