### PR TITLE
feat: added management command to rename filenames

### DIFF
--- a/websites/management/commands/remove_uuid_from_filenames.py
+++ b/websites/management/commands/remove_uuid_from_filenames.py
@@ -1,7 +1,6 @@
 """Remove legacy UUID prefixes from resource filenames in S3."""  # noqa: INP001
 
 import re
-from urllib.parse import quote
 
 from django.conf import settings
 
@@ -78,7 +77,10 @@ class Command(WebsiteFilterCommand):
             try:
                 s3.copy_object(
                     Bucket=settings.AWS_STORAGE_BUCKET_NAME,
-                    CopySource=f"{settings.AWS_STORAGE_BUCKET_NAME}/{quote(old_key)}",
+                    CopySource={
+                        "Bucket": settings.AWS_STORAGE_BUCKET_NAME,
+                        "Key": old_key,
+                    },
                     Key=new_key,
                     ACL="public-read",
                 )

--- a/websites/management/commands/remove_uuid_from_filenames.py
+++ b/websites/management/commands/remove_uuid_from_filenames.py
@@ -59,10 +59,17 @@ def _collect_renames(queryset):
     Returns (tasks, skipped_count) where:
       tasks         -- list of RenameTask, one per valid rename
       skipped_count -- number of records skipped due to empty-result or conflict
+
+    Pre-fetches all existing file→pk mappings once upfront so the per-record
+    conflict check is an O(1) dict lookup rather than an individual DB query.
     """
     tasks = []
     skipped = 0
     claimed_keys = set()  # new_keys already reserved by earlier tasks in this batch
+    # Pre-fetch all non-empty file→pk mappings to avoid an N+1 conflict check.
+    existing_files = dict(
+        WebsiteContent.objects.exclude(file="").values_list("file", "pk")
+    )
     for content in queryset.iterator():
         old_key = str(content.file)
         new_key = strip_uuid_prefix(old_key)
@@ -88,12 +95,10 @@ def _collect_renames(queryset):
             skipped += 1
             continue
 
-        conflicting = (
-            WebsiteContent.objects.filter(file=new_key).exclude(pk=content.pk).first()
-        )
-        if conflicting:
+        conflicting_pk = existing_files.get(new_key)
+        if conflicting_pk and conflicting_pk != content.pk:
             print(  # noqa: T201
-                f"Skipping {old_key}: target key {new_key} already used by content pk={conflicting.pk}",  # noqa: E501
+                f"Skipping {old_key}: target key {new_key} already used by content pk={conflicting_pk}",  # noqa: E501
                 file=sys.stderr,
             )
             skipped += 1
@@ -178,22 +183,24 @@ class Command(WebsiteFilterCommand):
 
         # --- Discovery phase (no S3/DB writes) ---
         renames, skipped_count = _collect_renames(contents)
-        affected_website_ids = {task.website_id for task in renames}
-        patches = _collect_metadata_patches(affected_website_ids)
+        planned_website_ids = {task.website_id for task in renames}
 
         if dry_run:
+            # Compute planned patches only for the dry-run summary count.
+            planned_patches = _collect_metadata_patches(planned_website_ids)
             for task in renames:
                 self.stdout.write(f"Would rename: {task.old_key} -> {task.new_key}")
             self.stdout.write(
                 f"Dry run complete: {len(renames)} files would be renamed, "
                 f"{skipped_count} skipped, "
-                f"{len(patches)} video metadata records would be patched"
+                f"{len(planned_patches)} video metadata records would be patched"
             )
             return
 
         # --- Execution phase ---
         renamed_count = 0
         error_count = 0
+        actually_renamed_website_ids = set()
 
         for task in renames:
             try:
@@ -216,21 +223,31 @@ class Command(WebsiteFilterCommand):
                 )
                 self.stdout.write(f"Renamed: {task.old_key} -> {task.new_key}")
                 renamed_count += 1
+                actually_renamed_website_ids.add(task.website_id)
             except Exception as exc:  # noqa: BLE001
                 self.stderr.write(
                     f"Error renaming {task.old_key} to {task.new_key}: {exc!s}"
                 )
                 error_count += 1
 
-        if affected_website_ids:
-            Website.objects.filter(uuid__in=affected_website_ids).update(
+        # Dirty-flag and metadata updates are scoped to websites where at least
+        # one rename actually committed to the DB — not the full planned set.
+        # This prevents marking websites dirty or patching video metadata when
+        # the underlying S3/DB rename failed.
+        if actually_renamed_website_ids:
+            Website.objects.filter(uuid__in=actually_renamed_website_ids).update(
                 has_unpublished_live=True,
                 has_unpublished_draft=True,
             )
 
-        for patch in patches:
-            WebsiteContent.objects.filter(pk=patch.pk).update(
-                metadata=patch.updated_metadata
+        patches = _collect_metadata_patches(actually_renamed_website_ids)
+        if patches:
+            WebsiteContent.objects.bulk_update(
+                [
+                    WebsiteContent(pk=patch.pk, metadata=patch.updated_metadata)
+                    for patch in patches
+                ],
+                ["metadata"],
             )
 
         self.stdout.write(

--- a/websites/management/commands/remove_uuid_from_filenames.py
+++ b/websites/management/commands/remove_uuid_from_filenames.py
@@ -1,13 +1,14 @@
 """Remove legacy UUID prefixes from resource filenames in S3."""  # noqa: INP001
 
 import re
+from urllib.parse import quote
 
 from django.conf import settings
 
 from gdrive_sync.models import DriveFile
 from main.management.commands.filter import WebsiteFilterCommand
 from main.s3_utils import get_boto3_client
-from websites.models import WebsiteContent
+from websites.models import Website, WebsiteContent
 
 UUID_FILENAME_RE = re.compile(r"^[0-9a-f]{32}_", re.IGNORECASE)
 
@@ -38,6 +39,7 @@ class Command(WebsiteFilterCommand):
         renamed_count = 0
         skipped_count = 0
         error_count = 0
+        updated_website_ids = set()
 
         for content in contents.iterator():
             old_key = str(content.file)
@@ -76,7 +78,7 @@ class Command(WebsiteFilterCommand):
             try:
                 s3.copy_object(
                     Bucket=settings.AWS_STORAGE_BUCKET_NAME,
-                    CopySource=f"{settings.AWS_STORAGE_BUCKET_NAME}/{old_key}",
+                    CopySource=f"{settings.AWS_STORAGE_BUCKET_NAME}/{quote(old_key)}",
                     Key=new_key,
                     ACL="public-read",
                 )
@@ -84,17 +86,22 @@ class Command(WebsiteFilterCommand):
                     Bucket=settings.AWS_STORAGE_BUCKET_NAME,
                     Key=old_key,
                 )
-                content.file = new_key
-                content.save()
-                drive_file = DriveFile.objects.filter(resource=content).first()
-                if drive_file and drive_file.s3_key == old_key:
-                    drive_file.s3_key = new_key
-                    drive_file.save()
+                WebsiteContent.objects.filter(pk=content.pk).update(file=new_key)
+                DriveFile.objects.filter(resource=content, s3_key=old_key).update(
+                    s3_key=new_key
+                )
+                updated_website_ids.add(content.website_id)
                 self.stdout.write(f"Renamed: {old_key} -> {new_key}")
                 renamed_count += 1
             except Exception as exc:  # noqa: BLE001
                 self.stderr.write(f"Error renaming {old_key} to {new_key}: {exc!s}")
                 error_count += 1
+
+        if updated_website_ids:
+            Website.objects.filter(uuid__in=updated_website_ids).update(
+                has_unpublished_live=True,
+                has_unpublished_draft=True,
+            )
 
         if dry_run:
             self.stdout.write(

--- a/websites/management/commands/remove_uuid_from_filenames.py
+++ b/websites/management/commands/remove_uuid_from_filenames.py
@@ -15,8 +15,8 @@ from websites.models import Website, WebsiteContent
 class RenameTask(NamedTuple):
     """A planned S3 + DB rename for one WebsiteContent record."""
 
-    pk: str  # WebsiteContent pk (UUID string)
-    website_id: str  # Website.uuid (FK, used for dirty-flag bulk update)
+    pk: str  # str(WebsiteContent.pk) — integer AutoField stringified
+    website_id: str  # str(Website.uuid) — UUID FK used for dirty-flag bulk update
     old_key: str
     new_key: str
 
@@ -24,7 +24,7 @@ class RenameTask(NamedTuple):
 class MetadataPatch(NamedTuple):
     """A planned metadata update for one Video-type WebsiteContent record."""
 
-    pk: str  # WebsiteContent pk (UUID string)
+    pk: str  # str(WebsiteContent.pk) — integer AutoField stringified
     updated_metadata: dict
 
 
@@ -116,7 +116,7 @@ def _collect_renames(queryset):
     return tasks, skipped
 
 
-def _collect_metadata_patches(website_uuids):
+def _collect_metadata_patches(website_uuids, renamed_keys=None):
     """
     Scan Video-type resource records in *website_uuids* for stale UUID-prefixed
     paths in metadata["video_files"]["video_captions_file"] and
