### PR TITLE
feat: auto-link video caption/transcript resource fields

### DIFF
--- a/drf_lint_baseline.json
+++ b/drf_lint_baseline.json
@@ -1,5 +1,5 @@
 [
   "content_sync/serializers.py:142:21:ORM001",
   "content_sync/serializers.py:61:21:ORM001",
-  "websites/serializers.py:266:23:ORM001"
+  "websites/serializers.py:267:23:ORM001"
 ]

--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -46,7 +46,11 @@ from videos.api import create_media_convert_job
 from videos.constants import VideoJobStatus, VideoStatus
 from videos.models import Video, VideoJob
 from videos.utils import resource_file_paths
-from websites.api import auto_link_video_captions_transcript, get_valid_new_filename
+from websites.api import (
+    auto_link_video_captions_transcript,
+    get_valid_new_filename,
+    sync_website_content_references,
+)
 from websites.constants import (
     CONTENT_TYPE_RESOURCE,
     RESOURCE_TYPE_DOCUMENT,
@@ -463,6 +467,7 @@ def _link_video_caption_transcript_resources(
 
     if resource_type == RESOURCE_TYPE_VIDEO:
         auto_link_video_captions_transcript(resource)
+        sync_website_content_references(resource)
     elif "_captions" in filename:
         video_base = filename.split("_captions")[0]
         _link_resource_to_video(
@@ -536,6 +541,7 @@ def _link_resource_to_video(
         video_resource.metadata = {}
     video_resource.metadata["video_files"] = video_files
     video_resource.save()
+    sync_website_content_references(video_resource)
 
 
 @transaction.atomic

--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -45,7 +45,6 @@ from main.utils import get_base_filename, get_dirpath_and_filename
 from videos.api import create_media_convert_job
 from videos.constants import VideoJobStatus, VideoStatus
 from videos.models import Video, VideoJob
-from videos.utils import resource_file_paths
 from websites.api import (
     auto_link_video_captions_transcript,
     get_valid_new_filename,
@@ -455,12 +454,16 @@ def _link_video_caption_transcript_resources(
     fields are kept in sync after a gdrive resource is created or updated.
 
     - If *resource* is a Video, look for existing captions/transcript resources
-      in the same website by the ``{base}_captions_vtt`` / ``{base}_transcript_pdf``
-      filename convention and set the relation fields on the video (without
+      in the same website by the ``{base}_captions-<lang>-<locale>_vtt`` /
+      ``{base}_transcript-<lang>-<locale>_pdf`` filename convention (or the
+      legacy no-suffix form) and set the relation fields on the video (without
       overwriting ones that are already present).
     - If *resource* is a captions or transcript file, find the corresponding
       video resource by the same convention and set the appropriate relation
       field on that video.
+
+    Only ``_resources`` relation fields are written; legacy ``_file`` fields in
+    stored metadata are left untouched.
     """
     resource_type = (resource.metadata or {}).get("resourcetype")
     filename = resource.filename or ""
@@ -520,22 +523,6 @@ def _link_resource_to_video(
             "content": [new_id],
             "website": website.name,
         }
-
-    data_field = (
-        "video_captions_file"
-        if "captions" in resource_field
-        else "video_transcript_file"
-    )
-    new_file_entries = resource_file_paths([resource])
-    if new_file_entries:
-        existing_files = video_files.get(data_field)
-        if isinstance(existing_files, list):
-            existing_paths = {e.get("file") for e in existing_files}
-            extra = [e for e in new_file_entries if e["file"] not in existing_paths]
-            if extra:
-                video_files[data_field] = existing_files + extra
-        else:
-            video_files[data_field] = new_file_entries
 
     if not isinstance(video_resource.metadata, dict):
         video_resource.metadata = {}

--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -46,7 +46,7 @@ from videos.api import create_media_convert_job
 from videos.constants import VideoJobStatus, VideoStatus
 from videos.models import Video, VideoJob
 from videos.utils import resource_file_paths
-from websites.api import get_valid_new_filename
+from websites.api import auto_link_video_captions_transcript, get_valid_new_filename
 from websites.constants import (
     CONTENT_TYPE_RESOURCE,
     RESOURCE_TYPE_DOCUMENT,
@@ -462,7 +462,7 @@ def _link_video_caption_transcript_resources(
     filename = resource.filename or ""
 
     if resource_type == RESOURCE_TYPE_VIDEO:
-        _link_captions_transcript_to_video(resource, website)
+        auto_link_video_captions_transcript(resource)
     elif "_captions" in filename:
         video_base = filename.split("_captions")[0]
         _link_resource_to_video(
@@ -473,74 +473,6 @@ def _link_video_caption_transcript_resources(
         _link_resource_to_video(
             resource, website, "video_transcript_resources", video_base
         )
-
-
-def _link_captions_transcript_to_video(
-    video_resource: WebsiteContent, website: Website
-) -> None:
-    """Set _resource relation fields on a video from existing captions/transcript."""
-    video_base = get_base_filename(video_resource.filename or "")
-    if not video_base:
-        return
-    video_files = (
-        video_resource.metadata.get("video_files") if video_resource.metadata else None
-    )
-    if not isinstance(video_files, dict):
-        video_files = {}
-
-    changed = False
-    for resource_field, data_field, prefix, suffix in [
-        (
-            "video_captions_resources",
-            "video_captions_file",
-            f"{video_base}_captions",
-            "_vtt",
-        ),
-        (
-            "video_transcript_resources",
-            "video_transcript_file",
-            f"{video_base}_transcript",
-            "_pdf",
-        ),
-    ]:
-        related_list = list(
-            WebsiteContent.objects.filter(
-                website=website,
-                filename__startswith=prefix,
-                filename__endswith=suffix,
-            )
-        )
-        if not related_list:
-            continue
-
-        existing = video_files.get(resource_field)
-        existing_ids = existing.get("content", []) if isinstance(existing, dict) else []
-        new_resources = [r for r in related_list if str(r.text_id) not in existing_ids]
-        if not new_resources:
-            continue
-
-        all_ids = existing_ids + [str(r.text_id) for r in new_resources]
-        video_files[resource_field] = {
-            "content": all_ids,
-            "website": website.name,
-        }
-        new_file_entries = resource_file_paths(new_resources)
-        if new_file_entries:
-            existing_files = video_files.get(data_field)
-            if isinstance(existing_files, list):
-                existing_paths = {e.get("file") for e in existing_files}
-                video_files[data_field] = existing_files + [
-                    e for e in new_file_entries if e["file"] not in existing_paths
-                ]
-            else:
-                video_files[data_field] = new_file_entries
-        changed = True
-
-    if changed:
-        if not isinstance(video_resource.metadata, dict):
-            video_resource.metadata = {}
-        video_resource.metadata["video_files"] = video_files
-        video_resource.save()
 
 
 def _link_resource_to_video(

--- a/gdrive_sync/api_test.py
+++ b/gdrive_sync/api_test.py
@@ -1045,8 +1045,8 @@ def test_link_resource_to_video_appends_second_language():
     )
     caption_fr = WebsiteContentFactory.create(
         website=website,
-        filename="lecture1_captions_fr_vtt",
-        file=f"courses/{website.name}/lecture1_captions_fr.vtt",
+        filename="lecture1_captions-fr-ca_vtt",
+        file=f"courses/{website.name}/lecture1_captions-fr-CA.vtt",
     )
 
     # Link English first
@@ -1063,12 +1063,8 @@ def test_link_resource_to_video_appends_second_language():
     assert str(caption_fr.text_id) in vf["video_captions_resources"]["content"]
     assert len(vf["video_captions_resources"]["content"]) == 2
 
-    # _file list must also have both entries with correct languages
-    file_entries = vf["video_captions_file"]
-    assert len(file_entries) == 2
-    languages = {e["language"] for e in file_entries}
-    assert "en" in languages
-    assert "fr" in languages
+    # Legacy _file fields in stored metadata are never written by gdrive linking
+    assert "video_captions_file" not in vf
 
 
 @pytest.mark.django_db

--- a/gdrive_sync/api_test.py
+++ b/gdrive_sync/api_test.py
@@ -14,6 +14,7 @@ from gdrive_sync import api
 from gdrive_sync.api import (
     GDriveStreamReader,
     _link_resource_to_video,
+    _link_video_caption_transcript_resources,
     create_gdrive_resource_content,
     gdrive_root_url,
     get_resource_type,
@@ -1068,3 +1069,53 @@ def test_link_resource_to_video_appends_second_language():
     languages = {e["language"] for e in file_entries}
     assert "en" in languages
     assert "fr" in languages
+
+
+@pytest.mark.django_db
+def test_link_resource_to_video_syncs_content_references():
+    """Linking a caption via gdrive sync must refresh the video's reference tracking."""
+    website = WebsiteFactory.create()
+
+    video = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        filename="lecture1_mp4",
+        metadata={"resourcetype": "Video", "video_files": {}},
+    )
+    caption_en = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_captions_vtt",
+        file=f"courses/{website.name}/lecture1_captions.vtt",
+    )
+
+    assert caption_en not in video.referenced_by.all()
+
+    _link_resource_to_video(caption_en, website, "video_captions_resources", "lecture1")
+
+    video.refresh_from_db()
+    assert caption_en in video.referenced_by.all()
+
+
+@pytest.mark.django_db
+def test_link_video_caption_transcript_resources_syncs_content_references():
+    """Auto-linking captions onto a newly-synced video resource must refresh reference tracking."""
+    website = WebsiteFactory.create()
+
+    caption_en = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_captions_vtt",
+        file=f"courses/{website.name}/lecture1_captions.vtt",
+    )
+    video = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        filename="lecture1_mp4",
+        metadata={"resourcetype": "Video", "video_files": {}},
+    )
+
+    assert caption_en not in video.referenced_by.all()
+
+    _link_video_caption_transcript_resources(video, website)
+
+    video.refresh_from_db()
+    assert caption_en in video.referenced_by.all()

--- a/videos/constants.py
+++ b/videos/constants.py
@@ -67,3 +67,12 @@ class YouTubeStatus:
     REJECTED = "rejected"
     FAILED = "failed"
     RETRY = "retry"
+
+
+# Real file extensions (from WebsiteContent.file, not the filename field —
+# which can carry an appended numeric uniqueness suffix, e.g.
+# "lecture1_captions-en-us_vtt2") that identify a caption/transcript
+# resource. Must stay in sync with the extensions
+# videos.utils.parse_caption_language_locale recognizes.
+CAPTION_FILE_EXTENSIONS = ("vtt", "webvtt", "srt")
+TRANSCRIPT_FILE_EXTENSIONS = ("pdf",)

--- a/videos/constants.py
+++ b/videos/constants.py
@@ -72,7 +72,8 @@ class YouTubeStatus:
 # Real file extensions (from WebsiteContent.file, not the filename field —
 # which can carry an appended numeric uniqueness suffix, e.g.
 # "lecture1_captions-en-us_vtt2") that identify a caption/transcript
-# resource. Must stay in sync with the extensions
-# videos.utils.parse_caption_language_locale recognizes.
-CAPTION_FILE_EXTENSIONS = ("vtt", "webvtt", "srt")
+# resource. srt is deliberately excluded: it is not natively playable by
+# the HTML5 <track> element the way vtt/webvtt are (see the long-standing
+# "wrong_caption_type" case in videos/tasks_test.py::test_start_transcript_job).
+CAPTION_FILE_EXTENSIONS = ("vtt", "webvtt")
 TRANSCRIPT_FILE_EXTENSIONS = ("pdf",)

--- a/videos/models.py
+++ b/videos/models.py
@@ -5,9 +5,11 @@ from django.db.models import CASCADE
 from mitol.common.models import TimestampedModel, TimestampedModelQuerySet
 
 from main import settings
-from main.utils import get_base_filename
+from main.utils import get_base_filename, get_file_extension
 from videos.constants import (
+    CAPTION_FILE_EXTENSIONS,
     DESTINATION_YOUTUBE,
+    TRANSCRIPT_FILE_EXTENSIONS,
     VideoFileStatus,
     VideoJobStatus,
     VideoStatus,
@@ -53,10 +55,15 @@ class Video(TimestampedModel):
 
         Returns a 2-tuple of lists: (captions, transcripts).  Each list may
         contain zero, one, or multiple WebsiteContent objects — one per
-        language-tagged file discovered in the website.  Captions are matched
-        by filename prefix ``{video_filename}_captions`` with suffix ``_vtt``;
-        transcripts by prefix ``{video_filename}_transcript`` with suffix
-        ``_pdf``.
+        language-tagged file discovered in the website.  Candidates are found
+        by filename prefix (``{video_filename}_captions`` /
+        ``{video_filename}_transcript``) then filtered by the real extension
+        of their uploaded file (one of ``CAPTION_FILE_EXTENSIONS`` /
+        ``TRANSCRIPT_FILE_EXTENSIONS``). The real file extension is used
+        rather than the filename's tail because Django's filename-uniqueness
+        logic can append a bare digit to a colliding filename (e.g.
+        ``..._vtt`` -> ``..._vtt2``), which would defeat an exact suffix
+        match.
         """
         youtube_id = self.youtube_id()
 
@@ -68,19 +75,20 @@ class Video(TimestampedModel):
         )
         if video_resource:
             video_filename = get_base_filename(video_resource.filename)
-            captions = list(
-                WebsiteContent.objects.filter(
-                    website=self.website,
-                    filename__startswith=f"{video_filename}_captions",
-                    filename__endswith="_vtt",
+
+            def _matching(prefix, extensions):
+                candidates = WebsiteContent.objects.filter(
+                    website=self.website, filename__startswith=prefix
                 )
-            )
-            transcripts = list(
-                WebsiteContent.objects.filter(
-                    website=self.website,
-                    filename__startswith=f"{video_filename}_transcript",
-                    filename__endswith="_pdf",
-                )
+                return [
+                    r
+                    for r in candidates
+                    if r.file and get_file_extension(r.file.name) in extensions
+                ]
+
+            captions = _matching(f"{video_filename}_captions", CAPTION_FILE_EXTENSIONS)
+            transcripts = _matching(
+                f"{video_filename}_transcript", TRANSCRIPT_FILE_EXTENSIONS
             )
             return captions, transcripts
         return [], []

--- a/videos/models_test.py
+++ b/videos/models_test.py
@@ -42,12 +42,14 @@ def test_video_caption_transcript_resources(
     if has_transcript:
         WebsiteContentFactory.create(
             filename=preexisting_captions_filenames["website_content"]["transcript"],
+            file=f"courses/{video.website.name}/file_transcript.pdf",
             website=video.website,
         )
 
     if has_caption:
         WebsiteContentFactory.create(
             filename=preexisting_captions_filenames["website_content"]["captions"],
+            file=f"courses/{video.website.name}/file_captions.vtt",
             website=video.website,
         )
 
@@ -95,18 +97,99 @@ def test_video_caption_transcript_resources_multi_language(
     base = "_".join(video_filename.rsplit("_", 1)[:-1])
     WebsiteContentFactory.create(
         filename=f"{base}_captions_en_vtt",
+        file=f"courses/{video.website.name}/{base}_captions_en.vtt",
         website=video.website,
     )
     WebsiteContentFactory.create(
         filename=f"{base}_captions_es_vtt",
+        file=f"courses/{video.website.name}/{base}_captions_es.vtt",
         website=video.website,
     )
     WebsiteContentFactory.create(
         filename=f"{base}_transcript_fr_pdf",
+        file=f"courses/{video.website.name}/{base}_transcript_fr.pdf",
         website=video.website,
     )
 
     captions, transcripts = video.caption_transcript_resources()
 
     assert len(captions) == 2
+    assert len(transcripts) == 1
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("filename_suffix", ["_vtt", "_webvtt", "_srt"])
+def test_video_caption_transcript_resources_matches_all_extensions(
+    filename_suffix, preexisting_captions_filenames
+):
+    """caption_transcript_resources finds captions regardless of extension.
+
+    A caption file may slugify to _vtt, _webvtt, or _srt depending on its
+    source extension (3Play produces .webvtt). All three must be found.
+    """
+    youtube_id = "yt-ext"
+
+    video = VideoFactory.create()
+    VideoFileFactory.create(
+        destination=DESTINATION_YOUTUBE, video=video, destination_id=youtube_id
+    )
+    video_filename = preexisting_captions_filenames["website_content"]["video"]
+    WebsiteContentFactory.create(
+        metadata={"video_metadata": {"youtube_id": youtube_id}},
+        filename=video_filename,
+        website=video.website,
+    )
+    base = "_".join(video_filename.rsplit("_", 1)[:-1])
+    extension = filename_suffix.lstrip("_")
+    WebsiteContentFactory.create(
+        filename=f"{base}_captions-en-us{filename_suffix}",
+        file=f"courses/{video.website.name}/{base}_captions-en-US.{extension}",
+        website=video.website,
+    )
+
+    captions, _ = video.caption_transcript_resources()
+
+    assert len(captions) == 1
+
+
+@pytest.mark.django_db
+def test_video_caption_transcript_resources_survives_filename_uniqueness_suffix(
+    preexisting_captions_filenames,
+):
+    """caption_transcript_resources still matches when Django's filename-uniqueness
+    logic has appended a bare digit to the colliding filename (e.g. "..._vtt2").
+
+    This is the actual production bug: matching must rely on the resource's real
+    uploaded file extension, not the filename field, since find_available_name
+    can mutate the filename's tail with no separator.
+    """
+    youtube_id = "yt-collision"
+
+    video = VideoFactory.create()
+    VideoFileFactory.create(
+        destination=DESTINATION_YOUTUBE, video=video, destination_id=youtube_id
+    )
+    video_filename = preexisting_captions_filenames["website_content"]["video"]
+    WebsiteContentFactory.create(
+        metadata={"video_metadata": {"youtube_id": youtube_id}},
+        filename=video_filename,
+        website=video.website,
+    )
+    base = "_".join(video_filename.rsplit("_", 1)[:-1])
+    # Simulates a second same-named upload: find_available_name would produce
+    # this exact filename by appending "2" directly onto "..._vtt" / "..._pdf".
+    WebsiteContentFactory.create(
+        filename=f"{base}_captions-en-us_vtt2",
+        file=f"courses/{video.website.name}/{base}_captions-en-US.vtt",
+        website=video.website,
+    )
+    WebsiteContentFactory.create(
+        filename=f"{base}_transcript-en-us_pdf2",
+        file=f"courses/{video.website.name}/{base}_transcript-en-US.pdf",
+        website=video.website,
+    )
+
+    captions, transcripts = video.caption_transcript_resources()
+
+    assert len(captions) == 1
     assert len(transcripts) == 1

--- a/videos/models_test.py
+++ b/videos/models_test.py
@@ -118,14 +118,16 @@ def test_video_caption_transcript_resources_multi_language(
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("filename_suffix", ["_vtt", "_webvtt", "_srt"])
+@pytest.mark.parametrize("filename_suffix", ["_vtt", "_webvtt"])
 def test_video_caption_transcript_resources_matches_all_extensions(
     filename_suffix, preexisting_captions_filenames
 ):
     """caption_transcript_resources finds captions regardless of extension.
 
-    A caption file may slugify to _vtt, _webvtt, or _srt depending on its
-    source extension (3Play produces .webvtt). All three must be found.
+    A caption file may slugify to _vtt or _webvtt depending on its source
+    extension (3Play produces .webvtt). Both must be found. srt is
+    deliberately excluded - it's not natively playable via the HTML5
+    <track> element (see test_start_transcript_job's wrong_caption_type).
     """
     youtube_id = "yt-ext"
 

--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -50,11 +50,11 @@ from videos.exceptions import (
     raise_missing_file_metadata_error,
 )
 from videos.models import Video, VideoFile
+from videos.threeplay_sync import link_threeplay_files_as_resources
 from videos.utils import (
     create_new_content,
     fetch_youtube_snippets,
     process_video_tags,
-    resource_file_paths,
 )
 from videos.youtube import (
     API_QUOTA_ERROR_MSG,
@@ -170,11 +170,6 @@ def start_transcript_job(self, video_id: int, timeout_override: int | None = Non
         if captions_list:
             set_dict_field(
                 video_resource.metadata,
-                settings.YT_FIELD_CAPTIONS,
-                resource_file_paths(captions_list),
-            )
-            set_dict_field(
-                video_resource.metadata,
                 settings.YT_FIELD_CAPTIONS_RESOURCES,
                 {
                     "content": [str(r.text_id) for r in captions_list],
@@ -182,11 +177,6 @@ def start_transcript_job(self, video_id: int, timeout_override: int | None = Non
                 },
             )
         if transcripts_list:
-            set_dict_field(
-                video_resource.metadata,
-                settings.YT_FIELD_TRANSCRIPT,
-                resource_file_paths(transcripts_list),
-            )
             set_dict_field(
                 video_resource.metadata,
                 settings.YT_FIELD_TRANSCRIPT_RESOURCES,
@@ -371,80 +361,31 @@ def update_transcripts_for_video(video_id: int):  # noqa: C901
         )
 
         for video_resource in website.websitecontent_set.filter(**search_fields):
-            metadata = video_resource.metadata
             if has_threeplay_update:
-                set_dict_field(
-                    metadata,
-                    settings.YT_FIELD_TRANSCRIPT,
-                    [
-                        {
-                            "file": urljoin(
-                                "/",
-                                video.pdf_transcript_file.name.replace(
-                                    video.website.s3_path, video.website.url_path
-                                ),
-                            ),
-                            "language": "en",
-                        }
-                    ],
-                )
-                set_dict_field(
-                    metadata,
-                    settings.YT_FIELD_CAPTIONS,
-                    [
-                        {
-                            "file": urljoin(
-                                "/",
-                                video.webvtt_transcript_file.name.replace(
-                                    video.website.s3_path, video.website.url_path
-                                ),
-                            ),
-                            "language": "en",
-                        }
-                    ],
-                )
-                video_resource.save()
+                # Create resources from the downloaded 3Play files and link
+                # them via the _resources relation fields. The legacy _file
+                # fields in stored metadata are left untouched.
+                if link_threeplay_files_as_resources(video, video_resource):
+                    video_resource.save()
+                    sync_website_content_references(video_resource)
             else:
-                s3_path = video.website.s3_path
-                url_path = website.url_path
-                for resource_list, (file_field, resource_field) in [
-                    (
-                        captions_list,
-                        (
-                            settings.YT_FIELD_CAPTIONS,
-                            settings.YT_FIELD_CAPTIONS_RESOURCES,
-                        ),
-                    ),
-                    (
-                        transcripts_list,
-                        (
-                            settings.YT_FIELD_TRANSCRIPT,
-                            settings.YT_FIELD_TRANSCRIPT_RESOURCES,
-                        ),
-                    ),
+                for resource_list, resource_field in [
+                    (captions_list, settings.YT_FIELD_CAPTIONS_RESOURCES),
+                    (transcripts_list, settings.YT_FIELD_TRANSCRIPT_RESOURCES),
                 ]:
                     if resource_list:
-                        new_entries = [
-                            {
-                                **entry,
-                                "file": entry["file"].replace(s3_path, url_path, 1),
-                            }
-                            for entry in resource_file_paths(resource_list)
-                        ]
+                        new_relation = {
+                            "content": [str(r.text_id) for r in resource_list],
+                            "website": website.name,
+                        }
                         current_value = get_dict_field(
-                            video_resource.metadata, file_field
+                            video_resource.metadata, resource_field
                         )
-                        if current_value != new_entries:
-                            set_dict_field(
-                                video_resource.metadata, file_field, new_entries
-                            )
+                        if current_value != new_relation:
                             set_dict_field(
                                 video_resource.metadata,
                                 resource_field,
-                                {
-                                    "content": [str(r.text_id) for r in resource_list],
-                                    "website": website.name,
-                                },
+                                new_relation,
                             )
                             video_resource.save()
 
@@ -569,27 +510,6 @@ def copy_gdrive_file(gdrive_file, destination_course):
     return new_file.get("id")
 
 
-def update_transcript_and_captions(resource, new_transcript_file, new_captions_file):
-    """
-    Update the associated transcript and captions files for a resource.
-    Writes the file data array used by the build pipeline.
-    """
-    transcript_path = f"/{str(new_transcript_file).lstrip('/')}"
-    captions_path = f"/{str(new_captions_file).lstrip('/')}"
-    set_dict_field(
-        resource.metadata,
-        settings.YT_FIELD_TRANSCRIPT,
-        [{"file": transcript_path, "language": "en"}],
-    )
-    set_dict_field(
-        resource.metadata,
-        settings.YT_FIELD_CAPTIONS,
-        [{"file": captions_path, "language": "en"}],
-    )
-    resource.save()
-    sync_website_content_references(resource)
-
-
 def create_drivefile(gdrive_file_id, new_resource, destination_course, files_or_videos):
     """
     Create a DriveFile for gdrive_file in the destination course.
@@ -622,17 +542,16 @@ def create_drivefile(gdrive_file_id, new_resource, destination_course, files_or_
 
 
 @app.task(acks_late=True)
-def copy_video_resource(source_course_id, destination_course_id, source_resource_id):  # noqa: C901
+def copy_video_resource(source_course_id, destination_course_id, source_resource_id):
     """
     Copy a video resource and associated captions/transcripts (celery task).
 
     Captions and transcripts are discovered via the ``video_captions_resources`` and
     ``video_transcript_resources`` relation fields introduced in migration 0075.  For
-    each linked resource the content record is copied to the destination course, the
-    relation field on the new video resource is updated to point at the copy, and the
-    build-pipeline file-data field (``video_captions_file`` / ``video_transcript_file``)
-    is populated with the new file path.  Associated Google Drive files are also copied
-    when present.
+    each linked resource the content record is copied to the destination course and the
+    relation field on the new video resource is updated to point at the copy.  The
+    legacy ``_file`` fields in stored metadata are left untouched.  Associated Google
+    Drive files are also copied when present.
     """
     source_course = Website.objects.get(uuid=source_course_id)
     destination_course = Website.objects.get(uuid=destination_course_id)
@@ -641,9 +560,9 @@ def copy_video_resource(source_course_id, destination_course_id, source_resource
     )
     new_resource = create_new_content(source_resource, destination_course)
 
-    for resource_field, data_field in (
-        (settings.YT_FIELD_CAPTIONS_RESOURCES, settings.YT_FIELD_CAPTIONS),
-        (settings.YT_FIELD_TRANSCRIPT_RESOURCES, settings.YT_FIELD_TRANSCRIPT),
+    for resource_field in (
+        settings.YT_FIELD_CAPTIONS_RESOURCES,
+        settings.YT_FIELD_TRANSCRIPT_RESOURCES,
     ):
         relation = get_dict_field(source_resource.metadata, resource_field) or {}
         content_ids = relation.get("content") or []
@@ -651,7 +570,6 @@ def copy_video_resource(source_course_id, destination_course_id, source_resource
             content_ids = [content_ids] if content_ids else []
 
         new_ids = []
-        file_entries = []
         for text_id in content_ids:
             source_content = WebsiteContent.objects.filter(
                 website=source_course, text_id=text_id
@@ -660,10 +578,6 @@ def copy_video_resource(source_course_id, destination_course_id, source_resource
                 continue
             new_content = create_new_content(source_content, destination_course)
             new_ids.append(str(new_content.text_id))
-
-            if new_content.file and new_content.file.name:
-                file_path = f"/{new_content.file.name.lstrip('/')}"
-                file_entries.append({"file": file_path, "language": "en"})
 
             # Copy the associated DriveFile if one exists.
             if source_content.file and source_content.file.name:
@@ -687,8 +601,6 @@ def copy_video_resource(source_course_id, destination_course_id, source_resource
                 resource_field,
                 {"content": new_ids, "website": destination_course.name},
             )
-        if file_entries:
-            set_dict_field(new_resource.metadata, data_field, file_entries)
 
     new_resource.save()
     sync_website_content_references(new_resource)

--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -330,7 +330,7 @@ def delete_s3_objects(
 @single_task(
     timeout=settings.UPDATE_TAGGED_3PLAY_TRANSCRIPT_FREQUENCY, raise_block=False
 )
-def update_transcripts_for_video(video_id: int):  # noqa: C901
+def update_transcripts_for_video(video_id: int):  # noqa: C901, PLR0912
     """Update transcripts for a video"""
     video = Video.objects.get(id=video_id)
     captions_list, transcripts_list = video.caption_transcript_resources()
@@ -369,6 +369,7 @@ def update_transcripts_for_video(video_id: int):  # noqa: C901
                     video_resource.save()
                     sync_website_content_references(video_resource)
             else:
+                resource_changed = False
                 for resource_list, resource_field in [
                     (captions_list, settings.YT_FIELD_CAPTIONS_RESOURCES),
                     (transcripts_list, settings.YT_FIELD_TRANSCRIPT_RESOURCES),
@@ -387,7 +388,9 @@ def update_transcripts_for_video(video_id: int):  # noqa: C901
                                 resource_field,
                                 new_relation,
                             )
-                            video_resource.save()
+                            resource_changed = True
+                if resource_changed:
+                    video_resource.save(update_fields=["metadata"])
 
             if first_transcript_download and len(videos_missing_captions(website)) == 0:
                 mail_transcripts_complete_notification(website)

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -47,7 +47,6 @@ from videos.tasks import (
     delete_s3_objects,
     mail_transcripts_complete_notification,
     start_transcript_job,
-    update_transcript_and_captions,
     update_transcripts_for_updated_videos,
     update_transcripts_for_video,
     update_transcripts_for_website,
@@ -419,27 +418,34 @@ def test_start_transcript_job(
     start_transcript_job.apply([video.id])
 
     video_content.refresh_from_db()
+    # Legacy _file fields in stored metadata are never written
+    assert get_dict_field(video_content.metadata, settings.YT_FIELD_CAPTIONS) is None
+    assert get_dict_field(video_content.metadata, settings.YT_FIELD_TRANSCRIPT) is None
     if caption_exists:
-        captions_result = get_dict_field(
-            video_content.metadata, settings.YT_FIELD_CAPTIONS
+        captions_relation = get_dict_field(
+            video_content.metadata, settings.YT_FIELD_CAPTIONS_RESOURCES
         )
-        assert isinstance(captions_result, list)
-        assert len(captions_result) == 1
-        assert captions_result[0]["language"] == "en"
+        assert isinstance(captions_relation, dict)
+        assert len(captions_relation["content"]) == 1
+        assert captions_relation["website"] == video.website.name
     else:
         assert (
-            get_dict_field(video_content.metadata, settings.YT_FIELD_CAPTIONS) is None
+            get_dict_field(video_content.metadata, settings.YT_FIELD_CAPTIONS_RESOURCES)
+            is None
         )
     if transcript_exists:
-        transcript_result = get_dict_field(
-            video_content.metadata, settings.YT_FIELD_TRANSCRIPT
+        transcript_relation = get_dict_field(
+            video_content.metadata, settings.YT_FIELD_TRANSCRIPT_RESOURCES
         )
-        assert isinstance(transcript_result, list)
-        assert len(transcript_result) == 1
-        assert transcript_result[0]["language"] == "en"
+        assert isinstance(transcript_relation, dict)
+        assert len(transcript_relation["content"]) == 1
+        assert transcript_relation["website"] == video.website.name
     else:
         assert (
-            get_dict_field(video_content.metadata, settings.YT_FIELD_TRANSCRIPT) is None
+            get_dict_field(
+                video_content.metadata, settings.YT_FIELD_TRANSCRIPT_RESOURCES
+            )
+            is None
         )
 
     if transcript_exists or caption_exists:
@@ -766,18 +772,34 @@ def test_update_transcripts_for_video(  # pylint: disable=too-many-arguments  # 
         return_value=update_transcript_return_value,
     )
 
+    def fake_link(video_arg, video_resource_arg):
+        set_dict_field(
+            video_resource_arg.metadata,
+            settings.YT_FIELD_CAPTIONS_RESOURCES,
+            {"content": ["captions-id"], "website": video.website.name},
+        )
+        return True
+
+    link_mock = mocker.patch(
+        "videos.tasks.link_threeplay_files_as_resources", side_effect=fake_link
+    )
+    sync_refs_mock = mocker.patch("videos.tasks.sync_website_content_references")
+
     update_transcripts_for_video(video.id)
     update_transcript_mock.assert_called_with(video)
 
     resource.refresh_from_db()
 
+    # Legacy _file fields in stored metadata are never written
+    assert get_dict_field(resource.metadata, settings.YT_FIELD_CAPTIONS) is None
+    assert get_dict_field(resource.metadata, settings.YT_FIELD_TRANSCRIPT) is None
+
     if update_transcript_return_value and is_ocw:
-        assert get_dict_field(resource.metadata, settings.YT_FIELD_CAPTIONS) == [
-            {"file": f"/{video.website.url_path}/webvtt_transcript", "language": "en"}
-        ]
-        assert get_dict_field(resource.metadata, settings.YT_FIELD_TRANSCRIPT) == [
-            {"file": f"/{video.website.url_path}/pdf_transcript", "language": "en"}
-        ]
+        link_mock.assert_any_call(video, resource)
+        sync_refs_mock.assert_called()
+        assert get_dict_field(
+            resource.metadata, settings.YT_FIELD_CAPTIONS_RESOURCES
+        ) == {"content": ["captions-id"], "website": video.website.name}
 
         if initial_status == VideoStatus.SUBMITTED_FOR_TRANSCRIPTION and (
             not other_incomplete_video
@@ -787,8 +809,10 @@ def test_update_transcripts_for_video(  # pylint: disable=too-many-arguments  # 
             transcripts_notification_mock.assert_not_called()
 
     else:
-        assert get_dict_field(resource.metadata, settings.YT_FIELD_CAPTIONS) is None
-        assert get_dict_field(resource.metadata, settings.YT_FIELD_TRANSCRIPT) is None
+        assert (
+            get_dict_field(resource.metadata, settings.YT_FIELD_CAPTIONS_RESOURCES)
+            is None
+        )
 
 
 def test_update_transcripts_for_updated_videos(mocker):
@@ -864,10 +888,11 @@ def test_update_transcripts_for_video_no_3play(
     )
     resource.save()
 
+    captions_list, transcripts_list = video.caption_transcript_resources()
     if caption_exists:
-        assert len(video.caption_transcript_resources()[0]) > 0
+        assert len(captions_list) > 0
     if transcript_exists:
-        assert len(video.caption_transcript_resources()[1]) > 0
+        assert len(transcripts_list) > 0
 
     mock_3play = mocker.patch("videos.tasks.threeplay_api.update_transcripts_for_video")
 
@@ -876,23 +901,29 @@ def test_update_transcripts_for_video_no_3play(
 
     mock_3play.assert_not_called()
 
+    # The pre-existing scalar _file values are left completely untouched
     assert get_dict_field(resource.metadata, settings.YT_FIELD_CAPTIONS) == (
-        [
-            {
-                "file": f"/{video.website.url_path}/{base_resource_filename}_captions.vtt",
-                "language": "en",
-            }
-        ]
+        f"{base_path}_captions.vtt" if caption_exists else None
+    )
+    assert get_dict_field(resource.metadata, settings.YT_FIELD_TRANSCRIPT) == (
+        f"{base_path}_transcript.pdf" if transcript_exists else None
+    )
+    # The _resources relation fields are written from the found resources
+    assert get_dict_field(resource.metadata, settings.YT_FIELD_CAPTIONS_RESOURCES) == (
+        {
+            "content": [str(r.text_id) for r in captions_list],
+            "website": video.website.name,
+        }
         if caption_exists
         else None
     )
-    assert get_dict_field(resource.metadata, settings.YT_FIELD_TRANSCRIPT) == (
-        [
-            {
-                "file": f"/{video.website.url_path}/{base_resource_filename}_transcript.pdf",
-                "language": "en",
-            }
-        ]
+    assert get_dict_field(
+        resource.metadata, settings.YT_FIELD_TRANSCRIPT_RESOURCES
+    ) == (
+        {
+            "content": [str(r.text_id) for r in transcripts_list],
+            "website": video.website.name,
+        }
         if transcript_exists
         else None
     )
@@ -900,7 +931,7 @@ def test_update_transcripts_for_video_no_3play(
 
 @pytest.mark.django_db
 def test_update_transcripts_for_video_multi_language_with_locale(mocker):
-    """GDrive files with locale suffix produce {file, language, locale} entries."""
+    """All language variants matching the dash convention are linked via _resources."""
     mocker.patch("videos.tasks.is_ocw_site", return_value=True)
 
     videofile = VideoFileFactory.create(
@@ -914,19 +945,18 @@ def test_update_transcripts_for_video_multi_language_with_locale(mocker):
     # English (US locale) captions
     captions_en_us = WebsiteContentFactory.create(
         website=video.website,
-        filename=f"{base_resource_filename}_captions_en_us_vtt",
-        file=f"{base_path}_captions_en_us.vtt",
+        filename=f"{base_resource_filename}_captions-en-us_vtt",
+        file=f"{base_path}_captions-en-US.vtt",
     )
-    # French (no locale) captions
+    # French (CA locale) captions
     captions_fr = WebsiteContentFactory.create(
         website=video.website,
-        filename=f"{base_resource_filename}_captions_fr_vtt",
-        file=f"{base_path}_captions_fr.vtt",
+        filename=f"{base_resource_filename}_captions-fr-ca_vtt",
+        file=f"{base_path}_captions-fr-CA.vtt",
     )
 
     set_dict_field(resource.metadata, settings.FIELD_RESOURCETYPE, RESOURCE_TYPE_VIDEO)
     set_dict_field(resource.metadata, settings.YT_FIELD_ID, "expected_id")
-    set_dict_field(resource.metadata, settings.YT_FIELD_CAPTIONS, None)
     resource.save()
 
     mocker.patch("videos.tasks.threeplay_api.update_transcripts_for_video")
@@ -934,20 +964,15 @@ def test_update_transcripts_for_video_multi_language_with_locale(mocker):
     update_transcripts_for_video(video.id)
     resource.refresh_from_db()
 
-    captions_result = get_dict_field(resource.metadata, settings.YT_FIELD_CAPTIONS)
-    assert isinstance(captions_result, list)
-    assert len(captions_result) == 2
-
-    by_file = {entry["file"]: entry for entry in captions_result}
-    en_us_key = f"/{captions_en_us.file.name.lstrip('/')}"
-    fr_key = f"/{captions_fr.file.name.lstrip('/')}"
-    en_us_key = en_us_key.replace(video.website.s3_path, video.website.url_path)
-    fr_key = fr_key.replace(video.website.s3_path, video.website.url_path)
-
-    assert by_file[en_us_key]["language"] == "en"
-    assert by_file[en_us_key]["locale"] == "US"
-    assert by_file[fr_key]["language"] == "fr"
-    assert "locale" not in by_file[fr_key]
+    relation = get_dict_field(resource.metadata, settings.YT_FIELD_CAPTIONS_RESOURCES)
+    assert isinstance(relation, dict)
+    assert set(relation["content"]) == {
+        str(captions_en_us.text_id),
+        str(captions_fr.text_id),
+    }
+    assert relation["website"] == video.website.name
+    # Legacy _file fields in stored metadata are never written
+    assert get_dict_field(resource.metadata, settings.YT_FIELD_CAPTIONS) is None
 
 
 def test_attempt_to_update_missing_transcripts(mocker):
@@ -1037,29 +1062,6 @@ def test_copy_gdrive_file(mocker):
         fields="id, parents",
         supportsAllDrives=True,
     )
-
-
-def test_update_transcript_and_captions(mocker):
-    """update_transcript_and_captions writes file-data arrays for the build pipeline."""
-    test_resource = WebsiteContentFactory.create()
-    test_resource.metadata = {"video_files": {}}
-    new_transcript_file = "/path/to/new_transcript_file"
-    new_captions_file = "/path/to/new_captions_file"
-    mocker.spy(test_resource, "save")
-    sync_refs_mock = mocker.patch("videos.tasks.sync_website_content_references")
-
-    update_transcript_and_captions(
-        test_resource, new_transcript_file, new_captions_file
-    )
-
-    assert test_resource.metadata["video_files"]["video_transcript_file"] == [
-        {"file": new_transcript_file, "language": "en"}
-    ]
-    assert test_resource.metadata["video_files"]["video_captions_file"] == [
-        {"file": new_captions_file, "language": "en"}
-    ]
-    test_resource.save.assert_called_once()
-    sync_refs_mock.assert_called_once_with(test_resource)
 
 
 @pytest.mark.django_db

--- a/videos/threeplay_sync.py
+++ b/videos/threeplay_sync.py
@@ -62,8 +62,10 @@ def _append_resource_to_video_files(
     vf = video.metadata.setdefault("video_files", {})
     existing_resources = vf.get(resource_field)
     if isinstance(existing_resources, dict) and existing_resources.get("content"):
-        if text_id not in existing_resources["content"]:
-            existing_resources["content"] = [*existing_resources["content"], text_id]
+        content = existing_resources["content"]
+        content_list = [content] if isinstance(content, str) else list(content)
+        if text_id not in content_list:
+            existing_resources["content"] = [*content_list, text_id]
     else:
         vf[resource_field] = {"content": [text_id], "website": video.website.name}
 

--- a/videos/threeplay_sync.py
+++ b/videos/threeplay_sync.py
@@ -1,4 +1,6 @@
 import logging
+from collections.abc import Callable
+from io import BytesIO
 from typing import TYPE_CHECKING
 from uuid import uuid4
 
@@ -6,7 +8,7 @@ from django.conf import settings
 from django.core.files import File
 
 from main.s3_utils import get_boto3_resource
-from main.utils import get_dirpath_and_filename, get_file_extension
+from main.utils import get_base_filename, get_dirpath_and_filename, get_file_extension
 from videos.constants import PDF_FORMAT_ID, WEBVTT_FORMAT_ID
 from videos.threeplay_api import fetch_file, threeplay_transcript_api_request
 from videos.utils import generate_s3_path, get_content_dirpath
@@ -45,34 +47,29 @@ extension_map = {
 def _append_resource_to_video_files(
     video: WebsiteContent,
     resource_field: str,
-    file_field: str,
     text_id: str,
-    filepath: str,
 ) -> None:
     """
-    Append a caption/transcript resource entry to video_files metadata.
+    Append a caption/transcript resource id to the video's ``_resources``
+    relation field in video_files metadata.
 
     Preserves any existing entries (e.g. other-language variants already
-    linked from GDrive) instead of overwriting them.
+    linked from GDrive) instead of overwriting them.  The legacy ``_file``
+    fields in stored metadata are left untouched.
     """
-    vf = video.metadata["video_files"]
+    if not isinstance(video.metadata, dict):
+        video.metadata = {}
+    vf = video.metadata.setdefault("video_files", {})
     existing_resources = vf.get(resource_field)
     if isinstance(existing_resources, dict) and existing_resources.get("content"):
         if text_id not in existing_resources["content"]:
             existing_resources["content"] = [*existing_resources["content"], text_id]
     else:
         vf[resource_field] = {"content": [text_id], "website": video.website.name}
-    existing_files = vf.get(file_field)
-    new_file_entry = {"file": filepath, "language": "en"}
-    if isinstance(existing_files, list):
-        if not any(e.get("file") == filepath for e in existing_files):
-            vf[file_field] = [*existing_files, new_file_entry]
-    else:
-        vf[file_field] = [new_file_entry]
 
 
 def _threeplay_resource_already_linked(
-    video: WebsiteContent, resource_field: str, filename: str
+    video: WebsiteContent, resource_field: str, filename_prefix: str
 ) -> bool:
     """Return True if the 3Play-generated resource is already in the content list."""
     existing_content = (
@@ -84,7 +81,7 @@ def _threeplay_resource_already_linked(
         and WebsiteContent.objects.filter(
             website=video.website,
             text_id__in=existing_content,
-            filename=filename,
+            filename__startswith=filename_prefix,
         ).exists()
     )
 
@@ -114,14 +111,8 @@ def _attach_transcript_if_missing(
     if pdf_response:
         file_size = len(pdf_response.getvalue())
         pdf_file = File(pdf_response, name=f"{youtube_id}.pdf")
-        filepath, text_id = _create_new_content(pdf_file, video, file_size=file_size)
-        _append_resource_to_video_files(
-            video,
-            "video_transcript_resources",
-            "video_transcript_file",
-            text_id,
-            filepath,
-        )
+        _, text_id = _create_new_content(pdf_file, video, file_size=file_size)
+        _append_resource_to_video_files(video, "video_transcript_resources", text_id)
         if summary:
             summary["transcripts"]["updated"] += 1
         write_output(
@@ -160,14 +151,8 @@ def _attach_captions_if_missing(
     if webvtt_response:
         file_size = len(webvtt_response.getvalue())
         vtt_file = File(webvtt_response, name=f"{youtube_id}.webvtt")
-        filepath, text_id = _create_new_content(vtt_file, video, file_size)
-        _append_resource_to_video_files(
-            video,
-            "video_captions_resources",
-            "video_captions_file",
-            text_id,
-            filepath,
-        )
+        _, text_id = _create_new_content(vtt_file, video, file_size)
+        _append_resource_to_video_files(video, "video_captions_resources", text_id)
         if summary:
             summary["captions"]["updated"] += 1
         write_output(
@@ -180,6 +165,42 @@ def _attach_captions_if_missing(
         summary["captions"]["missing_details"].append(
             (youtube_id, video.website.short_id)
         )
+
+
+def link_threeplay_files_as_resources(video, video_resource: WebsiteContent) -> bool:
+    """
+    Create caption/transcript WebsiteContent resources from a Video's
+    already-downloaded 3Play files (``webvtt_transcript_file`` /
+    ``pdf_transcript_file``) and link them on the video resource's
+    ``_resources`` relation fields.
+
+    The created resources follow the ``{base}_captions`` / ``{base}_transcript``
+    filename convention (no language suffix — 3Play transcripts are English), so
+    subsequent auto-link passes and ``Video.caption_transcript_resources()``
+    lookups find them.  The legacy ``_file`` fields in stored metadata are left
+    untouched.
+
+    Returns True if the video resource's metadata was modified.
+    """
+    base = get_base_filename(video_resource.filename or "")
+    if not base:
+        return False
+    changed = False
+    for field_file, resource_field, extension in (
+        (video.webvtt_transcript_file, "video_captions_resources", "vtt"),
+        (video.pdf_transcript_file, "video_transcript_resources", "pdf"),
+    ):
+        if not (field_file and field_file.name):
+            continue
+        with field_file.open("rb") as file_handle:
+            content_bytes = file_handle.read()
+        file_obj = File(BytesIO(content_bytes), name=f"{base}.{extension}")
+        _, text_id = _create_new_content(
+            file_obj, video_resource, file_size=len(content_bytes)
+        )
+        _append_resource_to_video_files(video_resource, resource_field, text_id)
+        changed = True
+    return changed
 
 
 def sync_video_captions_and_transcripts(
@@ -274,7 +295,13 @@ def _create_new_content(
         new_text_id, new_s3_loc, file_content, video
     )
     collection_type = "resource"
+    # Append the extension suffix (e.g. _vtt/_pdf) so the created resource
+    # matches the {base}_captions*_vtt / {base}_transcript*_pdf filename
+    # convention used by gdrive ingestion and the auto-link lookups.
     filename = get_dirpath_and_filename(new_s3_loc)[1]
+    extension = get_file_extension(new_s3_loc)
+    if extension:
+        filename = f"{filename}_{extension}"
     dirpath = get_content_dirpath("ocw-course-v2", collection_type)
 
     obj, _ = WebsiteContent.objects.get_or_create(

--- a/videos/threeplay_sync_test.py
+++ b/videos/threeplay_sync_test.py
@@ -232,6 +232,70 @@ def test_sync_video_captions_and_transcripts_treats_empty_content_as_unset(mocke
     assert isinstance(vf["video_captions_resources"]["content"], list)
 
 
+def test_sync_video_captions_and_transcripts_appends_to_scalar_string_content(mocker):
+    """A legacy scalar-string content value is normalized to a list, not exploded
+    into characters, when 3Play appends a new resource id.
+    """
+    starter = WebsiteStarterFactory.create(slug="ocw-course-v2")
+    website = WebsiteFactory.create(starter=starter)
+    fr_caption = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_captions_fr_vtt",
+    )
+    fr_transcript = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_transcript_fr_pdf",
+    )
+    video = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        metadata={
+            "resourcetype": "Video",
+            "video_metadata": {"youtube_id": "yt789"},
+            "video_files": {
+                # Legacy single-item relation stored as a bare string, not a list
+                "video_captions_resources": {
+                    "content": str(fr_caption.text_id),
+                    "website": website.name,
+                },
+                "video_transcript_resources": {
+                    "content": str(fr_transcript.text_id),
+                    "website": website.name,
+                },
+            },
+        },
+    )
+
+    mocker.patch(
+        "videos.threeplay_sync.threeplay_transcript_api_request",
+        return_value={"data": [{"status": "complete", "id": 11, "media_file_id": 22}]},
+    )
+    mocker.patch(
+        "videos.threeplay_sync.fetch_file",
+        side_effect=[BytesIO(b"pdf"), BytesIO(b"webvtt")],
+    )
+    mocker.patch(
+        "videos.threeplay_sync.upload_to_s3",
+        side_effect=[
+            f"/courses/{website.name}/yt789_transcript.pdf",
+            f"/courses/{website.name}/yt789_captions.webvtt",
+        ],
+    )
+
+    sync_video_captions_and_transcripts(video)
+
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    captions_content = vf["video_captions_resources"]["content"]
+    transcript_content = vf["video_transcript_resources"]["content"]
+
+    # Original id preserved whole, not exploded into individual characters
+    assert str(fr_caption.text_id) in captions_content
+    assert str(fr_transcript.text_id) in transcript_content
+    assert len(captions_content) == 2
+    assert len(transcript_content) == 2
+
+
 def test_link_threeplay_files_as_resources(mocker):
     """Downloaded 3Play files become convention-named resources linked via _resources."""
     starter = WebsiteStarterFactory.create(slug="ocw-course-v2")

--- a/videos/threeplay_sync_test.py
+++ b/videos/threeplay_sync_test.py
@@ -4,13 +4,17 @@ from io import BytesIO
 
 import pytest
 
-from videos.threeplay_sync import sync_video_captions_and_transcripts
+from videos.threeplay_sync import (
+    link_threeplay_files_as_resources,
+    sync_video_captions_and_transcripts,
+)
 from websites.constants import CONTENT_TYPE_RESOURCE
 from websites.factories import (
     WebsiteContentFactory,
     WebsiteFactory,
     WebsiteStarterFactory,
 )
+from websites.models import WebsiteContent
 
 pytestmark = pytest.mark.django_db
 
@@ -177,17 +181,11 @@ def test_sync_video_captions_and_transcripts_appends_english_when_other_language
     assert len(transcript_content) == 2
     assert len(captions_content) == 2
 
-    # _file lists also have both entries
-    transcript_files = vf["video_transcript_file"]
-    captions_files = vf["video_captions_file"]
-    assert len(transcript_files) == 2
-    assert len(captions_files) == 2
-    transcript_languages = {e["language"] for e in transcript_files}
-    captions_languages = {e["language"] for e in captions_files}
-    assert "en" in transcript_languages
-    assert "fr" in transcript_languages
-    assert "en" in captions_languages
-    assert "fr" in captions_languages
+    # Pre-existing _file values in stored metadata are left untouched
+    assert vf["video_captions_file"] == [{"file": fr_caption_path, "language": "fr"}]
+    assert vf["video_transcript_file"] == [
+        {"file": fr_transcript_path, "language": "fr"}
+    ]
 
 
 def test_sync_video_captions_and_transcripts_treats_empty_content_as_unset(mocker):
@@ -232,3 +230,79 @@ def test_sync_video_captions_and_transcripts_treats_empty_content_as_unset(mocke
     vf = video.metadata["video_files"]
     assert isinstance(vf["video_transcript_resources"]["content"], list)
     assert isinstance(vf["video_captions_resources"]["content"], list)
+
+
+def test_link_threeplay_files_as_resources(mocker):
+    """Downloaded 3Play files become convention-named resources linked via _resources."""
+    starter = WebsiteStarterFactory.create(slug="ocw-course-v2")
+    website = WebsiteFactory.create(starter=starter)
+    video_resource = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        filename="lecture1_mp4",
+        metadata={
+            "resourcetype": "Video",
+            "video_metadata": {"youtube_id": "yt789"},
+            "video_files": {},
+        },
+    )
+    video = mocker.Mock()
+    video.webvtt_transcript_file.name = "sites/site/threeplay.webvtt"
+    video.webvtt_transcript_file.open.return_value.__enter__ = mocker.Mock(
+        return_value=BytesIO(b"WEBVTT")
+    )
+    video.webvtt_transcript_file.open.return_value.__exit__ = mocker.Mock(
+        return_value=False
+    )
+    video.pdf_transcript_file.name = "sites/site/threeplay.pdf"
+    video.pdf_transcript_file.open.return_value.__enter__ = mocker.Mock(
+        return_value=BytesIO(b"%PDF")
+    )
+    video.pdf_transcript_file.open.return_value.__exit__ = mocker.Mock(
+        return_value=False
+    )
+    upload_mock = mocker.patch(
+        "videos.threeplay_sync.upload_to_s3",
+        side_effect=[
+            f"/courses/{website.name}/lecture1_captions.vtt",
+            f"/courses/{website.name}/lecture1_transcript.pdf",
+        ],
+    )
+
+    changed = link_threeplay_files_as_resources(video, video_resource)
+
+    assert changed is True
+    assert upload_mock.call_count == 2
+    # The uploaded files carry the video's convention-based names
+    uploaded_names = [call.args[0].name for call in upload_mock.call_args_list]
+    assert uploaded_names == ["lecture1.vtt", "lecture1.pdf"]
+
+    vf = video_resource.metadata["video_files"]
+    captions = WebsiteContent.objects.get(
+        website=website, filename="lecture1_captions_vtt"
+    )
+    transcript = WebsiteContent.objects.get(
+        website=website, filename="lecture1_transcript_pdf"
+    )
+    assert vf["video_captions_resources"]["content"] == [str(captions.text_id)]
+    assert vf["video_transcript_resources"]["content"] == [str(transcript.text_id)]
+    # Legacy _file fields in stored metadata are never written
+    assert "video_captions_file" not in vf
+    assert "video_transcript_file" not in vf
+
+
+def test_link_threeplay_files_as_resources_no_files(mocker):
+    """Nothing happens when the Video has no downloaded 3Play files."""
+    website = WebsiteFactory.create()
+    video_resource = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        filename="lecture1_mp4",
+        metadata={"resourcetype": "Video", "video_files": {}},
+    )
+    video = mocker.Mock()
+    video.webvtt_transcript_file = None
+    video.pdf_transcript_file = None
+
+    assert link_threeplay_files_as_resources(video, video_resource) is False
+    assert video_resource.metadata["video_files"] == {}

--- a/videos/utils.py
+++ b/videos/utils.py
@@ -273,34 +273,42 @@ def process_video_tags(video_resource, snippet, youtube, *, add_course_tag):
     return "success" if tags_changed else "skip"
 
 
-# Regex that matches ``_captions-{lang}-{locale}_vtt`` /
-# ``_transcript-{lang}-{locale}_pdf`` at the end of a slugified filename.
-# GDrive caption/transcript files follow the pattern
-# ``<base>_captions-<lang>-<locale>.<ext>`` (e.g. ``lecture1_captions-en-US.vtt``)
-# where ``<lang>`` is an ISO 639-1 code and ``<locale>`` is an ISO 3166-1
-# alpha-2 region code. Slugification lowercases the name and turns the
-# extension into an ``_<ext>`` suffix.
+# Regex that matches "_captions-{lang}-{locale}" / "_transcript-{lang}-{locale}"
+# immediately before the extension, wherever it falls in the string (so it
+# matches whether the input is the raw uploaded file path, e.g.
+# "courses/site/lecture1_captions-en-US.vtt", or a slugified filename, e.g.
+# "lecture1_captions-en-us_vtt"). <lang> is an ISO 639-1 code, <locale> an
+# ISO 3166-1 alpha-2 region code. IGNORECASE handles mixed-case real
+# filenames; [._] handles both the dot (real file) and underscore
+# (slugified filename) extension delimiters.
 _LANG_LOCALE_RE = re.compile(
-    r"(?:_captions|_transcript)-([a-z]{2,3})-([a-z]{2,3})_(?:vtt|webvtt|srt|pdf)$"
+    r"(?:_captions|_transcript)-([a-z]{2,3})-([a-z]{2,3})[._](?:vtt|webvtt|srt|pdf)$",
+    re.IGNORECASE,
 )
 
 
 def parse_caption_language_locale(filename: str) -> tuple[str, str | None]:
     """Return ``(language_code, locale_code)`` embedded in a caption/transcript
-    filename.
+    filename or file path.
 
-    The filename is expected to be the slugified ``WebsiteContent.filename``.  GDrive
-    files follow the pattern ``<base>_captions-<lang>-<locale>.<ext>`` (e.g.
-    ``lecture1_captions-en-US.vtt``) where ``<lang>`` is an ISO 639-1 code and
-    ``<locale>`` is an ISO 3166-1 alpha-2 region code.  ``locale`` is returned
-    uppercase (e.g. ``"US"``).
+    Pass the resource's real uploaded file path (``resource.file.name``), not
+    the ``WebsiteContent.filename`` field — the latter can carry a numeric
+    uniqueness suffix appended by Django on a name collision (e.g.
+    ``lecture1_captions-en-us_vtt`` -> ``lecture1_captions-en-us_vtt2``),
+    which would prevent the pattern from matching at all.
 
-    Legacy single-language filenames without a language suffix
-    (e.g. ``lecture1_captions_vtt``) return ``("en", None)``.
+    GDrive files follow the pattern ``<base>_captions-<lang>-<locale>.<ext>``
+    (e.g. ``lecture1_captions-en-US.vtt``) where ``<lang>`` is an ISO 639-1
+    code and ``<locale>`` is an ISO 3166-1 alpha-2 region code.  ``locale`` is
+    returned uppercase (e.g. ``"US"``).
+
+    Legacy filenames without a language suffix, or with a language-only
+    suffix and no locale (e.g. ``lecture1_captions_vtt``,
+    ``lecture1_captions-fr.vtt``), return ``("en", None)``.
     """
     match = _LANG_LOCALE_RE.search(filename)
     if match:
-        return match.group(1), match.group(2).upper()
+        return match.group(1).lower(), match.group(2).upper()
     return "en", None
 
 
@@ -308,15 +316,16 @@ def resource_file_paths(resources: list) -> list:
     """Return a list of ``{file, language[, locale]}`` dicts for caption/transcript
     resources.
 
-    Language and optional locale are parsed from each resource's ``filename`` using
-    :func:`parse_caption_language_locale`.  Resources without a resolvable file are
-    omitted.  ``locale`` is only included in the dict when present in the filename.
+    Language and optional locale are parsed from each resource's real
+    uploaded file path (immune to the filename-uniqueness suffix described in
+    :func:`parse_caption_language_locale`).  Resources without a resolvable
+    file are omitted.  ``locale`` is only included in the dict when present.
     """
     result = []
     for resource in resources:
         file_name = getattr(getattr(resource, "file", None), "name", None)
         if file_name:
-            lang, locale = parse_caption_language_locale(resource.filename or "")
+            lang, locale = parse_caption_language_locale(file_name)
             entry: dict = {
                 "file": f"/{file_name.lstrip('/')}",
                 "language": lang,

--- a/videos/utils.py
+++ b/videos/utils.py
@@ -273,12 +273,15 @@ def process_video_tags(video_resource, snippet, youtube, *, add_course_tag):
     return "success" if tags_changed else "skip"
 
 
-# Regex that matches ``_captions_{lang}_vtt``, ``_transcript_{lang}_pdf``,
-# or ``_captions_{lang}_{locale}_vtt`` at the end of a slugified filename.
-# GDrive files follow the pattern ``<title>_<lang>_<locale>.<ext>`` where
-# the locale is an ISO 3166-1 alpha-2 region code (e.g. ``us``, ``gb``).
+# Regex that matches ``_captions-{lang}-{locale}_vtt`` /
+# ``_transcript-{lang}-{locale}_pdf`` at the end of a slugified filename.
+# GDrive caption/transcript files follow the pattern
+# ``<base>_captions-<lang>-<locale>.<ext>`` (e.g. ``lecture1_captions-en-US.vtt``)
+# where ``<lang>`` is an ISO 639-1 code and ``<locale>`` is an ISO 3166-1
+# alpha-2 region code. Slugification lowercases the name and turns the
+# extension into an ``_<ext>`` suffix.
 _LANG_LOCALE_RE = re.compile(
-    r"(?:_captions|_transcript)_([a-z]{2,3})_(?:([a-z]{2,3})_)?(?:vtt|webvtt|pdf)$"
+    r"(?:_captions|_transcript)-([a-z]{2,3})-([a-z]{2,3})_(?:vtt|webvtt|srt|pdf)$"
 )
 
 
@@ -287,19 +290,17 @@ def parse_caption_language_locale(filename: str) -> tuple[str, str | None]:
     filename.
 
     The filename is expected to be the slugified ``WebsiteContent.filename``.  GDrive
-    files follow the pattern ``<title>_captions_<lang>_<locale>_vtt`` where ``<lang>``
-    is an ISO 639-1 code (e.g. ``en``, ``fr``) and ``<locale>`` is an ISO 3166-1
-    alpha-2 region code (e.g. ``us``, ``gb``).  ``locale`` is returned uppercase
-    (e.g. ``"US"``) or ``None`` when absent.
+    files follow the pattern ``<base>_captions-<lang>-<locale>.<ext>`` (e.g.
+    ``lecture1_captions-en-US.vtt``) where ``<lang>`` is an ISO 639-1 code and
+    ``<locale>`` is an ISO 3166-1 alpha-2 region code.  ``locale`` is returned
+    uppercase (e.g. ``"US"``).
 
     Legacy single-language filenames without a language suffix
     (e.g. ``lecture1_captions_vtt``) return ``("en", None)``.
     """
     match = _LANG_LOCALE_RE.search(filename)
     if match:
-        lang = match.group(1)
-        locale = match.group(2).upper() if match.group(2) else None
-        return lang, locale
+        return match.group(1), match.group(2).upper()
     return "en", None
 
 

--- a/videos/utils.py
+++ b/videos/utils.py
@@ -273,16 +273,16 @@ def process_video_tags(video_resource, snippet, youtube, *, add_course_tag):
     return "success" if tags_changed else "skip"
 
 
-# Regex that matches "_captions-{lang}-{locale}" / "_transcript-{lang}-{locale}"
-# immediately before the extension, wherever it falls in the string (so it
-# matches whether the input is the raw uploaded file path, e.g.
-# "courses/site/lecture1_captions-en-US.vtt", or a slugified filename, e.g.
-# "lecture1_captions-en-us_vtt"). <lang> is an ISO 639-1 code, <locale> an
-# ISO 3166-1 alpha-2 region code. IGNORECASE handles mixed-case real
-# filenames; [._] handles both the dot (real file) and underscore
-# (slugified filename) extension delimiters.
+# Regex that matches "_captions-{lang}" / "_captions-{lang}-{locale}" (and the
+# _transcript equivalents) immediately before the extension, wherever it falls
+# in the string (so it matches whether the input is the raw uploaded file
+# path, e.g. "courses/site/lecture1_captions-en-US.vtt", or a slugified
+# filename, e.g. "lecture1_captions-en-us_vtt"). <lang> is an ISO 639-1 code,
+# <locale> an optional ISO 3166-1 alpha-2 region code. IGNORECASE handles
+# mixed-case real filenames; [._] handles both the dot (real file) and
+# underscore (slugified filename) extension delimiters.
 _LANG_LOCALE_RE = re.compile(
-    r"(?:_captions|_transcript)-([a-z]{2,3})-([a-z]{2,3})[._](?:vtt|webvtt|srt|pdf)$",
+    r"(?:_captions|_transcript)-([a-z]{2,3})(?:-([a-z]{2,3}))?[._](?:vtt|webvtt|srt|pdf)$",
     re.IGNORECASE,
 )
 
@@ -300,15 +300,17 @@ def parse_caption_language_locale(filename: str) -> tuple[str, str | None]:
     GDrive files follow the pattern ``<base>_captions-<lang>-<locale>.<ext>``
     (e.g. ``lecture1_captions-en-US.vtt``) where ``<lang>`` is an ISO 639-1
     code and ``<locale>`` is an ISO 3166-1 alpha-2 region code.  ``locale`` is
-    returned uppercase (e.g. ``"US"``).
+    returned uppercase (e.g. ``"US"``) when present.  A language-only suffix
+    with no locale (e.g. ``lecture1_captions-fr.vtt``) is also recognized and
+    returns ``("fr", None)``.
 
-    Legacy filenames without a language suffix, or with a language-only
-    suffix and no locale (e.g. ``lecture1_captions_vtt``,
-    ``lecture1_captions-fr.vtt``), return ``("en", None)``.
+    Legacy filenames with no language suffix at all (e.g.
+    ``lecture1_captions_vtt``) return ``("en", None)``.
     """
     match = _LANG_LOCALE_RE.search(filename)
     if match:
-        return match.group(1).lower(), match.group(2).upper()
+        locale = match.group(2)
+        return match.group(1).lower(), locale.upper() if locale else None
     return "en", None
 
 

--- a/videos/utils_test.py
+++ b/videos/utils_test.py
@@ -189,8 +189,8 @@ def test_get_tags_with_course_whitespace_handling():
         ("lecture1_transcript-fr-gb_pdf", ("fr", "GB")),
         # Longer filename still parsed correctly
         ("my_long_course_lecture_03_captions-pt-br_vtt", ("pt", "BR")),
-        # Language without locale is not part of the pattern — treated as legacy
-        ("lecture1_captions-fr_vtt", ("en", None)),
+        # Language-only suffix, no locale — locale group is optional
+        ("lecture1_captions-fr_vtt", ("fr", None)),
         # No recognised suffix -> defaults to English, no locale
         ("some_random_file_pdf", ("en", None)),
         ("lecture1_vtt", ("en", None)),

--- a/videos/utils_test.py
+++ b/videos/utils_test.py
@@ -176,25 +176,21 @@ def test_get_tags_with_course_whitespace_handling():
 @pytest.mark.parametrize(
     ("filename", "expected"),
     [
-        # Legacy single-language convention — defaults to English, no locale
+        # Legacy convention without a language suffix — defaults to English
         ("lecture1_captions_vtt", ("en", None)),
         ("lecture1_transcript_pdf", ("en", None)),
-        # Multi-language captions — language only, no locale
-        ("lecture1_captions_es_vtt", ("es", None)),
-        ("lecture1_captions_fr_vtt", ("fr", None)),
-        ("lecture1_captions_zh_vtt", ("zh", None)),
-        ("lecture1_captions_ar_vtt", ("ar", None)),
-        # Multi-language transcripts — language only, no locale
-        ("lecture1_transcript_es_pdf", ("es", None)),
-        ("lecture1_transcript_zh_pdf", ("zh", None)),
-        # GDrive pattern: <title>_<lang>_<locale>.<ext> — locale returned uppercase
-        ("lecture1_captions_en_us_vtt", ("en", "US")),
-        ("lecture1_captions_fr_en_vtt", ("fr", "EN")),
-        ("lecture1_transcript_en_us_pdf", ("en", "US")),
-        ("lecture1_transcript_fr_gb_pdf", ("fr", "GB")),
+        # GDrive pattern: <base>_captions-<lang>-<locale>.<ext> (slugified) —
+        # locale returned uppercase
+        ("lecture1_captions-en-us_vtt", ("en", "US")),
+        ("lecture1_captions-fr-ca_vtt", ("fr", "CA")),
+        ("lecture1_captions-zh-cn_webvtt", ("zh", "CN")),
+        ("lecture1_captions-es-mx_srt", ("es", "MX")),
+        ("lecture1_transcript-en-us_pdf", ("en", "US")),
+        ("lecture1_transcript-fr-gb_pdf", ("fr", "GB")),
         # Longer filename still parsed correctly
-        ("my_long_course_lecture_03_captions_pt_vtt", ("pt", None)),
-        ("my_long_course_lecture_03_captions_pt_br_vtt", ("pt", "BR")),
+        ("my_long_course_lecture_03_captions-pt-br_vtt", ("pt", "BR")),
+        # Language without locale is not part of the pattern — treated as legacy
+        ("lecture1_captions-fr_vtt", ("en", None)),
         # No recognised suffix -> defaults to English, no locale
         ("some_random_file_pdf", ("en", None)),
         ("lecture1_vtt", ("en", None)),

--- a/websites/api.py
+++ b/websites/api.py
@@ -224,6 +224,40 @@ def sync_website_content_references(content: WebsiteContent) -> None:
     content.referenced_by.set(referenced_content)
 
 
+def unlink_deleted_resource_from_videos(resource: WebsiteContent) -> None:
+    """
+    Remove a deleted resource's id from any video's
+    ``video_captions_resources``/``video_transcript_resources`` content list.
+
+    Relies on ``referencing_content`` (populated by ``sync_website_content_references``)
+    to find affected videos, rather than scanning every resource's metadata.
+    """
+    videos = resource.referencing_content.all()
+    text_id = str(resource.text_id)
+    for video in videos:
+        if (video.metadata or {}).get("resourcetype") != RESOURCE_TYPE_VIDEO:
+            continue
+        video_files = video.metadata.get("video_files")
+        if not isinstance(video_files, dict):
+            continue
+        changed = False
+        for resource_field in (
+            "video_captions_resources",
+            "video_transcript_resources",
+        ):
+            relation = video_files.get(resource_field)
+            if not isinstance(relation, dict):
+                continue
+            content_list = relation.get("content")
+            if isinstance(content_list, list) and text_id in content_list:
+                relation["content"] = [c for c in content_list if c != text_id]
+                changed = True
+        if changed:
+            video.metadata["video_files"] = video_files
+            video.save()
+            sync_website_content_references(video)
+
+
 def _merge_caption_resource(  # noqa: PLR0913
     video_files: dict,
     website: "Website",

--- a/websites/api.py
+++ b/websites/api.py
@@ -14,13 +14,14 @@ from mitol.common.utils import max_or_none, now_in_utc
 from mitol.mail.api import get_message_sender
 
 from content_sync.constants import VERSION_DRAFT, VERSION_LIVE
-from main.utils import NestableKeyTextTransform
+from main.utils import NestableKeyTextTransform, get_base_filename
 from users.models import User
 from videos.constants import (
     YT_MAX_LENGTH_DESCRIPTION,
     YT_MAX_LENGTH_TITLE,
     YT_THUMBNAIL_IMG,
 )
+from videos.utils import parse_caption_language_locale
 from websites.constants import (
     CONTENT_FILENAME_MAX_LEN,
     PUBLISH_STATUS_ABORTED,
@@ -221,6 +222,108 @@ def sync_website_content_references(content: WebsiteContent) -> None:
         id__in=resolve_referenced_content_ids(content)
     )
     content.referenced_by.set(referenced_content)
+
+
+def _merge_caption_resource(  # noqa: PLR0913
+    video_files: dict,
+    website: "Website",
+    resource_field: str,
+    data_field: str,
+    filename_prefix: str,
+    filename_suffix: str,
+) -> bool:
+    """Find caption/transcript resources by prefix and merge into video_files.
+
+    Returns True if video_files was modified.
+    """
+    existing = video_files.get(resource_field)
+    existing_ids: set[str] = set()
+    if isinstance(existing, dict):
+        content = existing.get("content")
+        if isinstance(content, list):
+            existing_ids = {c for c in content if c}
+        elif isinstance(content, str) and content:
+            existing_ids = {content}
+
+    related_resources = list(
+        WebsiteContent.objects.filter(
+            website=website,
+            filename__startswith=filename_prefix,
+            filename__endswith=filename_suffix,
+        ).order_by("filename")
+    )
+    new_resources = [r for r in related_resources if str(r.text_id) not in existing_ids]
+    if not new_resources:
+        return False
+
+    video_files[resource_field] = {
+        "content": [*existing_ids, *(str(r.text_id) for r in new_resources)],
+        "website": website.name,
+    }
+
+    existing_files: list = []
+    existing_files_val = video_files.get(data_field)
+    if isinstance(existing_files_val, list):
+        existing_files = list(existing_files_val)
+    for r in new_resources:
+        if r.file and r.file.name:
+            lang, locale = parse_caption_language_locale(r.filename or "")
+            entry: dict = {"file": f"/{r.file.name.lstrip('/')}", "language": lang}
+            if locale:
+                entry["locale"] = locale
+            existing_files.append(entry)
+    if existing_files:
+        video_files[data_field] = existing_files
+    return True
+
+
+def auto_link_video_captions_transcript(video_resource: WebsiteContent) -> None:
+    """
+    For a Video resource, auto-populate ``video_captions_resources`` and
+    ``video_transcript_resources`` from existing WebsiteContent records in the
+    same website that match the ``{base}_captions_*_vtt`` /
+    ``{base}_transcript_*_pdf`` filename prefix convention.  Finds ALL language
+    variants and merges them into the multi-select content list without
+    overwriting existing non-empty entries.
+    """
+    if (video_resource.metadata or {}).get("resourcetype") != RESOURCE_TYPE_VIDEO:
+        return
+    video_base = get_base_filename(video_resource.filename or "")
+    if not video_base:
+        return
+    website = video_resource.website
+    video_files = (
+        video_resource.metadata.get("video_files") if video_resource.metadata else None
+    )
+    if not isinstance(video_files, dict):
+        video_files = {}
+
+    results = [
+        _merge_caption_resource(
+            video_files, website, resource_field, data_field, prefix, suffix
+        )
+        for resource_field, data_field, prefix, suffix in [
+            (
+                "video_captions_resources",
+                "video_captions_file",
+                f"{video_base}_captions_",
+                "_vtt",
+            ),
+            (
+                "video_transcript_resources",
+                "video_transcript_file",
+                f"{video_base}_transcript_",
+                "_pdf",
+            ),
+        ]
+    ]
+    changed = any(results)
+
+    if changed:
+        if not isinstance(video_resource.metadata, dict):
+            video_resource.metadata = {}
+        video_resource.metadata["video_files"] = video_files
+        video_resource.save()
 
 
 def videos_with_unassigned_youtube_ids(website: Website) -> list[WebsiteContent]:

--- a/websites/api.py
+++ b/websites/api.py
@@ -287,13 +287,14 @@ def _merge_caption_resource(
     Returns True if video_files was modified.
     """
     existing = video_files.get(resource_field)
-    existing_ids: set[str] = set()
+    existing_ids: list[str] = []
     if isinstance(existing, dict):
         content = existing.get("content")
         if isinstance(content, list):
-            existing_ids = {c for c in content if c}
+            existing_ids = [c for c in content if c]
         elif isinstance(content, str) and content:
-            existing_ids = {content}
+            existing_ids = [content]
+    existing_ids_set = set(existing_ids)
 
     candidates = WebsiteContent.objects.filter(
         website=website, filename__startswith=filename_prefix
@@ -303,7 +304,9 @@ def _merge_caption_resource(
         for r in candidates
         if r.file and get_file_extension(r.file.name) in valid_extensions
     ]
-    new_resources = [r for r in related_resources if str(r.text_id) not in existing_ids]
+    new_resources = [
+        r for r in related_resources if str(r.text_id) not in existing_ids_set
+    ]
     if not new_resources:
         return False
 
@@ -362,7 +365,7 @@ def auto_link_video_captions_transcript(video_resource: WebsiteContent) -> None:
         if not isinstance(video_resource.metadata, dict):
             video_resource.metadata = {}
         video_resource.metadata["video_files"] = video_files
-        video_resource.save()
+        video_resource.save(update_fields=["metadata"])
 
 
 def videos_with_unassigned_youtube_ids(website: Website) -> list[WebsiteContent]:

--- a/websites/api.py
+++ b/websites/api.py
@@ -21,7 +21,6 @@ from videos.constants import (
     YT_MAX_LENGTH_TITLE,
     YT_THUMBNAIL_IMG,
 )
-from videos.utils import parse_caption_language_locale
 from websites.constants import (
     CONTENT_FILENAME_MAX_LEN,
     PUBLISH_STATUS_ABORTED,
@@ -258,15 +257,17 @@ def unlink_deleted_resource_from_videos(resource: WebsiteContent) -> None:
             sync_website_content_references(video)
 
 
-def _merge_caption_resource(  # noqa: PLR0913
+def _merge_caption_resource(
     video_files: dict,
     website: "Website",
     resource_field: str,
-    data_field: str,
     filename_prefix: str,
     filename_suffix: str,
 ) -> bool:
     """Find caption/transcript resources by prefix and merge into video_files.
+
+    Only the ``_resources`` relation field is written; the legacy ``_file``
+    fields in stored metadata are left untouched.
 
     Returns True if video_files was modified.
     """
@@ -294,20 +295,6 @@ def _merge_caption_resource(  # noqa: PLR0913
         "content": [*existing_ids, *(str(r.text_id) for r in new_resources)],
         "website": website.name,
     }
-
-    existing_files: list = []
-    existing_files_val = video_files.get(data_field)
-    if isinstance(existing_files_val, list):
-        existing_files = list(existing_files_val)
-    for r in new_resources:
-        if r.file and r.file.name:
-            lang, locale = parse_caption_language_locale(r.filename or "")
-            entry: dict = {"file": f"/{r.file.name.lstrip('/')}", "language": lang}
-            if locale:
-                entry["locale"] = locale
-            existing_files.append(entry)
-    if existing_files:
-        video_files[data_field] = existing_files
     return True
 
 
@@ -315,10 +302,12 @@ def auto_link_video_captions_transcript(video_resource: WebsiteContent) -> None:
     """
     For a Video resource, auto-populate ``video_captions_resources`` and
     ``video_transcript_resources`` from existing WebsiteContent records in the
-    same website that match the ``{base}_captions_*_vtt`` /
-    ``{base}_transcript_*_pdf`` filename prefix convention.  Finds ALL language
+    same website that match the ``{base}_captions-<lang>-<locale>_vtt`` /
+    ``{base}_transcript-<lang>-<locale>_pdf`` filename convention (or the
+    legacy no-suffix form ``{base}_captions_vtt``).  Finds ALL language
     variants and merges them into the multi-select content list without
-    overwriting existing non-empty entries.
+    overwriting existing non-empty entries.  Only ``_resources`` relation
+    fields are written; legacy ``_file`` fields are left untouched.
     """
     if (video_resource.metadata or {}).get("resourcetype") != RESOURCE_TYPE_VIDEO:
         return
@@ -333,20 +322,16 @@ def auto_link_video_captions_transcript(video_resource: WebsiteContent) -> None:
         video_files = {}
 
     results = [
-        _merge_caption_resource(
-            video_files, website, resource_field, data_field, prefix, suffix
-        )
-        for resource_field, data_field, prefix, suffix in [
+        _merge_caption_resource(video_files, website, resource_field, prefix, suffix)
+        for resource_field, prefix, suffix in [
             (
                 "video_captions_resources",
-                "video_captions_file",
-                f"{video_base}_captions_",
+                f"{video_base}_captions",
                 "_vtt",
             ),
             (
                 "video_transcript_resources",
-                "video_transcript_file",
-                f"{video_base}_transcript_",
+                f"{video_base}_transcript",
                 "_pdf",
             ),
         ]
@@ -415,11 +400,21 @@ def videos_missing_captions(website: Website) -> list[WebsiteContent]:
     query_resource_type_field = get_dict_query_field(
         "metadata", settings.FIELD_RESOURCETYPE
     )
-    query_caption_field = get_dict_query_field("metadata", settings.YT_FIELD_CAPTIONS)
+    # A video has captions when its _resources relation has non-empty content;
+    # the key may be entirely absent, JSON null, the site-config default "" or
+    # an emptied list.
+    query_caption_content_field = get_dict_query_field(
+        "metadata", f"{settings.YT_FIELD_CAPTIONS_RESOURCES}.content"
+    )
     return WebsiteContent.objects.filter(
         Q(website=website)
         & Q(**{query_resource_type_field: RESOURCE_TYPE_VIDEO})
-        & (Q(**{query_caption_field: None}) | Q(**{query_caption_field: ""}))
+        & (
+            Q(**{f"{query_caption_content_field}__isnull": True})
+            | Q(**{query_caption_content_field: None})
+            | Q(**{query_caption_content_field: ""})
+            | Q(**{query_caption_content_field: []})
+        )
     )
 
 

--- a/websites/api.py
+++ b/websites/api.py
@@ -265,7 +265,7 @@ def unlink_deleted_resource_from_videos(resource: WebsiteContent) -> None:
 
 def _merge_caption_resource(
     video_files: dict,
-    website: "Website",
+    website: Website,
     resource_field: str,
     filename_prefix: str,
     valid_extensions: tuple[str, ...],

--- a/websites/api.py
+++ b/websites/api.py
@@ -14,9 +14,15 @@ from mitol.common.utils import max_or_none, now_in_utc
 from mitol.mail.api import get_message_sender
 
 from content_sync.constants import VERSION_DRAFT, VERSION_LIVE
-from main.utils import NestableKeyTextTransform, get_base_filename
+from main.utils import (
+    NestableKeyTextTransform,
+    get_base_filename,
+    get_file_extension,
+)
 from users.models import User
 from videos.constants import (
+    CAPTION_FILE_EXTENSIONS,
+    TRANSCRIPT_FILE_EXTENSIONS,
     YT_MAX_LENGTH_DESCRIPTION,
     YT_MAX_LENGTH_TITLE,
     YT_THUMBNAIL_IMG,
@@ -262,9 +268,18 @@ def _merge_caption_resource(
     website: "Website",
     resource_field: str,
     filename_prefix: str,
-    filename_suffix: str,
+    valid_extensions: tuple[str, ...],
 ) -> bool:
     """Find caption/transcript resources by prefix and merge into video_files.
+
+    Candidates are found by filename prefix only, then filtered by the real
+    extension of their uploaded ``file`` (not the ``filename`` field's tail).
+    Django's filename-uniqueness logic (``find_available_name``) appends a
+    bare digit directly onto a colliding filename with no separator — e.g.
+    ``lecture1_captions-en-us_vtt`` collides and becomes
+    ``lecture1_captions-en-us_vtt2`` — which would silently defeat an exact
+    ``filename__endswith`` suffix check. The uploaded file's own extension is
+    unaffected by that renaming, so it's used here instead.
 
     Only the ``_resources`` relation field is written; the legacy ``_file``
     fields in stored metadata are left untouched.
@@ -280,13 +295,14 @@ def _merge_caption_resource(
         elif isinstance(content, str) and content:
             existing_ids = {content}
 
-    related_resources = list(
-        WebsiteContent.objects.filter(
-            website=website,
-            filename__startswith=filename_prefix,
-            filename__endswith=filename_suffix,
-        ).order_by("filename")
-    )
+    candidates = WebsiteContent.objects.filter(
+        website=website, filename__startswith=filename_prefix
+    ).order_by("filename")
+    related_resources = [
+        r
+        for r in candidates
+        if r.file and get_file_extension(r.file.name) in valid_extensions
+    ]
     new_resources = [r for r in related_resources if str(r.text_id) not in existing_ids]
     if not new_resources:
         return False
@@ -302,12 +318,16 @@ def auto_link_video_captions_transcript(video_resource: WebsiteContent) -> None:
     """
     For a Video resource, auto-populate ``video_captions_resources`` and
     ``video_transcript_resources`` from existing WebsiteContent records in the
-    same website that match the ``{base}_captions-<lang>-<locale>_vtt`` /
-    ``{base}_transcript-<lang>-<locale>_pdf`` filename convention (or the
-    legacy no-suffix form ``{base}_captions_vtt``).  Finds ALL language
-    variants and merges them into the multi-select content list without
-    overwriting existing non-empty entries.  Only ``_resources`` relation
-    fields are written; legacy ``_file`` fields are left untouched.
+    same website whose filename starts with ``{base}_captions`` /
+    ``{base}_transcript`` (covering both the ``{base}_captions-<lang>-<locale>``
+    convention and the legacy no-suffix form) and whose uploaded file has a
+    matching real extension. The real file extension is used rather than the
+    filename's tail because Django's filename-uniqueness logic can append a
+    bare digit to a colliding filename (e.g. ``..._vtt`` -> ``..._vtt2``),
+    which would defeat an exact suffix match. Finds ALL language variants and
+    merges them into the multi-select content list without overwriting
+    existing non-empty entries. Only ``_resources`` relation fields are
+    written; legacy ``_file`` fields are left untouched.
     """
     if (video_resource.metadata or {}).get("resourcetype") != RESOURCE_TYPE_VIDEO:
         return
@@ -322,17 +342,17 @@ def auto_link_video_captions_transcript(video_resource: WebsiteContent) -> None:
         video_files = {}
 
     results = [
-        _merge_caption_resource(video_files, website, resource_field, prefix, suffix)
-        for resource_field, prefix, suffix in [
+        _merge_caption_resource(video_files, website, resource_field, prefix, suffixes)
+        for resource_field, prefix, suffixes in [
             (
                 "video_captions_resources",
                 f"{video_base}_captions",
-                "_vtt",
+                CAPTION_FILE_EXTENSIONS,
             ),
             (
                 "video_transcript_resources",
                 f"{video_base}_transcript",
-                "_pdf",
+                TRANSCRIPT_FILE_EXTENSIONS,
             ),
         ]
     ]

--- a/websites/api.py
+++ b/websites/api.py
@@ -254,12 +254,15 @@ def unlink_deleted_resource_from_videos(resource: WebsiteContent) -> None:
             if not isinstance(relation, dict):
                 continue
             content_list = relation.get("content")
-            if isinstance(content_list, list) and text_id in content_list:
+            if isinstance(content_list, str) and content_list == text_id:
+                relation["content"] = []
+                changed = True
+            elif isinstance(content_list, list) and text_id in content_list:
                 relation["content"] = [c for c in content_list if c != text_id]
                 changed = True
         if changed:
             video.metadata["video_files"] = video_files
-            video.save()
+            video.save(update_fields=["metadata"])
             sync_website_content_references(video)
 
 

--- a/websites/api_test.py
+++ b/websites/api_test.py
@@ -11,6 +11,7 @@ from content_sync.constants import VERSION_DRAFT, VERSION_LIVE
 from users.factories import UserFactory
 from videos.constants import YT_THUMBNAIL_IMG
 from websites.api import (
+    auto_link_video_captions_transcript,
     detect_mime_type,
     fetch_website,
     get_content_warnings,
@@ -719,3 +720,159 @@ def test_get_short_id(course_num, term, year, expected_id):
     else:
         with pytest.raises(ValueError, match="Primary course number is missing"):
             get_short_id("random-name", metadata)
+
+
+# ── auto_link_video_captions_transcript ──────────────────────────────────────
+
+
+def test_auto_link_video_skips_non_video():
+    """auto_link_video_captions_transcript is a no-op for non-video resources."""
+    content = WebsiteContentFactory.create(
+        metadata={"resourcetype": "Image"},
+        filename="some-image",
+    )
+    auto_link_video_captions_transcript(content)
+    content.refresh_from_db()
+    assert content.metadata == {"resourcetype": "Image"}
+
+
+def test_auto_link_video_no_matching_captions():
+    """auto_link_video_captions_transcript makes no changes when no captions/transcript exist."""
+    website = WebsiteFactory.create()
+    video = WebsiteContentFactory.create(
+        website=website,
+        metadata={"resourcetype": RESOURCE_TYPE_VIDEO, "video_files": {}},
+        filename="lecture01_mp4",
+    )
+    auto_link_video_captions_transcript(video)
+    video.refresh_from_db()
+    assert video.metadata["video_files"] == {}
+
+
+def test_auto_link_video_links_existing_captions_and_transcript():
+    """auto_link_video_captions_transcript sets _resource fields from existing content."""
+    website = WebsiteFactory.create()
+    captions = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture01_captions_vtt",
+        file=f"courses/{website.name}/lecture01_captions.vtt",
+    )
+    transcript = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture01_transcript_pdf",
+        file=f"courses/{website.name}/lecture01_transcript.pdf",
+    )
+    video = WebsiteContentFactory.create(
+        website=website,
+        metadata={"resourcetype": RESOURCE_TYPE_VIDEO, "video_files": {}},
+        filename="lecture01_mp4",
+    )
+    auto_link_video_captions_transcript(video)
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    assert vf["video_captions_resources"] == {
+        "content": [str(captions.text_id)],
+        "website": website.name,
+    }
+    assert vf["video_captions_file"] == [
+        {"file": f"/courses/{website.name}/lecture01_captions.vtt", "language": "en"}
+    ]
+    assert vf["video_transcript_resources"] == {
+        "content": [str(transcript.text_id)],
+        "website": website.name,
+    }
+    assert vf["video_transcript_file"] == [
+        {"file": f"/courses/{website.name}/lecture01_transcript.pdf", "language": "en"}
+    ]
+
+
+def test_auto_link_video_treats_empty_content_as_unset():
+    """_resource fields with empty-string content (site config default) are treated as unset."""
+    website = WebsiteFactory.create()
+    captions = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture01_captions_vtt",
+        file=f"courses/{website.name}/lecture01_captions.vtt",
+    )
+    video = WebsiteContentFactory.create(
+        website=website,
+        metadata={
+            "resourcetype": RESOURCE_TYPE_VIDEO,
+            "video_files": {
+                # site-config-initialised empty relation — should be overwritten
+                "video_captions_resources": {"content": "", "website": website.name},
+            },
+        },
+        filename="lecture01_mp4",
+    )
+    auto_link_video_captions_transcript(video)
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    assert vf["video_captions_resources"] == {
+        "content": [str(captions.text_id)],
+        "website": website.name,
+    }
+
+
+def test_auto_link_video_appends_new_without_overwriting_existing():
+    """New captions found by convention are appended to existing content list."""
+    website = WebsiteFactory.create()
+    existing_captions = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture01_captions_fr_vtt",
+        file=f"courses/{website.name}/lecture01_captions_fr.vtt",
+    )
+    new_captions = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture01_captions_en_vtt",
+        file=f"courses/{website.name}/lecture01_captions_en.vtt",
+    )
+    video = WebsiteContentFactory.create(
+        website=website,
+        metadata={
+            "resourcetype": RESOURCE_TYPE_VIDEO,
+            "video_files": {
+                "video_captions_resources": {
+                    "content": [str(existing_captions.text_id)],
+                    "website": website.name,
+                },
+            },
+        },
+        filename="lecture01_mp4",
+    )
+    auto_link_video_captions_transcript(video)
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    # Existing id preserved, new id appended
+    assert str(existing_captions.text_id) in vf["video_captions_resources"]["content"]
+    assert str(new_captions.text_id) in vf["video_captions_resources"]["content"]
+    assert len(vf["video_captions_resources"]["content"]) == 2
+
+
+def test_auto_link_video_multi_language_captions():
+    """auto_link_video_captions_transcript links all language variants, not just English."""
+    website = WebsiteFactory.create()
+    captions_en = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture01_captions_en_vtt",
+        file=f"courses/{website.name}/lecture01_captions_en.vtt",
+    )
+    captions_fr = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture01_captions_fr_vtt",
+        file=f"courses/{website.name}/lecture01_captions_fr.vtt",
+    )
+    video = WebsiteContentFactory.create(
+        website=website,
+        metadata={"resourcetype": RESOURCE_TYPE_VIDEO, "video_files": {}},
+        filename="lecture01_mp4",
+    )
+    auto_link_video_captions_transcript(video)
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    content = vf["video_captions_resources"]["content"]
+    assert str(captions_en.text_id) in content
+    assert str(captions_fr.text_id) in content
+    assert len(content) == 2
+    languages = {e["language"] for e in vf["video_captions_file"]}
+    assert languages == {"en", "fr"}

--- a/websites/api_test.py
+++ b/websites/api_test.py
@@ -21,6 +21,8 @@ from websites.api import (
     get_website_in_root_website_metadata,
     is_ocw_site,
     mail_on_publish,
+    sync_website_content_references,
+    unlink_deleted_resource_from_videos,
     update_website_status,
     update_youtube_thumbnail,
     videos_missing_captions,
@@ -28,6 +30,7 @@ from websites.api import (
     videos_with_unassigned_youtube_ids,
 )
 from websites.constants import (
+    CONTENT_TYPE_RESOURCE,
     PUBLISH_STATUS_ERRORED,
     PUBLISH_STATUS_STARTED,
     PUBLISH_STATUS_SUCCEEDED,
@@ -876,3 +879,93 @@ def test_auto_link_video_multi_language_captions():
     assert len(content) == 2
     languages = {e["language"] for e in vf["video_captions_file"]}
     assert languages == {"en", "fr"}
+
+
+# ── unlink_deleted_resource_from_videos ──────────────────────────────────────
+
+
+def test_unlink_deleted_resource_removes_from_video_captions_resources():
+    """Deleting a linked caption resource removes it from the video's relation content."""
+    website = WebsiteFactory.create()
+    captions = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture01_captions_vtt",
+        file=f"courses/{website.name}/lecture01_captions.vtt",
+    )
+    video = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        metadata={
+            "resourcetype": RESOURCE_TYPE_VIDEO,
+            "video_files": {
+                "video_captions_resources": {
+                    "content": [str(captions.text_id)],
+                    "website": website.name,
+                }
+            },
+        },
+        filename="lecture01_mp4",
+    )
+    sync_website_content_references(video)
+    assert captions in video.referenced_by.all()
+
+    unlink_deleted_resource_from_videos(captions)
+
+    video.refresh_from_db()
+    assert video.metadata["video_files"]["video_captions_resources"]["content"] == []
+    assert captions not in video.referenced_by.all()
+
+
+def test_unlink_deleted_resource_preserves_other_language():
+    """Deleting one language variant leaves other linked languages intact."""
+    website = WebsiteFactory.create()
+    captions_en = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture01_captions_vtt",
+        file=f"courses/{website.name}/lecture01_captions.vtt",
+    )
+    captions_fr = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture01_captions_fr_vtt",
+        file=f"courses/{website.name}/lecture01_captions_fr.vtt",
+    )
+    video = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        metadata={
+            "resourcetype": RESOURCE_TYPE_VIDEO,
+            "video_files": {
+                "video_captions_resources": {
+                    "content": [str(captions_en.text_id), str(captions_fr.text_id)],
+                    "website": website.name,
+                }
+            },
+        },
+        filename="lecture01_mp4",
+    )
+    sync_website_content_references(video)
+
+    unlink_deleted_resource_from_videos(captions_en)
+
+    video.refresh_from_db()
+    assert video.metadata["video_files"]["video_captions_resources"]["content"] == [
+        str(captions_fr.text_id)
+    ]
+
+
+def test_unlink_deleted_resource_no_op_when_not_referenced():
+    """A resource that no video references is a no-op."""
+    website = WebsiteFactory.create()
+    orphan = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture01_captions_vtt",
+        file=f"courses/{website.name}/lecture01_captions.vtt",
+    )
+    video = WebsiteContentFactory.create(
+        website=website,
+        metadata={"resourcetype": RESOURCE_TYPE_VIDEO, "video_files": {}},
+        filename="lecture01_mp4",
+    )
+    unlink_deleted_resource_from_videos(orphan)
+    video.refresh_from_db()
+    assert video.metadata["video_files"] == {}

--- a/websites/api_test.py
+++ b/websites/api_test.py
@@ -915,15 +915,15 @@ def test_auto_link_video_multi_language_captions():
     [
         ("vtt", "_vtt"),
         ("webvtt", "_webvtt"),
-        ("srt", "_srt"),
     ],
 )
 def test_auto_link_video_matches_all_caption_extensions(extension, filename_suffix):
     """auto_link_video_captions_transcript finds captions regardless of extension.
 
-    Caption files may slugify to _vtt, _webvtt, or _srt depending on the
-    source file's extension (e.g. 3Play produces .webvtt). All three must be
-    found by the video-side lookup, not just .vtt.
+    Caption files may slugify to _vtt or _webvtt depending on the source
+    file's extension (e.g. 3Play produces .webvtt). Both must be found by
+    the video-side lookup, not just .vtt. srt is deliberately excluded -
+    it's not natively playable via the HTML5 <track> element.
     """
     website = WebsiteFactory.create()
     captions = WebsiteContentFactory.create(

--- a/websites/api_test.py
+++ b/websites/api_test.py
@@ -303,26 +303,58 @@ def test_videos_missing_captions(mocker, is_ocw):
     """videos_missing_captions should return WebsiteContent objects for videos with no captions"""
     mocker.patch("websites.api.is_ocw_site", return_value=is_ocw)
     website = WebsiteFactory.create()
+    # Videos WITH captions: non-empty _resources relation content
     WebsiteContentFactory.create_batch(
         3,
         website=website,
         metadata={
             "resourcetype": RESOURCE_TYPE_VIDEO,
-            "video_files": {"video_captions_file": "abc123"},
+            "video_files": {
+                "video_captions_resources": {
+                    "content": ["abc123"],
+                    "website": website.name,
+                }
+            },
         },
     )
-    videos_without_captions = []
-
-    for captions in [None, ""]:
-        videos_without_captions.append(  # noqa: PERF401
-            WebsiteContentFactory.create(
-                website=website,
-                metadata={
-                    "resourcetype": RESOURCE_TYPE_VIDEO,
-                    "video_files": {"video_captions_file": captions},
+    videos_without_captions = [
+        # Relation key entirely absent
+        WebsiteContentFactory.create(
+            website=website,
+            metadata={"resourcetype": RESOURCE_TYPE_VIDEO, "video_files": {}},
+        ),
+        # Site-config default: empty-string content
+        WebsiteContentFactory.create(
+            website=website,
+            metadata={
+                "resourcetype": RESOURCE_TYPE_VIDEO,
+                "video_files": {
+                    "video_captions_resources": {"content": "", "website": ""}
                 },
-            )
-        )
+            },
+        ),
+        # Emptied list (e.g. after unlinking a deleted resource)
+        WebsiteContentFactory.create(
+            website=website,
+            metadata={
+                "resourcetype": RESOURCE_TYPE_VIDEO,
+                "video_files": {
+                    "video_captions_resources": {
+                        "content": [],
+                        "website": website.name,
+                    }
+                },
+            },
+        ),
+        # Legacy scalar _file value only — no _resources relation
+        WebsiteContentFactory.create(
+            website=website,
+            metadata={
+                "resourcetype": RESOURCE_TYPE_VIDEO,
+                "video_files": {"video_captions_file": "abc123"},
+            },
+        ),
+    ]
     WebsiteContentFactory.create(
         website=website,
         metadata={
@@ -333,7 +365,7 @@ def test_videos_missing_captions(mocker, is_ocw):
 
     unassigned_content = videos_missing_captions(website)
     if is_ocw:
-        assert len(unassigned_content) == 2
+        assert len(unassigned_content) == len(videos_without_captions)
         for content in videos_without_captions:
             assert content in unassigned_content
     else:
@@ -777,16 +809,13 @@ def test_auto_link_video_links_existing_captions_and_transcript():
         "content": [str(captions.text_id)],
         "website": website.name,
     }
-    assert vf["video_captions_file"] == [
-        {"file": f"/courses/{website.name}/lecture01_captions.vtt", "language": "en"}
-    ]
     assert vf["video_transcript_resources"] == {
         "content": [str(transcript.text_id)],
         "website": website.name,
     }
-    assert vf["video_transcript_file"] == [
-        {"file": f"/courses/{website.name}/lecture01_transcript.pdf", "language": "en"}
-    ]
+    # Legacy _file fields in stored metadata are never written by auto-link
+    assert "video_captions_file" not in vf
+    assert "video_transcript_file" not in vf
 
 
 def test_auto_link_video_treats_empty_content_as_unset():
@@ -857,13 +886,13 @@ def test_auto_link_video_multi_language_captions():
     website = WebsiteFactory.create()
     captions_en = WebsiteContentFactory.create(
         website=website,
-        filename="lecture01_captions_en_vtt",
-        file=f"courses/{website.name}/lecture01_captions_en.vtt",
+        filename="lecture01_captions-en-us_vtt",
+        file=f"courses/{website.name}/lecture01_captions-en-US.vtt",
     )
     captions_fr = WebsiteContentFactory.create(
         website=website,
-        filename="lecture01_captions_fr_vtt",
-        file=f"courses/{website.name}/lecture01_captions_fr.vtt",
+        filename="lecture01_captions-fr-ca_vtt",
+        file=f"courses/{website.name}/lecture01_captions-fr-CA.vtt",
     )
     video = WebsiteContentFactory.create(
         website=website,
@@ -877,8 +906,8 @@ def test_auto_link_video_multi_language_captions():
     assert str(captions_en.text_id) in content
     assert str(captions_fr.text_id) in content
     assert len(content) == 2
-    languages = {e["language"] for e in vf["video_captions_file"]}
-    assert languages == {"en", "fr"}
+    # Legacy _file fields in stored metadata are never written by auto-link
+    assert "video_captions_file" not in vf
 
 
 # ── unlink_deleted_resource_from_videos ──────────────────────────────────────

--- a/websites/api_test.py
+++ b/websites/api_test.py
@@ -1011,6 +1011,36 @@ def test_unlink_deleted_resource_removes_from_video_captions_resources():
     assert captions not in video.referenced_by.all()
 
 
+def test_unlink_deleted_resource_removes_legacy_scalar_string_content():
+    """Deleting a resource linked via a legacy scalar-string content value still unlinks it."""
+    website = WebsiteFactory.create()
+    captions = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture01_captions_vtt",
+        file=f"courses/{website.name}/lecture01_captions.vtt",
+    )
+    video = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        metadata={
+            "resourcetype": RESOURCE_TYPE_VIDEO,
+            "video_files": {
+                "video_captions_resources": {
+                    "content": str(captions.text_id),
+                    "website": website.name,
+                }
+            },
+        },
+        filename="lecture01_mp4",
+    )
+    sync_website_content_references(video)
+
+    unlink_deleted_resource_from_videos(captions)
+
+    video.refresh_from_db()
+    assert video.metadata["video_files"]["video_captions_resources"]["content"] == []
+
+
 def test_unlink_deleted_resource_preserves_other_language():
     """Deleting one language variant leaves other linked languages intact."""
     website = WebsiteFactory.create()

--- a/websites/api_test.py
+++ b/websites/api_test.py
@@ -910,6 +910,72 @@ def test_auto_link_video_multi_language_captions():
     assert "video_captions_file" not in vf
 
 
+@pytest.mark.parametrize(
+    ("extension", "filename_suffix"),
+    [
+        ("vtt", "_vtt"),
+        ("webvtt", "_webvtt"),
+        ("srt", "_srt"),
+    ],
+)
+def test_auto_link_video_matches_all_caption_extensions(extension, filename_suffix):
+    """auto_link_video_captions_transcript finds captions regardless of extension.
+
+    Caption files may slugify to _vtt, _webvtt, or _srt depending on the
+    source file's extension (e.g. 3Play produces .webvtt). All three must be
+    found by the video-side lookup, not just .vtt.
+    """
+    website = WebsiteFactory.create()
+    captions = WebsiteContentFactory.create(
+        website=website,
+        filename=f"lecture01_captions-en-us{filename_suffix}",
+        file=f"courses/{website.name}/lecture01_captions-en-US.{extension}",
+    )
+    video = WebsiteContentFactory.create(
+        website=website,
+        metadata={"resourcetype": RESOURCE_TYPE_VIDEO, "video_files": {}},
+        filename="lecture01_mp4",
+    )
+    auto_link_video_captions_transcript(video)
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    assert vf["video_captions_resources"]["content"] == [str(captions.text_id)]
+
+
+def test_auto_link_video_survives_filename_uniqueness_suffix():
+    """auto_link_video_captions_transcript still matches when Django's
+    filename-uniqueness logic has appended a bare digit to the colliding
+    filename (e.g. "..._vtt2").
+
+    This is the actual production bug: matching must rely on the resource's
+    real uploaded file extension, not the filename field, since
+    find_available_name can mutate the filename's tail with no separator.
+    """
+    website = WebsiteFactory.create()
+    # Simulates a second same-named upload: find_available_name would produce
+    # this exact filename by appending "2" directly onto "..._vtt" / "..._pdf".
+    captions = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture01_captions-en-us_vtt2",
+        file=f"courses/{website.name}/lecture01_captions-en-US.vtt",
+    )
+    transcript = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture01_transcript-en-us_pdf2",
+        file=f"courses/{website.name}/lecture01_transcript-en-US.pdf",
+    )
+    video = WebsiteContentFactory.create(
+        website=website,
+        metadata={"resourcetype": RESOURCE_TYPE_VIDEO, "video_files": {}},
+        filename="lecture01_mp4",
+    )
+    auto_link_video_captions_transcript(video)
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    assert vf["video_captions_resources"]["content"] == [str(captions.text_id)]
+    assert vf["video_transcript_resources"]["content"] == [str(transcript.text_id)]
+
+
 # ── unlink_deleted_resource_from_videos ──────────────────────────────────────
 
 

--- a/websites/models_test.py
+++ b/websites/models_test.py
@@ -585,8 +585,8 @@ def test_websitecontent_full_metadata_resolves_resources_relation():
     )
     captions_es = WebsiteContentFactory.create(
         website=website,
-        filename="lecture1_captions_es_vtt",
-        file="sites/mysite/lecture1_captions_es.vtt",
+        filename="lecture1_captions-es-mx_vtt",
+        file="sites/mysite/lecture1_captions-es-MX.vtt",
         type="resource",
     )
 
@@ -616,8 +616,9 @@ def test_websitecontent_full_metadata_resolves_resources_relation():
         "file": "/sites/mysite-fall-2008/lecture1_captions.vtt",
         "language": "en",
     } in resolved
-    # and "es" for the _es suffix — language detection added in this branch
+    # and "es"/"MX" for the -es-mx suffix — dash lang-locale convention
     assert {
-        "file": "/sites/mysite-fall-2008/lecture1_captions_es.vtt",
+        "file": "/sites/mysite-fall-2008/lecture1_captions-es-MX.vtt",
         "language": "es",
+        "locale": "MX",
     } in resolved

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -24,7 +24,6 @@ from gdrive_sync.tasks import create_gdrive_folders
 from main.posthog import is_feature_enabled
 from main.serializers import RequestUserSerializerMixin
 from users.models import User
-from videos.utils import resource_file_paths
 from websites import constants
 from websites.api import (
     detect_mime_type,
@@ -42,53 +41,12 @@ from websites.constants import (
 from websites.models import Website, WebsiteContent, WebsiteStarter
 from websites.permissions import is_global_admin, is_site_admin
 from websites.site_config_api import SiteConfig
-from websites.utils import (
-    get_dict_field,
-    permissions_group_name_for_role,
-    set_dict_field,
-)
+from websites.utils import permissions_group_name_for_role
 
 log = logging.getLogger(__name__)
 
 
 ROLE_ERROR_MESSAGES = {"invalid_choice": "Invalid role", "required": "Role is required"}
-
-
-RELATION_URL_FIELDS = (
-    (settings.YT_FIELD_CAPTIONS_RESOURCES, settings.YT_FIELD_CAPTIONS),
-    (settings.YT_FIELD_TRANSCRIPT_RESOURCES, settings.YT_FIELD_TRANSCRIPT),
-)
-
-
-def sync_video_relation_urls(metadata: dict) -> None:
-    if get_dict_field(metadata, settings.FIELD_RESOURCETYPE) != RESOURCE_TYPE_VIDEO:
-        return
-    for relation_field, target_field in RELATION_URL_FIELDS:
-        relation_value = get_dict_field(metadata, relation_field)
-        if not isinstance(relation_value, dict):
-            continue
-        content = relation_value.get("content")
-        # Normalize: content may be a scalar str (legacy) or a list (multi-select)
-        if isinstance(content, str):
-            content_ids = [content] if content else []
-        elif isinstance(content, list):
-            content_ids = [c for c in content if c]
-        else:
-            content_ids = []
-        website_name = relation_value.get("website")
-        resources = (
-            list(
-                WebsiteContent.objects.filter(
-                    website__name=website_name, text_id__in=content_ids
-                )
-                if website_name
-                else WebsiteContent.objects.filter(text_id__in=content_ids)
-            )
-            if content_ids
-            else []
-        )
-        file_entries = resource_file_paths(resources)
-        set_dict_field(metadata, target_field, file_entries or None)
 
 
 class WebsiteStarterSerializer(serializers.ModelSerializer):
@@ -617,7 +575,6 @@ class WebsiteContentDetailSerializer(
         existing_metadata = instance.metadata if instance.metadata else {}
         if "metadata" in validated_data:
             merged_metadata = {**existing_metadata, **validated_data["metadata"]}
-            sync_video_relation_urls(merged_metadata)
             validated_data["metadata"] = merged_metadata
         instance = super().update(
             instance, {"updated_by": self.user_from_request(), **validated_data}
@@ -759,9 +716,6 @@ class WebsiteContentCreateSerializer(
             validated_data["metadata"]["file_type"] = detect_mime_type(
                 validated_data["file"]
             )
-
-        if validated_data.get("metadata"):
-            sync_video_relation_urls(validated_data["metadata"])
 
         instance = super().create(
             {

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -27,6 +27,7 @@ from users.models import User
 from videos.utils import resource_file_paths
 from websites import constants
 from websites.api import (
+    auto_link_video_captions_transcript,
     detect_mime_type,
     get_content_warnings,
     sync_website_title,
@@ -622,6 +623,7 @@ class WebsiteContentDetailSerializer(
         instance = super().update(
             instance, {"updated_by": self.user_from_request(), **validated_data}
         )
+        auto_link_video_captions_transcript(instance)
         update_website_backend(instance.website)
         # Sync the metadata title and website title if appropriate
         if instance.type == CONTENT_TYPE_METADATA:
@@ -772,6 +774,7 @@ class WebsiteContentCreateSerializer(
                 **added_context_data,
             }
         )
+        auto_link_video_captions_transcript(instance)
         update_website_backend(instance.website)
         if instance.type == CONTENT_TYPE_METADATA:
             sync_website_title(instance)

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -27,7 +27,6 @@ from users.models import User
 from videos.utils import resource_file_paths
 from websites import constants
 from websites.api import (
-    auto_link_video_captions_transcript,
     detect_mime_type,
     get_content_warnings,
     sync_website_title,
@@ -264,7 +263,7 @@ class WebsiteUnpublishSerializer(serializers.ModelSerializer):
 
     def get_site_uid(self, instance):
         """Get the website uid"""
-        meta_content = WebsiteContent.objects.filter(
+        meta_content = WebsiteContent.objects.filter(  # noqa: ORM001
             type=CONTENT_TYPE_METADATA, website=instance
         ).first()
         legacy_uid = (
@@ -623,7 +622,6 @@ class WebsiteContentDetailSerializer(
         instance = super().update(
             instance, {"updated_by": self.user_from_request(), **validated_data}
         )
-        auto_link_video_captions_transcript(instance)
         update_website_backend(instance.website)
         # Sync the metadata title and website title if appropriate
         if instance.type == CONTENT_TYPE_METADATA:
@@ -774,7 +772,6 @@ class WebsiteContentCreateSerializer(
                 **added_context_data,
             }
         )
-        auto_link_video_captions_transcript(instance)
         update_website_backend(instance.website)
         if instance.type == CONTENT_TYPE_METADATA:
             sync_website_title(instance)

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -938,76 +938,15 @@ def test_update_page_url_on_title_change_legacy_index_behavior(
     assert page.title == "New Title"
 
 
-def test_website_content_detail_serializer_syncs_video_relation_files(
+def test_website_content_detail_serializer_leaves_file_fields_untouched(
     mocker, mocked_website_funcs
 ):
-    """Updating video caption/transcript resources should populate URLs."""
-    mocker.patch("websites.serializers.update_youtube_thumbnail")
-    video_metadata = {
-        settings.FIELD_RESOURCETYPE: RESOURCE_TYPE_VIDEO,
-        "video_files": {},
-    }
-    set_dict_field(video_metadata, settings.YT_FIELD_CAPTIONS, "")
-    set_dict_field(video_metadata, settings.YT_FIELD_TRANSCRIPT, "")
-
-    video = WebsiteContentFactory.create(
-        type=CONTENT_TYPE_RESOURCE,
-        metadata=video_metadata,
-    )
-    caption = WebsiteContentFactory.create(
-        type=CONTENT_TYPE_RESOURCE, is_page_content=True
-    )
-    caption.file = SimpleUploadedFile("captions.vtt", b"caption data")
-    caption.save()
-    transcript = WebsiteContentFactory.create(
-        type=CONTENT_TYPE_RESOURCE, is_page_content=True
-    )
-    transcript.file = SimpleUploadedFile("transcript.pdf", b"transcript data")
-    transcript.save()
-
-    metadata_patch = {"video_files": {}}
-    set_dict_field(
-        metadata_patch,
-        settings.YT_FIELD_CAPTIONS_RESOURCES,
-        {"content": str(caption.text_id)},
-    )
-    set_dict_field(
-        metadata_patch,
-        settings.YT_FIELD_TRANSCRIPT_RESOURCES,
-        {"content": str(transcript.text_id)},
-    )
-
-    serializer = WebsiteContentDetailSerializer(
-        instance=video,
-        data={"metadata": metadata_patch},
-        partial=True,
-        context={"request": mocker.Mock(user=UserFactory.create())},
-    )
-    serializer.is_valid(raise_exception=True)
-    serializer.save()
-    video.refresh_from_db()
-    caption.refresh_from_db()
-    transcript.refresh_from_db()
-
-    expected_caption_path = f"/{caption.file.name.lstrip('/')}"
-    expected_transcript_path = f"/{transcript.file.name.lstrip('/')}"
-    assert get_dict_field(video.metadata, settings.YT_FIELD_CAPTIONS) == [
-        {"file": expected_caption_path, "language": "en"}
-    ]
-    assert get_dict_field(video.metadata, settings.YT_FIELD_TRANSCRIPT) == [
-        {"file": expected_transcript_path, "language": "en"}
-    ]
-
-
-@pytest.mark.parametrize("update_field", ["captions", "transcript"])
-def test_website_content_detail_serializer_syncs_video_relation_files_partial(
-    mocker, mocked_website_funcs, update_field
-):
-    """Updating only either the captions/transcript resource updates just that URL."""
+    """Saving _resources relations stores them as-is and never derives _file fields."""
     mocker.patch("websites.serializers.update_youtube_thumbnail")
     video_metadata = {
         settings.FIELD_RESOURCETYPE: RESOURCE_TYPE_VIDEO,
         "video_files": {
+            # Legacy scalar _file values must survive the save untouched
             "video_captions_file": "/old/captions.vtt",
             "video_transcript_file": "/old/transcript.pdf",
         },
@@ -1017,116 +956,16 @@ def test_website_content_detail_serializer_syncs_video_relation_files_partial(
         type=CONTENT_TYPE_RESOURCE,
         metadata=video_metadata,
     )
-    resource = WebsiteContentFactory.create(
+    caption = WebsiteContentFactory.create(
         type=CONTENT_TYPE_RESOURCE, is_page_content=True
     )
-    resource.file = SimpleUploadedFile(
-        f"{update_field}.txt", f"{update_field} data".encode()
-    )
-    resource.save()
 
     metadata_patch = {"video_files": video.metadata["video_files"].copy()}
-
-    relation_field = (
-        settings.YT_FIELD_CAPTIONS_RESOURCES
-        if update_field == "captions"
-        else settings.YT_FIELD_TRANSCRIPT_RESOURCES
-    )
-    set_dict_field(
-        metadata_patch,
-        relation_field,
-        {"content": str(resource.text_id)},
-    )
-
-    serializer = WebsiteContentDetailSerializer(
-        instance=video,
-        data={"metadata": metadata_patch},
-        partial=True,
-        context={"request": mocker.Mock(user=UserFactory.create())},
-    )
-    serializer.is_valid(raise_exception=True)
-    serializer.save()
-    video.refresh_from_db()
-
-    expected_new_path = f"/{resource.file.name.lstrip('/')}"
-
-    if update_field == "captions":
-        assert get_dict_field(video.metadata, settings.YT_FIELD_CAPTIONS) == [
-            {"file": expected_new_path, "language": "en"}
-        ]
-        assert (
-            get_dict_field(video.metadata, settings.YT_FIELD_TRANSCRIPT)
-            == "/old/transcript.pdf"
-        )
-    else:
-        assert get_dict_field(video.metadata, settings.YT_FIELD_TRANSCRIPT) == [
-            {"file": expected_new_path, "language": "en"}
-        ]
-        assert (
-            get_dict_field(video.metadata, settings.YT_FIELD_CAPTIONS)
-            == "/old/captions.vtt"
-        )
-
-
-@pytest.mark.django_db
-def test_website_content_detail_serializer_syncs_video_relation_files_multi_language(
-    mocker, mocked_website_funcs
-):
-    """Updating video with multiple language resources stores list of {file, language}."""
-    mocker.patch("websites.serializers.update_youtube_thumbnail")
-    video_metadata = {
-        settings.FIELD_RESOURCETYPE: RESOURCE_TYPE_VIDEO,
-        "video_files": {},
+    relation_value = {
+        "content": [str(caption.text_id)],
+        "website": video.website.name,
     }
-    set_dict_field(video_metadata, settings.YT_FIELD_CAPTIONS, [])
-    set_dict_field(video_metadata, settings.YT_FIELD_TRANSCRIPT, [])
-
-    video = WebsiteContentFactory.create(
-        type=CONTENT_TYPE_RESOURCE,
-        metadata=video_metadata,
-    )
-
-    caption_en = WebsiteContentFactory.create(
-        type=CONTENT_TYPE_RESOURCE,
-        is_page_content=True,
-        filename="lecture1_captions_vtt",
-        website=video.website,
-    )
-    caption_en.file = SimpleUploadedFile("lecture1_captions.vtt", b"en captions")
-    caption_en.save()
-
-    caption_es = WebsiteContentFactory.create(
-        type=CONTENT_TYPE_RESOURCE,
-        is_page_content=True,
-        filename="lecture1_captions_es_vtt",
-        website=video.website,
-    )
-    caption_es.file = SimpleUploadedFile("lecture1_captions_es.vtt", b"es captions")
-    caption_es.save()
-
-    transcript_en = WebsiteContentFactory.create(
-        type=CONTENT_TYPE_RESOURCE,
-        is_page_content=True,
-        filename="lecture1_transcript_pdf",
-        website=video.website,
-    )
-    transcript_en.file = SimpleUploadedFile("lecture1_transcript.pdf", b"en transcript")
-    transcript_en.save()
-
-    metadata_patch = {"video_files": {}}
-    set_dict_field(
-        metadata_patch,
-        settings.YT_FIELD_CAPTIONS_RESOURCES,
-        {
-            "content": [str(caption_en.text_id), str(caption_es.text_id)],
-            "website": video.website.name,
-        },
-    )
-    set_dict_field(
-        metadata_patch,
-        settings.YT_FIELD_TRANSCRIPT_RESOURCES,
-        {"content": [str(transcript_en.text_id)], "website": video.website.name},
-    )
+    set_dict_field(metadata_patch, settings.YT_FIELD_CAPTIONS_RESOURCES, relation_value)
 
     serializer = WebsiteContentDetailSerializer(
         instance=video,
@@ -1138,90 +977,17 @@ def test_website_content_detail_serializer_syncs_video_relation_files_multi_lang
     serializer.save()
     video.refresh_from_db()
 
-    captions_result = get_dict_field(video.metadata, settings.YT_FIELD_CAPTIONS)
-    assert isinstance(captions_result, list)
-    assert len(captions_result) == 2
-    # Language detection via parse_caption_language: en (no suffix) and es
-    languages = {entry["language"] for entry in captions_result}
-    assert languages == {"en", "es"}
-    files = {entry["file"] for entry in captions_result}
-    assert f"/{caption_en.file.name.lstrip('/')}" in files
-    assert f"/{caption_es.file.name.lstrip('/')}" in files
-
-    transcript_result = get_dict_field(video.metadata, settings.YT_FIELD_TRANSCRIPT)
-    assert isinstance(transcript_result, list)
-    assert len(transcript_result) == 1
-    assert transcript_result[0]["language"] == "en"
-    assert transcript_result[0]["file"] == f"/{transcript_en.file.name.lstrip('/')}"
-
-
-@pytest.mark.django_db
-def test_website_content_detail_serializer_syncs_video_relation_files_with_locale(
-    mocker, mocked_website_funcs
-):
-    """Caption resources with locale suffix in filename produce {file, language, locale} entries."""
-    mocker.patch("websites.serializers.update_youtube_thumbnail")
-    video_metadata = {
-        settings.FIELD_RESOURCETYPE: RESOURCE_TYPE_VIDEO,
-        "video_files": {},
-    }
-    set_dict_field(video_metadata, settings.YT_FIELD_CAPTIONS, [])
-    video = WebsiteContentFactory.create(
-        type=CONTENT_TYPE_RESOURCE,
-        metadata=video_metadata,
+    # The relation is stored exactly as sent
+    assert (
+        get_dict_field(video.metadata, settings.YT_FIELD_CAPTIONS_RESOURCES)
+        == relation_value
     )
-
-    # English (US locale) — filename carries locale suffix
-    caption_en_us = WebsiteContentFactory.create(
-        type=CONTENT_TYPE_RESOURCE,
-        is_page_content=True,
-        filename="lecture1_captions_en_us_vtt",
-        website=video.website,
+    # The legacy scalar _file values are untouched
+    assert (
+        get_dict_field(video.metadata, settings.YT_FIELD_CAPTIONS)
+        == "/old/captions.vtt"
     )
-    caption_en_us.file = SimpleUploadedFile(
-        "lecture1_captions_en_us.vtt", b"en-US captions"
+    assert (
+        get_dict_field(video.metadata, settings.YT_FIELD_TRANSCRIPT)
+        == "/old/transcript.pdf"
     )
-    caption_en_us.save()
-
-    # French — no locale
-    caption_fr = WebsiteContentFactory.create(
-        type=CONTENT_TYPE_RESOURCE,
-        is_page_content=True,
-        filename="lecture1_captions_fr_vtt",
-        website=video.website,
-    )
-    caption_fr.file = SimpleUploadedFile("lecture1_captions_fr.vtt", b"fr captions")
-    caption_fr.save()
-
-    metadata_patch = {"video_files": {}}
-    set_dict_field(
-        metadata_patch,
-        settings.YT_FIELD_CAPTIONS_RESOURCES,
-        {
-            "content": [str(caption_en_us.text_id), str(caption_fr.text_id)],
-            "website": video.website.name,
-        },
-    )
-
-    serializer = WebsiteContentDetailSerializer(
-        instance=video,
-        data={"metadata": metadata_patch},
-        partial=True,
-        context={"request": mocker.Mock(user=UserFactory.create())},
-    )
-    serializer.is_valid(raise_exception=True)
-    serializer.save()
-    video.refresh_from_db()
-
-    captions_result = get_dict_field(video.metadata, settings.YT_FIELD_CAPTIONS)
-    assert isinstance(captions_result, list)
-    assert len(captions_result) == 2
-
-    by_file = {entry["file"]: entry for entry in captions_result}
-    en_us_key = f"/{caption_en_us.file.name.lstrip('/')}"
-    fr_key = f"/{caption_fr.file.name.lstrip('/')}"
-
-    assert by_file[en_us_key]["language"] == "en"
-    assert by_file[en_us_key]["locale"] == "US"
-    assert by_file[fr_key]["language"] == "fr"
-    assert "locale" not in by_file[fr_key]

--- a/websites/signals.py
+++ b/websites/signals.py
@@ -4,7 +4,9 @@ from django.db import transaction
 from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 from django.utils.text import slugify
+from safedelete.signals import post_softdelete
 
+from websites.api import unlink_deleted_resource_from_videos
 from websites.constants import (
     CONTENT_TYPE_NAVMENU,
     CONTENT_TYPE_PAGE,
@@ -73,3 +75,18 @@ def update_navmenu_on_page_url_change(
                 navmenu.save(update_fields=["metadata"])
         except WebsiteContent.DoesNotExist:
             pass
+
+
+@receiver(post_softdelete, sender=WebsiteContent)
+def unlink_deleted_resource_on_softdelete(
+    sender,  # noqa: ARG001
+    instance,
+    **kwargs,  # noqa: ARG001
+):
+    """
+    When a resource referenced by a video (as a caption/transcript) is
+    deleted, remove it from that video's relation content list.
+    """
+    if not instance.referencing_content.exists():
+        return
+    unlink_deleted_resource_from_videos(instance)

--- a/websites/signals_test.py
+++ b/websites/signals_test.py
@@ -4,6 +4,8 @@ import pytest
 
 from users.factories import UserFactory
 from websites import constants
+from websites.api import sync_website_content_references
+from websites.constants import RESOURCE_TYPE_VIDEO
 from websites.factories import WebsiteContentFactory, WebsiteFactory
 from websites.serializers import WebsiteContentDetailSerializer
 
@@ -54,3 +56,34 @@ def test_navmenu_updated_on_page_title_change(mocker, enable_websitecontent_sign
     menu_item = navmenu.metadata[constants.WEBSITE_CONTENT_LEFTNAV][0]
     assert menu_item["pageRef"] == "/pages/new-title"
     assert menu_item["name"] == "New Title"
+
+
+@pytest.mark.django_db
+def test_deleting_linked_resource_unlinks_it_from_video():
+    """Soft-deleting a linked caption resource removes it from the video's relation content."""
+    website = WebsiteFactory.create()
+    captions = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture01_captions_vtt",
+        file=f"courses/{website.name}/lecture01_captions.vtt",
+    )
+    video = WebsiteContentFactory.create(
+        website=website,
+        type=constants.CONTENT_TYPE_RESOURCE,
+        metadata={
+            "resourcetype": RESOURCE_TYPE_VIDEO,
+            "video_files": {
+                "video_captions_resources": {
+                    "content": [str(captions.text_id)],
+                    "website": website.name,
+                }
+            },
+        },
+        filename="lecture01_mp4",
+    )
+    sync_website_content_references(video)
+
+    captions.delete()
+
+    video.refresh_from_db()
+    assert video.metadata["video_files"]["video_captions_resources"]["content"] == []

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -1187,14 +1187,12 @@ def test_websites_content_create_video_resource_sets_3play_references(
         captions.id,
         transcript.id,
     }
-    # build-pipeline file arrays populated by sync_video_relation_urls on create
+    # Only _resources is written; sync_video_relation_urls (which derived
+    # video_captions_file/video_transcript_file) has been removed - _file
+    # fields are left untouched throughout this branch.
     vf = content.metadata["video_files"]
-    assert vf["video_captions_file"] == [
-        {"file": f"/courses/{website.name}/video-captions.webvtt", "language": "en"}
-    ]
-    assert vf["video_transcript_file"] == [
-        {"file": f"/courses/{website.name}/video-transcript.pdf", "language": "en"}
-    ]
+    assert "video_captions_file" not in vf
+    assert "video_transcript_file" not in vf
 
 
 def test_websites_content_create_video_does_not_auto_link_by_filename_convention(
@@ -1816,11 +1814,9 @@ def test_websites_content_update_video_resource_sets_3play_references(
         captions.id,
         transcript.id,
     }
-    # build-pipeline file arrays populated by sync_video_relation_urls on update
+    # Only _resources is written; sync_video_relation_urls (which derived
+    # video_captions_file/video_transcript_file) has been removed - _file
+    # fields are left untouched throughout this branch.
     vf = video.metadata["video_files"]
-    assert vf["video_captions_file"] == [
-        {"file": f"/courses/{website.name}/updated-captions.webvtt", "language": "en"}
-    ]
-    assert vf["video_transcript_file"] == [
-        {"file": f"/courses/{website.name}/updated-transcript.pdf", "language": "en"}
-    ]
+    assert "video_captions_file" not in vf
+    assert "video_transcript_file" not in vf

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -1197,24 +1197,24 @@ def test_websites_content_create_video_resource_sets_3play_references(
     ]
 
 
-def test_websites_content_create_video_auto_links_by_filename_convention(
+def test_websites_content_create_video_does_not_auto_link_by_filename_convention(
     drf_client, global_admin_user
 ):
     """
-    When a video is created via the API and _resource fields are absent or
-    initialised with empty content (the site-config default), any existing
-    captions/transcript resources matching the filename convention are
-    automatically linked.
+    Creating a video via the API must NOT auto-link existing captions/transcript
+    resources by filename convention, even when they'd match. Auto-linking by
+    convention only happens during gdrive/3play sync, not on CMS form saves —
+    the relation widget content is authoritative for whatever the user submits.
     """
     drf_client.force_login(global_admin_user)
     website = WebsiteFactory.create()
-    captions = WebsiteContentFactory.create(
+    WebsiteContentFactory.create(
         website=website,
         type=constants.CONTENT_TYPE_RESOURCE,
         filename="vid_captions_vtt",
         file=f"courses/{website.name}/vid_captions.vtt",
     )
-    transcript = WebsiteContentFactory.create(
+    WebsiteContentFactory.create(
         website=website,
         type=constants.CONTENT_TYPE_RESOURCE,
         filename="vid_transcript_pdf",
@@ -1250,14 +1250,8 @@ def test_websites_content_create_video_auto_links_by_filename_convention(
         text_id=resp.data["text_id"],
     )
     vf = content.metadata["video_files"]
-    assert vf["video_captions_resources"] == {
-        "content": [str(captions.text_id)],
-        "website": website.name,
-    }
-    assert vf["video_transcript_resources"] == {
-        "content": [str(transcript.text_id)],
-        "website": website.name,
-    }
+    assert vf["video_captions_resources"]["content"] == ""
+    assert vf["video_transcript_resources"]["content"] == ""
 
 
 def test_websites_content_create_with_textid(drf_client, global_admin_user):

--- a/websites/views_test.py
+++ b/websites/views_test.py
@@ -1197,6 +1197,69 @@ def test_websites_content_create_video_resource_sets_3play_references(
     ]
 
 
+def test_websites_content_create_video_auto_links_by_filename_convention(
+    drf_client, global_admin_user
+):
+    """
+    When a video is created via the API and _resource fields are absent or
+    initialised with empty content (the site-config default), any existing
+    captions/transcript resources matching the filename convention are
+    automatically linked.
+    """
+    drf_client.force_login(global_admin_user)
+    website = WebsiteFactory.create()
+    captions = WebsiteContentFactory.create(
+        website=website,
+        type=constants.CONTENT_TYPE_RESOURCE,
+        filename="vid_captions_vtt",
+        file=f"courses/{website.name}/vid_captions.vtt",
+    )
+    transcript = WebsiteContentFactory.create(
+        website=website,
+        type=constants.CONTENT_TYPE_RESOURCE,
+        filename="vid_transcript_pdf",
+        file=f"courses/{website.name}/vid_transcript.pdf",
+    )
+
+    # Simulate what the site config relation widget sends when left empty.
+    payload = {
+        "type": constants.CONTENT_TYPE_RESOURCE,
+        "title": "vid",
+        "filename": "vid_mp4",
+        "metadata": {
+            "resourcetype": "Video",
+            "video_metadata": {"youtube_id": ""},
+            "video_files": {
+                "video_captions_resources": {"content": "", "website": website.name},
+                "video_transcript_resources": {"content": "", "website": website.name},
+            },
+        },
+    }
+    resp = drf_client.post(
+        reverse(
+            "websites_content_api-list",
+            kwargs={"parent_lookup_website": website.name},
+        ),
+        data=payload,
+        format="json",
+    )
+
+    assert resp.status_code == 201
+    content = WebsiteContent.objects.get(
+        website=website,
+        text_id=resp.data["text_id"],
+    )
+    vf = content.metadata["video_files"]
+    assert vf["video_captions_resources"] == {
+        "content": [str(captions.text_id)],
+        "website": website.name,
+    }
+    assert vf["video_transcript_resources"] == {
+        "content": [str(transcript.text_id)],
+        "website": website.name,
+    }
+
+
 def test_websites_content_create_with_textid(drf_client, global_admin_user):
     """If a text_id is added when POSTing to the WebsiteContent, we should use that instead of creating a uuid"""
     drf_client.force_login(global_admin_user)


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/10984

### Description (What does it do?)
Adds `auto_link_video_captions_transcript()`, a shared helper that finds caption/transcript `WebsiteContent` resources by the `{base}_captions[-<lang>[-<locale>]]` / `{base}_transcript[-<lang>[-<locale>]]` filename convention and merges all language variants into a video's `video_captions_resources` / `video_transcript_resources` relation fields, without overwriting entries already present. Only `_resources` is written; the legacy scalar `_file` fields are left untouched throughout this branch (a separate stacked branch migrates/removes those).

This covers the case where captions/transcripts are already uploaded to a course (e.g. via GDrive sync) before the corresponding video resource is created or edited in Studio — previously nothing would auto-link them until a separate GDrive sync ran against the video itself.

**Auto-linking is sync-only, not called from the CMS save path.** An earlier version of this PR called it from `WebsiteContentDetailSerializer.update()`/`WebsiteContentCreateSerializer.create()`, but since it re-discovers matches by filename convention on every save, it silently undid a user's manual removal of a resource from the relation widget — even on saves unrelated to captions/transcripts. Auto-linking now only runs during GDrive sync and 3Play sync; the CMS relation widget is fully authoritative for whatever a user selects there. Since resources can no longer be excluded by convention alone, a new `post_softdelete` signal (`unlink_deleted_resource_from_videos`) removes a deleted resource's id from any video's relation list on delete.

Matching is done by filename prefix plus the real extension of the resource's *uploaded file* (`resource.file.name`), not the `WebsiteContent.filename` tail — Django's filename-uniqueness logic (`find_available_name`) appends a bare digit to a colliding filename with no separator (e.g. `..._vtt` → `..._vtt2`), which would silently defeat an exact filename suffix match.

- `websites/api.py`: `_merge_caption_resource()`, `auto_link_video_captions_transcript()`, `unlink_deleted_resource_from_videos()`
- `websites/signals.py`: `post_softdelete` signal wiring for the unlink cleanup
- `gdrive_sync/api.py`: calls the shared auto-link helper for the video-resource case; `_link_resource_to_video` handles the reverse direction (caption/transcript resource synced after the video already exists)
- `videos/threeplay_sync.py`: 3Play now creates real `WebsiteContent` resources and links them via `_resources`, instead of writing only `_file` arrays with no backing resource
- `videos/utils.py`: `parse_caption_language_locale()` extracts language/locale from the GDrive naming convention; recognizes a language-only suffix (no locale) as well as the full lang-locale form
- `videos/models.py`: `Video.caption_transcript_resources()` — multi-language lookup used by the 3Play flow

### How can this be tested?
1. Switch to `umar/10984-auto-link-caption-transcripts-video-resource-add` branch
2. **GDrive path:** upload a video and matching caption/transcript files (e.g. `lecture1.mp4`, `lecture1_captions-en-US.vtt`) to a course's GDrive folder and sync. Confirm the video's `video_captions_resources`/`video_transcript_resources` get populated automatically, including multiple language variants if present.
3. **3Play path:** trigger a 3Play transcript job for a video with no existing captions/transcripts. Confirm real caption/transcript `WebsiteContent` resources are created and linked via `_resources` (not just raw files with no resource).
4. **Manual unlink sticks:** remove a linked caption/transcript from the relation widget in Studio and save. Confirm it stays removed on subsequent saves (including saves unrelated to captions/transcripts).
5. **Delete cleanup:** delete a linked caption/transcript resource directly. Confirm it's removed from the video's relation content automatically.