### PR TITLE
fix: normalize s3 keys and export csv

### DIFF
--- a/websites/management/commands/remove_uuid_from_filenames.py
+++ b/websites/management/commands/remove_uuid_from_filenames.py
@@ -2,6 +2,7 @@
 
 import re
 import sys
+from collections import Counter
 from typing import NamedTuple
 
 from django.conf import settings
@@ -60,16 +61,22 @@ def _collect_renames(queryset):
       tasks         -- list of RenameTask, one per valid rename
       skipped_count -- number of records skipped due to empty-result or conflict
 
+    When multiple UUID-prefixed files would resolve to the same target key,
+    ALL of them are skipped — not just the second-and-later. This prevents a
+    collision where one source renames successfully but the other sources are
+    left with UUID prefixes still pointing at conflicting paths.
+
     Pre-fetches all existing file→pk mappings once upfront so the per-record
     conflict check is an O(1) dict lookup rather than an individual DB query.
     """
-    tasks = []
     skipped = 0
-    claimed_keys = set()  # new_keys already reserved by earlier tasks in this batch
     # Pre-fetch all non-empty file→pk mappings to avoid an N+1 conflict check.
     existing_files = dict(
         WebsiteContent.objects.exclude(file="").values_list("file", "pk")
     )
+
+    # Pass 1: collect all candidates that have a strippable UUID prefix.
+    candidates = []
     for content in queryset.iterator():
         old_key = str(content.file)
         new_key = strip_uuid_prefix(old_key)
@@ -86,17 +93,24 @@ def _collect_renames(queryset):
                 skipped += 1
             continue
 
-        # Check intra-batch conflict first (another task in this run claims new_key).
-        if new_key in claimed_keys:
+        candidates.append((content.pk, str(content.website_id), old_key, new_key))
+
+    # Pass 2: find target keys claimed by more than one source — ALL must be skipped.
+    target_counts = Counter(new_key for _, _, _, new_key in candidates)
+
+    # Pass 3: build the final task list, dropping ambiguous and conflicting targets.
+    tasks = []
+    for pk, website_id, old_key, new_key in candidates:
+        if target_counts[new_key] > 1:
             print(  # noqa: T201
-                f"Skipping {old_key}: target key {new_key} already claimed by another record in this batch",  # noqa: E501
+                f"Skipping {old_key}: target key {new_key} is claimed by {target_counts[new_key]} sources",  # noqa: E501
                 file=sys.stderr,
             )
             skipped += 1
             continue
 
         conflicting_pk = existing_files.get(new_key)
-        if conflicting_pk and conflicting_pk != content.pk:
+        if conflicting_pk and conflicting_pk != pk:
             print(  # noqa: T201
                 f"Skipping {old_key}: target key {new_key} already used by content pk={conflicting_pk}",  # noqa: E501
                 file=sys.stderr,
@@ -104,11 +118,10 @@ def _collect_renames(queryset):
             skipped += 1
             continue
 
-        claimed_keys.add(new_key)
         tasks.append(
             RenameTask(
-                pk=str(content.pk),
-                website_id=str(content.website_id),
+                pk=str(pk),
+                website_id=website_id,
                 old_key=old_key,
                 new_key=new_key,
             )

--- a/websites/management/commands/remove_uuid_from_filenames.py
+++ b/websites/management/commands/remove_uuid_from_filenames.py
@@ -71,10 +71,13 @@ def _collect_renames(queryset):
     conflict check is an O(1) dict lookup rather than an individual DB query.
     """
     skipped = 0
-    # Pre-fetch all non-empty file→pk mappings to avoid an N+1 conflict check.
-    existing_files = dict(
-        WebsiteContent.objects.exclude(file="").values_list("file", "pk")
-    )
+    # Normalize keys to strip any leading slash so conflict detection works
+    # regardless of whether legacy content stores paths with or without one.
+    existing_files = {
+        f.lstrip("/"): pk
+        for f, pk in WebsiteContent.objects.exclude(file="").values_list("file", "pk")
+        if f
+    }
 
     # Pass 1: collect all candidates that have a strippable UUID prefix.
     candidates = []
@@ -97,20 +100,23 @@ def _collect_renames(queryset):
         candidates.append((content.pk, str(content.website_id), old_key, new_key))
 
     # Pass 2: find target keys claimed by more than one source — ALL must be skipped.
-    target_counts = Counter(new_key for _, _, _, new_key in candidates)
+    # Normalize with lstrip to catch collisions between slash-prefixed and non-prefixed
+    # variants that resolve to the same S3 key.
+    target_counts = Counter(new_key.lstrip("/") for _, _, _, new_key in candidates)
 
     # Pass 3: build the final task list, dropping ambiguous and conflicting targets.
     tasks = []
     for pk, website_id, old_key, new_key in candidates:
-        if target_counts[new_key] > 1:
+        norm_new = new_key.lstrip("/")
+        if target_counts[norm_new] > 1:
             print(  # noqa: T201
-                f"Skipping {old_key}: target key {new_key} is claimed by {target_counts[new_key]} sources",  # noqa: E501
+                f"Skipping {old_key}: target key {new_key} is claimed by {target_counts[norm_new]} sources",  # noqa: E501
                 file=sys.stderr,
             )
             skipped += 1
             continue
 