@@ -124,6 +124,13 @@ def _collect_metadata_patches(website_uuids):
 
     Returns list[MetadataPatch] — one entry per record that needs updating.
     Does not write to the database.
+
+    *renamed_keys* — if provided, only patch metadata values whose path
+    (after stripping a leading slash) appears in this set. This prevents
+    patching video metadata for a captions/transcript file whose rename was
+    skipped (e.g. due to a conflict), which would otherwise leave the metadata
+    pointing at the wrong S3 path. Omit for dry-run paths where all planned
+    renames are assumed to succeed.
     """
     if not website_uuids:
         return []
@@ -146,6 +153,11 @@ def _collect_metadata_patches(website_uuids):
         for field in ("video_captions_file", "video_transcript_file"):
             val = vf.get(field) or ""
             if val:
+                # If a renamed_keys filter is provided, skip values whose
+                # underlying file was not actually renamed (e.g. skipped due
+                # to a conflict). lstrip handles leading-slash variants.
+                if renamed_keys is not None and val.lstrip("/") not in renamed_keys:
+                    continue
                 new_val = strip_uuid_prefix(val)
                 if new_val != val:
                     vf[field] = new_val
@@ -201,6 +213,7 @@ class Command(WebsiteFilterCommand):
         renamed_count = 0
         error_count = 0
         actually_renamed_website_ids = set()
+        successfully_renamed_old_keys: set[str] = set()
 
         for task in renames:
             try:
@@ -224,6 +237,7 @@ class Command(WebsiteFilterCommand):
                 self.stdout.write(f"Renamed: {task.old_key} -> {task.new_key}")
                 renamed_count += 1
                 actually_renamed_website_ids.add(task.website_id)
+                successfully_renamed_old_keys.add(task.old_key)
             except Exception as exc:  # noqa: BLE001
                 self.stderr.write(
                     f"Error renaming {task.old_key} to {task.new_key}: {exc!s}"
@@ -240,7 +254,14 @@ class Command(WebsiteFilterCommand):
                 has_unpublished_draft=True,
             )
 
-        patches = _collect_metadata_patches(actually_renamed_website_ids)
+        # Pass successfully_renamed_old_keys so metadata is only patched for
+        # captions/transcript files whose underlying rename actually committed.
+        # Skipped files (e.g. due to a conflict) are excluded, preventing
+        # metadata from pointing at the wrong S3 path.
+        patches = _collect_metadata_patches(
+            actually_renamed_website_ids,
+            renamed_keys=successfully_renamed_old_keys,
+        )
         if patches:
             WebsiteContent.objects.bulk_update(
                 [

--- a/websites/management/commands/remove_uuid_from_filenames.py
+++ b/websites/management/commands/remove_uuid_from_filenames.py
@@ -1,6 +1,8 @@
 """Remove legacy UUID prefixes from resource filenames in S3."""  # noqa: INP001
 
 import re
+import sys
+from typing import NamedTuple
 
 from django.conf import settings
 
@@ -9,7 +11,146 @@ from main.management.commands.filter import WebsiteFilterCommand
 from main.s3_utils import get_boto3_client
 from websites.models import Website, WebsiteContent
 
+
+class RenameTask(NamedTuple):
+    """A planned S3 + DB rename for one WebsiteContent record."""
+
+    pk: str  # WebsiteContent pk (UUID string)
+    website_id: str  # Website.uuid (FK, used for dirty-flag bulk update)
+    old_key: str
+    new_key: str
+
+
+class MetadataPatch(NamedTuple):
+    """A planned metadata update for one Video-type WebsiteContent record."""
+
+    pk: str  # WebsiteContent pk (UUID string)
+    updated_metadata: dict
+
+
 UUID_FILENAME_RE = re.compile(r"^[0-9a-f]{32}_", re.IGNORECASE)
+
+
+def strip_uuid_prefix(path):
+    """
+    Strip a UUID prefix from the basename of a path value.
+
+    Handles values stored with or without a leading slash.
+    Returns the original value unchanged if no UUID prefix is found or if
+    stripping would leave an empty basename.
+    """
+    stripped = path.lstrip("/")
+    lead = path[: len(path) - len(stripped)]  # "" or "/"
+    prefix_path, _, basename = stripped.rpartition("/")
+    if not UUID_FILENAME_RE.match(basename):
+        return path
+    new_basename = basename[33:]  # 32 hex chars + 1 underscore
+    if not new_basename:
+        return path
+    new_path = f"{prefix_path}/{new_basename}" if prefix_path else new_basename
+    return f"{lead}{new_path}"
+
+
+def _collect_renames(queryset):
+    """
+    Scan *queryset* for WebsiteContent records whose file basename has a UUID
+    prefix and return the planned renames.
+
+    Returns (tasks, skipped_count) where:
+      tasks         -- list of RenameTask, one per valid rename
+      skipped_count -- number of records skipped due to empty-result or conflict
+    """
+    tasks = []
+    skipped = 0
+    claimed_keys = set()  # new_keys already reserved by earlier tasks in this batch
+    for content in queryset.iterator():
+        old_key = str(content.file)
+        new_key = strip_uuid_prefix(old_key)
+
+        if new_key == old_key:
+            # Either no UUID prefix, or strip would leave empty basename.
+            # Distinguish: re-check the basename directly.
+            _, _, basename = old_key.rpartition("/")
+            if UUID_FILENAME_RE.match(basename) and not basename[33:]:
+                print(  # noqa: T201
+                    f"Skipping {old_key}: filename would be empty after removing UUID prefix",  # noqa: E501
+                    file=sys.stderr,
+                )
+                skipped += 1
+            continue
+
+        # Check intra-batch conflict first (another task in this run claims new_key).
+        if new_key in claimed_keys:
+            print(  # noqa: T201
+                f"Skipping {old_key}: target key {new_key} already claimed by another record in this batch",  # noqa: E501
+                file=sys.stderr,
+            )
+            skipped += 1
+            continue
+
+        conflicting = (
+            WebsiteContent.objects.filter(file=new_key).exclude(pk=content.pk).first()
+        )
+        if conflicting:
+            print(  # noqa: T201
+                f"Skipping {old_key}: target key {new_key} already used by content pk={conflicting.pk}",  # noqa: E501
+                file=sys.stderr,
+            )
+            skipped += 1
+            continue
+
+        claimed_keys.add(new_key)
+        tasks.append(
+            RenameTask(
+                pk=str(content.pk),
+                website_id=str(content.website_id),
+                old_key=old_key,
+                new_key=new_key,
+            )
+        )
+    return tasks, skipped
+
+
+def _collect_metadata_patches(website_uuids):
+    """
+    Scan Video-type resource records in *website_uuids* for stale UUID-prefixed
+    paths in metadata["video_files"]["video_captions_file"] and
+    ["video_transcript_file"].
+
+    Returns list[MetadataPatch] — one entry per record that needs updating.
+    Does not write to the database.
+    """
+    if not website_uuids:
+        return []
+
+    patches = []
+    video_resources = (
+        WebsiteContent.objects.filter(
+            website__uuid__in=website_uuids,
+            type="resource",
+            metadata__resourcetype="Video",
+            metadata__video_files__isnull=False,
+        )
+        .values("pk", "metadata")
+        .iterator()
+    )
+    for resource in video_resources:
+        metadata = resource["metadata"] or {}
+        vf = metadata.get("video_files") or {}
+        changed = False
+        for field in ("video_captions_file", "video_transcript_file"):
+            val = vf.get(field) or ""
+            if val:
+                new_val = strip_uuid_prefix(val)
+                if new_val != val:
+                    vf[field] = new_val
+                    changed = True
+        if changed:
+            metadata["video_files"] = vf
+            patches.append(
+                MetadataPatch(pk=str(resource["pk"]), updated_metadata=metadata)
+            )
+    return patches
 
 
 class Command(WebsiteFilterCommand):
@@ -35,81 +176,64 @@ class Command(WebsiteFilterCommand):
             WebsiteContent.objects.filter(file__isnull=False).exclude(file="")
         )
 
-        renamed_count = 0
-        skipped_count = 0
-        error_count = 0
-        updated_website_ids = set()
+        # --- Discovery phase (no S3/DB writes) ---
+        renames, skipped_count = _collect_renames(contents)
+        affected_website_ids = {task.website_id for task in renames}
+        patches = _collect_metadata_patches(affected_website_ids)
 
-        for content in contents.iterator():
-            old_key = str(content.file)
-            prefix_path, _, basename = old_key.rpartition("/")
-
-            if not UUID_FILENAME_RE.match(basename):
-                continue
-
-            new_basename = basename[33:]  # 32 hex chars + 1 underscore
-            if not new_basename:
-                self.stderr.write(
-                    f"Skipping {old_key}: filename would be empty after removing UUID prefix"  # noqa: E501
-                )
-                skipped_count += 1
-                continue
-
-            new_key = f"{prefix_path}/{new_basename}" if prefix_path else new_basename
-
-            conflicting = (
-                WebsiteContent.objects.filter(file=new_key)
-                .exclude(pk=content.pk)
-                .first()
+        if dry_run:
+            for task in renames:
+                self.stdout.write(f"Would rename: {task.old_key} -> {task.new_key}")
+            self.stdout.write(
+                f"Dry run complete: {len(renames)} files would be renamed, "
+                f"{skipped_count} skipped, "
+                f"{len(patches)} video metadata records would be patched"
             )
-            if conflicting:
-                self.stderr.write(
-                    f"Skipping {old_key}: target key {new_key} already used by content pk={conflicting.pk}"  # noqa: E501
-                )
-                skipped_count += 1
-                continue
+            return
 
-            if dry_run:
-                self.stdout.write(f"Would rename: {old_key} -> {new_key}")
-                renamed_count += 1
-                continue
+        # --- Execution phase ---
+        renamed_count = 0
+        error_count = 0
 
+        for task in renames:
             try:
                 s3.copy_object(
                     Bucket=settings.AWS_STORAGE_BUCKET_NAME,
                     CopySource={
                         "Bucket": settings.AWS_STORAGE_BUCKET_NAME,
-                        "Key": old_key,
+                        "Key": task.old_key,
                     },
-                    Key=new_key,
+                    Key=task.new_key,
                     ACL="public-read",
                 )
+                WebsiteContent.objects.filter(pk=task.pk).update(file=task.new_key)
+                DriveFile.objects.filter(
+                    resource_id=task.pk, s3_key=task.old_key
+                ).update(s3_key=task.new_key)
                 s3.delete_object(
                     Bucket=settings.AWS_STORAGE_BUCKET_NAME,
-                    Key=old_key,
+                    Key=task.old_key,
                 )
-                WebsiteContent.objects.filter(pk=content.pk).update(file=new_key)
-                DriveFile.objects.filter(resource=content, s3_key=old_key).update(
-                    s3_key=new_key
-                )
-                updated_website_ids.add(content.website_id)
-                self.stdout.write(f"Renamed: {old_key} -> {new_key}")
+                self.stdout.write(f"Renamed: {task.old_key} -> {task.new_key}")
                 renamed_count += 1
             except Exception as exc:  # noqa: BLE001
-                self.stderr.write(f"Error renaming {old_key} to {new_key}: {exc!s}")
+                self.stderr.write(
+                    f"Error renaming {task.old_key} to {task.new_key}: {exc!s}"
+                )
                 error_count += 1
 
-        if updated_website_ids:
-            Website.objects.filter(uuid__in=updated_website_ids).update(
+        if affected_website_ids:
+            Website.objects.filter(uuid__in=affected_website_ids).update(
                 has_unpublished_live=True,
                 has_unpublished_draft=True,
             )
 
-        if dry_run:
-            self.stdout.write(
-                f"Dry run complete: {renamed_count} files would be renamed, {skipped_count} skipped"  # noqa: E501
+        for patch in patches:
+            WebsiteContent.objects.filter(pk=patch.pk).update(
+                metadata=patch.updated_metadata
             )
-        else:
-            self.stdout.write(
-                f"Done: {renamed_count} renamed, {skipped_count} skipped, {error_count} errors"  # noqa: E501
-            )
+
+        self.stdout.write(
+            f"Done: {renamed_count} renamed, {skipped_count} skipped, "
+            f"{error_count} errors, {len(patches)} video metadata records patched"
+        )

--- a/websites/management/commands/remove_uuid_from_filenames.py
+++ b/websites/management/commands/remove_uuid_from_filenames.py
@@ -1,0 +1,106 @@
+"""Remove legacy UUID prefixes from resource filenames in S3."""  # noqa: INP001
+
+import re
+
+from django.conf import settings
+
+from gdrive_sync.models import DriveFile
+from main.management.commands.filter import WebsiteFilterCommand
+from main.s3_utils import get_boto3_client
+from websites.models import WebsiteContent
+
+UUID_FILENAME_RE = re.compile(r"^[0-9a-f]{32}_", re.IGNORECASE)
+
+
+class Command(WebsiteFilterCommand):
+    """Remove legacy UUID prefixes from resource filenames in S3 and update database records."""  # noqa: E501
+
+    help = __doc__
+
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            dest="dry_run",
+            help="Print what would be done without making any changes",
+        )
+
+    def handle(self, *args, **options):
+        super().handle(*args, **options)
+        dry_run = options["dry_run"]
+        s3 = get_boto3_client("s3")
+
+        contents = self.filter_website_contents(
+            WebsiteContent.objects.filter(file__isnull=False).exclude(file="")
+        )
+
+        renamed_count = 0
+        skipped_count = 0
+        error_count = 0
+
+        for content in contents.iterator():
+            old_key = str(content.file)
+            prefix_path, _, basename = old_key.rpartition("/")
+
+            if not UUID_FILENAME_RE.match(basename):
+                continue
+
+            new_basename = basename[33:]  # 32 hex chars + 1 underscore
+            if not new_basename:
+                self.stderr.write(
+                    f"Skipping {old_key}: filename would be empty after removing UUID prefix"  # noqa: E501
+                )
+                skipped_count += 1
+                continue
+
+            new_key = f"{prefix_path}/{new_basename}" if prefix_path else new_basename
+
+            conflicting = (
+                WebsiteContent.objects.filter(file=new_key)
+                .exclude(pk=content.pk)
+                .first()
+            )
+            if conflicting:
+                self.stderr.write(
+                    f"Skipping {old_key}: target key {new_key} already used by content pk={conflicting.pk}"  # noqa: E501
+                )
+                skipped_count += 1
+                continue
+
+            if dry_run:
+                self.stdout.write(f"Would rename: {old_key} -> {new_key}")
+                renamed_count += 1
+                continue
+
+            try:
+                s3.copy_object(
+                    Bucket=settings.AWS_STORAGE_BUCKET_NAME,
+                    CopySource=f"{settings.AWS_STORAGE_BUCKET_NAME}/{old_key}",
+                    Key=new_key,
+                    ACL="public-read",
+                )
+                s3.delete_object(
+                    Bucket=settings.AWS_STORAGE_BUCKET_NAME,
+                    Key=old_key,
+                )
+                content.file = new_key
+                content.save()
+                drive_file = DriveFile.objects.filter(resource=content).first()
+                if drive_file and drive_file.s3_key == old_key:
+                    drive_file.s3_key = new_key
+                    drive_file.save()
+                self.stdout.write(f"Renamed: {old_key} -> {new_key}")
+                renamed_count += 1
+            except Exception as exc:  # noqa: BLE001
+                self.stderr.write(f"Error renaming {old_key} to {new_key}: {exc!s}")
+                error_count += 1
+
+        if dry_run:
+            self.stdout.write(
+                f"Dry run complete: {renamed_count} files would be renamed, {skipped_count} skipped"  # noqa: E501
+            )
+        else:
+            self.stdout.write(
+                f"Done: {renamed_count} renamed, {skipped_count} skipped, {error_count} errors"  # noqa: E501
+            )

--- a/websites/management/commands/remove_uuid_from_filenames_test.py
+++ b/websites/management/commands/remove_uuid_from_filenames_test.py
@@ -1,0 +1,143 @@
+"""Tests for the remove_uuid_from_filenames management command."""  # noqa: INP001
+
+import pytest
+from django.core.management import call_command
+
+from gdrive_sync.factories import DriveFileFactory
+from websites.factories import WebsiteContentFactory, WebsiteFactory
+
+pytestmark = pytest.mark.django_db
+
+
+UUID_PREFIX = "ab3d029952cda060f4afcd811189a591"
+
+
+@pytest.fixture
+def mock_s3(mocker):
+    """Mock S3 client used by the command."""
+    return mocker.patch(
+        "websites.management.commands.remove_uuid_from_filenames.get_boto3_client"
+    )
+
+
+def test_renames_file_with_uuid_prefix(settings, mock_s3):
+    """Files whose basename starts with a 32-char hex UUID prefix are renamed in S3 and in the DB."""
+    website = WebsiteFactory.create()
+    old_key = f"sites/{website.name}/{UUID_PREFIX}_document.pdf"
+    content = WebsiteContentFactory.create(website=website, file=old_key)
+    expected_new_key = f"sites/{website.name}/document.pdf"
+
+    call_command("remove_uuid_from_filenames", filter=website.name)
+
+    mock_s3_client = mock_s3.return_value
+    mock_s3_client.copy_object.assert_called_once_with(
+        Bucket=settings.AWS_STORAGE_BUCKET_NAME,
+        CopySource=f"{settings.AWS_STORAGE_BUCKET_NAME}/{old_key}",
+        Key=expected_new_key,
+        ACL="public-read",
+    )
+    mock_s3_client.delete_object.assert_called_once_with(
+        Bucket=settings.AWS_STORAGE_BUCKET_NAME,
+        Key=old_key,
+    )
+    content.refresh_from_db()
+    assert str(content.file) == expected_new_key
+
+
+def test_also_updates_drive_file(settings, mock_s3):
+    """The associated DriveFile.s3_key is updated when it matches the old S3 key."""
+    website = WebsiteFactory.create()
+    old_key = f"sites/{website.name}/{UUID_PREFIX}_photo.jpg"
+    content = WebsiteContentFactory.create(website=website, file=old_key)
+    drive_file = DriveFileFactory.create(
+        resource=content, website=website, s3_key=old_key
+    )
+    expected_new_key = f"sites/{website.name}/photo.jpg"
+
+    call_command("remove_uuid_from_filenames", filter=website.name)
+
+    drive_file.refresh_from_db()
+    assert drive_file.s3_key == expected_new_key
+
+
+def test_skips_file_without_uuid_prefix(mock_s3):
+    """Files whose basename does not start with a UUID prefix are left unchanged."""
+    website = WebsiteFactory.create()
+    plain_key = f"sites/{website.name}/document.pdf"
+    content = WebsiteContentFactory.create(website=website, file=plain_key)
+
+    call_command("remove_uuid_from_filenames", filter=website.name)
+
+    mock_s3.return_value.copy_object.assert_not_called()
+    content.refresh_from_db()
+    assert str(content.file) == plain_key
+
+
+def test_skips_conflicting_target_key(mock_s3):
+    """A file is skipped when the target key is already used by another WebsiteContent."""
+    website = WebsiteFactory.create()
+    old_key = f"sites/{website.name}/{UUID_PREFIX}_notes.txt"
+    new_key = f"sites/{website.name}/notes.txt"
+    WebsiteContentFactory.create(website=website, file=old_key)
+    WebsiteContentFactory.create(website=website, file=new_key)
+
+    call_command("remove_uuid_from_filenames", filter=website.name)
+
+    mock_s3.return_value.copy_object.assert_not_called()
+
+
+def test_dry_run_makes_no_changes(mock_s3):
+    """With --dry-run, no S3 operations are performed and the DB is not modified."""
+    website = WebsiteFactory.create()
+    old_key = f"sites/{website.name}/{UUID_PREFIX}_slides.pptx"
+    content = WebsiteContentFactory.create(website=website, file=old_key)
+
+    call_command("remove_uuid_from_filenames", filter=website.name, dry_run=True)
+
+    mock_s3.return_value.copy_object.assert_not_called()
+    mock_s3.return_value.delete_object.assert_not_called()
+    content.refresh_from_db()
+    assert str(content.file) == old_key
+
+
+def test_filter_limits_to_specified_website(mock_s3):
+    """The --filter argument restricts processing to the named website only."""
+    website_a = WebsiteFactory.create()
+    website_b = WebsiteFactory.create()
+    key_a = f"sites/{website_a.name}/{UUID_PREFIX}_file.pdf"
+    key_b = f"sites/{website_b.name}/{UUID_PREFIX}_file.pdf"
+    content_a = WebsiteContentFactory.create(website=website_a, file=key_a)
+    content_b = WebsiteContentFactory.create(website=website_b, file=key_b)
+
+    call_command("remove_uuid_from_filenames", filter=website_a.name)
+
+    assert mock_s3.return_value.copy_object.call_count == 1
+    content_a.refresh_from_db()
+    assert str(content_a.file) == f"sites/{website_a.name}/file.pdf"
+    content_b.refresh_from_db()
+    assert str(content_b.file) == key_b
+
+
+def test_s3_error_is_reported_and_does_not_abort(mock_s3):
+    """An S3 error on one file is reported and processing continues for other files."""
+    website = WebsiteFactory.create()
+    failing_key = f"sites/{website.name}/{UUID_PREFIX}_bad.pdf"
+    good_uuid = "cc4d029952cda060f4afcd811189a591"
+    succeeding_key = f"sites/{website.name}/{good_uuid}_good.pdf"
+    failing_content = WebsiteContentFactory.create(website=website, file=failing_key)
+    succeeding_content = WebsiteContentFactory.create(
+        website=website, file=succeeding_key
+    )
+
+    mock_s3.return_value.copy_object.side_effect = [
+        Exception("S3 unavailable"),
+        None,
+    ]
+
+    call_command("remove_uuid_from_filenames", filter=website.name)
+
+    assert mock_s3.return_value.copy_object.call_count == 2
+    failing_content.refresh_from_db()
+    assert str(failing_content.file) == failing_key
+    succeeding_content.refresh_from_db()
+    assert str(succeeding_content.file) == f"sites/{website.name}/good.pdf"

--- a/websites/management/commands/remove_uuid_from_filenames_test.py
+++ b/websites/management/commands/remove_uuid_from_filenames_test.py
@@ -1,11 +1,18 @@
 """Tests for the remove_uuid_from_filenames management command."""  # noqa: INP001
 
+from io import StringIO
+
 import pytest
 from django.core.management import call_command
 
 from gdrive_sync.factories import DriveFileFactory
 from websites.factories import WebsiteContentFactory, WebsiteFactory
-from websites.models import Website
+from websites.management.commands.remove_uuid_from_filenames import (
+    _collect_metadata_patches,
+    _collect_renames,
+    strip_uuid_prefix,
+)
+from websites.models import Website, WebsiteContent
 
 pytestmark = pytest.mark.django_db
 
@@ -19,6 +26,115 @@ def mock_s3(mocker):
     return mocker.patch(
         "websites.management.commands.remove_uuid_from_filenames.get_boto3_client"
     )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _collect_renames
+# ---------------------------------------------------------------------------
+
+
+def test_collect_renames_yields_task_for_uuid_prefixed_file():
+    """Returns a RenameTask for a file whose basename has a UUID prefix."""
+    website = WebsiteFactory.create()
+    old_key = f"sites/{website.name}/{UUID_PREFIX}_doc.pdf"
+    content = WebsiteContentFactory.create(website=website, file=old_key)
+    qs = WebsiteContent.objects.filter(pk=content.pk)
+
+    tasks, skipped = _collect_renames(qs)
+
+    assert skipped == 0
+    assert len(tasks) == 1
+    assert tasks[0].pk == str(content.pk)
+    assert tasks[0].old_key == old_key
+    assert tasks[0].new_key == f"sites/{website.name}/doc.pdf"
+    assert tasks[0].website_id == str(content.website_id)
+
+
+def test_collect_renames_skips_file_without_uuid_prefix():
+    """Files with no UUID prefix are silently skipped and not counted."""
+    website = WebsiteFactory.create()
+    content = WebsiteContentFactory.create(
+        website=website, file=f"sites/{website.name}/plain.pdf"
+    )
+    qs = WebsiteContent.objects.filter(pk=content.pk)
+
+    tasks, skipped = _collect_renames(qs)
+
+    assert tasks == []
+    assert skipped == 0  # not counted — no UUID prefix at all
+
+
+def test_collect_renames_skips_and_counts_empty_result_basename():
+    """A file whose basename is only <uuid>_ is skipped and counted."""
+    website = WebsiteFactory.create()
+    content = WebsiteContentFactory.create(
+        website=website, file=f"sites/{website.name}/{UUID_PREFIX}_"
+    )
+    qs = WebsiteContent.objects.filter(pk=content.pk)
+
+    tasks, skipped = _collect_renames(qs)
+
+    assert tasks == []
+    assert skipped == 1
+
+
+def test_collect_renames_skips_and_counts_conflict():
+    """A file is skipped when its target key is already held by another record."""
+    website = WebsiteFactory.create()
+    old_key = f"sites/{website.name}/{UUID_PREFIX}_notes.txt"
+    new_key = f"sites/{website.name}/notes.txt"
+    source = WebsiteContentFactory.create(website=website, file=old_key)
+    WebsiteContentFactory.create(website=website, file=new_key)  # occupies target
+    qs = WebsiteContent.objects.filter(pk=source.pk)
+
+    tasks, skipped = _collect_renames(qs)
+
+    assert tasks == []
+    assert skipped == 1
+
+
+def test_collect_renames_skips_intra_conflict():
+    """When two UUID-prefixed records want the same target, the second is skipped."""
+    website = WebsiteFactory.create()
+    uuid_b = "bb3d029952cda060f4afcd811189a591"  # pragma: allowlist secret
+    key_a = f"sites/{website.name}/{UUID_PREFIX}_file.pdf"
+    key_b = f"sites/{website.name}/{uuid_b}_file.pdf"
+    content_a = WebsiteContentFactory.create(website=website, file=key_a)
+    content_b = WebsiteContentFactory.create(website=website, file=key_b)
+    qs = WebsiteContent.objects.filter(pk__in=[content_a.pk, content_b.pk]).order_by(
+        "pk"
+    )
+
+    tasks, skipped = _collect_renames(qs)
+
+    # First record in pk order wins; second is a conflict
+    assert len(tasks) + skipped == 2
+    assert skipped == 1
+
+
+@pytest.mark.parametrize(
+    ("filename", "expected_result"),
+    [
+        # Path with directory prefix
+        (
+            f"sites/my-course/{UUID_PREFIX}_captions.vtt",
+            "sites/my-course/captions.vtt",
+        ),
+        # Path with no directory
+        (f"{UUID_PREFIX}_standalone.pdf", "standalone.pdf"),
+        # Path with leading slash
+        (
+            f"/sites/my-course/{UUID_PREFIX}_captions.vtt",
+            "/sites/my-course/captions.vtt",
+        ),
+        # Path with no UUID prefix should be unchanged
+        ("sites/my-course/captions.vtt", "sites/my-course/captions.vtt"),
+        # Path where stripping would leave an empty name should be unchanged
+        (f"sites/my-course/{UUID_PREFIX}_", f"sites/my-course/{UUID_PREFIX}_"),
+    ],
+)
+def test_strip_uuid_prefix(filename, expected_result):
+    assert strip_uuid_prefix(filename) == expected_result
 
 
 def test_renames_file_with_uuid_prefix(settings, mock_s3):
@@ -74,6 +190,20 @@ def test_skips_file_without_uuid_prefix(mock_s3):
     assert str(content.file) == plain_key
 
 
+def test_skips_file_with_empty_name_after_uuid_strip(mock_s3):
+    """A file whose basename is only the UUID prefix is skipped (stripping would leave an empty name)."""
+    website = WebsiteFactory.create()
+    # Basename is exactly "<uuid>_" with nothing after the underscore
+    empty_result_key = f"sites/{website.name}/{UUID_PREFIX}_"
+    content = WebsiteContentFactory.create(website=website, file=empty_result_key)
+
+    call_command("remove_uuid_from_filenames", filter=website.name)
+
+    mock_s3.return_value.copy_object.assert_not_called()
+    content.refresh_from_db()
+    assert str(content.file) == empty_result_key
+
+
 def test_skips_conflicting_target_key(mock_s3):
     """A file is skipped when the target key is already used by another WebsiteContent."""
     website = WebsiteFactory.create()
@@ -99,6 +229,36 @@ def test_dry_run_makes_no_changes(mock_s3):
     mock_s3.return_value.delete_object.assert_not_called()
     content.refresh_from_db()
     assert str(content.file) == old_key
+
+
+def test_dry_run_reports_metadata_patch_count(mock_s3):
+    """Dry-run summary includes the number of video metadata records that would be patched."""
+    website = WebsiteFactory.create()
+    captions_old = f"sites/{website.name}/{UUID_PREFIX}_captions.vtt"
+    # The file rename will be detected and trigger a metadata patch on the video resource
+    WebsiteContentFactory.create(website=website, file=captions_old)
+    WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_file": captions_old,
+                "video_transcript_file": None,
+            },
+        },
+    )
+
+    stdout = StringIO()
+    call_command(
+        "remove_uuid_from_filenames",
+        filter=website.name,
+        dry_run=True,
+        stdout=stdout,
+    )
+
+    output = stdout.getvalue()
+    assert "1 video metadata records would be patched" in output
 
 
 def test_filter_limits_to_specified_website(mock_s3):
@@ -176,3 +336,234 @@ def test_dry_run_does_not_mark_website_dirty(mock_s3):
     website.refresh_from_db()
     assert website.has_unpublished_live is False
     assert website.has_unpublished_draft is False
+
+
+def test_patches_video_metadata_captions_and_transcript(mock_s3):
+    """After renaming captions/transcript files, the parent video resource metadata is updated."""
+    website = WebsiteFactory.create()
+    captions_old = f"sites/{website.name}/{UUID_PREFIX}_captions.vtt"
+    transcript_old = f"sites/{website.name}/{UUID_PREFIX}_transcript.pdf"
+    captions_new = f"sites/{website.name}/captions.vtt"
+    transcript_new = f"sites/{website.name}/transcript.pdf"
+
+    WebsiteContentFactory.create(website=website, file=captions_old)
+    WebsiteContentFactory.create(website=website, file=transcript_old)
+    video_resource = WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_file": captions_old,
+                "video_transcript_file": transcript_old,
+            },
+        },
+    )
+
+    call_command("remove_uuid_from_filenames", filter=website.name)
+
+    video_resource.refresh_from_db()
+    assert video_resource.metadata["video_files"]["video_captions_file"] == captions_new
+    assert (
+        video_resource.metadata["video_files"]["video_transcript_file"]
+        == transcript_new
+    )
+
+
+def test_patches_video_metadata_with_leading_slash(mock_s3):
+    """Metadata paths stored with a leading slash are also patched correctly."""
+    website = WebsiteFactory.create()
+    captions_old = f"sites/{website.name}/{UUID_PREFIX}_captions.vtt"
+    video_resource = WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_file": f"/{captions_old}",
+                "video_transcript_file": None,
+            },
+        },
+    )
+    WebsiteContentFactory.create(website=website, file=captions_old)
+
+    call_command("remove_uuid_from_filenames", filter=website.name)
+
+    video_resource.refresh_from_db()
+    expected = f"/sites/{website.name}/captions.vtt"
+    assert video_resource.metadata["video_files"]["video_captions_file"] == expected
+
+
+def test_does_not_patch_non_video_resource_metadata(mock_s3):
+    """Metadata patching only touches records with resourcetype=Video."""
+    website = WebsiteFactory.create()
+    old_key = f"sites/{website.name}/{UUID_PREFIX}_doc.pdf"
+    doc_resource = WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        file=old_key,
+        metadata={"resourcetype": "Document", "video_files": None},
+    )
+
+    call_command("remove_uuid_from_filenames", filter=website.name)
+
+    doc_resource.refresh_from_db()
+    assert doc_resource.metadata.get("video_files") is None
+
+
+def test_dry_run_does_not_patch_video_metadata(mock_s3):
+    """With --dry-run, video metadata is not modified."""
+    website = WebsiteFactory.create()
+    captions_old = f"sites/{website.name}/{UUID_PREFIX}_captions.vtt"
+    WebsiteContentFactory.create(website=website, file=captions_old)
+    video_resource = WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_file": captions_old,
+                "video_transcript_file": None,
+            },
+        },
+    )
+
+    call_command("remove_uuid_from_filenames", filter=website.name, dry_run=True)
+
+    video_resource.refresh_from_db()
+    assert video_resource.metadata["video_files"]["video_captions_file"] == captions_old
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _collect_metadata_patches
+# ---------------------------------------------------------------------------
+
+
+def test_collect_metadata_patches_captions():
+    """Returns a MetadataPatch when video_captions_file has a UUID prefix."""
+    website = WebsiteFactory.create()
+    old_captions = f"sites/{website.name}/{UUID_PREFIX}_captions.vtt"
+    video = WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_file": old_captions,
+                "video_transcript_file": None,
+            },
+        },
+    )
+
+    patches = _collect_metadata_patches({str(website.uuid)})
+
+    assert len(patches) == 1
+    assert patches[0].pk == str(video.pk)
+    vf = patches[0].updated_metadata["video_files"]
+    assert vf["video_captions_file"] == f"sites/{website.name}/captions.vtt"
+    assert vf["video_transcript_file"] is None
+
+
+def test_collect_metadata_patches_transcript():
+    """Returns a MetadataPatch when video_transcript_file has a UUID prefix."""
+    website = WebsiteFactory.create()
+    old_transcript = f"sites/{website.name}/{UUID_PREFIX}_transcript.pdf"
+    WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_file": None,
+                "video_transcript_file": old_transcript,
+            },
+        },
+    )
+
+    patches = _collect_metadata_patches({str(website.uuid)})
+
+    assert len(patches) == 1
+    vf = patches[0].updated_metadata["video_files"]
+    assert vf["video_transcript_file"] == f"sites/{website.name}/transcript.pdf"
+
+
+def test_collect_metadata_patches_no_uuid_prefix_returns_empty():
+    """Returns nothing when metadata paths have no UUID prefix."""
+    website = WebsiteFactory.create()
+    WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_file": f"sites/{website.name}/captions.vtt",
+                "video_transcript_file": None,
+            },
+        },
+    )
+
+    patches = _collect_metadata_patches({str(website.uuid)})
+
+    assert patches == []
+
+
+def test_collect_metadata_patches_ignores_non_video_resource():
+    """Records with resourcetype != Video are not patched."""
+    website = WebsiteFactory.create()
+    WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        metadata={
+            "resourcetype": "Document",
+            "video_files": {
+                "video_captions_file": f"sites/{website.name}/{UUID_PREFIX}_cap.vtt",
+            },
+        },
+    )
+
+    patches = _collect_metadata_patches({str(website.uuid)})
+
+    assert patches == []
+
+
+def test_collect_metadata_patches_handles_null_values():
+    """None values in captions/transcript fields do not raise errors."""
+    website = WebsiteFactory.create()
+    WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_file": None,
+                "video_transcript_file": None,
+            },
+        },
+    )
+
+    patches = _collect_metadata_patches({str(website.uuid)})
+
+    assert patches == []
+
+
+def test_collect_metadata_patches_scoped_to_website_uuids():
+    """Only patches records in the supplied website UUID set."""
+    website_a = WebsiteFactory.create()
+    website_b = WebsiteFactory.create()
+    old_captions = f"sites/{website_b.name}/{UUID_PREFIX}_cap.vtt"
+    WebsiteContentFactory.create(
+        website=website_b,
+        type="resource",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_file": old_captions,
+                "video_transcript_file": None,
+            },
+        },
+    )
+
+    # Only pass website_a's UUID — website_b's record must not appear
+    patches = _collect_metadata_patches({str(website_a.uuid)})
+
+    assert patches == []

--- a/websites/management/commands/remove_uuid_from_filenames_test.py
+++ b/websites/management/commands/remove_uuid_from_filenames_test.py
@@ -1,10 +1,13 @@
 """Tests for the remove_uuid_from_filenames management command."""  # noqa: INP001
 
+from urllib.parse import quote
+
 import pytest
 from django.core.management import call_command
 
 from gdrive_sync.factories import DriveFileFactory
 from websites.factories import WebsiteContentFactory, WebsiteFactory
+from websites.models import Website
 
 pytestmark = pytest.mark.django_db
 
@@ -32,7 +35,7 @@ def test_renames_file_with_uuid_prefix(settings, mock_s3):
     mock_s3_client = mock_s3.return_value
     mock_s3_client.copy_object.assert_called_once_with(
         Bucket=settings.AWS_STORAGE_BUCKET_NAME,
-        CopySource=f"{settings.AWS_STORAGE_BUCKET_NAME}/{old_key}",
+        CopySource=f"{settings.AWS_STORAGE_BUCKET_NAME}/{quote(old_key)}",
         Key=expected_new_key,
         ACL="public-read",
     )
@@ -141,3 +144,37 @@ def test_s3_error_is_reported_and_does_not_abort(mock_s3):
     assert str(failing_content.file) == failing_key
     succeeding_content.refresh_from_db()
     assert str(succeeding_content.file) == f"sites/{website.name}/good.pdf"
+
+
+def test_marks_website_dirty_after_rename(mock_s3):
+    """Websites with renamed files are marked as having unpublished changes."""
+    website = WebsiteFactory.create()
+    old_key = f"sites/{website.name}/{UUID_PREFIX}_report.pdf"
+    WebsiteContentFactory.create(website=website, file=old_key)
+    # Reset flags after content creation (signals set them on save)
+    Website.objects.filter(uuid=website.uuid).update(
+        has_unpublished_live=False, has_unpublished_draft=False
+    )
+
+    call_command("remove_uuid_from_filenames", filter=website.name)
+
+    website.refresh_from_db()
+    assert website.has_unpublished_live is True
+    assert website.has_unpublished_draft is True
+
+
+def test_dry_run_does_not_mark_website_dirty(mock_s3):
+    """With --dry-run, website dirty flags are not set."""
+    website = WebsiteFactory.create()
+    old_key = f"sites/{website.name}/{UUID_PREFIX}_report.pdf"
+    WebsiteContentFactory.create(website=website, file=old_key)
+    # Reset flags after content creation (signals set them on save)
+    Website.objects.filter(uuid=website.uuid).update(
+        has_unpublished_live=False, has_unpublished_draft=False
+    )
+
+    call_command("remove_uuid_from_filenames", filter=website.name, dry_run=True)
+
+    website.refresh_from_db()
+    assert website.has_unpublished_live is False
+    assert website.has_unpublished_draft is False

--- a/websites/management/commands/remove_uuid_from_filenames_test.py
+++ b/websites/management/commands/remove_uuid_from_filenames_test.py
@@ -157,6 +157,11 @@ def test_renames_file_with_uuid_prefix(settings, mock_s3):
         Bucket=settings.AWS_STORAGE_BUCKET_NAME,
         Key=old_key,
     )
+    # copy_object must precede delete_object — data-safe ordering invariant.
+    call_names = [c[0] for c in mock_s3_client.mock_calls]
+    assert call_names.index("copy_object") < call_names.index("delete_object"), (
+        "copy_object must be called before delete_object"
+    )
     content.refresh_from_db()
     assert str(content.file) == expected_new_key
 
@@ -335,6 +340,39 @@ def test_s3_error_does_not_dirty_website_or_patch_metadata(mock_s3):
     assert website.has_unpublished_live is False
     assert website.has_unpublished_draft is False
     # Video metadata must NOT be patched — the underlying file was not renamed
+    video_resource.refresh_from_db()
+    assert video_resource.metadata["video_files"]["video_captions_file"] == captions_old
+
+
+def test_metadata_not_patched_for_skipped_captions_rename(mock_s3):
+    """Video metadata is not patched when the captions file rename was skipped (conflict)."""
+    website = WebsiteFactory.create()
+    # File A renames successfully — puts website into actually_renamed_website_ids.
+    other_uuid = "cc4d029952cda060f4afcd811189a591"
+    old_key_a = f"sites/{website.name}/{other_uuid}_main.mp4"
+    WebsiteContentFactory.create(website=website, file=old_key_a)
+    # Captions file B: rename skipped — target key is already occupied.
+    captions_uuid = "bb3d029952cda060f4afcd811189a591"  # pragma: allowlist secret
+    captions_old = f"sites/{website.name}/{captions_uuid}_captions.vtt"
+    captions_new = f"sites/{website.name}/captions.vtt"
+    WebsiteContentFactory.create(website=website, file=captions_old)
+    WebsiteContentFactory.create(website=website, file=captions_new)  # occupies target
+    # Video resource references the skipped captions file.
+    video_resource = WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_file": captions_old,
+                "video_transcript_file": None,
+            },
+        },
+    )
+
+    call_command("remove_uuid_from_filenames", filter=website.name)
+
+    # Captions rename was skipped — metadata must NOT be patched to the stripped path.
     video_resource.refresh_from_db()
     assert video_resource.metadata["video_files"]["video_captions_file"] == captions_old
 

--- a/websites/management/commands/remove_uuid_from_filenames_test.py
+++ b/websites/management/commands/remove_uuid_from_filenames_test.py
@@ -1,7 +1,5 @@
 """Tests for the remove_uuid_from_filenames management command."""  # noqa: INP001
 
-from urllib.parse import quote
-
 import pytest
 from django.core.management import call_command
 
@@ -35,7 +33,7 @@ def test_renames_file_with_uuid_prefix(settings, mock_s3):
     mock_s3_client = mock_s3.return_value
     mock_s3_client.copy_object.assert_called_once_with(
         Bucket=settings.AWS_STORAGE_BUCKET_NAME,
-        CopySource=f"{settings.AWS_STORAGE_BUCKET_NAME}/{quote(old_key)}",
+        CopySource={"Bucket": settings.AWS_STORAGE_BUCKET_NAME, "Key": old_key},
         Key=expected_new_key,
         ACL="public-read",
     )

--- a/websites/management/commands/remove_uuid_from_filenames_test.py
+++ b/websites/management/commands/remove_uuid_from_filenames_test.py
@@ -304,6 +304,41 @@ def test_s3_error_is_reported_and_does_not_abort(mock_s3):
     assert str(succeeding_content.file) == f"sites/{website.name}/good.pdf"
 
 
+def test_s3_error_does_not_dirty_website_or_patch_metadata(mock_s3):
+    """A failed rename must not mark the website dirty or patch video metadata."""
+    website = WebsiteFactory.create()
+    captions_old = f"sites/{website.name}/{UUID_PREFIX}_captions.vtt"
+    captions_content = WebsiteContentFactory.create(website=website, file=captions_old)
+    video_resource = WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_file": captions_old,
+                "video_transcript_file": None,
+            },
+        },
+    )
+    Website.objects.filter(uuid=website.uuid).update(
+        has_unpublished_live=False, has_unpublished_draft=False
+    )
+    mock_s3.return_value.copy_object.side_effect = Exception("S3 unavailable")
+
+    call_command("remove_uuid_from_filenames", filter=website.name)
+
+    # Rename failed: file unchanged in DB
+    captions_content.refresh_from_db()
+    assert str(captions_content.file) == captions_old
+    # Website must NOT be marked dirty — no rename committed to DB
+    website.refresh_from_db()
+    assert website.has_unpublished_live is False
+    assert website.has_unpublished_draft is False
+    # Video metadata must NOT be patched — the underlying file was not renamed
+    video_resource.refresh_from_db()
+    assert video_resource.metadata["video_files"]["video_captions_file"] == captions_old
+
+
 def test_marks_website_dirty_after_rename(mock_s3):
     """Websites with renamed files are marked as having unpublished changes."""
     website = WebsiteFactory.create()


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/5790

### Description (What does it do?)
Adds a `remove_uuid_from_filenames` management command that strips the legacy UUID prefix (e.g. `ab3d029952cda060f4afcd811189a591_document.pdf` → `document.pdf`) from resource filenames stored in S3, then updates the corresponding `WebsiteContent.file` and `DriveFile.s3_key` database records.

Background: the UUID prefix was added to S3 keys to avoid collisions (see `WebsiteContent.upload_file_to`), but it was never meaningful to end users. A frontend workaround already hides it in the Edit Resource drawer, but the raw S3 URLs and downloads still expose it.

Key details:
- Uses `WebsiteFilterCommand`, so `--filter` / `--exclude` / `--filter-json` narrow the run to specific courses. With no filter, the command runs across the entire database.
- `--dry-run` prints what would change without touching S3 or the database.
- S3 rename is a copy-then-delete; `CopySource` is passed as a dict so boto3 handles key escaping correctly.
- DB updates use `QuerySet.update()` (no `.save()` calls in the loop) to avoid N+1 writes and signal side effects.
- Websites whose files are renamed are bulk-marked `has_unpublished_live=True` / `has_unpublished_draft=True` at the end.
- Files are skipped (with a stderr message) if the target key is already occupied by another `WebsiteContent` record.

### How can this be tested?
**Dry run against a single course:**
```bash
python manage.py remove_uuid_from_filenames --filter <course-name> --dry-run
```
Verify the output lists the expected renames without modifying S3 or the database.

**Live run against a single course:**
```bash
python manage.py remove_uuid_from_filenames --filter <course-name>
```
Then confirm in S3 (or via the Django admin) that the affected `WebsiteContent.file` values no longer contain the 32-character hex prefix, and that the course is marked as having unpublished changes.

**Run across the entire database** (omit the filter):
```bash
python manage.py remove_uuid_from_filenames --dry-run
```