### PR TITLE
fix: added `SECURE_PROXY_SSL_HEADER` in django settings

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -97,6 +97,7 @@ SECURE_SSL_REDIRECT = get_bool(
     description="Application-level SSL redirect setting.",
 )
 
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 USE_X_FORWARDED_HOST = get_bool(
     name="USE_X_FORWARDED_HOST",


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)

Adds `SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")` to Django settings.

The recent migration from uWSGI to Granian (via [ol-infrastructure#4834](https://github.com/mitodl/ol-infrastructure/pull/4834)) changed how the WSGI server receives requests. With uWSGI, the scheme was passed directly in the WSGI environ. With Granian, the nginx sidecar proxies requests over HTTP and communicates the original scheme via the `X-Forwarded-Proto: https` header. But Django ignores that header unless `SECURE_PROXY_SSL_HEADER` is configured.

Without this setting, `request.build_absolute_uri()` always produces `http://` URLs. This broke Keycloak login on RC because social-auth uses `build_absolute_uri` to construct the `redirect_uri` sent to Keycloak, and the Keycloak client only had the `https://` callback registered as a valid redirect URI.

### How can this be tested?

Make sure login works end-to-end and redirect-uri has `https://` scheme