-        conflicting_pk = existing_files.get(new_key)
+        conflicting_pk = existing_files.get(norm_new)
         if conflicting_pk and conflicting_pk != pk:
             print(  # noqa: T201
                 f"Skipping {old_key}: target key {new_key} already used by content pk={conflicting_pk}",  # noqa: E501
@@ -184,6 +190,24 @@ def _collect_metadata_patches(website_uuids, renamed_keys=None):
     return patches
 
 
+_CSV_FIELDNAMES = ["pk", "website_id", "website_name", "old_key", "new_key"]
+
+
+def _write_csv_rows(writer, renames, website_names):
+    """Write header + one row per RenameTask to *writer*."""
+    writer.writeheader()
+    for task in renames:
+        writer.writerow(
+            {
+                "pk": task.pk,
+                "website_id": task.website_id,
+                "website_name": website_names.get(task.website_id, ""),
+                "old_key": task.old_key,
+                "new_key": task.new_key,
+            }
+        )
+
+
 class Command(WebsiteFilterCommand):
     """Remove legacy UUID prefixes from resource filenames in S3 and update database records."""  # noqa: E501
 
@@ -210,7 +234,6 @@ class Command(WebsiteFilterCommand):
     def handle(self, *args, **options):
         super().handle(*args, **options)
         dry_run = options["dry_run"]
-        s3 = get_boto3_client("s3")
 
         contents = self.filter_website_contents(
             WebsiteContent.objects.filter(file__isnull=False).exclude(file="")
@@ -235,36 +258,21 @@ class Command(WebsiteFilterCommand):
                 if planned_website_ids
                 else {}
             )
-            fieldnames = ["pk", "website_id", "website_name", "old_key", "new_key"]
             output_path = options.get("output")
             if output_path:
                 with open(output_path, "w", newline="") as f:  # noqa: PTH123
-                    writer = csv.DictWriter(f, fieldnames=fieldnames)
-                    writer.writeheader()
-                    for task in renames:
-                        writer.writerow(
-                            {
-                                "pk": task.pk,
-                                "website_id": task.website_id,
-                                "website_name": website_names.get(task.website_id, ""),
-                                "old_key": task.old_key,
-                                "new_key": task.new_key,
-                            }
-                        )
+                    _write_csv_rows(
+                        csv.DictWriter(f, fieldnames=_CSV_FIELDNAMES),
+                        renames,
+                        website_names,
+                    )
                 plan_dest = output_path
             else:
-                writer = csv.DictWriter(self.stdout, fieldnames=fieldnames)
-                writer.writeheader()
-                for task in renames:
-                    writer.writerow(
-                        {
-                            "pk": task.pk,
-                            "website_id": task.website_id,
-                            "website_name": website_names.get(task.website_id, ""),
-                            "old_key": task.old_key,
-                            "new_key": task.new_key,
-                        }
-                    )
+                _write_csv_rows(
+                    csv.DictWriter(self.stdout, fieldnames=_CSV_FIELDNAMES),
+                    renames,
+                    website_names,
+                )
                 plan_dest = "stdout"
             self.stdout.write(
                 f"Dry run complete: {len(renames)} files would be renamed, "
@@ -275,18 +283,19 @@ class Command(WebsiteFilterCommand):
             return
 
         # --- Execution phase ---
+        s3 = get_boto3_client("s3")
         renamed_count = 0
         error_count = 0
         actually_renamed_website_ids = set()
         successfully_renamed_old_keys: set[str] = set()
 
         for task in renames:
+            # Legacy content.file values may be stored with a leading slash
+            # (e.g. /courses/...) but S3 keys never start with /.  Normalize
+            # before S3 operations to avoid NoSuchKey on pre-sites/ content.
+            s3_old_key = task.old_key.lstrip("/")
+            s3_new_key = task.new_key.lstrip("/")
             try:
-                # Legacy content.file values may be stored with a leading slash
-                # (e.g. /courses/...) but S3 keys never start with /.  Normalize
-                # before S3 operations to avoid NoSuchKey on pre-sites/ content.
-                s3_old_key = task.old_key.lstrip("/")
-                s3_new_key = task.new_key.lstrip("/")
                 s3.copy_object(
                     Bucket=settings.AWS_STORAGE_BUCKET_NAME,
                     CopySource={
@@ -300,21 +309,34 @@ class Command(WebsiteFilterCommand):
                 DriveFile.objects.filter(resource_id=task.pk, s3_key=s3_old_key).update(
                     s3_key=s3_new_key
                 )
-                s3.delete_object(
-                    Bucket=settings.AWS_STORAGE_BUCKET_NAME,
-                    Key=s3_old_key,
-                )
-                self.stdout.write(f"Renamed: {task.old_key} -> {task.new_key}")
-                renamed_count += 1
-                actually_renamed_website_ids.add(task.website_id)
-                # Store normalized key so _collect_metadata_patches can match
-                # val.lstrip("/") against it regardless of slash format.
-                successfully_renamed_old_keys.add(s3_old_key)
             except Exception as exc:  # noqa: BLE001
                 self.stderr.write(
                     f"Error renaming {task.old_key} to {task.new_key}: {exc!s}"
                 )
                 error_count += 1
+                continue
+
+            # copy + DB updates committed — record success for dirty-flag and
+            # metadata patching regardless of whether the old-key cleanup below
+            # succeeds.
+            self.stdout.write(f"Renamed: {task.old_key} -> {task.new_key}")
+            renamed_count += 1
+            actually_renamed_website_ids.add(task.website_id)
+            # Store normalized key so _collect_metadata_patches can match
+            # val.lstrip("/") against it regardless of slash format.
+            successfully_renamed_old_keys.add(s3_old_key)
+
+            try:
+                s3.delete_object(
+                    Bucket=settings.AWS_STORAGE_BUCKET_NAME,
+                    Key=s3_old_key,
+                )
+            except Exception as exc:  # noqa: BLE001
+                # The rename is already committed in DB and S3; the old key is
+                # now an orphan.  Log a warning but keep the success counters.
+                self.stderr.write(
+                    f"Warning: failed to delete old key {s3_old_key}: {exc!s}"
+                )
 
         # Dirty-flag and metadata updates are scoped to websites where at least
         # one rename actually committed to the DB — not the full planned set.

--- a/websites/management/commands/remove_uuid_from_filenames.py
+++ b/websites/management/commands/remove_uuid_from_filenames.py
@@ -195,9 +195,9 @@ class Command(WebsiteFilterCommand):
 
         # --- Discovery phase (no S3/DB writes) ---
         renames, skipped_count = _collect_renames(contents)
-        planned_website_ids = {task.website_id for task in renames}
 
         if dry_run:
+            planned_website_ids = {task.website_id for task in renames}
             # Compute planned patches only for the dry-run summary count.
             planned_patches = _collect_metadata_patches(planned_website_ids)
             for task in renames:
@@ -217,27 +217,34 @@ class Command(WebsiteFilterCommand):
 
         for task in renames:
             try:
+                # Legacy content.file values may be stored with a leading slash
+                # (e.g. /courses/...) but S3 keys never start with /.  Normalize
+                # before S3 operations to avoid NoSuchKey on pre-sites/ content.
+                s3_old_key = task.old_key.lstrip("/")
+                s3_new_key = task.new_key.lstrip("/")
                 s3.copy_object(
                     Bucket=settings.AWS_STORAGE_BUCKET_NAME,
                     CopySource={
                         "Bucket": settings.AWS_STORAGE_BUCKET_NAME,
-                        "Key": task.old_key,
+                        "Key": s3_old_key,
                     },
-                    Key=task.new_key,
+                    Key=s3_new_key,
                     ACL="public-read",
                 )
                 WebsiteContent.objects.filter(pk=task.pk).update(file=task.new_key)
-                DriveFile.objects.filter(
-                    resource_id=task.pk, s3_key=task.old_key
-                ).update(s3_key=task.new_key)
+                DriveFile.objects.filter(resource_id=task.pk, s3_key=s3_old_key).update(
+                    s3_key=s3_new_key
+                )
                 s3.delete_object(
                     Bucket=settings.AWS_STORAGE_BUCKET_NAME,
-                    Key=task.old_key,
+                    Key=s3_old_key,
                 )
                 self.stdout.write(f"Renamed: {task.old_key} -> {task.new_key}")
                 renamed_count += 1
                 actually_renamed_website_ids.add(task.website_id)
-                successfully_renamed_old_keys.add(task.old_key)
+                # Store normalized key so _collect_metadata_patches can match
+                # val.lstrip("/") against it regardless of slash format.
+                successfully_renamed_old_keys.add(s3_old_key)
             except Exception as exc:  # noqa: BLE001
                 self.stderr.write(
                     f"Error renaming {task.old_key} to {task.new_key}: {exc!s}"

--- a/websites/management/commands/remove_uuid_from_filenames.py
+++ b/websites/management/commands/remove_uuid_from_filenames.py
@@ -8,6 +8,7 @@ from typing import NamedTuple
 
 from django.conf import settings
 from django.core.management.base import CommandError
+from django.db import transaction
 
 from gdrive_sync.models import DriveFile
 from main.management.commands.filter import WebsiteFilterCommand
@@ -72,11 +73,15 @@ def _collect_renames(queryset):
     conflict check is an O(1) dict lookup rather than an individual DB query.
     """
     skipped = 0
-    # Normalize keys to strip any leading slash so conflict detection works
-    # regardless of whether legacy content stores paths with or without one.
+    # Restrict conflict detection to the websites present in the queryset.
+    # S3 keys are namespaced by website name, so cross-website collisions
+    # are impossible and scanning the whole table is wasteful at scale.
+    website_ids = set(queryset.values_list("website_id", flat=True).distinct())
     existing_files = {
         f.lstrip("/"): pk
-        for f, pk in WebsiteContent.objects.exclude(file="").values_list("file", "pk")
+        for f, pk in WebsiteContent.objects.filter(website_id__in=website_ids)
+        .exclude(file="")
+        .values_list("file", "pk")
         if f
     }
 
@@ -260,7 +265,7 @@ class Command(WebsiteFilterCommand):
                 if planned_website_ids
                 else {}
             )
-            with open(output_path, "w", newline="") as f:  # noqa: PTH123
+            with open(output_path, "w", newline="", encoding="utf-8") as f:  # noqa: PTH123
                 _write_csv_rows(
                     csv.DictWriter(f, fieldnames=_CSV_FIELDNAMES),
                     renames,
@@ -297,10 +302,11 @@ class Command(WebsiteFilterCommand):
                     Key=s3_new_key,
                     ACL="public-read",
                 )
-                WebsiteContent.objects.filter(pk=task.pk).update(file=task.new_key)
-                DriveFile.objects.filter(resource_id=task.pk, s3_key=s3_old_key).update(
-                    s3_key=s3_new_key
-                )
+                with transaction.atomic():
+                    WebsiteContent.objects.filter(pk=task.pk).update(file=task.new_key)
+                    DriveFile.objects.filter(
+                        resource_id=task.pk, s3_key=s3_old_key
+                    ).update(s3_key=s3_new_key)
             except Exception as exc:  # noqa: BLE001
                 self.stderr.write(
                     f"Error renaming {task.old_key} to {task.new_key}: {exc!s}"

--- a/websites/management/commands/remove_uuid_from_filenames.py
+++ b/websites/management/commands/remove_uuid_from_filenames.py
@@ -7,6 +7,7 @@ from collections import Counter
 from typing import NamedTuple
 
 from django.conf import settings
+from django.core.management.base import CommandError
 
 from gdrive_sync.models import DriveFile
 from main.management.commands.filter import WebsiteFilterCommand
@@ -225,10 +226,7 @@ class Command(WebsiteFilterCommand):
             "--output",
             dest="output",
             default=None,
-            help=(
-                "File path for the dry-run CSV plan (default: stdout). "
-                "Only used with --dry-run."
-            ),
+            help="File path for the CSV plan. Required with --dry-run.",
         )
 
     def handle(self, *args, **options):
@@ -243,6 +241,10 @@ class Command(WebsiteFilterCommand):
         renames, skipped_count = _collect_renames(contents)
 
         if dry_run:
+            output_path = options.get("output")
+            if not output_path:
+                msg = "--output is required when using --dry-run"
+                raise CommandError(msg)
             planned_website_ids = {task.website_id for task in renames}
             # Compute planned patches only for the dry-run summary count.
             planned_patches = _collect_metadata_patches(planned_website_ids)
@@ -258,27 +260,17 @@ class Command(WebsiteFilterCommand):
                 if planned_website_ids
                 else {}
             )
-            output_path = options.get("output")
-            if output_path:
-                with open(output_path, "w", newline="") as f:  # noqa: PTH123
-                    _write_csv_rows(
-                        csv.DictWriter(f, fieldnames=_CSV_FIELDNAMES),
-                        renames,
-                        website_names,
-                    )
-                plan_dest = output_path
-            else:
+            with open(output_path, "w", newline="") as f:  # noqa: PTH123
                 _write_csv_rows(
-                    csv.DictWriter(self.stdout, fieldnames=_CSV_FIELDNAMES),
+                    csv.DictWriter(f, fieldnames=_CSV_FIELDNAMES),
                     renames,
                     website_names,
                 )
-                plan_dest = "stdout"
             self.stdout.write(
                 f"Dry run complete: {len(renames)} files would be renamed, "
                 f"{skipped_count} skipped, "
                 f"{len(planned_patches)} video metadata records would be patched. "
-                f"Plan written to {plan_dest}."
+                f"Plan written to {output_path}."
             )
             return
 

--- a/websites/management/commands/remove_uuid_from_filenames.py
+++ b/websites/management/commands/remove_uuid_from_filenames.py
@@ -1,5 +1,6 @@
 """Remove legacy UUID prefixes from resource filenames in S3."""  # noqa: INP001
 
+import csv
 import re
 import sys
 from collections import Counter
@@ -194,7 +195,16 @@ class Command(WebsiteFilterCommand):
             "--dry-run",
             action="store_true",
             dest="dry_run",
-            help="Print what would be done without making any changes",
+            help="Export a rename plan CSV without making any changes",
+        )
+        parser.add_argument(
+            "--output",
+            dest="output",
+            default=None,
+            help=(
+                "File path for the dry-run CSV plan (default: stdout). "
+                "Only used with --dry-run."
+            ),
         )
 
     def handle(self, *args, **options):
@@ -213,12 +223,54 @@ class Command(WebsiteFilterCommand):
             planned_website_ids = {task.website_id for task in renames}
             # Compute planned patches only for the dry-run summary count.
             planned_patches = _collect_metadata_patches(planned_website_ids)
-            for task in renames:
-                self.stdout.write(f"Would rename: {task.old_key} -> {task.new_key}")
+            # Look up website names for the human-readable CSV column.
+            # Use str(uuid) as key to match task.website_id (already stringified).
+            website_names = (
+                {
+                    str(uuid): name
+                    for uuid, name in Website.objects.filter(
+                        uuid__in=planned_website_ids
+                    ).values_list("uuid", "name")
+                }
+                if planned_website_ids
+                else {}
+            )
+            fieldnames = ["pk", "website_id", "website_name", "old_key", "new_key"]
+            output_path = options.get("output")
+            if output_path:
+                with open(output_path, "w", newline="") as f:  # noqa: PTH123
+                    writer = csv.DictWriter(f, fieldnames=fieldnames)
+                    writer.writeheader()
+                    for task in renames:
+                        writer.writerow(
+                            {
+                                "pk": task.pk,
+                                "website_id": task.website_id,
+                                "website_name": website_names.get(task.website_id, ""),
+                                "old_key": task.old_key,
+                                "new_key": task.new_key,
+                            }
+                        )
+                plan_dest = output_path
+            else:
+                writer = csv.DictWriter(self.stdout, fieldnames=fieldnames)
+                writer.writeheader()
+                for task in renames:
+                    writer.writerow(
+                        {
+                            "pk": task.pk,
+                            "website_id": task.website_id,
+                            "website_name": website_names.get(task.website_id, ""),
+                            "old_key": task.old_key,
+                            "new_key": task.new_key,
+                        }
+                    )
+                plan_dest = "stdout"
             self.stdout.write(
                 f"Dry run complete: {len(renames)} files would be renamed, "
                 f"{skipped_count} skipped, "
-                f"{len(planned_patches)} video metadata records would be patched"
+                f"{len(planned_patches)} video metadata records would be patched. "
+                f"Plan written to {plan_dest}."
             )
             return
 

--- a/websites/management/commands/remove_uuid_from_filenames_test.py
+++ b/websites/management/commands/remove_uuid_from_filenames_test.py
@@ -1,5 +1,6 @@
 """Tests for the remove_uuid_from_filenames management command."""  # noqa: INP001
 
+import csv
 from io import StringIO
 
 import pytest
@@ -300,6 +301,31 @@ def test_dry_run_reports_metadata_patch_count(mock_s3):
 
     output = stdout.getvalue()
     assert "1 video metadata records would be patched" in output
+
+
+def test_dry_run_writes_csv_plan(tmp_path, mock_s3):
+    """Dry-run exports a CSV with pk, website info, and old/new S3 keys."""
+    website = WebsiteFactory.create()
+    old_key = f"sites/{website.name}/{UUID_PREFIX}_doc.pdf"
+    content = WebsiteContentFactory.create(website=website, file=old_key)
+    output_file = tmp_path / "plan.csv"
+
+    call_command(
+        "remove_uuid_from_filenames",
+        filter=website.name,
+        dry_run=True,
+        output=str(output_file),
+    )
+
+    assert output_file.exists()
+    with output_file.open("r", newline="") as f:
+        rows = list(csv.DictReader(f))
+    assert len(rows) == 1
+    assert rows[0]["pk"] == str(content.pk)
+    assert rows[0]["old_key"] == old_key
+    assert rows[0]["new_key"] == f"sites/{website.name}/doc.pdf"
+    assert rows[0]["website_id"] == str(website.uuid)
+    assert rows[0]["website_name"] == website.name
 
 
 def test_filter_limits_to_specified_website(mock_s3):

--- a/websites/management/commands/remove_uuid_from_filenames_test.py
+++ b/websites/management/commands/remove_uuid_from_filenames_test.py
@@ -443,6 +443,57 @@ def test_patches_video_metadata_captions_and_transcript(mock_s3):
     )
 
 
+def test_renames_file_with_leading_slash_normalizes_s3_key(settings, mock_s3):
+    """content.file paths with a leading slash are stripped before S3 operations."""
+    website = WebsiteFactory.create()
+    # Legacy courses/ content stores file paths with a leading slash in the DB.
+    old_key_db = f"/courses/{website.name}/{UUID_PREFIX}_ch8.pdf"
+    content = WebsiteContentFactory.create(website=website, file=old_key_db)
+    expected_s3_old = f"courses/{website.name}/{UUID_PREFIX}_ch8.pdf"
+    expected_s3_new = f"courses/{website.name}/ch8.pdf"
+
+    call_command("remove_uuid_from_filenames", filter=website.name)
+
+    mock_s3_client = mock_s3.return_value
+    mock_s3_client.copy_object.assert_called_once_with(
+        Bucket=settings.AWS_STORAGE_BUCKET_NAME,
+        CopySource={"Bucket": settings.AWS_STORAGE_BUCKET_NAME, "Key": expected_s3_old},
+        Key=expected_s3_new,
+        ACL="public-read",
+    )
+    mock_s3_client.delete_object.assert_called_once_with(
+        Bucket=settings.AWS_STORAGE_BUCKET_NAME,
+        Key=expected_s3_old,
+    )
+    content.refresh_from_db()
+    # DB value preserves the original leading-slash format; only UUID prefix stripped.
+    assert str(content.file) == f"/courses/{website.name}/ch8.pdf"
+
+
+def test_patches_video_metadata_when_file_has_leading_slash(mock_s3):
+    """Metadata is patched correctly when content.file and metadata both use leading-slash paths."""
+    website = WebsiteFactory.create()
+    captions_old_db = f"/courses/{website.name}/{UUID_PREFIX}_captions.vtt"
+    WebsiteContentFactory.create(website=website, file=captions_old_db)
+    video_resource = WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_file": captions_old_db,
+                "video_transcript_file": None,
+            },
+        },
+    )
+
+    call_command("remove_uuid_from_filenames", filter=website.name)
+
+    video_resource.refresh_from_db()
+    expected = f"/courses/{website.name}/captions.vtt"
+    assert video_resource.metadata["video_files"]["video_captions_file"] == expected
+
+
 def test_patches_video_metadata_with_leading_slash(mock_s3):
     """Metadata paths stored with a leading slash are also patched correctly."""
     website = WebsiteFactory.create()

--- a/websites/management/commands/remove_uuid_from_filenames_test.py
+++ b/websites/management/commands/remove_uuid_from_filenames_test.py
@@ -259,13 +259,18 @@ def test_skips_all_when_multiple_sources_target_same_key(mock_s3):
     assert str(content_b.file) == key_b
 
 
-def test_dry_run_makes_no_changes(mock_s3):
+def test_dry_run_makes_no_changes(tmp_path, mock_s3):
     """With --dry-run, no S3 operations are performed and the DB is not modified."""
     website = WebsiteFactory.create()
     old_key = f"sites/{website.name}/{UUID_PREFIX}_slides.pptx"
     content = WebsiteContentFactory.create(website=website, file=old_key)
 
-    call_command("remove_uuid_from_filenames", filter=website.name, dry_run=True)
+    call_command(
+        "remove_uuid_from_filenames",
+        filter=website.name,
+        dry_run=True,
+        output=str(tmp_path / "plan.csv"),
+    )
 
     mock_s3.return_value.copy_object.assert_not_called()
     mock_s3.return_value.delete_object.assert_not_called()
@@ -273,7 +278,7 @@ def test_dry_run_makes_no_changes(mock_s3):
     assert str(content.file) == old_key
 
 
-def test_dry_run_reports_metadata_patch_count(mock_s3):
+def test_dry_run_reports_metadata_patch_count(tmp_path, mock_s3):
     """Dry-run summary includes the number of video metadata records that would be patched."""
     website = WebsiteFactory.create()
     captions_old = f"sites/{website.name}/{UUID_PREFIX}_captions.vtt"
@@ -296,6 +301,7 @@ def test_dry_run_reports_metadata_patch_count(mock_s3):
         "remove_uuid_from_filenames",
         filter=website.name,
         dry_run=True,
+        output=str(tmp_path / "plan.csv"),
         stdout=stdout,
     )
 
@@ -326,6 +332,18 @@ def test_dry_run_writes_csv_plan(tmp_path, mock_s3):
     assert rows[0]["new_key"] == f"sites/{website.name}/doc.pdf"
     assert rows[0]["website_id"] == str(website.uuid)
     assert rows[0]["website_name"] == website.name
+
+
+def test_dry_run_requires_output(mock_s3):
+    """--dry-run without --output raises CommandError instead of writing to stdout."""
+    from django.core.management.base import CommandError  # noqa: PLC0415
+
+    website = WebsiteFactory.create()
+    WebsiteContentFactory.create(
+        website=website, file=f"sites/{website.name}/{UUID_PREFIX}_doc.pdf"
+    )
+    with pytest.raises(CommandError, match="--output is required"):
+        call_command("remove_uuid_from_filenames", filter=website.name, dry_run=True)
 
 
 def test_filter_limits_to_specified_website(mock_s3):
@@ -510,7 +528,7 @@ def test_marks_website_dirty_after_rename(mock_s3):
     assert website.has_unpublished_draft is True
 
 
-def test_dry_run_does_not_mark_website_dirty(mock_s3):
+def test_dry_run_does_not_mark_website_dirty(tmp_path, mock_s3):
     """With --dry-run, website dirty flags are not set."""
     website = WebsiteFactory.create()
     old_key = f"sites/{website.name}/{UUID_PREFIX}_report.pdf"
@@ -520,7 +538,12 @@ def test_dry_run_does_not_mark_website_dirty(mock_s3):
         has_unpublished_live=False, has_unpublished_draft=False
     )
 
-    call_command("remove_uuid_from_filenames", filter=website.name, dry_run=True)
+    call_command(
+        "remove_uuid_from_filenames",
+        filter=website.name,
+        dry_run=True,
+        output=str(tmp_path / "plan.csv"),
+    )
 
     website.refresh_from_db()
     assert website.has_unpublished_live is False
@@ -651,7 +674,7 @@ def test_does_not_patch_non_video_resource_metadata(mock_s3):
     assert doc_resource.metadata.get("video_files") is None
 
 
-def test_dry_run_does_not_patch_video_metadata(mock_s3):
+def test_dry_run_does_not_patch_video_metadata(tmp_path, mock_s3):
     """With --dry-run, video metadata is not modified."""
     website = WebsiteFactory.create()
     captions_old = f"sites/{website.name}/{UUID_PREFIX}_captions.vtt"
@@ -668,7 +691,12 @@ def test_dry_run_does_not_patch_video_metadata(mock_s3):
         },
     )
 
-    call_command("remove_uuid_from_filenames", filter=website.name, dry_run=True)
+    call_command(
+        "remove_uuid_from_filenames",
+        filter=website.name,
+        dry_run=True,
+        output=str(tmp_path / "plan.csv"),
+    )
 
     video_resource.refresh_from_db()
     assert video_resource.metadata["video_files"]["video_captions_file"] == captions_old

--- a/websites/management/commands/remove_uuid_from_filenames_test.py
+++ b/websites/management/commands/remove_uuid_from_filenames_test.py
@@ -182,6 +182,24 @@ def test_also_updates_drive_file(settings, mock_s3):
     assert drive_file.s3_key == expected_new_key
 
 
+def test_also_updates_drive_file_with_leading_slash_content(settings, mock_s3):
+    """DriveFile.s3_key is updated correctly when content.file has a leading slash."""
+    website = WebsiteFactory.create()
+    old_key_db = f"/courses/{website.name}/{UUID_PREFIX}_photo.jpg"
+    content = WebsiteContentFactory.create(website=website, file=old_key_db)
+    # DriveFile.s3_key is always stored without a leading slash (backfill normalizes it).
+    drive_file = DriveFileFactory.create(
+        resource=content,
+        website=website,
+        s3_key=f"courses/{website.name}/{UUID_PREFIX}_photo.jpg",
+    )
+
+    call_command("remove_uuid_from_filenames", filter=website.name)
+
+    drive_file.refresh_from_db()
+    assert drive_file.s3_key == f"courses/{website.name}/photo.jpg"
+
+
 def test_skips_file_without_uuid_prefix(mock_s3):
     """Files whose basename does not start with a UUID prefix are left unchanged."""
     website = WebsiteFactory.create()

--- a/websites/management/commands/remove_uuid_from_filenames_test.py
+++ b/websites/management/commands/remove_uuid_from_filenames_test.py
@@ -94,7 +94,7 @@ def test_collect_renames_skips_and_counts_conflict():
 
 
 def test_collect_renames_skips_intra_conflict():
-    """When two UUID-prefixed records want the same target, the second is skipped."""
+    """When two UUID-prefixed records want the same target, both are skipped."""
     website = WebsiteFactory.create()
     uuid_b = "bb3d029952cda060f4afcd811189a591"  # pragma: allowlist secret
     key_a = f"sites/{website.name}/{UUID_PREFIX}_file.pdf"
@@ -107,9 +107,9 @@ def test_collect_renames_skips_intra_conflict():
 
     tasks, skipped = _collect_renames(qs)
 
-    # First record in pk order wins; second is a conflict
-    assert len(tasks) + skipped == 2
-    assert skipped == 1
+    # Both sources target the same key — neither should be renamed.
+    assert tasks == []
+    assert skipped == 2
 
 
 @pytest.mark.parametrize(
@@ -238,6 +238,24 @@ def test_skips_conflicting_target_key(mock_s3):
     call_command("remove_uuid_from_filenames", filter=website.name)
 
     mock_s3.return_value.copy_object.assert_not_called()
+
+
+def test_skips_all_when_multiple_sources_target_same_key(mock_s3):
+    """When two UUID-prefixed files resolve to the same target, neither is renamed."""
+    website = WebsiteFactory.create()
+    uuid_b = "bb3d029952cda060f4afcd811189a591"  # pragma: allowlist secret
+    key_a = f"sites/{website.name}/{UUID_PREFIX}_report.pdf"
+    key_b = f"sites/{website.name}/{uuid_b}_report.pdf"
+    content_a = WebsiteContentFactory.create(website=website, file=key_a)
+    content_b = WebsiteContentFactory.create(website=website, file=key_b)
+
+    call_command("remove_uuid_from_filenames", filter=website.name)
+
+    mock_s3.return_value.copy_object.assert_not_called()
+    content_a.refresh_from_db()
+    content_b.refresh_from_db()
+    assert str(content_a.file) == key_a
+    assert str(content_b.file) == key_b
 
 
 def test_dry_run_makes_no_changes(mock_s3):

--- a/websites/management/commands/remove_uuid_from_filenames_test.py
+++ b/websites/management/commands/remove_uuid_from_filenames_test.py
@@ -439,6 +439,60 @@ def test_metadata_not_patched_for_skipped_captions_rename(mock_s3):
     assert video_resource.metadata["video_files"]["video_captions_file"] == captions_old
 
 
+def test_delete_object_failure_still_records_rename(mock_s3):
+    """A delete_object failure after a committed copy+DB rename still marks dirty and patches metadata."""
+    website = WebsiteFactory.create()
+    captions_old = f"sites/{website.name}/{UUID_PREFIX}_captions.vtt"
+    captions_content = WebsiteContentFactory.create(website=website, file=captions_old)
+    video_resource = WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_file": captions_old,
+                "video_transcript_file": None,
+            },
+        },
+    )
+    Website.objects.filter(uuid=website.uuid).update(
+        has_unpublished_live=False, has_unpublished_draft=False
+    )
+    mock_s3.return_value.delete_object.side_effect = Exception("Delete failed")
+
+    call_command("remove_uuid_from_filenames", filter=website.name)
+
+    # copy + DB updates committed before delete — rename should be counted
+    captions_content.refresh_from_db()
+    assert str(captions_content.file) == f"sites/{website.name}/captions.vtt"
+    # Website must be marked dirty despite delete failure
+    website.refresh_from_db()
+    assert website.has_unpublished_live is True
+    assert website.has_unpublished_draft is True
+    # Metadata must be patched
+    video_resource.refresh_from_db()
+    assert (
+        video_resource.metadata["video_files"]["video_captions_file"]
+        == f"sites/{website.name}/captions.vtt"
+    )
+
+
+def test_conflict_detection_normalizes_leading_slash(mock_s3):
+    """A conflict is detected even when the existing target key and the rename target differ only by leading slash."""
+    website = WebsiteFactory.create()
+    # Existing record holds the target path WITHOUT a leading slash.
+    existing_key = f"courses/{website.name}/doc.pdf"
+    WebsiteContentFactory.create(website=website, file=existing_key)
+    # Source has a leading slash and UUID prefix — would rename to /courses/.../doc.pdf.
+    # After lstrip normalization, this is the same S3 key as existing_key.
+    source_key = f"/courses/{website.name}/{UUID_PREFIX}_doc.pdf"
+    WebsiteContentFactory.create(website=website, file=source_key)
+
+    call_command("remove_uuid_from_filenames", filter=website.name)
+
+    mock_s3.return_value.copy_object.assert_not_called()
+
+
 def test_marks_website_dirty_after_rename(mock_s3):
     """Websites with renamed files are marked as having unpublished changes."""
     website = WebsiteFactory.create()

--- a/websites/management/commands/remove_uuid_from_filenames_test.py
+++ b/websites/management/commands/remove_uuid_from_filenames_test.py
@@ -324,7 +324,7 @@ def test_dry_run_writes_csv_plan(tmp_path, mock_s3):
     )
 
     assert output_file.exists()
-    with output_file.open("r", newline="") as f:
+    with output_file.open("r", newline="", encoding="utf-8") as f:
         rows = list(csv.DictReader(f))
     assert len(rows) == 1
     assert rows[0]["pk"] == str(content.pk)


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/5790

### Description
Follow-up fixes and improvements to the `remove_uuid_from_filenames` command introduced in #3064.

**S3 key normalization**: legacy `WebsiteContent.file` values stored with a leading slash (e.g., `/courses/...`) were causing `NoSuchKey` errors on `CopyObject`. Keys are now stripped of the leading slash before S3 operations.

**All-collision skipping**: When multiple UUID-prefixed files resolve to the same target key, all of them are skipped (previously only the second and later were skipped, silently leaving the first renamed into a potentially conflicting position).

**Conflict detection normalization**: `existing_files` conflict lookup now normalizes keys with `lstrip("/")` so a record stored as `courses/foo.pdf` correctly blocks a rename targeting `/courses/foo.pdf`.

**Dry-run exports CSV**: `--dry-run` no longer prints to stdout (impractical for large datasets). `--output <file>` is now required with `--dry-run` and writes a CSV with columns: `pk`, `website_id`, `website_name`, `old_key`, `new_key`.

**Partial-state safety**: `copy_object` + DB updates and `delete_object` are now in separate `try/except` blocks. A `delete_object` failure (orphaned old key) no longer prevents the website dirty flags and video metadata from being updated.

### How can this be tested?

**Dry run (single course):**
```bash
docker-compose exec web manage.py remove_uuid_from_filenames \
    --filter <course-name> \
    --dry-run \
    --output rename_plan.csv
```
Inspect `rename_plan.csv` and verify expected `old_key` → `new_key` pairs. No S3 or DB changes should occur.

**Live run (single course):**
```bash
python manage.py remove_uuid_from_filenames --filter <course-name>
```
Verify in S3 and Django admin that `WebsiteContent.file` values no longer carry the 32-char hex prefix, and the course is marked with unpublished changes.

**Collision handling**: if two UUID-prefixed files would rename to the same target, both should appear in stderr and be excluded from the CSV; neither should be renamed in a live run.

**Legacy leading-slash records**: for any `WebsiteContent` with `file` starting with `/courses/...`, the command should complete without `NoSuchKey` errors.
