### PR TITLE
Add per-theme GTM settings to pipelines

### DIFF
--- a/content_sync/conftest.py
+++ b/content_sync/conftest.py
@@ -88,6 +88,7 @@ def required_concourse_settings(settings):
     settings.COURSE_SEARCH_API_URL = "http://test.edu/api/v1/learning_resources_search"
     settings.CONTENT_FILE_SEARCH_API_URL = "http://test.edu/api/v1/content_file_search"
     settings.OCW_GTM_ACCOUNT_ID = "abc123"
+    settings.OCW_EXTRA_THEMES_GTM_IDS = {}
     settings.TEST_ROOT_WEBSITE_NAME = "ocw-ci-test-www"
     settings.OCW_TEST_SITE_SLUGS = ["ocw-ci-test-www", "ocw-ci-test-course"]
     return settings

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -108,6 +108,7 @@ def get_site_pipeline_definition_vars(namespace: str):
         "hugo_args_offline": f"(({namespace}hugo_args_offline))",
         "prefix": f"(({namespace}prefix))",
         "theme_slug": f"(({namespace}theme_slug))",
+        "gtm_account_id": f"(({namespace}gtm_account_id))",
     }
 
 
@@ -203,6 +204,12 @@ class SitePipelineDefinitionConfig:
             if self.is_root_website:
                 self.url_path = site.name
         self.is_extra_theme = is_extra_theme(theme_slug)
+        self.gtm_account_id = settings.OCW_GTM_ACCOUNT_ID
+        if self.is_extra_theme:
+            self.gtm_account_id = (
+                settings.OCW_EXTRA_THEMES_GTM_IDS.get(theme_slug)
+                or settings.OCW_GTM_ACCOUNT_ID
+            )
         starter_slug = theme_slug if theme_slug else site.starter.slug
         base_hugo_args = {"--themesDir": f"../{OCW_HUGO_THEMES_GIT_IDENTIFIER}/"}
         base_online_args = base_hugo_args.copy()
@@ -269,6 +276,7 @@ class SitePipelineDefinitionConfig:
             "hugo_args_offline": hugo_args_offline,
             "prefix": self.prefix,
             "theme_slug": theme_slug or "",
+            "gtm_account_id": self.gtm_account_id,
         }
 
 
@@ -543,7 +551,7 @@ class SitePipelineOnlineTasks(list[StepModifierMixin]):
                 attempts=3,
                 params={
                     "API_BEARER_TOKEN": settings.API_BEARER_TOKEN,
-                    "GTM_ACCOUNT_ID": settings.OCW_GTM_ACCOUNT_ID,
+                    "GTM_ACCOUNT_ID": pipeline_vars["gtm_account_id"],
                     "OCW_STUDIO_BASE_URL": pipeline_vars["ocw_studio_url"],
                     "STATIC_API_BASE_URL": pipeline_vars["static_api_url"],
                     "OCW_IMPORT_STARTER_SLUG": settings.OCW_COURSE_STARTER_SLUG,
@@ -765,7 +773,7 @@ class SitePipelineOfflineTasks(list[StepModifierMixin]):
                 attempts=3,
                 params={
                     "API_BEARER_TOKEN": settings.API_BEARER_TOKEN,
-                    "GTM_ACCOUNT_ID": settings.OCW_GTM_ACCOUNT_ID,
+                    "GTM_ACCOUNT_ID": pipeline_vars["gtm_account_id"],
                     "OCW_STUDIO_BASE_URL": pipeline_vars["ocw_studio_url"],
                     "STATIC_API_BASE_URL": pipeline_vars["static_api_url"],
                     "OCW_IMPORT_STARTER_SLUG": settings.OCW_COURSE_STARTER_SLUG,
@@ -1019,6 +1027,7 @@ class SitePipelineDefinition(Pipeline):
                     "hugo_args_offline": config.values["hugo_args_offline"],
                     "prefix": config.values["prefix"],
                     "theme_slug": config.values["theme_slug"],
+                    "gtm_account_id": config.values["gtm_account_id"],
                 }
             ),
         )

