### PR TITLE
Add reconcile_open_textbook_lrt management command

### DIFF
--- a/websites/management/commands/reconcile_open_textbook_lrt.py
+++ b/websites/management/commands/reconcile_open_textbook_lrt.py
@@ -17,8 +17,6 @@ log = logging.getLogger(__name__)
 
 OPEN_TEXTBOOK_LRT = "Open Textbooks"
 LRT_FIELD = "learning_resource_types"
-# Postgres JSONField containment lookup: matches rows whose
-# metadata["learning_resource_types"] list currently contains OPEN_TEXTBOOK_LRT.
 HAS_TAG_FILTER = {f"metadata__{LRT_FIELD}__contains": OPEN_TEXTBOOK_LRT}
 BULK_UPDATE_BATCH_SIZE = 100
 

--- a/websites/management/commands/reconcile_open_textbook_lrt.py
+++ b/websites/management/commands/reconcile_open_textbook_lrt.py
@@ -52,6 +52,8 @@ def add_open_textbook(objects) -> list:
     for obj in objects:
         metadata = obj.metadata if isinstance(obj.metadata, dict) else {}
         learning_resource_types = metadata.get(LRT_FIELD) or []
+        if not isinstance(learning_resource_types, list):
+            learning_resource_types = []
         if OPEN_TEXTBOOK_LRT not in learning_resource_types:
             obj.metadata = {
                 **metadata,

--- a/websites/management/commands/reconcile_open_textbook_lrt.py
+++ b/websites/management/commands/reconcile_open_textbook_lrt.py
@@ -1,0 +1,189 @@
+"""Reconcile the "Open Textbooks" learning resource type to complete-textbook resources."""  # noqa: INP001, E501
+
+import logging
+from collections import Counter
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from websites.constants import (
+    CONTENT_TYPE_METADATA,
+    CONTENT_TYPE_PAGE,
+    CONTENT_TYPE_RESOURCE,
+)
+from websites.models import Website, WebsiteContent
+
+log = logging.getLogger(__name__)
+
+OPEN_TEXTBOOK_LRT = "Open Textbooks"
+LRT_FIELD = "learning_resource_types"
+# Postgres JSONField containment lookup: matches rows whose
+# metadata["learning_resource_types"] list currently contains OPEN_TEXTBOOK_LRT.
+HAS_TAG_FILTER = {f"metadata__{LRT_FIELD}__contains": OPEN_TEXTBOOK_LRT}
+BULK_UPDATE_BATCH_SIZE = 100
+
+
+def strip_open_textbook(objects) -> list:
+    """
+    Remove OPEN_TEXTBOOK_LRT from each object's ``metadata[LRT_FIELD]`` list.
+
+    ``objects`` is any iterable of objects exposing a ``.metadata`` dict (both
+    ``WebsiteContent`` and ``Website``). Returns the objects as a list, ready for
+    ``bulk_update(..., ["metadata"])`` and for collecting impacted website ids.
+    """
+    objects = list(objects)
+    for obj in objects:
+        learning_resource_types = obj.metadata.get(LRT_FIELD) or []
+        obj.metadata = {
+            **obj.metadata,
+            LRT_FIELD: [
+                lrt for lrt in learning_resource_types if lrt != OPEN_TEXTBOOK_LRT
+            ],
+        }
+    return objects
+
+
+def add_open_textbook(objects) -> list:
+    """
+    Add OPEN_TEXTBOOK_LRT to each object's ``metadata[LRT_FIELD]`` list if absent.
+
+    Returns the objects as a list, ready for ``bulk_update(..., ["metadata"])`` and
+    for collecting impacted website ids.
+    """
+    objects = list(objects)
+    for obj in objects:
+        metadata = obj.metadata if isinstance(obj.metadata, dict) else {}
+        learning_resource_types = metadata.get(LRT_FIELD) or []
+        if OPEN_TEXTBOOK_LRT not in learning_resource_types:
+            obj.metadata = {
+                **metadata,
+                LRT_FIELD: [*learning_resource_types, OPEN_TEXTBOOK_LRT],
+            }
+    return objects
+
+
+class Command(BaseCommand):
+    """Reconcile the "Open Textbooks" learning resource type to a set of complete-textbook resources."""  # noqa: E501
+
+    help = __doc__
+
+    def add_arguments(self, parser):
+        """Register the --textbook-uuids option."""
+        parser.add_argument(
+            "--textbook-uuids",
+            dest="textbook_uuids",
+            required=True,
+            help=(
+                "Comma-separated resource text_ids (UUIDs) for the complete-textbook "
+                'PDFs that should carry the "Open Textbooks" tag. The tag is removed '
+                "from everything else and from all Website.metadata, and added to "
+                "these resources and their courses' sitemetadata."
+            ),
+        )
+
+    def handle(self, *args, **options):  # noqa: ARG002
+        """Reconcile the tag to the textbook set and mark impacted sites dirty."""
+        textbook_uuids = {
+            uuid.strip()
+            for uuid in (options["textbook_uuids"] or "").split(",")
+            if uuid.strip()
+        }
+
+        # Validate the keep-list up front so a bad input never mutates data.
+        textbook_resources = WebsiteContent.objects.filter(
+            type=CONTENT_TYPE_RESOURCE, text_id__in=textbook_uuids
+        )
+        missing = sorted(
+            textbook_uuids - set(textbook_resources.values_list("text_id", flat=True))
+        )
+        if missing:
+            msg = f"No resource found for textbook UUID(s): {', '.join(missing)}"
+            raise CommandError(msg)
+        match_count = textbook_resources.count()
+        if match_count != len(textbook_uuids):
+            msg = (
+                f"{len(textbook_uuids)} textbook UUID(s) matched {match_count} "
+                "resources — a UUID resolves to more than one resource "
+                "(text_id is unique per site, not globally). Resolve the ambiguity "
+                "and retry."
+            )
+            raise CommandError(msg)
+        textbook_website_ids = set(
+            textbook_resources.values_list("website_id", flat=True)
+        )
+
+        with transaction.atomic():
+            # 1. Strip the tag from every Website and WebsiteContent that has it.
+            stripped_content = strip_open_textbook(
+                WebsiteContent.objects.filter(**HAS_TAG_FILTER)
+            )
+            WebsiteContent.objects.bulk_update(
+                stripped_content, ["metadata"], batch_size=BULK_UPDATE_BATCH_SIZE
+            )
+            stripped_websites = strip_open_textbook(
+                Website.objects.filter(**HAS_TAG_FILTER)
+            )
+            Website.objects.bulk_update(
+                stripped_websites, ["metadata"], batch_size=BULK_UPDATE_BATCH_SIZE
+            )
+
+            # 2. Add the tag to the textbook resources and their sitemetadata.
+            #    (Re-fetched so they reflect the strip above. Website.metadata is
+            #    intentionally not re-tagged — it is strip-only.)
+            tagged_content = add_open_textbook(
+                [
+                    *textbook_resources,
+                    *WebsiteContent.objects.filter(
+                        type=CONTENT_TYPE_METADATA,
+                        website_id__in=textbook_website_ids,
+                    ),
+                ]
+            )
+            WebsiteContent.objects.bulk_update(
+                tagged_content, ["metadata"], batch_size=BULK_UPDATE_BATCH_SIZE
+            )
+
+            # 3. Mark every touched site dirty. This is a best-effort superset:
+            #    every site that actually changed is flagged, and a few that only
+            #    saw no-op writes (e.g. a textbook already tagged) may be too.
+            impacted_website_ids = {content.website_id for content in stripped_content}
+            impacted_website_ids |= {website.uuid for website in stripped_websites}
+            impacted_website_ids |= {content.website_id for content in tagged_content}
+            Website.objects.filter(uuid__in=impacted_website_ids).update(
+                has_unpublished_live=True,
+                has_unpublished_draft=True,
+            )
+
+        self._log_summary(
+            stripped_content, stripped_websites, tagged_content, impacted_website_ids
+        )
+
+    def _log_summary(
+        self, stripped_content, stripped_websites, tagged_content, impacted_website_ids
+    ):
+        """Log per-type counts and the impacted sites for later selective publish."""
+        removed_by_type = Counter(content.type for content in stripped_content)
+        # Names (the publish identifier) of impacted sites, logged so the run can
+        # be followed by a targeted republish of exactly these sites.
+        impacted_names = sorted(
+            Website.objects.filter(uuid__in=impacted_website_ids).values_list(
+                "name", flat=True
+            )
+        )
+        log.info(
+            'Reconciled "%s": %d site(s) impacted and marked for republish: %s',
+            OPEN_TEXTBOOK_LRT,
+            len(impacted_names),
+            ", ".join(impacted_names),
+        )
+        self.stdout.write(
+            self.style.SUCCESS(
+                f'"{OPEN_TEXTBOOK_LRT}" reconciliation complete:\n'
+                f"  removed from {removed_by_type[CONTENT_TYPE_PAGE]} pages, "
+                f"{removed_by_type[CONTENT_TYPE_RESOURCE]} resources, "
+                f"{removed_by_type[CONTENT_TYPE_METADATA]} sitemetadata content, "
+                f"{len(stripped_websites)} Website.metadata records\n"
+                f"  ensured on {len(tagged_content)} textbook resource/sitemetadata item(s)\n"  # noqa: E501
+                f"  {len(impacted_names)} site(s) marked as having unpublished changes"
+            )
+        )

--- a/websites/management/commands/reconcile_open_textbook_lrt_test.py
+++ b/websites/management/commands/reconcile_open_textbook_lrt_test.py
@@ -24,15 +24,26 @@ from websites.models import Website
 
 pytestmark = pytest.mark.django_db
 
+# An unrelated metadata key the command must never touch. Seeded into every
+# object below so tests can assert reconciliation leaves other keys intact.
+OTHER_KEY = "title"
+OTHER_VALUE = "Unrelated metadata"
+
 
 def create_content(website, content_type, learning_resource_types, **kwargs):
     """Create a WebsiteContent with the given learning_resource_types list."""
     return WebsiteContentFactory.create(
         website=website,
         type=content_type,
-        metadata={LRT_FIELD: list(learning_resource_types)},
+        metadata={LRT_FIELD: list(learning_resource_types), OTHER_KEY: OTHER_VALUE},
         **kwargs,
     )
+
+
+def assert_unrelated_metadata_preserved(*objects):
+    """Assert the command left each (already-refreshed) object's other keys intact."""
+    for obj in objects:
+        assert obj.metadata[OTHER_KEY] == OTHER_VALUE
 
 
 def reset_dirty_flags(website):
@@ -58,30 +69,47 @@ def run_command(textbook_uuids):
 
 def test_strip_removes_tag_and_preserves_other_lrts():
     """strip_open_textbook drops only Open Textbooks, keeping other LRTs."""
-    objects = [SimpleNamespace(metadata={LRT_FIELD: [OPEN_TEXTBOOK_LRT, "Readings"]})]
+    objects = [
+        SimpleNamespace(
+            metadata={
+                LRT_FIELD: [OPEN_TEXTBOOK_LRT, "Readings"],
+                OTHER_KEY: OTHER_VALUE,
+            }
+        )
+    ]
     result = strip_open_textbook(objects)
     assert result[0].metadata[LRT_FIELD] == ["Readings"]
+    assert result[0].metadata[OTHER_KEY] == OTHER_VALUE  # unrelated key untouched
 
 
 def test_add_appends_tag_when_absent():
     """add_open_textbook appends the tag when missing."""
-    objects = [SimpleNamespace(metadata={LRT_FIELD: ["Readings"]})]
+    objects = [
+        SimpleNamespace(metadata={LRT_FIELD: ["Readings"], OTHER_KEY: OTHER_VALUE})
+    ]
     result = add_open_textbook(objects)
     assert result[0].metadata[LRT_FIELD] == ["Readings", OPEN_TEXTBOOK_LRT]
+    assert result[0].metadata[OTHER_KEY] == OTHER_VALUE  # unrelated key untouched
 
 
 def test_add_is_noop_when_already_present():
     """add_open_textbook does not duplicate an existing tag."""
-    objects = [SimpleNamespace(metadata={LRT_FIELD: [OPEN_TEXTBOOK_LRT]})]
+    objects = [
+        SimpleNamespace(
+            metadata={LRT_FIELD: [OPEN_TEXTBOOK_LRT], OTHER_KEY: OTHER_VALUE}
+        )
+    ]
     result = add_open_textbook(objects)
     assert result[0].metadata[LRT_FIELD] == [OPEN_TEXTBOOK_LRT]
+    assert result[0].metadata[OTHER_KEY] == OTHER_VALUE  # unrelated key untouched
 
 
 def test_add_handles_missing_field():
     """add_open_textbook creates the LRT list when it is absent."""
-    objects = [SimpleNamespace(metadata={})]
+    objects = [SimpleNamespace(metadata={OTHER_KEY: OTHER_VALUE})]
     result = add_open_textbook(objects)
     assert result[0].metadata[LRT_FIELD] == [OPEN_TEXTBOOK_LRT]
+    assert result[0].metadata[OTHER_KEY] == OTHER_VALUE  # unrelated key untouched
 
 
 def test_add_handles_none_metadata():
@@ -143,6 +171,7 @@ def test_strips_tag_from_page():
     run_command("")
     page.refresh_from_db()
     assert page.metadata[LRT_FIELD] == ["Readings"]
+    assert_unrelated_metadata_preserved(page)
 
 
 def test_keeps_textbook_resource_and_strips_other_resource():
@@ -155,6 +184,7 @@ def test_keeps_textbook_resource_and_strips_other_resource():
     excerpt.refresh_from_db()
     assert textbook.metadata[LRT_FIELD] == [OPEN_TEXTBOOK_LRT]
     assert excerpt.metadata[LRT_FIELD] == []
+    assert_unrelated_metadata_preserved(textbook, excerpt)
 
 
 def test_adds_tag_to_untagged_textbook_resource():
@@ -164,6 +194,7 @@ def test_adds_tag_to_untagged_textbook_resource():
     run_command(textbook.text_id)
     textbook.refresh_from_db()
     assert textbook.metadata[LRT_FIELD] == ["Readings", OPEN_TEXTBOOK_LRT]
+    assert_unrelated_metadata_preserved(textbook)
 
 
 def test_removes_only_open_textbook_from_multi_lrt_resource():
@@ -177,6 +208,7 @@ def test_removes_only_open_textbook_from_multi_lrt_resource():
     run_command("")
     resource.refresh_from_db()
     assert resource.metadata[LRT_FIELD] == ["Readings", "Lecture Notes"]
+    assert_unrelated_metadata_preserved(resource)
 
 
 # ---------------------------------------------------------------------------
@@ -186,7 +218,9 @@ def test_removes_only_open_textbook_from_multi_lrt_resource():
 
 def test_strips_course_level_for_textbookless_course():
     """A course with no textbook loses the tag from sitemetadata and Website.metadata."""
-    website = WebsiteFactory.create(metadata={LRT_FIELD: [OPEN_TEXTBOOK_LRT, "Exams"]})
+    website = WebsiteFactory.create(
+        metadata={LRT_FIELD: [OPEN_TEXTBOOK_LRT, "Exams"], OTHER_KEY: OTHER_VALUE}
+    )
     sitemeta = create_content(
         website, CONTENT_TYPE_METADATA, [OPEN_TEXTBOOK_LRT, "Exams"]
     )
@@ -195,11 +229,14 @@ def test_strips_course_level_for_textbookless_course():
     website.refresh_from_db()
     assert sitemeta.metadata[LRT_FIELD] == ["Exams"]
     assert website.metadata[LRT_FIELD] == ["Exams"]
+    assert_unrelated_metadata_preserved(sitemeta, website)
 
 
 def test_textbook_course_adds_to_sitemetadata_but_not_website_metadata():
     """A textbook course gains the tag on sitemetadata but never on Website.metadata."""
-    website = WebsiteFactory.create(metadata={LRT_FIELD: ["Exams"]})
+    website = WebsiteFactory.create(
+        metadata={LRT_FIELD: ["Exams"], OTHER_KEY: OTHER_VALUE}
+    )
     textbook = create_content(website, CONTENT_TYPE_RESOURCE, [OPEN_TEXTBOOK_LRT])
     sitemeta = create_content(website, CONTENT_TYPE_METADATA, ["Exams"])
     run_command(textbook.text_id)
@@ -207,13 +244,16 @@ def test_textbook_course_adds_to_sitemetadata_but_not_website_metadata():
     website.refresh_from_db()
     assert OPEN_TEXTBOOK_LRT in sitemeta.metadata[LRT_FIELD]  # added
     assert OPEN_TEXTBOOK_LRT not in website.metadata[LRT_FIELD]  # never added
+    assert_unrelated_metadata_preserved(sitemeta, website)
 
 
 def test_textbook_course_strips_website_metadata_even_when_sitemetadata_tagged():
     """Website.metadata is strip-only: a textbook course loses it there but keeps it
     on the sitemetadata content.
     """
-    website = WebsiteFactory.create(metadata={LRT_FIELD: [OPEN_TEXTBOOK_LRT]})
+    website = WebsiteFactory.create(
+        metadata={LRT_FIELD: [OPEN_TEXTBOOK_LRT], OTHER_KEY: OTHER_VALUE}
+    )
     textbook = create_content(website, CONTENT_TYPE_RESOURCE, [OPEN_TEXTBOOK_LRT])
     sitemeta = create_content(website, CONTENT_TYPE_METADATA, [OPEN_TEXTBOOK_LRT])
     run_command(textbook.text_id)
@@ -221,6 +261,7 @@ def test_textbook_course_strips_website_metadata_even_when_sitemetadata_tagged()
     sitemeta.refresh_from_db()
     assert website.metadata[LRT_FIELD] == []  # stripped, never re-added
     assert sitemeta.metadata[LRT_FIELD] == [OPEN_TEXTBOOK_LRT]  # retained
+    assert_unrelated_metadata_preserved(website, sitemeta)
 
 
 # ---------------------------------------------------------------------------
@@ -281,16 +322,20 @@ def test_reconciles_across_multiple_sites():
     """Several textbooks across several courses reconcile independently and correctly."""
     # Course A: a textbook (tagged) + an excerpt (tagged) + sitemetadata (untagged)
     # + Website.metadata (tagged).
-    course_a = WebsiteFactory.create(metadata={LRT_FIELD: [OPEN_TEXTBOOK_LRT]})
+    course_a = WebsiteFactory.create(
+        metadata={LRT_FIELD: [OPEN_TEXTBOOK_LRT], OTHER_KEY: OTHER_VALUE}
+    )
     textbook_a = create_content(course_a, CONTENT_TYPE_RESOURCE, [OPEN_TEXTBOOK_LRT])
     excerpt_a = create_content(course_a, CONTENT_TYPE_RESOURCE, [OPEN_TEXTBOOK_LRT])
     sitemeta_a = create_content(course_a, CONTENT_TYPE_METADATA, ["Exams"])
     # Course B: a textbook missing the tag + sitemetadata already tagged.
-    course_b = WebsiteFactory.create(metadata={LRT_FIELD: []})
+    course_b = WebsiteFactory.create(metadata={LRT_FIELD: [], OTHER_KEY: OTHER_VALUE})
     textbook_b = create_content(course_b, CONTENT_TYPE_RESOURCE, ["Readings"])
     sitemeta_b = create_content(course_b, CONTENT_TYPE_METADATA, [OPEN_TEXTBOOK_LRT])
     # Course C: no textbook — fully stripped.
-    course_c = WebsiteFactory.create(metadata={LRT_FIELD: [OPEN_TEXTBOOK_LRT]})
+    course_c = WebsiteFactory.create(
+        metadata={LRT_FIELD: [OPEN_TEXTBOOK_LRT], OTHER_KEY: OTHER_VALUE}
+    )
     page_c = create_content(course_c, CONTENT_TYPE_PAGE, [OPEN_TEXTBOOK_LRT])
     sitemeta_c = create_content(course_c, CONTENT_TYPE_METADATA, [OPEN_TEXTBOOK_LRT])
 
@@ -322,3 +367,15 @@ def test_reconciles_across_multiple_sites():
     assert page_c.metadata[LRT_FIELD] == []
     assert sitemeta_c.metadata[LRT_FIELD] == []
     assert course_c.metadata[LRT_FIELD] == []
+    # Every object's unrelated metadata key survived reconciliation.
+    assert_unrelated_metadata_preserved(
+        textbook_a,
+        excerpt_a,
+        sitemeta_a,
+        course_a,
+        textbook_b,
+        sitemeta_b,
+        page_c,
+        sitemeta_c,
+        course_c,
+    )

--- a/websites/management/commands/reconcile_open_textbook_lrt_test.py
+++ b/websites/management/commands/reconcile_open_textbook_lrt_test.py
@@ -1,0 +1,324 @@
+"""Tests for the reconcile_open_textbook_lrt management command."""  # noqa: INP001
+
+import logging
+from io import StringIO
+from types import SimpleNamespace
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from websites.constants import (
+    CONTENT_TYPE_METADATA,
+    CONTENT_TYPE_PAGE,
+    CONTENT_TYPE_RESOURCE,
+)
+from websites.factories import WebsiteContentFactory, WebsiteFactory
+from websites.management.commands.reconcile_open_textbook_lrt import (
+    LRT_FIELD,
+    OPEN_TEXTBOOK_LRT,
+    add_open_textbook,
+    strip_open_textbook,
+)
+from websites.models import Website
+
+pytestmark = pytest.mark.django_db
+
+
+def create_content(website, content_type, learning_resource_types, **kwargs):
+    """Create a WebsiteContent with the given learning_resource_types list."""
+    return WebsiteContentFactory.create(
+        website=website,
+        type=content_type,
+        metadata={LRT_FIELD: list(learning_resource_types)},
+        **kwargs,
+    )
+
+
+def reset_dirty_flags(website):
+    """Clear dirty flags without triggering WebsiteContent.save() side effects."""
+    Website.objects.filter(pk=website.pk).update(
+        has_unpublished_live=False, has_unpublished_draft=False
+    )
+
+
+def run_command(textbook_uuids):
+    """Invoke the command, returning captured stdout."""
+    out = StringIO()
+    call_command(
+        "reconcile_open_textbook_lrt", textbook_uuids=textbook_uuids, stdout=out
+    )
+    return out.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for the strip/add helpers
+# ---------------------------------------------------------------------------
+
+
+def test_strip_removes_tag_and_preserves_other_lrts():
+    """strip_open_textbook drops only Open Textbooks, keeping other LRTs."""
+    objects = [SimpleNamespace(metadata={LRT_FIELD: [OPEN_TEXTBOOK_LRT, "Readings"]})]
+    result = strip_open_textbook(objects)
+    assert result[0].metadata[LRT_FIELD] == ["Readings"]
+
+
+def test_add_appends_tag_when_absent():
+    """add_open_textbook appends the tag when missing."""
+    objects = [SimpleNamespace(metadata={LRT_FIELD: ["Readings"]})]
+    result = add_open_textbook(objects)
+    assert result[0].metadata[LRT_FIELD] == ["Readings", OPEN_TEXTBOOK_LRT]
+
+
+def test_add_is_noop_when_already_present():
+    """add_open_textbook does not duplicate an existing tag."""
+    objects = [SimpleNamespace(metadata={LRT_FIELD: [OPEN_TEXTBOOK_LRT]})]
+    result = add_open_textbook(objects)
+    assert result[0].metadata[LRT_FIELD] == [OPEN_TEXTBOOK_LRT]
+
+
+def test_add_handles_missing_field():
+    """add_open_textbook creates the LRT list when it is absent."""
+    objects = [SimpleNamespace(metadata={})]
+    result = add_open_textbook(objects)
+    assert result[0].metadata[LRT_FIELD] == [OPEN_TEXTBOOK_LRT]
+
+
+def test_add_handles_none_metadata():
+    """add_open_textbook tolerates a null metadata value."""
+    objects = [SimpleNamespace(metadata=None)]
+    result = add_open_textbook(objects)
+    assert result[0].metadata[LRT_FIELD] == [OPEN_TEXTBOOK_LRT]
+
+
+# ---------------------------------------------------------------------------
+# Input validation (runs before any data is mutated)
+# ---------------------------------------------------------------------------
+
+
+def test_unmatched_uuid_raises_error():
+    """A UUID that matches no resource aborts the command."""
+    with pytest.raises(CommandError, match="No resource found"):
+        run_command("does-not-exist")
+
+
+def test_uuid_matching_multiple_resources_raises_error():
+    """A UUID resolving to resources in more than one site aborts the command."""
+    site_a = WebsiteFactory.create()
+    site_b = WebsiteFactory.create()
+    create_content(site_a, CONTENT_TYPE_RESOURCE, [OPEN_TEXTBOOK_LRT], text_id="dup")
+    create_content(site_b, CONTENT_TYPE_RESOURCE, [OPEN_TEXTBOOK_LRT], text_id="dup")
+    with pytest.raises(CommandError, match="matched 2 resources"):
+        run_command("dup")
+
+
+def test_validation_failure_makes_no_changes():
+    """A failed validation leaves existing tags untouched."""
+    website = WebsiteFactory.create()
+    page = create_content(website, CONTENT_TYPE_PAGE, [OPEN_TEXTBOOK_LRT])
+    with pytest.raises(CommandError):
+        run_command("does-not-exist")
+    page.refresh_from_db()
+    assert page.metadata[LRT_FIELD] == [OPEN_TEXTBOOK_LRT]  # unchanged
+
+
+def test_duplicate_and_whitespace_uuids_are_deduped():
+    """Repeated UUIDs (and surrounding whitespace) are deduped, not a count error."""
+    website = WebsiteFactory.create()
+    textbook = create_content(website, CONTENT_TYPE_RESOURCE, ["Readings"])
+    run_command(f" {textbook.text_id}, {textbook.text_id} ")  # same UUID twice
+    textbook.refresh_from_db()
+    assert textbook.metadata[LRT_FIELD] == ["Readings", OPEN_TEXTBOOK_LRT]
+
+
+# ---------------------------------------------------------------------------
+# Pages and non-textbook resources are stripped
+# ---------------------------------------------------------------------------
+
+
+def test_strips_tag_from_page():
+    """Pages always lose the tag (they are never textbooks)."""
+    website = WebsiteFactory.create()
+    page = create_content(website, CONTENT_TYPE_PAGE, [OPEN_TEXTBOOK_LRT, "Readings"])
+    run_command("")
+    page.refresh_from_db()
+    assert page.metadata[LRT_FIELD] == ["Readings"]
+
+
+def test_keeps_textbook_resource_and_strips_other_resource():
+    """A textbook resource keeps the tag; a non-textbook resource loses it."""
+    website = WebsiteFactory.create()
+    textbook = create_content(website, CONTENT_TYPE_RESOURCE, [OPEN_TEXTBOOK_LRT])
+    excerpt = create_content(website, CONTENT_TYPE_RESOURCE, [OPEN_TEXTBOOK_LRT])
+    run_command(textbook.text_id)
+    textbook.refresh_from_db()
+    excerpt.refresh_from_db()
+    assert textbook.metadata[LRT_FIELD] == [OPEN_TEXTBOOK_LRT]
+    assert excerpt.metadata[LRT_FIELD] == []
+
+
+def test_adds_tag_to_untagged_textbook_resource():
+    """A textbook resource that lacks the tag gains it."""
+    website = WebsiteFactory.create()
+    textbook = create_content(website, CONTENT_TYPE_RESOURCE, ["Readings"])
+    run_command(textbook.text_id)
+    textbook.refresh_from_db()
+    assert textbook.metadata[LRT_FIELD] == ["Readings", OPEN_TEXTBOOK_LRT]
+
+
+def test_removes_only_open_textbook_from_multi_lrt_resource():
+    """Only Open Textbooks is removed; other LRTs are left untouched."""
+    website = WebsiteFactory.create()
+    resource = create_content(
+        website,
+        CONTENT_TYPE_RESOURCE,
+        ["Readings", OPEN_TEXTBOOK_LRT, "Lecture Notes"],
+    )
+    run_command("")
+    resource.refresh_from_db()
+    assert resource.metadata[LRT_FIELD] == ["Readings", "Lecture Notes"]
+
+
+# ---------------------------------------------------------------------------
+# Course level — sitemetadata reconciled, Website.metadata strip-only
+# ---------------------------------------------------------------------------
+
+
+def test_strips_course_level_for_textbookless_course():
+    """A course with no textbook loses the tag from sitemetadata and Website.metadata."""
+    website = WebsiteFactory.create(metadata={LRT_FIELD: [OPEN_TEXTBOOK_LRT, "Exams"]})
+    sitemeta = create_content(
+        website, CONTENT_TYPE_METADATA, [OPEN_TEXTBOOK_LRT, "Exams"]
+    )
+    run_command("")  # no textbook resources -> course has no full textbook
+    sitemeta.refresh_from_db()
+    website.refresh_from_db()
+    assert sitemeta.metadata[LRT_FIELD] == ["Exams"]
+    assert website.metadata[LRT_FIELD] == ["Exams"]
+
+
+def test_textbook_course_adds_to_sitemetadata_but_not_website_metadata():
+    """A textbook course gains the tag on sitemetadata but never on Website.metadata."""
+    website = WebsiteFactory.create(metadata={LRT_FIELD: ["Exams"]})
+    textbook = create_content(website, CONTENT_TYPE_RESOURCE, [OPEN_TEXTBOOK_LRT])
+    sitemeta = create_content(website, CONTENT_TYPE_METADATA, ["Exams"])
+    run_command(textbook.text_id)
+    sitemeta.refresh_from_db()
+    website.refresh_from_db()
+    assert OPEN_TEXTBOOK_LRT in sitemeta.metadata[LRT_FIELD]  # added
+    assert OPEN_TEXTBOOK_LRT not in website.metadata[LRT_FIELD]  # never added
+
+
+def test_textbook_course_strips_website_metadata_even_when_sitemetadata_tagged():
+    """Website.metadata is strip-only: a textbook course loses it there but keeps it
+    on the sitemetadata content.
+    """
+    website = WebsiteFactory.create(metadata={LRT_FIELD: [OPEN_TEXTBOOK_LRT]})
+    textbook = create_content(website, CONTENT_TYPE_RESOURCE, [OPEN_TEXTBOOK_LRT])
+    sitemeta = create_content(website, CONTENT_TYPE_METADATA, [OPEN_TEXTBOOK_LRT])
+    run_command(textbook.text_id)
+    website.refresh_from_db()
+    sitemeta.refresh_from_db()
+    assert website.metadata[LRT_FIELD] == []  # stripped, never re-added
+    assert sitemeta.metadata[LRT_FIELD] == [OPEN_TEXTBOOK_LRT]  # retained
+
+
+# ---------------------------------------------------------------------------
+# Dirty flags and impacted-site logging
+# ---------------------------------------------------------------------------
+
+
+def test_marks_affected_site_dirty():
+    """A site whose content changed is marked as having unpublished changes."""
+    website = WebsiteFactory.create()
+    create_content(website, CONTENT_TYPE_PAGE, [OPEN_TEXTBOOK_LRT])
+    reset_dirty_flags(website)
+    run_command("")
+    website.refresh_from_db()
+    assert website.has_unpublished_live is True
+    assert website.has_unpublished_draft is True
+
+
+def test_site_without_tag_not_dirtied():
+    """A site with no Open Textbooks tag anywhere is left clean."""
+    website = WebsiteFactory.create()
+    create_content(website, CONTENT_TYPE_RESOURCE, ["Readings"])
+    reset_dirty_flags(website)
+    run_command("")
+    website.refresh_from_db()
+    assert website.has_unpublished_live is False
+    assert website.has_unpublished_draft is False
+
+
+def test_logs_impacted_sites_for_selective_publish(caplog):
+    """Impacted site names are logged so they can be republished afterward."""
+    website = WebsiteFactory.create()
+    create_content(website, CONTENT_TYPE_PAGE, [OPEN_TEXTBOOK_LRT])
+    with caplog.at_level(logging.INFO):
+        run_command("")
+    assert "impacted" in caplog.text
+    assert website.name in caplog.text
+
+
+def test_summary_reports_per_type_counts():
+    """The stdout summary reports how many of each content type were stripped."""
+    website = WebsiteFactory.create()
+    create_content(website, CONTENT_TYPE_PAGE, [OPEN_TEXTBOOK_LRT])
+    create_content(website, CONTENT_TYPE_RESOURCE, [OPEN_TEXTBOOK_LRT])  # excerpt
+    output = run_command("")
+    assert "reconciliation complete" in output
+    assert "1 pages" in output
+    assert "1 resources" in output
+    assert "1 site(s)" in output
+
+
+# ---------------------------------------------------------------------------
+# Cross-site integration — the realistic many-courses scenario
+# ---------------------------------------------------------------------------
+
+
+def test_reconciles_across_multiple_sites():
+    """Several textbooks across several courses reconcile independently and correctly."""
+    # Course A: a textbook (tagged) + an excerpt (tagged) + sitemetadata (untagged)
+    # + Website.metadata (tagged).
+    course_a = WebsiteFactory.create(metadata={LRT_FIELD: [OPEN_TEXTBOOK_LRT]})
+    textbook_a = create_content(course_a, CONTENT_TYPE_RESOURCE, [OPEN_TEXTBOOK_LRT])
+    excerpt_a = create_content(course_a, CONTENT_TYPE_RESOURCE, [OPEN_TEXTBOOK_LRT])
+    sitemeta_a = create_content(course_a, CONTENT_TYPE_METADATA, ["Exams"])
+    # Course B: a textbook missing the tag + sitemetadata already tagged.
+    course_b = WebsiteFactory.create(metadata={LRT_FIELD: []})
+    textbook_b = create_content(course_b, CONTENT_TYPE_RESOURCE, ["Readings"])
+    sitemeta_b = create_content(course_b, CONTENT_TYPE_METADATA, [OPEN_TEXTBOOK_LRT])
+    # Course C: no textbook — fully stripped.
+    course_c = WebsiteFactory.create(metadata={LRT_FIELD: [OPEN_TEXTBOOK_LRT]})
+    page_c = create_content(course_c, CONTENT_TYPE_PAGE, [OPEN_TEXTBOOK_LRT])
+    sitemeta_c = create_content(course_c, CONTENT_TYPE_METADATA, [OPEN_TEXTBOOK_LRT])
+
+    run_command(f"{textbook_a.text_id},{textbook_b.text_id}")
+
+    for obj in (
+        textbook_a,
+        excerpt_a,
+        sitemeta_a,
+        course_a,
+        textbook_b,
+        sitemeta_b,
+        page_c,
+        sitemeta_c,
+        course_c,
+    ):
+        obj.refresh_from_db()
+
+    # Course A: textbook kept, excerpt stripped, sitemetadata gains it,
+    # Website.metadata stripped.
+    assert textbook_a.metadata[LRT_FIELD] == [OPEN_TEXTBOOK_LRT]
+    assert excerpt_a.metadata[LRT_FIELD] == []
+    assert sitemeta_a.metadata[LRT_FIELD] == ["Exams", OPEN_TEXTBOOK_LRT]
+    assert course_a.metadata[LRT_FIELD] == []
+    # Course B: textbook gains it, sitemetadata retains it.
+    assert textbook_b.metadata[LRT_FIELD] == ["Readings", OPEN_TEXTBOOK_LRT]
+    assert sitemeta_b.metadata[LRT_FIELD] == [OPEN_TEXTBOOK_LRT]
+    # Course C: everything stripped.
+    assert page_c.metadata[LRT_FIELD] == []
+    assert sitemeta_c.metadata[LRT_FIELD] == []
+    assert course_c.metadata[LRT_FIELD] == []


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11882

### Description (What does it do?)
Adds a management command, `reconcile_open_textbook_lrt`, that restricts the **"Open Textbooks"** Learning Resource Type (LRT) to complete-textbook PDF resources, so open-textbook search results link to complete texts rather than chapter excerpts/fragments.

The `--textbook-uuids` list is the single source of truth. The command is declarative (strip-everything-then-add-back):

1. **Strip** `"Open Textbooks"` from every `WebsiteContent` and every `Website` that has it.
2. **Add** it to the complete-textbook resources and their courses' `sitemetadata` content. `Website.metadata` is **strip-only** — never re-added (the published/indexed course metadata is built from the `sitemetadata` content, not `Website.metadata`).
3. **Flag** every impacted site `has_unpublished_draft/live = True` and **log** their names so they can be selectively republished afterward (the command does not auto-publish).

Net effect: only the complete-textbook resources (and the course-level metadata of courses that own one) keep the tag; pages, excerpts, and textbook-less courses lose it.

Input is validated up front (no data is mutated on bad input): it errors if a UUID matches no resource, or if a UUID resolves to resources in more than one site (`text_id` is unique per-site, not globally). Duplicate/whitespace UUIDs are deduped.

Intentional trade-offs: dirty-flagging is best-effort (a few already-correct textbook sites may be flagged), and re-runs are not idempotent (textbook sites are re-stripped/re-added to the same final state and re-flagged each run) — acceptable for a one-off cleanup.


### How can this be tested?
2. In a local site, tag a page and two resources with "Open Textbooks" (one of the resources representing a complete-textbook PDF), and a couple of courses' sitemetadata.
3. Run `./manage.py reconcile_open_textbook_lrt --textbook-uuids <textbook_resource_text_id>`.
4. Verify: the page and the non-textbook resource lose the tag; the textbook resource keeps/gains it; the owning course's `sitemetadata` content gains the tag while its `Website.metadata` is stripped; a textbook-less course is fully stripped; and the impacted site is logged and marked `has_unpublished_live/draft`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)