### PR TITLE
feat: add resource checking to concourse publish executions.

### DIFF
--- a/content_sync/api.py
+++ b/content_sync/api.py
@@ -222,6 +222,7 @@ def publish_website(  # pylint: disable=too-many-arguments
                     if not website.publish_date:
                         theme_pipeline.upsert_pipeline()
                     theme_pipeline.unpause_pipeline(theme_pipeline_name)
+                    theme_pipeline.check_online_site_job_resources(theme_pipeline_name)
                     theme_pipeline.trigger_pipeline_build(theme_pipeline_name)
 
         # Need to update additional fields

--- a/content_sync/api.py
+++ b/content_sync/api.py
@@ -201,6 +201,7 @@ def publish_website(  # pylint: disable=too-many-arguments
             if not website.publish_date:
                 pipeline.upsert_pipeline()
             pipeline.unpause_pipeline(version)
+            pipeline.check_online_site_job_resources(version)
             build_id = pipeline.trigger_pipeline_build(version)
             update_kwargs[f"latest_build_id_{version}"] = build_id
 

--- a/content_sync/api_test.py
+++ b/content_sync/api_test.py
@@ -408,6 +408,7 @@ def test_publish_website_with_extra_themes(settings, mocker, version, publish_da
     expected_upsert_calls = 0 if publish_date else 3
     assert mock_pipeline.upsert_pipeline.call_count == expected_upsert_calls
     assert mock_pipeline.unpause_pipeline.call_count == 3
+    assert mock_pipeline.check_online_site_job_resources.call_count == 3
     assert mock_pipeline.trigger_pipeline_build.call_count == 3
 
     unpause_calls = [
@@ -415,6 +416,10 @@ def test_publish_website_with_extra_themes(settings, mocker, version, publish_da
     ]
     trigger_calls = [
         call[0][0] for call in mock_pipeline.trigger_pipeline_build.call_args_list
+    ]
+    check_resource_calls = [
+        call[0][0]
+        for call in mock_pipeline.check_online_site_job_resources.call_args_list
     ]
 
     assert version in unpause_calls
@@ -424,6 +429,10 @@ def test_publish_website_with_extra_themes(settings, mocker, version, publish_da
     assert version in trigger_calls
     assert f"{version}-ocw-course-v3" in trigger_calls
     assert f"{version}-ocw-course-v4" in trigger_calls
+
+    assert version in check_resource_calls
+    assert f"{version}-ocw-course-v3" in check_resource_calls
+    assert f"{version}-ocw-course-v4" in check_resource_calls
 
 
 def test_publish_website_no_extra_themes_for_non_ocw_site(settings, mocker):

--- a/content_sync/api_test.py
+++ b/content_sync/api_test.py
@@ -274,6 +274,7 @@ def test_publish_website(  # pylint:disable=redefined-outer-name,too-many-argume
             website, api=pipeline_api
         )
         assert pipeline.upsert_pipeline.call_count == (0 if publish_date else 1)
+        pipeline.check_online_site_job_resources.assert_called_once_with(version)
         pipeline.trigger_pipeline_build.assert_called_once_with(version)
         pipeline.unpause_pipeline.assert_called_once_with(version)
         assert getattr(website, f"latest_build_id_{version}") == build_id
@@ -281,6 +282,7 @@ def test_publish_website(  # pylint:disable=redefined-outer-name,too-many-argume
         mock_api_funcs.mock_get_pipeline.assert_not_called()
         pipeline.trigger_pipeline_build.assert_not_called()
         pipeline.unpause_pipeline.assert_not_called()
+        pipeline.check_online_site_job_resources.assert_not_called()
         assert getattr(website, f"latest_build_id_{version}") is None
     assert getattr(website, f"has_unpublished_{version}") is False
     assert getattr(website, f"{version}_last_published_by") is None

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -307,7 +307,10 @@ class GeneralPipeline(BaseGeneralPipeline):
 
     def check_resource(self, pipeline_name: str, resource_name: str):
         """Trigger a resource check for a pipeline resource"""
-        self.api.post(self._make_resource_check_url(pipeline_name, resource_name))
+        self.api.post(
+            self._make_resource_check_url(pipeline_name, resource_name),
+            data=json.dumps({"from": None}),
+        )
 
     def trigger_pipeline_build(self, pipeline_name: str) -> int:
         """Trigger a pipeline build"""

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -46,6 +46,12 @@ from content_sync.pipelines.definitions.concourse.remove_unpublished_sites impor
 from content_sync.pipelines.definitions.concourse.s3_bucket_sync_pipeline import (
     S3BucketSyncPipelineDefinition,
 )
+from content_sync.pipelines.definitions.concourse.common.identifiers import (
+    OCW_HUGO_PROJECTS_GIT_IDENTIFIER,
+    OCW_HUGO_THEMES_GIT_IDENTIFIER,
+    SITE_CONTENT_GIT_IDENTIFIER,
+    WEBPACK_MANIFEST_S3_IDENTIFIER,
+)
 from content_sync.pipelines.definitions.concourse.site_pipeline import (
     SitePipelineDefinition,
     SitePipelineDefinitionConfig,
@@ -295,6 +301,14 @@ class GeneralPipeline(BaseGeneralPipeline):
         """Make URL for unpausing a pipeline"""
         return f"/api/v1/teams/{settings.CONCOURSE_TEAM}/pipelines/{pipeline_name}/unpause{self.instance_vars}"  # noqa: E501
 
+    def _make_resource_check_url(self, pipeline_name: str, resource_name: str) -> str:
+        """Make URL for triggering a resource check"""
+        return f"/api/v1/teams/{settings.CONCOURSE_TEAM}/pipelines/{pipeline_name}/resources/{resource_name}/check{self.instance_vars}"  # noqa: E501
+
+    def check_resource(self, pipeline_name: str, resource_name: str):
+        """Trigger a resource check for a pipeline resource"""
+        self.api.post(self._make_resource_check_url(pipeline_name, resource_name))
+
     def trigger_pipeline_build(self, pipeline_name: str) -> int:
         """Trigger a pipeline build"""
         pipeline_info = self.api.get(self._make_pipeline_config_url(pipeline_name))
@@ -515,6 +529,16 @@ class SitePipeline(BaseSitePipeline, GeneralPipeline):
             self.upsert_config(
                 SitePipelineDefinition(config=pipeline_config).json(), pipeline_name
             )
+
+    def check_online_site_job_resources(self, pipeline_name: str):
+        """Trigger resource checks for all resources required by online-site-job"""
+        for resource_name in [
+            WEBPACK_MANIFEST_S3_IDENTIFIER,
+            OCW_HUGO_THEMES_GIT_IDENTIFIER,
+            OCW_HUGO_PROJECTS_GIT_IDENTIFIER,
+            SITE_CONTENT_GIT_IDENTIFIER,
+        ]:
+            self.check_resource(pipeline_name, resource_name)
 
 
 class MassBuildSitesPipeline(BaseMassBuildSitesPipeline, GeneralPipeline):  # pylint: disable=too-many-instance-attributes

--- a/content_sync/pipelines/concourse.py
+++ b/content_sync/pipelines/concourse.py
@@ -33,6 +33,12 @@ from content_sync.pipelines.base import (
     BaseThemeAssetsPipeline,
     BaseUnpublishedSiteRemovalPipeline,
 )
+from content_sync.pipelines.definitions.concourse.common.identifiers import (
+    OCW_HUGO_PROJECTS_GIT_IDENTIFIER,
+    OCW_HUGO_THEMES_GIT_IDENTIFIER,
+    SITE_CONTENT_GIT_IDENTIFIER,
+    WEBPACK_MANIFEST_S3_IDENTIFIER,
+)
 from content_sync.pipelines.definitions.concourse.e2e_test_site_pipeline import (
     EndToEndTestPipelineDefinition,
 )
@@ -45,12 +51,6 @@ from content_sync.pipelines.definitions.concourse.remove_unpublished_sites impor
 )
 from content_sync.pipelines.definitions.concourse.s3_bucket_sync_pipeline import (
     S3BucketSyncPipelineDefinition,
-)
-from content_sync.pipelines.definitions.concourse.common.identifiers import (
-    OCW_HUGO_PROJECTS_GIT_IDENTIFIER,
-    OCW_HUGO_THEMES_GIT_IDENTIFIER,
-    SITE_CONTENT_GIT_IDENTIFIER,
-    WEBPACK_MANIFEST_S3_IDENTIFIER,
 )
 from content_sync.pipelines.definitions.concourse.site_pipeline import (
     SitePipelineDefinition,

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -610,7 +610,8 @@ def test_check_resource(settings, mocker, mock_auth, version):
     resource_name = WEBPACK_MANIFEST_S3_IDENTIFIER
     pipeline.check_resource(version, resource_name)
     mock_post.assert_called_once_with(
-        f"/api/v1/teams/myteam/pipelines/{version}/resources/{resource_name}/check{pipeline.instance_vars}"
+        f"/api/v1/teams/myteam/pipelines/{version}/resources/{resource_name}/check{pipeline.instance_vars}",
+        data='{"from": null}',
     )
 
 

--- a/content_sync/pipelines/concourse_test.py
+++ b/content_sync/pipelines/concourse_test.py
@@ -28,6 +28,8 @@ from content_sync.pipelines.concourse import (
 from content_sync.pipelines.definitions.concourse.common.identifiers import (
     OCW_HUGO_PROJECTS_GIT_IDENTIFIER,
     OCW_HUGO_THEMES_GIT_IDENTIFIER,
+    SITE_CONTENT_GIT_IDENTIFIER,
+    WEBPACK_MANIFEST_S3_IDENTIFIER,
 )
 from content_sync.utils import (
     get_common_pipeline_vars,
@@ -592,6 +594,51 @@ def test_pause_unpause_pipeline(settings, mocker, mock_auth, version, action):
     mock_put.assert_any_call(
         f"/api/v1/teams/myteam/pipelines/ocw-theme-assets/{action}{pipeline.instance_vars}"
     )
+
+
+@pytest.mark.parametrize("version", ["live", "draft"])
+def test_check_resource(settings, mocker, mock_auth, version):
+    """check_resource should POST to the correct resource check URL"""
+    settings.CONCOURSE_TEAM = "myteam"
+    mock_post = mocker.patch("content_sync.pipelines.concourse.PipelineApi.post")
+    website = WebsiteFactory.create(
+        starter=WebsiteStarterFactory.create(
+            source=STARTER_SOURCE_GITHUB, path="https://github.com/org/repo/config"
+        )
+    )
+    pipeline = SitePipeline(website)
+    resource_name = WEBPACK_MANIFEST_S3_IDENTIFIER
+    pipeline.check_resource(version, resource_name)
+    mock_post.assert_called_once_with(
+        f"/api/v1/teams/myteam/pipelines/{version}/resources/{resource_name}/check{pipeline.instance_vars}"
+    )
+
+
+@pytest.mark.parametrize("version", ["live", "draft"])
+def test_check_online_site_job_resources(settings, mocker, mock_auth, version):
+    """check_online_site_job_resources should trigger checks for all 4 online-site-job resources"""
+    settings.CONCOURSE_TEAM = "myteam"
+    mock_post = mocker.patch("content_sync.pipelines.concourse.PipelineApi.post")
+    website = WebsiteFactory.create(
+        starter=WebsiteStarterFactory.create(
+            source=STARTER_SOURCE_GITHUB, path="https://github.com/org/repo/config"
+        )
+    )
+    pipeline = SitePipeline(website)
+    pipeline.check_online_site_job_resources(version)
+    expected_resources = [
+        WEBPACK_MANIFEST_S3_IDENTIFIER,
+        OCW_HUGO_THEMES_GIT_IDENTIFIER,
+        OCW_HUGO_PROJECTS_GIT_IDENTIFIER,
+        SITE_CONTENT_GIT_IDENTIFIER,
+    ]
+    assert mock_post.call_count == len(expected_resources)
+    actual_urls = [call.args[0] for call in mock_post.call_args_list]
+    for resource_name in expected_resources:
+        assert (
+            f"/api/v1/teams/myteam/pipelines/{version}/resources/{resource_name}/check{pipeline.instance_vars}"
+            in actual_urls
+        )
 
 
 def test_get_build_status(mocker, mock_auth):


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11520

### Description (What does it do?)

 content_sync/pipelines/concourse.py

   - Imported WEBPACK_MANIFEST_S3_IDENTIFIER, OCW_HUGO_THEMES_GIT_IDENTIFIER,   OCW_HUGO_PROJECTS_GIT_IDENTIFIER, SITE_CONTENT_GIT_IDENTIFIER from identifiers module
   - Added _make_resource_check_url(pipeline_name, resource_name) to GeneralPipeline — builds POST   /api/v1/teams/{team}/pipelines/{name}/resources/{resource}/check URL
   - Added check_resource(pipeline_name, resource_name) to GeneralPipeline — POSTs to the check URL
   - Added check_online_site_job_resources(pipeline_name) to SitePipeline — checks all 4 resources:   webpack-manifest-s3, ocw-hugo-themes-git, ocw-hugo-projects-git, site-content-git

  content_sync/api.py

   - In publish_website, calls pipeline.check_online_site_job_resources(version) immediately before   pipeline.trigger_pipeline_build(version)

  content_sync/pipelines/concourse_test.py

   - Added test_check_resource — verifies the correct Concourse API URL is POSTed to
   - Added test_check_online_site_job_resources — verifies all 4 resources are checked with correct URLs

  content_sync/api_test.py

   - Updated test_publish_website to assert check_online_site_job_resources is called (when trigger=True) or   not called (when trigger=False)


### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
  Problem

  When a course author publishes a site, ocw-studio triggers the Concourse online-site-job. The resources that job depends on were not being checked beforehand, which could cause the job to use stale resource versions, or in our case, not run all because the resources never get checked. 

  Solution

  Added resource check calls for all 4 resources required by online-site-job, invoked automatically as part of every publish.
  