--- a/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
@@ -380,7 +380,7 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
     )
     build_online_site_expected_params = {
         "API_BEARER_TOKEN": settings.API_BEARER_TOKEN,
-        "GTM_ACCOUNT_ID": settings.OCW_GTM_ACCOUNT_ID,
+        "GTM_ACCOUNT_ID": config.vars["gtm_account_id"],
         "OCW_STUDIO_BASE_URL": ocw_studio_url,
         "STATIC_API_BASE_URL": branch_vars["static_api_url"],
         "OCW_IMPORT_STARTER_SLUG": settings.OCW_COURSE_STARTER_SLUG,
@@ -399,6 +399,10 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
         )
     assert set(build_online_site_expected_params).issubset(
         set(build_online_site_task["params"])
+    )
+    assert (
+        build_online_site_task["params"]["GTM_ACCOUNT_ID"]
+        == config.vars["gtm_account_id"]
     )
     upload_online_build_task = get_dict_list_item_by_field(
         items=online_site_tasks, field="task", value=UPLOAD_ONLINE_BUILD_IDENTIFIER
@@ -597,7 +601,7 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
     assert f"zip -r ../../{BUILD_OFFLINE_SITE_IDENTIFIER}/{config.vars['short_id']}-video.zip ./"  # noqa: PLW0129
     build_offline_site_expected_params = {
         "API_BEARER_TOKEN": settings.API_BEARER_TOKEN,
-        "GTM_ACCOUNT_ID": settings.OCW_GTM_ACCOUNT_ID,
+        "GTM_ACCOUNT_ID": config.vars["gtm_account_id"],
         "OCW_STUDIO_BASE_URL": ocw_studio_url,
         "STATIC_API_BASE_URL": branch_vars["static_api_url"],
         "OCW_IMPORT_STARTER_SLUG": settings.OCW_COURSE_STARTER_SLUG,
@@ -616,6 +620,10 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
         )
     assert set(build_offline_site_expected_params).issubset(
         set(build_offline_site_task["params"])
+    )
+    assert (
+        build_offline_site_task["params"]["GTM_ACCOUNT_ID"]
+        == config.vars["gtm_account_id"]
     )
     upload_offline_build_task = get_dict_list_item_by_field(
         offline_site_tasks, "task", UPLOAD_OFFLINE_BUILD_IDENTIFIER
@@ -1028,6 +1036,94 @@ def test_site_pipeline_definition_config_theme_slug(settings, mocker, theme_slug
     expected_slug = theme_slug if theme_slug else starter.slug
     assert f"/{expected_slug}/config.yaml" in config.hugo_args_online
     assert f"/{expected_slug}/config-offline.yaml" in config.hugo_args_offline
+
+
+@pytest.mark.parametrize(
+    "gtm_case",
+    [
+        {
+            "theme_slug": None,
+            "extra_themes": ["ocw-course-v3"],
+            "extra_themes_gtm_ids": {"ocw-course-v3": "extra-theme-tracking-id"},
+            "expected_gtm_account_id": "default-tracking-id",
+        },
+        {
+            "theme_slug": "ocw-course-v2",
+            "extra_themes": ["ocw-course-v3"],
+            "extra_themes_gtm_ids": {"ocw-course-v3": "extra-theme-tracking-id"},
+            "expected_gtm_account_id": "default-tracking-id",
+        },
+        {
+            "theme_slug": "another-theme",
+            "extra_themes": ["ocw-course-v3"],
+            "extra_themes_gtm_ids": {"another-theme": "alternate-theme-tracking-id"},
+            "expected_gtm_account_id": "default-tracking-id",
+        },
+        {
+            "theme_slug": "ocw-course-v3",
+            "extra_themes": ["ocw-course-v3"],
+            "extra_themes_gtm_ids": {},
+            "expected_gtm_account_id": "default-tracking-id",
+        },
+        {
+            "theme_slug": "ocw-course-v3",
+            "extra_themes": ["ocw-course-v3"],
+            "extra_themes_gtm_ids": {"ocw-course-v3": ""},
+            "expected_gtm_account_id": "default-tracking-id",
+        },
+        {
+            "theme_slug": "ocw-course-v3",
+            "extra_themes": ["ocw-course-v3"],
+            "extra_themes_gtm_ids": {
+                "ocw-course-v3": "extra-theme-tracking-id&gtm_auth=fake-auth"
+            },
+            "expected_gtm_account_id": "extra-theme-tracking-id&gtm_auth=fake-auth",
+        },
+        {
+            "theme_slug": "another-extra-theme",
+            "extra_themes": ["ocw-course-v3", "another-extra-theme"],
+            "extra_themes_gtm_ids": {
+                "ocw-course-v3": "extra-theme-tracking-id",
+                "another-extra-theme": "alternate-theme-tracking-id",
+            },
+            "expected_gtm_account_id": "alternate-theme-tracking-id",
+        },
+    ],
+)
+def test_site_pipeline_definition_config_gtm_account_id(settings, mocker, gtm_case):
+    """Extra course themes should use their mapped GTM override when configured."""
+    mocker.patch(
+        "content_sync.pipelines.definitions.concourse.site_pipeline.is_dev",
+        return_value=False,
+    )
+    settings.OCW_GTM_ACCOUNT_ID = "default-tracking-id"
+    settings.OCW_EXTRA_THEMES_GTM_IDS = gtm_case["extra_themes_gtm_ids"]
+    settings.OCW_EXTRA_COURSE_THEMES = gtm_case["extra_themes"]
+    starter = WebsiteStarterFactory.create(
+        source=STARTER_SOURCE_GITHUB,
+        path="https://github.com/org/repo/site",
+        slug="gtm-config-test",
+    )
+    website = WebsiteFactory.create(starter=starter)
+
+    config = SitePipelineDefinitionConfig(
+        site=website,
+        pipeline_name=VERSION_LIVE,
+        instance_vars="?vars={}",
+        site_content_branch="release",
+        static_api_url="https://ocw.mit.edu/",
+        storage_bucket="test-bucket",
+        artifacts_bucket="test-artifacts",
+        web_bucket="test-web",
+        offline_bucket="test-offline",
+        resource_base_url="https://ocw.mit.edu/",
+        ocw_hugo_themes_branch="main",
+        ocw_hugo_projects_branch="main",
+        theme_slug=gtm_case["theme_slug"],
+    )
+
+    assert config.gtm_account_id == gtm_case["expected_gtm_account_id"]
+    assert config.values["gtm_account_id"] == gtm_case["expected_gtm_account_id"]
 
 
 @pytest.mark.parametrize(

--- a/main/envs.py
+++ b/main/envs.py
@@ -130,6 +130,39 @@ def get_list_of_str(name, default):
     return parsed_value
 
 
+def get_dict_of_str(name, default):
+    """
+    Get an environment variable as a dictionary of strings.
+    Args:
+        name (str): An environment variable name
+        default (dict): The default value to use if the environment variable doesn't exist.
+    Returns:
+        dict[str, str]:
+            The environment variable value parsed as a dictionary of strings
+    """  # noqa: E501
+    value = os.environ.get(name)
+    if value is None:
+        return default
+
+    parse_exception = EnvironmentVariableParseException(
+        f"Expected value in {name}={value} to be a dict of str"
+    )
+
+    try:
+        parsed_value = literal_eval(value)
+    except (ValueError, SyntaxError) as ex:
+        raise parse_exception from ex
+
+    if not isinstance(parsed_value, dict):
+        raise parse_exception
+
+    for key, item in parsed_value.items():
+        if not isinstance(key, str) or not isinstance(item, str):
+            raise parse_exception
+
+    return parsed_value
+
+
 def get_key(name, default):
     """
     Get an environment variable as a string representing a private or public key.

--- a/main/envs_test.py
+++ b/main/envs_test.py
@@ -1,0 +1,44 @@
+"""Environment variable parser tests"""
+
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+
+from main.envs import get_dict_of_str
+
+
+def test_get_dict_of_str(mocker):
+    """get_dict_of_str should parse a dictionary of string keys and values."""
+    mocker.patch.dict(
+        "os.environ",
+        {
+            "TEST_DICT": (
+                '{"ocw-course-v3": "extra-theme-tracking-id&gtm_auth=fake", '
+                '"theme": "alternate-theme-tracking-id"}'
+            )
+        },
+    )
+
+    assert get_dict_of_str("TEST_DICT", {}) == {
+        "ocw-course-v3": "extra-theme-tracking-id&gtm_auth=fake",
+        "theme": "alternate-theme-tracking-id",
+    }
+
+
+def test_get_dict_of_str_default(mocker):
+    """get_dict_of_str should return the default if the variable is unset."""
+    mocker.patch.dict("os.environ", {}, clear=True)
+
+    assert get_dict_of_str("TEST_DICT", {"theme": "default-tracking-id"}) == {
+        "theme": "default-tracking-id"
+    }
+
+
+@pytest.mark.parametrize(
+    "value", ['["theme"]', '{"theme": 123}', '{1: "alternate-theme-tracking-id"}']
+)
+def test_get_dict_of_str_invalid(mocker, value):
+    """get_dict_of_str should reject non-dictionary or non-string values."""
+    mocker.patch.dict("os.environ", {"TEST_DICT": value})
+
+    with pytest.raises(ImproperlyConfigured):
+        get_dict_of_str("TEST_DICT", {})

--- a/main/settings.py
+++ b/main/settings.py
@@ -21,7 +21,7 @@ from mitol.common.envs import (
 )
 
 from main.constants import PRODUCTION_NAMES
-from main.envs import get_list_of_str
+from main.envs import get_dict_of_str, get_list_of_str
 from main.sentry import init_sentry
 
 # pylint: disable=too-many-lines
@@ -1297,6 +1297,19 @@ OCW_EXTRA_COURSE_THEMES = get_delimited_list(
     description="Additional Hugo themes to build for OCW course sites",
     required=False,
 )
+OCW_EXTRA_THEMES_GTM_IDS = get_dict_of_str(
+    name="OCW_EXTRA_THEMES_GTM_IDS",
+    default={},
+)
+unknown_extra_theme_gtm_ids = set(OCW_EXTRA_THEMES_GTM_IDS) - set(
+    OCW_EXTRA_COURSE_THEMES
+)
+if unknown_extra_theme_gtm_ids:
+    msg = (
+        "OCW_EXTRA_THEMES_GTM_IDS contains theme slugs that are not configured in "
+        f"OCW_EXTRA_COURSE_THEMES: {', '.join(sorted(unknown_extra_theme_gtm_ids))}"
+    )
+    raise ImproperlyConfigured(msg)
 OCW_HUGO_PROJECTS_BRANCH = get_string(
     name="OCW_HUGO_PROJECTS_BRANCH",
     description="The branch to use in development of ocw-hugo-projects",

--- a/main/settings_test.py
+++ b/main/settings_test.py
@@ -134,6 +134,32 @@ class TestSettings(TestCase):
             "sslmode": "require"
         }
 
+    def test_extra_theme_gtm_ids_must_match_extra_themes(self):
+        """Extra theme GTM ID keys must be configured extra theme slugs."""
+        settings_vars = self.patch_settings(
+            {
+                **REQUIRED_SETTINGS,
+                "OCW_EXTRA_COURSE_THEMES": "ocw-course-v3,another-extra-theme",
+                "OCW_EXTRA_THEMES_GTM_IDS": (
+                    '{"ocw-course-v3": "extra-theme-tracking-id"}'
+                ),
+            }
+        )
+        assert settings_vars["OCW_EXTRA_THEMES_GTM_IDS"] == {
+            "ocw-course-v3": "extra-theme-tracking-id"
+        }
+
+        with pytest.raises(ImproperlyConfigured):
+            self.patch_settings(
+                {
+                    **REQUIRED_SETTINGS,
+                    "OCW_EXTRA_COURSE_THEMES": "ocw-course-v3",
+                    "OCW_EXTRA_THEMES_GTM_IDS": (
+                        '{"ocw_course_v3": "extra-theme-tracking-id"}'
+                    ),
+                }
+            )
+
     @staticmethod
     def test_semantic_version():
         """


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/11018.

### Description (What does it do?)
This PR adds per-extra-theme GTM overrides for OCW Hugo build pipelines.

A new `OCW_EXTRA_THEMES_GTM_IDS` setting accepts a mapping of extra theme slugs to full GTM values:

`OCW_EXTRA_THEMES_GTM_IDS='{"ocw-course-v3": "extra-theme-tracking-id&gtm_auth=...&gtm_preview=env-N&gtm_cookies_win=x"}'`

`SitePipelineDefinitionConfig` now resolves a single `gtm_account_id` value per build. Extra themes listed in `OCW_EXTRA_COURSE_THEMES` use their matching value from `OCW_EXTRA_THEMES_GTM_IDS`; missing or empty entries fall back to `OCW_GTM_ACCOUNT_ID`.

www and default (v2) course theme builds continue using `OCW_GTM_ACCOUNT_ID` unchanged. Both online and offline build tasks pass the resolved value through the existing `GTM_ACCOUNT_ID` Hugo build env param.

### How can this be tested?
Add test values to your local `.env` file:

```sh
OCW_GTM_ACCOUNT_ID=default-tracking-id
OCW_EXTRA_COURSE_THEMES=ocw-course-v3
OCW_EXTRA_THEMES_GTM_IDS={"ocw-course-v3": "extra-theme-tracking-id&gtm_auth=fake-auth&gtm_preview=env-test&gtm_cookies_win=x"}
```

Then upsert pipelines for a course site:

`docker compose exec web ./manage.py backpopulate_pipelines --filter <course-id>`

In Concourse, inspect the generated pipelines for that course:

- `draft` / `live` should still set `GTM_ACCOUNT_ID` to `default-tracking-id`.
- `draft-ocw-course-v3` / `live-ocw-course-v3` should set `GTM_ACCOUNT_ID` to `extra-theme-tracking-id&gtm_auth=fake-auth&gtm_preview=env-test&gtm_cookies_win=x`.
- Check both `build-online-site` and `build-offline-site` task params.

Optionally, trigger a v3 build and confirm the published source includes the extra-theme GTM value in the GTM script/noscript URLs, while the default v2 course build still uses `default-tracking-id`.