### PR TITLE
refactor: backfill orphaned captions/transcripts, remove legacy _file fields

### DIFF
--- a/drf_lint_baseline.json
+++ b/drf_lint_baseline.json
@@ -1,5 +1,4 @@
 [
   "content_sync/serializers.py:142:21:ORM001",
-  "content_sync/serializers.py:61:21:ORM001",
-  "websites/serializers.py:267:23:ORM001"
+  "content_sync/serializers.py:61:21:ORM001"
 ]

--- a/main/settings.py
+++ b/main/settings.py
@@ -576,11 +576,6 @@ FIELD_METADATA_TITLE = get_string(
     description="The site metadata field for title",
 )
 # YouTube OCW metadata fields
-YT_FIELD_CAPTIONS = get_string(
-    name="YT_FIELD_CAPTIONS",
-    default="video_files.video_captions_file",
-    description="The site config metadata field for the captions URL",
-)
 YT_FIELD_CAPTIONS_RESOURCES = get_string(
     name="YT_FIELD_CAPTIONS_RESOURCES",
     default="video_files.video_captions_resources",
@@ -611,11 +606,6 @@ YT_FIELD_THUMBNAIL = get_string(
     name="YT_FIELD_THUMBNAIL",
     default="video_files.video_thumbnail_file",
     description="The site config metadata field for YouTube thumbnail URL",
-)
-YT_FIELD_TRANSCRIPT = get_string(
-    name="YT_FIELD_TRANSCRIPT",
-    default="video_files.video_transcript_file",
-    description="The site config metadata field for the transcript URL",
 )
 YT_FIELD_TRANSCRIPT_RESOURCES = get_string(
     name="YT_FIELD_TRANSCRIPT_RESOURCES",

--- a/videos/management/commands/clear_webvtt_files.py
+++ b/videos/management/commands/clear_webvtt_files.py
@@ -48,6 +48,10 @@ class Command(BaseCommand):
             for resource in website.websitecontent_set.filter(
                 metadata__resourcetype=RESOURCE_TYPE_VIDEO
             ):
-                set_dict_field(resource.metadata, "video_files.video_captions_file", "")
+                set_dict_field(
+                    resource.metadata,
+                    "video_files.video_captions_resources",
+                    {"content": [], "website": website.name},
+                )
                 resource.save()
             self.stdout.write(f"Caption file data cleared for {website.name}")

--- a/videos/management/commands/sync_transcripts.py
+++ b/videos/management/commands/sync_transcripts.py
@@ -77,11 +77,6 @@ class Command(BaseCommand):
                             "content": [str(source_captions.text_id)],
                             "website": to_course.name,
                         }
-                        if source_captions.file and source_captions.file.name:
-                            file_path = f"/{source_captions.file.name.lstrip('/')}"
-                            video.metadata["video_files"]["video_captions_file"] = [
-                                {"file": file_path, "language": "en"}
-                            ]
                         video.save()
 
                 elif (  # create a new captions object
@@ -100,11 +95,6 @@ class Command(BaseCommand):
                             "content": [str(new_captions.text_id)],
                             "website": to_course.name,
                         }
-                        if new_captions.file and new_captions.file.name:
-                            file_path = f"/{new_captions.file.name.lstrip('/')}"
-                            video.metadata["video_files"]["video_captions_file"] = [
-                                {"file": file_path, "language": "en"}
-                            ]
                         video.save()
 
             transcript_resource = (
@@ -132,11 +122,6 @@ class Command(BaseCommand):
                             "content": [str(source_transcript.text_id)],
                             "website": to_course.name,
                         }
-                        if source_transcript.file and source_transcript.file.name:
-                            file_path = f"/{source_transcript.file.name.lstrip('/')}"
-                            video.metadata["video_files"]["video_transcript_file"] = [
-                                {"file": file_path, "language": "en"}
-                            ]
                         video.save()
                 elif (  # create a new transcript object
                     video_youtube_id in from_course_videos
@@ -156,11 +141,6 @@ class Command(BaseCommand):
                             "content": [str(new_transcript.text_id)],
                             "website": to_course.name,
                         }
-                        if new_transcript.file and new_transcript.file.name:
-                            file_path = f"/{new_transcript.file.name.lstrip('/')}"
-                            video.metadata["video_files"]["video_transcript_file"] = [
-                                {"file": file_path, "language": "en"}
-                            ]
                         video.save()
 
         self.stdout.write(

--- a/videos/models.py
+++ b/videos/models.py
@@ -60,10 +60,9 @@ class Video(TimestampedModel):
         ``{video_filename}_transcript``) then filtered by the real extension
         of their uploaded file (one of ``CAPTION_FILE_EXTENSIONS`` /
         ``TRANSCRIPT_FILE_EXTENSIONS``). The real file extension is used
-        rather than the filename's tail because this project's own
-        filename-uniqueness helper (``find_available_name``) can append a
-        bare digit to a colliding filename (e.g. ``..._vtt`` -> ``..._vtt2``),
-        which would defeat an exact suffix match.
+        rather than the filename's tail because ``find_available_name`` can
+        append a bare digit to a colliding filename (e.g. ``..._vtt`` ->
+        ``..._vtt2``), which would defeat an exact suffix match.
         """
         youtube_id = self.youtube_id()
 

--- a/videos/models.py
+++ b/videos/models.py
@@ -60,10 +60,10 @@ class Video(TimestampedModel):
         ``{video_filename}_transcript``) then filtered by the real extension
         of their uploaded file (one of ``CAPTION_FILE_EXTENSIONS`` /
         ``TRANSCRIPT_FILE_EXTENSIONS``). The real file extension is used
-        rather than the filename's tail because Django's filename-uniqueness
-        logic can append a bare digit to a colliding filename (e.g.
-        ``..._vtt`` -> ``..._vtt2``), which would defeat an exact suffix
-        match.
+        rather than the filename's tail because this project's own
+        filename-uniqueness helper (``find_available_name``) can append a
+        bare digit to a colliding filename (e.g. ``..._vtt`` -> ``..._vtt2``),
+        which would defeat an exact suffix match.
         """
         youtube_id = self.youtube_id()
 

--- a/videos/models_test.py
+++ b/videos/models_test.py
@@ -158,9 +158,8 @@ def test_video_caption_transcript_resources_matches_all_extensions(
 def test_video_caption_transcript_resources_survives_filename_uniqueness_suffix(
     preexisting_captions_filenames,
 ):
-    """caption_transcript_resources still matches when find_available_name (this
-    project's own filename-uniqueness helper, not Django's) has appended a bare
-    digit to the colliding filename (e.g. "..._vtt2").
+    """caption_transcript_resources still matches when find_available_name has
+    appended a bare digit to the colliding filename (e.g. "..._vtt2").
 
     This is the actual production bug: matching must rely on the resource's real
     uploaded file extension, not the filename field, since find_available_name

--- a/videos/models_test.py
+++ b/videos/models_test.py
@@ -158,8 +158,9 @@ def test_video_caption_transcript_resources_matches_all_extensions(
 def test_video_caption_transcript_resources_survives_filename_uniqueness_suffix(
     preexisting_captions_filenames,
 ):
-    """caption_transcript_resources still matches when Django's filename-uniqueness
-    logic has appended a bare digit to the colliding filename (e.g. "..._vtt2").
+    """caption_transcript_resources still matches when find_available_name (this
+    project's own filename-uniqueness helper, not Django's) has appended a bare
+    digit to the colliding filename (e.g. "..._vtt2").
 
     This is the actual production bug: matching must rely on the resource's real
     uploaded file extension, not the filename field, since find_available_name

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -418,9 +418,6 @@ def test_start_transcript_job(
     start_transcript_job.apply([video.id])
 
     video_content.refresh_from_db()
-    # Legacy _file fields in stored metadata are never written
-    assert get_dict_field(video_content.metadata, settings.YT_FIELD_CAPTIONS) is None
-    assert get_dict_field(video_content.metadata, settings.YT_FIELD_TRANSCRIPT) is None
     if caption_exists:
         captions_relation = get_dict_field(
             video_content.metadata, settings.YT_FIELD_CAPTIONS_RESOURCES
@@ -792,10 +789,6 @@ def test_update_transcripts_for_video(  # pylint: disable=too-many-arguments  # 
 
     resource.refresh_from_db()
 
-    # Legacy _file fields in stored metadata are never written
-    assert get_dict_field(resource.metadata, settings.YT_FIELD_CAPTIONS) is None
-    assert get_dict_field(resource.metadata, settings.YT_FIELD_TRANSCRIPT) is None
-
     if update_transcript_return_value and is_ocw:
         link_mock.assert_any_call(video, resource)
         sync_refs_mock.assert_called()
@@ -897,13 +890,6 @@ def test_update_transcripts_for_video_no_3play(
 
     mock_3play.assert_not_called()
 
-    # The pre-existing scalar _file values are left completely untouched
-    assert get_dict_field(resource.metadata, settings.YT_FIELD_CAPTIONS) == (
-        f"{base_path}_captions.vtt" if caption_exists else None
-    )
-    assert get_dict_field(resource.metadata, settings.YT_FIELD_TRANSCRIPT) == (
-        f"{base_path}_transcript.pdf" if transcript_exists else None
-    )
     # The _resources relation fields are written from the found resources
     assert get_dict_field(resource.metadata, settings.YT_FIELD_CAPTIONS_RESOURCES) == (
         {
@@ -967,8 +953,6 @@ def test_update_transcripts_for_video_multi_language_with_locale(mocker):
         str(captions_fr.text_id),
     }
     assert relation["website"] == video.website.name
-    # Legacy _file fields in stored metadata are never written
-    assert get_dict_field(resource.metadata, settings.YT_FIELD_CAPTIONS) is None
 
 
 def test_attempt_to_update_missing_transcripts(mocker):

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -753,8 +753,8 @@ def test_update_transcripts_for_video(  # pylint: disable=too-many-arguments  # 
 
     set_nested_dicts(metadata, settings.FIELD_RESOURCETYPE, RESOURCE_TYPE_VIDEO)
     set_nested_dicts(metadata, settings.YT_FIELD_ID, "expected_id")
-    set_nested_dicts(metadata, settings.YT_FIELD_CAPTIONS, None)
-    set_nested_dicts(metadata, settings.YT_FIELD_TRANSCRIPT, None)
+    set_nested_dicts(metadata, settings.YT_FIELD_CAPTIONS_RESOURCES, None)
+    set_nested_dicts(metadata, settings.YT_FIELD_TRANSCRIPT_RESOURCES, None)
 
     resource.save()
 
@@ -764,7 +764,9 @@ def test_update_transcripts_for_video(  # pylint: disable=too-many-arguments  # 
         )
         metadata = other_resource.metadata
         set_nested_dicts(metadata, settings.FIELD_RESOURCETYPE, RESOURCE_TYPE_VIDEO)
-        set_nested_dicts(metadata, settings.YT_FIELD_CAPTIONS, None)
+        set_nested_dicts(
+            metadata, f"{settings.YT_FIELD_CAPTIONS_RESOURCES}.content", None
+        )
         other_resource.save()
 
     update_transcript_mock = mocker.patch(
@@ -811,6 +813,10 @@ def test_update_transcripts_for_video(  # pylint: disable=too-many-arguments  # 
     else:
         assert (
             get_dict_field(resource.metadata, settings.YT_FIELD_CAPTIONS_RESOURCES)
+            is None
+        )
+        assert (
+            get_dict_field(resource.metadata, settings.YT_FIELD_TRANSCRIPT_RESOURCES)
             is None
         )
 
@@ -876,16 +882,6 @@ def test_update_transcripts_for_video_no_3play(
 
     set_dict_field(metadata, settings.FIELD_RESOURCETYPE, RESOURCE_TYPE_VIDEO)
     set_dict_field(metadata, settings.YT_FIELD_ID, "expected_id")
-    set_dict_field(
-        metadata,
-        settings.YT_FIELD_CAPTIONS,
-        (f"{base_path}_captions.vtt" if caption_exists else None),
-    )
-    set_dict_field(
-        metadata,
-        settings.YT_FIELD_TRANSCRIPT,
-        (f"{base_path}_transcript.pdf" if transcript_exists else None),
-    )
     resource.save()
 
     captions_list, transcripts_list = video.caption_transcript_resources()

--- a/videos/threeplay_sync.py
+++ b/videos/threeplay_sync.py
@@ -197,7 +197,7 @@ def link_threeplay_files_as_resources(video, video_resource: WebsiteContent) -> 
         with field_file.open("rb") as file_handle:
             content_bytes = file_handle.read()
         file_obj = File(BytesIO(content_bytes), name=f"{base}.{extension}")
-        _, text_id = _create_new_content(
+        text_id = _create_new_content(
             file_obj, video_resource, file_size=len(content_bytes)
         )
         _append_resource_to_video_files(video_resource, resource_field, text_id)

--- a/videos/threeplay_sync.py
+++ b/videos/threeplay_sync.py
@@ -113,7 +113,7 @@ def _attach_transcript_if_missing(
     if pdf_response:
         file_size = len(pdf_response.getvalue())
         pdf_file = File(pdf_response, name=f"{youtube_id}.pdf")
-        _, text_id = _create_new_content(pdf_file, video, file_size=file_size)
+        text_id = _create_new_content(pdf_file, video, file_size=file_size)
         _append_resource_to_video_files(video, "video_transcript_resources", text_id)
         if summary:
             summary["transcripts"]["updated"] += 1
@@ -153,7 +153,7 @@ def _attach_captions_if_missing(
     if webvtt_response:
         file_size = len(webvtt_response.getvalue())
         vtt_file = File(webvtt_response, name=f"{youtube_id}.webvtt")
-        _, text_id = _create_new_content(vtt_file, video, file_size)
+        text_id = _create_new_content(vtt_file, video, file_size)
         _append_resource_to_video_files(video, "video_captions_resources", text_id)
         if summary:
             summary["captions"]["updated"] += 1
@@ -285,11 +285,11 @@ def generate_metadata(
 
 def _create_new_content(
     file_content: File, video: WebsiteContent, file_size: int | None = None
-) -> tuple[str, str]:
+) -> str:
     """
     Create and save a new WebsiteContent object
     for a caption or transcript file.
-    Returns a (s3_path, text_id) tuple.
+    Returns the new resource's text_id.
     """
     new_text_id = str(uuid4())
     new_s3_loc = upload_to_s3(file_content, video)
@@ -322,4 +322,4 @@ def _create_new_content(
     obj.file = new_s3_loc
     obj.save()
 
-    return new_s3_loc, str(obj.text_id)
+    return str(obj.text_id)

--- a/videos/threeplay_sync_test.py
+++ b/videos/threeplay_sync_test.py
@@ -127,8 +127,6 @@ def test_sync_video_captions_and_transcripts_appends_english_when_other_language
         website=website,
         filename="lecture1_transcript_fr_pdf",
     )
-    fr_caption_path = f"courses/{website.name}/lecture1_captions_fr.vtt"
-    fr_transcript_path = f"courses/{website.name}/lecture1_transcript_fr.pdf"
     video = WebsiteContentFactory.create(
         website=website,
         type=CONTENT_TYPE_RESOURCE,
@@ -144,10 +142,6 @@ def test_sync_video_captions_and_transcripts_appends_english_when_other_language
                     "content": [str(fr_transcript.text_id)],
                     "website": website.name,
                 },
-                "video_captions_file": [{"file": fr_caption_path, "language": "fr"}],
-                "video_transcript_file": [
-                    {"file": fr_transcript_path, "language": "fr"}
-                ],
             },
         },
     )
@@ -180,12 +174,6 @@ def test_sync_video_captions_and_transcripts_appends_english_when_other_language
     assert str(fr_caption.text_id) in captions_content
     assert len(transcript_content) == 2
     assert len(captions_content) == 2
-
-    # Pre-existing _file values in stored metadata are left untouched
-    assert vf["video_captions_file"] == [{"file": fr_caption_path, "language": "fr"}]
-    assert vf["video_transcript_file"] == [
-        {"file": fr_transcript_path, "language": "fr"}
-    ]
 
 
 def test_sync_video_captions_and_transcripts_treats_empty_content_as_unset(mocker):

--- a/videos/utils.py
+++ b/videos/utils.py
@@ -293,9 +293,10 @@ def parse_caption_language_locale(filename: str) -> tuple[str, str | None]:
 
     Pass the resource's real uploaded file path (``resource.file.name``), not
     the ``WebsiteContent.filename`` field — the latter can carry a numeric
-    uniqueness suffix appended by Django on a name collision (e.g.
-    ``lecture1_captions-en-us_vtt`` -> ``lecture1_captions-en-us_vtt2``),
-    which would prevent the pattern from matching at all.
+    uniqueness suffix appended by this project's own ``find_available_name``
+    helper on a name collision (e.g. ``lecture1_captions-en-us_vtt`` ->
+    ``lecture1_captions-en-us_vtt2``), which would prevent the pattern from
+    matching at all.
 
     GDrive files follow the pattern ``<base>_captions-<lang>-<locale>.<ext>``
     (e.g. ``lecture1_captions-en-US.vtt``) where ``<lang>`` is an ISO 639-1

--- a/videos/utils.py
+++ b/videos/utils.py
@@ -293,10 +293,9 @@ def parse_caption_language_locale(filename: str) -> tuple[str, str | None]:
 
     Pass the resource's real uploaded file path (``resource.file.name``), not
     the ``WebsiteContent.filename`` field — the latter can carry a numeric
-    uniqueness suffix appended by this project's own ``find_available_name``
-    helper on a name collision (e.g. ``lecture1_captions-en-us_vtt`` ->
-    ``lecture1_captions-en-us_vtt2``), which would prevent the pattern from
-    matching at all.
+    uniqueness suffix appended by ``find_available_name`` on a name collision
+    (e.g. ``lecture1_captions-en-us_vtt`` -> ``lecture1_captions-en-us_vtt2``),
+    which would prevent the pattern from matching at all.
 
     GDrive files follow the pattern ``<base>_captions-<lang>-<locale>.<ext>``
     (e.g. ``lecture1_captions-en-US.vtt``) where ``<lang>`` is an ISO 639-1

--- a/websites/api.py
+++ b/websites/api.py
@@ -43,6 +43,7 @@ from websites.models import Website, WebsiteContent, WebsiteStarter
 from websites.utils import (
     get_dict_field,
     get_dict_query_field,
+    query_field_is_empty,
     resolve_referenced_content_ids,
     set_dict_field,
 )
@@ -378,15 +379,10 @@ def videos_with_unassigned_youtube_ids(website: Website) -> list[WebsiteContent]
     query_resource_type_field = get_dict_query_field(
         "metadata", settings.FIELD_RESOURCETYPE
     )
-    query_id_field = f"metadata__{'__'.join(settings.YT_FIELD_ID.split('.'))}"
     return WebsiteContent.objects.filter(
         Q(website=website)
         & Q(**{query_resource_type_field: RESOURCE_TYPE_VIDEO})
-        & (
-            Q(**{f"{query_id_field}__isnull": True})
-            | Q(**{f"{query_id_field}": None})
-            | Q(**{query_id_field: ""})
-        )
+        & query_field_is_empty(settings.YT_FIELD_ID)
     )
 
 
@@ -426,20 +422,13 @@ def videos_missing_captions(website: Website) -> list[WebsiteContent]:
     query_resource_type_field = get_dict_query_field(
         "metadata", settings.FIELD_RESOURCETYPE
     )
-    # A video has captions when its _resources relation has non-empty content;
-    # the key may be entirely absent, JSON null, the site-config default "" or
-    # an emptied list.
-    query_caption_content_field = get_dict_query_field(
-        "metadata", f"{settings.YT_FIELD_CAPTIONS_RESOURCES}.content"
-    )
     return WebsiteContent.objects.filter(
         Q(website=website)
         & Q(**{query_resource_type_field: RESOURCE_TYPE_VIDEO})
-        & (
-            Q(**{f"{query_caption_content_field}__isnull": True})
-            | Q(**{query_caption_content_field: None})
-            | Q(**{query_caption_content_field: ""})
-            | Q(**{query_caption_content_field: []})
+        & query_field_is_empty(
+            f"{settings.YT_FIELD_CAPTIONS_RESOURCES}.content",
+            empty_values=(None, [], ""),
+            include_isnull=False,
         )
     )
 

--- a/websites/api.py
+++ b/websites/api.py
@@ -278,12 +278,11 @@ def _merge_caption_resource(
 
     Candidates are found by filename prefix only, then filtered by the real
     extension of their uploaded ``file`` (not the ``filename`` field's tail).
-    This project's own filename-uniqueness helper (``find_available_name``)
-    appends a bare digit directly onto a colliding filename with no
-    separator — e.g. ``lecture1_captions-en-us_vtt`` collides and becomes
-    ``lecture1_captions-en-us_vtt2`` — which would silently defeat an exact
-    ``filename__endswith`` suffix check. The uploaded file's own extension is
-    unaffected by that renaming, so it's used here instead.
+    ``find_available_name`` appends a bare digit directly onto a colliding
+    filename with no separator — e.g. ``lecture1_captions-en-us_vtt`` collides
+    and becomes ``lecture1_captions-en-us_vtt2`` — which would silently
+    defeat an exact ``filename__endswith`` suffix check. The uploaded file's
+    own extension is unaffected by that renaming, so it's used here instead.
 
     Only the ``_resources`` relation field is written; the legacy ``_file``
     fields in stored metadata are left untouched.
@@ -329,10 +328,9 @@ def auto_link_video_captions_transcript(video_resource: WebsiteContent) -> None:
     ``{base}_transcript`` (covering both the ``{base}_captions-<lang>-<locale>``
     convention and the legacy no-suffix form) and whose uploaded file has a
     matching real extension. The real file extension is used rather than the
-    filename's tail because this project's own filename-uniqueness helper
-    (``find_available_name``) can append a bare digit to a colliding filename
-    (e.g. ``..._vtt`` -> ``..._vtt2``), which would defeat an exact suffix
-    match. Finds ALL language variants and
+    filename's tail because ``find_available_name`` can append a bare digit
+    to a colliding filename (e.g. ``..._vtt`` -> ``..._vtt2``), which would
+    defeat an exact suffix match. Finds ALL language variants and
     merges them into the multi-select content list without overwriting
     existing non-empty entries. Only ``_resources`` relation fields are
     written; legacy ``_file`` fields are left untouched.

--- a/websites/api.py
+++ b/websites/api.py
@@ -278,9 +278,9 @@ def _merge_caption_resource(
 
     Candidates are found by filename prefix only, then filtered by the real
     extension of their uploaded ``file`` (not the ``filename`` field's tail).
-    Django's filename-uniqueness logic (``find_available_name``) appends a
-    bare digit directly onto a colliding filename with no separator — e.g.
-    ``lecture1_captions-en-us_vtt`` collides and becomes
+    This project's own filename-uniqueness helper (``find_available_name``)
+    appends a bare digit directly onto a colliding filename with no
+    separator — e.g. ``lecture1_captions-en-us_vtt`` collides and becomes
     ``lecture1_captions-en-us_vtt2`` — which would silently defeat an exact
     ``filename__endswith`` suffix check. The uploaded file's own extension is
     unaffected by that renaming, so it's used here instead.
@@ -329,9 +329,10 @@ def auto_link_video_captions_transcript(video_resource: WebsiteContent) -> None:
     ``{base}_transcript`` (covering both the ``{base}_captions-<lang>-<locale>``
     convention and the legacy no-suffix form) and whose uploaded file has a
     matching real extension. The real file extension is used rather than the
-    filename's tail because Django's filename-uniqueness logic can append a
-    bare digit to a colliding filename (e.g. ``..._vtt`` -> ``..._vtt2``),
-    which would defeat an exact suffix match. Finds ALL language variants and
+    filename's tail because this project's own filename-uniqueness helper
+    (``find_available_name``) can append a bare digit to a colliding filename
+    (e.g. ``..._vtt`` -> ``..._vtt2``), which would defeat an exact suffix
+    match. Finds ALL language variants and
     merges them into the multi-select content list without overwriting
     existing non-empty entries. Only ``_resources`` relation fields are
     written; legacy ``_file`` fields are left untouched.

--- a/websites/api.py
+++ b/websites/api.py
@@ -428,7 +428,6 @@ def videos_missing_captions(website: Website) -> list[WebsiteContent]:
         & query_field_is_empty(
             f"{settings.YT_FIELD_CAPTIONS_RESOURCES}.content",
             empty_values=(None, [], ""),
-            include_isnull=False,
         )
     )
 

--- a/websites/api_test.py
+++ b/websites/api_test.py
@@ -354,6 +354,19 @@ def test_videos_missing_captions(mocker, is_ocw):
                 "video_files": {"video_captions_file": "abc123"},
             },
         ),
+        # video_captions_resources present but has no "content" key at all
+        WebsiteContentFactory.create(
+            website=website,
+            metadata={
+                "resourcetype": RESOURCE_TYPE_VIDEO,
+                "video_files": {"video_captions_resources": {"website": website.name}},
+            },
+        ),
+        # video_files key itself absent from metadata
+        WebsiteContentFactory.create(
+            website=website,
+            metadata={"resourcetype": RESOURCE_TYPE_VIDEO},
+        ),
     ]
     WebsiteContentFactory.create(
         website=website,

--- a/websites/management/commands/backpopulate_referencing_content.py
+++ b/websites/management/commands/backpopulate_referencing_content.py
@@ -15,12 +15,12 @@ from websites.utils import (
 
 BATCH_SIZE_DEFAULT = 500  # Default batch size for processing content
 
-# Top-level metadata keys under which video file paths are stored, derived from
-# settings so custom field paths are respected.
+# Top-level metadata keys under which video caption/transcript resources are
+# stored, derived from settings so custom field paths are respected.
 _VIDEO_FILE_TOP_KEYS = frozenset(
     {
-        settings.YT_FIELD_CAPTIONS.split(".")[0],
-        settings.YT_FIELD_TRANSCRIPT.split(".")[0],
+        settings.YT_FIELD_CAPTIONS_RESOURCES.split(".")[0],
+        settings.YT_FIELD_TRANSCRIPT_RESOURCES.split(".")[0],
     }
 )
 

--- a/websites/management/commands/backpopulate_referencing_content_test.py
+++ b/websites/management/commands/backpopulate_referencing_content_test.py
@@ -964,37 +964,3 @@ def test_video_resource_captions_only_reference_detected():
     referenced_content = list(video_resource.referenced_by.all())
     assert len(referenced_content) == 1
     assert captions_resource in referenced_content
-
-
-def test_video_resource_resources_references_detected():
-    """Test that video_captions_resources and video_transcript_resources content is resolved to referenced content"""
-    website = WebsiteFactory.create()
-    captions_content = WebsiteContentFactory.create(
-        website=website,
-        type=CONTENT_TYPE_RESOURCE,
-    )
-    transcript_content = WebsiteContentFactory.create(
-        website=website,
-        type=CONTENT_TYPE_RESOURCE,
-    )
-    video_resource = WebsiteContentFactory.create(
-        website=website,
-        type=CONTENT_TYPE_RESOURCE,
-        metadata={
-            "resourcetype": "Video",
-            "video_files": {
-                "video_captions_resources": {"content": captions_content.text_id},
-                "video_transcript_resources": {"content": transcript_content.text_id},
-            },
-        },
-    )
-
-    assert video_resource.referenced_by.count() == 0
-
-    call_command("backpopulate_referencing_content", verbosity=0, stdout=StringIO())
-
-    video_resource.refresh_from_db()
-    referenced_content = list(video_resource.referenced_by.all())
-    assert len(referenced_content) == 2
-    assert captions_content in referenced_content
-    assert transcript_content in referenced_content

--- a/websites/management/commands/backpopulate_referencing_content_test.py
+++ b/websites/management/commands/backpopulate_referencing_content_test.py
@@ -966,20 +966,16 @@ def test_video_resource_captions_only_reference_detected():
     assert captions_resource in referenced_content
 
 
-def test_video_resource_file_path_references_detected():
-    """Test that video_captions_file and video_transcript_file paths are resolved to referenced content"""
+def test_video_resource_resources_references_detected():
+    """Test that video_captions_resources and video_transcript_resources content is resolved to referenced content"""
     website = WebsiteFactory.create()
     captions_content = WebsiteContentFactory.create(
         website=website,
         type=CONTENT_TYPE_RESOURCE,
-        filename="nXyqvKrQGZ8_captions",
-        file=f"courses/{website.name}/nXyqvKrQGZ8_captions.webvtt",
     )
     transcript_content = WebsiteContentFactory.create(
         website=website,
         type=CONTENT_TYPE_RESOURCE,
-        filename="pdf_testpage",
-        file=f"courses/{website.name}/pdf_testpage.pdf",
     )
     video_resource = WebsiteContentFactory.create(
         website=website,
@@ -987,8 +983,8 @@ def test_video_resource_file_path_references_detected():
         metadata={
             "resourcetype": "Video",
             "video_files": {
-                "video_captions_file": f"/courses/{website.name}/nXyqvKrQGZ8_captions.webvtt",
-                "video_transcript_file": f"/courses/{website.name}/pdf_testpage.pdf",
+                "video_captions_resources": {"content": captions_content.text_id},
+                "video_transcript_resources": {"content": transcript_content.text_id},
             },
         },
     )

--- a/websites/management/commands/detect_unrelated_content.py
+++ b/websites/management/commands/detect_unrelated_content.py
@@ -196,6 +196,11 @@ class Command(WebsiteFilterCommand):
         Returns:
             normalized_files: Set of normalized file paths
         """
+        # Caption/transcript resources are protected via the generic per-row
+        # `file` loop below, not by reading video_files here. This assumes
+        # such resources already have `file` set by the time they're linked
+        # via video_captions_resources/video_transcript_resources; a resource
+        # linked before its file is set would not be protected.
         video_metadata_fields = [
             "video_thumbnail_file",
         ]

--- a/websites/management/commands/detect_unrelated_content.py
+++ b/websites/management/commands/detect_unrelated_content.py
@@ -198,8 +198,6 @@ class Command(WebsiteFilterCommand):
         """
         video_metadata_fields = [
             "video_thumbnail_file",
-            "video_captions_file",
-            "video_transcript_file",
         ]
 
         website_contents = WebsiteContent.all_objects.filter(

--- a/websites/management/commands/detect_unrelated_content_test.py
+++ b/websites/management/commands/detect_unrelated_content_test.py
@@ -134,16 +134,16 @@ def test_leading_slash_in_file_is_normalized(mock_s3):
     assert key in mock_s3.current()  # not treated as unrelated, not deleted
 
 
-def test_video_metadata_files_are_treated_as_related(mock_s3):
-    """video_files metadata protects thumbnails; captions/transcripts are now
-    protected via their own WebsiteContent resource row's ``file`` field.
+def test_video_thumbnail_and_linked_caption_resource_are_protected(mock_s3):
+    """video_files metadata protects the thumbnail path directly; a linked
+    caption resource is protected separately, via its own WebsiteContent row's
+    ``file`` field rather than via video_files.
 
-    Covers the two remaining normalization branches in _filter_unrelated_files
-    for video_thumbnail_file: a full path already under s3_path is kept as-is,
-    and (separately, for the caption resource) an http(s) value is ignored.
-    The caption resource is linked via video_captions_resources, and its S3
-    key is protected by the generic per-row loop over WebsiteContent.file,
-    not by reading video_files directly.
+    Covers the video_thumbnail_file normalization branch in
+    _filter_unrelated_files (a full path already under s3_path is kept
+    as-is), and confirms that a resource referenced by
+    video_captions_resources is protected by the generic per-row loop over
+    WebsiteContent.file -- not by anything read from video_files.
     """
     website = WebsiteFactory.create(name="video-site", short_id="video-site")
     video_file = f"{website.s3_path}/vid_video.mp4"
@@ -180,24 +180,14 @@ def test_video_metadata_files_are_treated_as_related(mock_s3):
         assert related not in output
 
 
-def test_video_metadata_protected_when_video_row_has_no_file(mock_s3):
+def test_video_thumbnail_protected_when_video_row_has_no_file(mock_s3):
     """A YouTube video resource usually has file=None. Its thumbnail path in
     video_files must still be protected -- the related-set scan no longer
-    filters on file__isnull, so the file-less row is still inspected. Its
-    caption resource (a separate WebsiteContent row linked via
-    video_captions_resources) is protected independently via that row's own
-    ``file`` field, per the generic per-row loop.
+    filters on file__isnull, so the file-less row is still inspected.
     """
     website = WebsiteFactory.create(name="yt-site", short_id="yt-site")
     thumb = f"{website.s3_path}/thumb.jpg"
-    captions = f"{website.s3_path}/captions.vtt"
     orphan = f"{website.s3_path}/orphan.bin"
-    caption_content = WebsiteContentFactory.create(
-        website=website,
-        type="resource",
-        file=captions,
-        metadata={},
-    )
     WebsiteContentFactory.create(
         website=website,
         type="resource",
@@ -206,21 +196,17 @@ def test_video_metadata_protected_when_video_row_has_no_file(mock_s3):
             "resourcetype": "Video",
             "video_files": {
                 "video_thumbnail_file": thumb,
-                "video_captions_resources": {
-                    "content": [str(caption_content.text_id)],
-                    "website": website.name,
-                },
+                "video_captions_resources": {"content": []},
                 "video_transcript_resources": {"content": []},
             },
         },
     )
-    mock_s3.put({thumb, captions, orphan})
+    mock_s3.put({thumb, orphan})
 
     _run(filter="yt-site", delete=True)
 
     remaining = mock_s3.current()
     assert thumb in remaining  # protected despite the video row having no file
-    assert captions in remaining  # protected via the resource's own file row
     assert orphan not in remaining  # genuine orphan still cleaned
 
 

--- a/websites/management/commands/detect_unrelated_content_test.py
+++ b/websites/management/commands/detect_unrelated_content_test.py
@@ -135,17 +135,27 @@ def test_leading_slash_in_file_is_normalized(mock_s3):
 
 
 def test_video_metadata_files_are_treated_as_related(mock_s3):
-    """video_files metadata protects thumbnails/captions/transcripts.
+    """video_files metadata protects thumbnails; captions/transcripts are now
+    protected via their own WebsiteContent resource row's ``file`` field.
 
-    Covers the three normalization branches in _filter_unrelated_files:
-    a full path already under s3_path is kept as-is, a bare filename is
-    re-rooted under s3_path, and an http(s) value is ignored.
+    Covers the two remaining normalization branches in _filter_unrelated_files
+    for video_thumbnail_file: a full path already under s3_path is kept as-is,
+    and (separately, for the caption resource) an http(s) value is ignored.
+    The caption resource is linked via video_captions_resources, and its S3
+    key is protected by the generic per-row loop over WebsiteContent.file,
+    not by reading video_files directly.
     """
     website = WebsiteFactory.create(name="video-site", short_id="video-site")
     video_file = f"{website.s3_path}/vid_video.mp4"
     thumb = f"{website.s3_path}/thumb.jpg"
     captions_key = f"{website.s3_path}/captions.vtt"
     orphan = f"{website.s3_path}/orphan.bin"
+    caption_content = WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        file=captions_key,
+        metadata={},
+    )
     WebsiteContentFactory.create(
         website=website,
         type="resource",
@@ -153,8 +163,11 @@ def test_video_metadata_files_are_treated_as_related(mock_s3):
         metadata={
             "video_files": {
                 "video_thumbnail_file": thumb,  # full path -> kept as-is
-                "video_captions_file": "captions.vtt",  # bare name -> re-rooted
-                "video_transcript_file": "https://youtu.be/x",  # http -> ignored
+                "video_captions_resources": {
+                    "content": [str(caption_content.text_id)],
+                    "website": website.name,
+                },
+                "video_transcript_resources": {"content": []},
             }
         },
     )
@@ -168,14 +181,23 @@ def test_video_metadata_files_are_treated_as_related(mock_s3):
 
 
 def test_video_metadata_protected_when_video_row_has_no_file(mock_s3):
-    """A YouTube video resource usually has file=None. Its caption/thumbnail
-    paths in video_files must still be protected -- the related-set scan no
-    longer filters on file__isnull, so the file-less row is still inspected.
+    """A YouTube video resource usually has file=None. Its thumbnail path in
+    video_files must still be protected -- the related-set scan no longer
+    filters on file__isnull, so the file-less row is still inspected. Its
+    caption resource (a separate WebsiteContent row linked via
+    video_captions_resources) is protected independently via that row's own
+    ``file`` field, per the generic per-row loop.
     """
     website = WebsiteFactory.create(name="yt-site", short_id="yt-site")
     thumb = f"{website.s3_path}/thumb.jpg"
     captions = f"{website.s3_path}/captions.vtt"
     orphan = f"{website.s3_path}/orphan.bin"
+    caption_content = WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        file=captions,
+        metadata={},
+    )
     WebsiteContentFactory.create(
         website=website,
         type="resource",
@@ -184,8 +206,11 @@ def test_video_metadata_protected_when_video_row_has_no_file(mock_s3):
             "resourcetype": "Video",
             "video_files": {
                 "video_thumbnail_file": thumb,
-                "video_captions_file": captions,
-                "video_transcript_file": None,
+                "video_captions_resources": {
+                    "content": [str(caption_content.text_id)],
+                    "website": website.name,
+                },
+                "video_transcript_resources": {"content": []},
             },
         },
     )
@@ -195,7 +220,7 @@ def test_video_metadata_protected_when_video_row_has_no_file(mock_s3):
 
     remaining = mock_s3.current()
     assert thumb in remaining  # protected despite the video row having no file
-    assert captions in remaining
+    assert captions in remaining  # protected via the resource's own file row
     assert orphan not in remaining  # genuine orphan still cleaned
 
 

--- a/websites/migration_0076_test.py
+++ b/websites/migration_0076_test.py
@@ -1,0 +1,256 @@
+"""Tests for website migration 0076 -- backfill orphaned caption/transcript files"""
+
+import importlib
+
+import pytest
+from django.apps import apps
+from moto import mock_aws
+
+from main.s3_utils import get_boto3_resource
+from websites.factories import WebsiteContentFactory, WebsiteFactory
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def migration_module():
+    """Import the migration module (names with leading digits need importlib)."""
+    return importlib.import_module(
+        "websites.migrations.0076_backfill_orphaned_caption_transcript_files"
+    )
+
+
+def _setup_s3_bucket(settings):
+    """Create a mocked S3 bucket for the test.
+
+    Must be called from inside a function decorated with @mock_aws (not from
+    a pytest fixture) -- get_boto3_options() injects a hardcoded minio
+    endpoint_url whenever ENVIRONMENT == "dev" (the default in this repo's
+    .env), which bypasses moto's interception if the settings mutation and
+    S3 calls happen outside the mock context. This matches the pattern used
+    by videos/conftest.py's setup_s3() and gdrive_sync/utils_test.py.
+    """
+    settings.ENVIRONMENT = "test"
+    settings.AWS_ACCESS_KEY_ID = "abc"
+    settings.AWS_SECRET_ACCESS_KEY = "abc"  # noqa: S105
+    settings.AWS_STORAGE_BUCKET_NAME = "test-bucket"
+    conn = get_boto3_resource("s3")
+    conn.create_bucket(Bucket=settings.AWS_STORAGE_BUCKET_NAME)
+    return conn.Bucket(name=settings.AWS_STORAGE_BUCKET_NAME)
+
+
+@mock_aws
+def test_migration_0076_removes_empty_string_leftovers(migration_module, settings):
+    """Empty-string _file values are removed with no resource created."""
+    _setup_s3_bucket(settings)
+    video = WebsiteContentFactory.create(
+        filename="lecture1_mp4",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_file": "",
+                "video_transcript_file": "",
+            },
+        },
+    )
+
+    migration_module._backfill_orphaned_files(apps, None)  # noqa: SLF001
+
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    assert "video_captions_file" not in vf
+    assert "video_transcript_file" not in vf
+    assert "video_captions_resources" not in vf
+    assert "video_transcript_resources" not in vf
+
+
+@mock_aws
+def test_migration_0076_creates_resource_for_existing_s3_object(
+    migration_module, settings
+):
+    """A real orphan path with an existing S3 object gets a new resource created."""
+    s3_bucket = _setup_s3_bucket(settings)
+    website = WebsiteFactory.create()
+    caption_key = f"courses/{website.name}/1AbCdEf_transcript.webvtt"
+    s3_bucket.put_object(Key=caption_key, Body=b"WEBVTT")
+
+    video = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_mp4",
+        dirpath="content/resources",
+        title="Lecture 1",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {"video_captions_file": f"/{caption_key}"},
+        },
+    )
+
+    migration_module._backfill_orphaned_files(apps, None)  # noqa: SLF001
+
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    assert "video_captions_file" not in vf
+    resources = vf["video_captions_resources"]
+    assert resources["website"] == website.name
+    assert len(resources["content"]) == 1
+
+    WebsiteContent = apps.get_model("websites", "WebsiteContent")
+    created = WebsiteContent.objects.get(text_id=resources["content"][0])
+    assert created.filename == "lecture1_mp4_captions"
+    assert created.dirpath == "content/resources"
+    assert created.file.name == caption_key
+    assert created.metadata["resourcetype"] == "Other"
+    assert created.metadata["file"] == f"/{caption_key}"
+
+
+@mock_aws
+def test_migration_0076_skips_missing_s3_object(migration_module, settings, capsys):
+    """A real orphan path whose S3 object no longer exists is left untouched."""
+    _setup_s3_bucket(settings)
+    website = WebsiteFactory.create()
+    transcript_path = f"/courses/{website.name}/1Missing_transcript.pdf"
+
+    video = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_mp4",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {"video_transcript_file": transcript_path},
+        },
+    )
+
+    migration_module._backfill_orphaned_files(apps, None)  # noqa: SLF001
+
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    assert vf["video_transcript_file"] == transcript_path
+    assert "video_transcript_resources" not in vf
+    assert "Skipping missing S3 object" in capsys.readouterr().out
+
+
+@mock_aws
+def test_migration_0076_appends_to_existing_resources(migration_module, settings):
+    """A backfilled resource is appended to an existing _resources content list."""
+    s3_bucket = _setup_s3_bucket(settings)
+    website = WebsiteFactory.create()
+    fr_caption = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_captions_fr_vtt",
+        file=f"courses/{website.name}/lecture1_captions_fr.vtt",
+    )
+    en_key = f"courses/{website.name}/1EnglishId_transcript.webvtt"
+    s3_bucket.put_object(Key=en_key, Body=b"WEBVTT")
+
+    video = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_mp4",
+        dirpath="content/resources",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_file": f"/{en_key}",
+                "video_captions_resources": {
+                    "content": [str(fr_caption.text_id)],
+                    "website": website.name,
+                },
+            },
+        },
+    )
+
+    migration_module._backfill_orphaned_files(apps, None)  # noqa: SLF001
+
+    video.refresh_from_db()
+    content = video.metadata["video_files"]["video_captions_resources"]["content"]
+    assert str(fr_caption.text_id) in content
+    assert len(content) == 2
+
+
+@mock_aws
+def test_migration_0076_deduplicates_filename_collision(migration_module, settings):
+    """Filename collisions in the same (website, dirpath) get a numeric suffix."""
+    s3_bucket = _setup_s3_bucket(settings)
+    website = WebsiteFactory.create()
+    WebsiteContentFactory.create(
+        website=website, filename="lecture1_mp4_captions", dirpath="content/resources"
+    )
+    key = f"courses/{website.name}/1AbC_transcript.webvtt"
+    s3_bucket.put_object(Key=key, Body=b"WEBVTT")
+
+    video = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_mp4",
+        dirpath="content/resources",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {"video_captions_file": f"/{key}"},
+        },
+    )
+
+    migration_module._backfill_orphaned_files(apps, None)  # noqa: SLF001
+
+    video.refresh_from_db()
+    resources = video.metadata["video_files"]["video_captions_resources"]
+    WebsiteContent = apps.get_model("websites", "WebsiteContent")
+    created = WebsiteContent.objects.get(text_id=resources["content"][0])
+    assert created.filename == "lecture1_mp4_captions_2"
+
+
+def test_migration_0076_skips_non_video_content(migration_module):
+    """Content without resourcetype=Video is not modified even if it has video_files."""
+    content = WebsiteContentFactory.create(
+        metadata={
+            "resourcetype": "Document",
+            "video_files": {"video_captions_file": ""},
+        }
+    )
+
+    migration_module._backfill_orphaned_files(apps, None)  # noqa: SLF001
+
+    content.refresh_from_db()
+    # Non-video content is untouched because the queryset filters to resourcetype=Video
+    assert "video_captions_file" in content.metadata["video_files"]
+
+
+@mock_aws
+def test_migration_0076_backfills_both_captions_and_transcript_for_same_video(
+    migration_module, settings
+):
+    """A video with both orphaned fields gets both backfilled in the same run."""
+    s3_bucket = _setup_s3_bucket(settings)
+    website = WebsiteFactory.create()
+    captions_key = f"courses/{website.name}/1Caption_transcript.webvtt"
+    transcript_key = f"courses/{website.name}/1Transcript_transcript.pdf"
+    s3_bucket.put_object(Key=captions_key, Body=b"WEBVTT")
+    s3_bucket.put_object(Key=transcript_key, Body=b"%PDF")
+
+    video = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_mp4",
+        dirpath="content/resources",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_file": f"/{captions_key}",
+                "video_transcript_file": f"/{transcript_key}",
+            },
+        },
+    )
+
+    migration_module._backfill_orphaned_files(apps, None)  # noqa: SLF001
+
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    assert "video_captions_file" not in vf
+    assert "video_transcript_file" not in vf
+
+    WebsiteContent = apps.get_model("websites", "WebsiteContent")
+    captions_resource = WebsiteContent.objects.get(
+        text_id=vf["video_captions_resources"]["content"][0]
+    )
+    transcript_resource = WebsiteContent.objects.get(
+        text_id=vf["video_transcript_resources"]["content"][0]
+    )
+    assert captions_resource.filename == "lecture1_mp4_captions"
+    assert transcript_resource.filename == "lecture1_mp4_transcript"
+    assert captions_resource.metadata["resourcetype"] == "Other"
+    assert transcript_resource.metadata["resourcetype"] == "Document"

--- a/websites/migration_0076_test.py
+++ b/websites/migration_0076_test.py
@@ -166,6 +166,46 @@ def test_migration_0076_appends_to_existing_resources(migration_module, settings
 
 
 @mock_aws
+def test_migration_0076_appends_to_existing_scalar_string_content(
+    migration_module, settings
+):
+    """A legacy scalar-string _resources.content value is preserved, not dropped."""
+    s3_bucket = _setup_s3_bucket(settings)
+    website = WebsiteFactory.create()
+    fr_caption = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_captions_fr_vtt",
+        file=f"courses/{website.name}/lecture1_captions_fr.vtt",
+    )
+    en_key = f"courses/{website.name}/1EnglishId_transcript.webvtt"
+    s3_bucket.put_object(Key=en_key, Body=b"WEBVTT")
+
+    video = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_mp4",
+        dirpath="content/resources",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {
+                "video_captions_file": f"/{en_key}",
+                "video_captions_resources": {
+                    "content": str(fr_caption.text_id),
+                    "website": website.name,
+                },
+            },
+        },
+    )
+
+    migration_module._backfill_orphaned_files(apps, None)  # noqa: SLF001
+
+    video.refresh_from_db()
+    content = video.metadata["video_files"]["video_captions_resources"]["content"]
+    assert isinstance(content, list)
+    assert str(fr_caption.text_id) in content
+    assert len(content) == 2
+
+
+@mock_aws
 def test_migration_0076_reuses_existing_resource_for_same_s3_key(
     migration_module, settings
 ):

--- a/websites/migration_0076_test.py
+++ b/websites/migration_0076_test.py
@@ -166,6 +166,42 @@ def test_migration_0076_appends_to_existing_resources(migration_module, settings
 
 
 @mock_aws
+def test_migration_0076_reuses_existing_resource_for_same_s3_key(
+    migration_module, settings
+):
+    """An orphan path matching an already-created resource is linked, not duplicated."""
+    _setup_s3_bucket(settings)
+    website = WebsiteFactory.create()
+    key = f"courses/{website.name}/1AbCdEf_transcript.webvtt"
+    already_linked = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_mp4_captions",
+        file=key,
+    )
+
+    video = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_mp4",
+        dirpath="content/resources",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {"video_captions_file": f"/{key}"},
+        },
+    )
+
+    migration_module._backfill_orphaned_files(apps, None)  # noqa: SLF001
+
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    assert "video_captions_file" not in vf
+    resources = vf["video_captions_resources"]
+    assert resources["content"] == [str(already_linked.text_id)]
+
+    WebsiteContent = apps.get_model("websites", "WebsiteContent")
+    assert WebsiteContent.objects.filter(website=website, file=key).count() == 1
+
+
+@mock_aws
 def test_migration_0076_deduplicates_filename_collision(migration_module, settings):
     """Filename collisions in the same (website, dirpath) get a numeric suffix."""
     s3_bucket = _setup_s3_bucket(settings)

--- a/websites/migrations/0076_backfill_orphaned_caption_transcript_files.py
+++ b/websites/migrations/0076_backfill_orphaned_caption_transcript_files.py
@@ -1,0 +1,169 @@
+"""
+Data migration: back-populate video_captions_resources / video_transcript_resources
+for video resources whose legacy _file path was left orphaned by migration 0074
+(no matching WebsiteContent found at the time). Also removes empty-string _file
+leftovers from the pre-relation-widget string field, which 0074's falsy-value
+guard correctly skipped but never cleaned up.
+
+Two cases handled per video:
+
+1. Empty-string _file value (e.g. video_captions_file == ""): no caption/transcript
+   was ever set for this video. The key is simply removed -- there is nothing to
+   back-fill.
+
+2. Non-empty orphan _file path: the referenced S3 object may still exist even
+   though no WebsiteContent record was ever created for it (e.g. content
+   uploaded directly to S3 outside of the GDrive/3Play pipelines, using a
+   Google Drive file ID as the filename). If the object exists in S3, a new
+   WebsiteContent resource is created for it, named after the video's own
+   filename (``{video.filename}_captions`` / ``{video.filename}_transcript``)
+   rather than the orphan path's filename, since the orphan path is often an
+   opaque identifier. If the S3 object no longer exists, the _file path is left
+   in place for manual inspection, matching migration 0074's philosophy.
+
+IMPORTANT: this migration must not run in production until the
+`remove_uuid_from_filenames` management command has been run against
+production data (see docs/superpowers/specs/2026-07-02-multi-language-cleanup-design.md,
+kept locally in the ocw-studio repo -- not committed).
+
+This migration is irreversible: reverse_code is a no-op. Cleanly reversing would
+require deleting the WebsiteContent rows this migration creates, which needs a
+tracking marker we deliberately don't add.
+"""
+
+import uuid
+
+from botocore.exceptions import ClientError
+from django.db import migrations
+
+from main.s3_utils import get_boto3_resource
+
+_FIELD_CONFIG = (
+    # (file_field, resource_field, filename_suffix, resourcetype)
+    ("video_captions_file", "video_captions_resources", "captions", "Other"),
+    ("video_transcript_file", "video_transcript_resources", "transcript", "Document"),
+)
+
+
+def _object_exists_in_s3(bucket_name, key):
+    """Return True if the S3 object exists."""
+    s3 = get_boto3_resource("s3")
+    try:
+        s3.Object(bucket_name, key).load()
+    except ClientError as exc:
+        if exc.response["Error"]["Code"] in ("404", "NoSuchKey"):
+            return False
+        raise
+    return True
+
+
+def _unique_filename(WebsiteContent, website, dirpath, base_filename):
+    """Return a filename unique within (website, dirpath), suffixing with _2, _3, ... if needed."""
+    filename = base_filename
+    suffix = 2
+    while WebsiteContent.objects.filter(
+        website=website, dirpath=dirpath, filename=filename
+    ).exists():
+        filename = f"{base_filename}_{suffix}"
+        suffix += 1
+    return filename
+
+
+def _backfill_orphaned_files(apps, schema_editor):  # noqa: ARG001
+    """Clean up empty-string _file leftovers and back-fill real orphaned paths."""
+    from django.conf import settings  # noqa: PLC0415
+
+    WebsiteContent = apps.get_model("websites", "WebsiteContent")
+    Website = apps.get_model("websites", "Website")
+    bucket_name = settings.AWS_STORAGE_BUCKET_NAME
+
+    updated_website_ids = set()
+
+    for content in (
+        WebsiteContent.objects.filter(
+            metadata__resourcetype="Video", metadata__video_files__isnull=False
+        )
+        .select_related("website")
+        .only("id", "filename", "dirpath", "title", "metadata", "website__name")
+        .iterator()
+    ):
+        video_files = content.metadata.get("video_files")
+        if not isinstance(video_files, dict):
+            continue
+
+        changed = False
+
+        for file_field, resource_field, suffix, resourcetype in _FIELD_CONFIG:
+            path = video_files.get(file_field)
+            if not isinstance(path, str):
+                continue
+
+            # Case 1: empty-string leftover -- nothing to back-fill, just drop it.
+            if not path:
+                video_files.pop(file_field)
+                changed = True
+                continue
+
+            # Case 2: real orphan path -- verify the S3 object still exists.
+            key = path.lstrip("/")
+            if not _object_exists_in_s3(bucket_name, key):
+                print(  # noqa: T201
+                    f"[0076] Skipping missing S3 object for "
+                    f"{content.website.name}/{content.filename}: {path}"
+                )
+                continue
+
+            base_filename = f"{content.filename}_{suffix}"
+            filename = _unique_filename(
+                WebsiteContent, content.website, content.dirpath, base_filename
+            )
+            new_text_id = str(uuid.uuid4())
+            title = f"{content.title} {suffix}" if content.title else filename
+            resource = WebsiteContent.objects.create(
+                website=content.website,
+                type="resource",
+                is_page_content=True,
+                filename=filename,
+                dirpath=content.dirpath,
+                file=key,
+                text_id=new_text_id,
+                title=title,
+                metadata={
+                    "file": path,
+                    "resourcetype": resourcetype,
+                },
+            )
+
+            existing = video_files.get(resource_field)
+            existing_ids = []
+            if isinstance(existing, dict) and isinstance(existing.get("content"), list):
+                existing_ids = existing["content"]
+            video_files[resource_field] = {
+                "content": [*existing_ids, str(resource.text_id)],
+                "website": content.website.name,
+            }
+            video_files.pop(file_field)
+            changed = True
+
+        if changed:
+            content.save(update_fields=["metadata"])
+            updated_website_ids.add(content.website_id)
+
+    if updated_website_ids:
+        Website.objects.filter(pk__in=updated_website_ids).update(
+            has_unpublished_draft=True,
+            has_unpublished_live=True,
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("websites", "0075_remove_video_file_path_fields"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            _backfill_orphaned_files,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/websites/migrations/0076_backfill_orphaned_caption_transcript_files.py
+++ b/websites/migrations/0076_backfill_orphaned_caption_transcript_files.py
@@ -29,8 +29,7 @@ Two cases handled per video:
 
 IMPORTANT: this migration must not run in production until the
 `remove_uuid_from_filenames` management command has been run against
-production data (see docs/superpowers/specs/2026-07-02-multi-language-cleanup-design.md,
-kept locally in the ocw-studio repo -- not committed).
+production data.
 
 This migration is irreversible: reverse_code is a no-op. Cleanly reversing would
 require deleting the WebsiteContent rows this migration creates, which needs a

--- a/websites/migrations/0076_backfill_orphaned_caption_transcript_files.py
+++ b/websites/migrations/0076_backfill_orphaned_caption_transcript_files.py
@@ -105,35 +105,43 @@ def _backfill_orphaned_files(apps, schema_editor):  # noqa: ARG001
                 changed = True
                 continue
 
-            # Case 2: real orphan path -- verify the S3 object still exists.
+            # Case 2: real orphan path. Reuse a resource already pointing at
+            # this exact S3 key if one exists (e.g. created by a later sync
+            # or manual remediation after migration 0074 ran) instead of
+            # creating a duplicate; otherwise verify the object still exists
+            # in S3 and create a new resource for it.
             key = path.lstrip("/")
-            if not _object_exists_in_s3(bucket_name, key):
-                print(  # noqa: T201
-                    f"[0076] Skipping missing S3 object for "
-                    f"{content.website.name}/{content.filename}: {path}"
-                )
-                continue
+            resource = WebsiteContent.objects.filter(
+                website=content.website, file=key
+            ).first()
+            if resource is None:
+                if not _object_exists_in_s3(bucket_name, key):
+                    print(  # noqa: T201
+                        f"[0076] Skipping missing S3 object for "
+                        f"{content.website.name}/{content.filename}: {path}"
+                    )
+                    continue
 
-            base_filename = f"{content.filename}_{suffix}"
-            filename = _unique_filename(
-                WebsiteContent, content.website, content.dirpath, base_filename
-            )
-            new_text_id = str(uuid.uuid4())
-            title = f"{content.title} {suffix}" if content.title else filename
-            resource = WebsiteContent.objects.create(
-                website=content.website,
-                type="resource",
-                is_page_content=True,
-                filename=filename,
-                dirpath=content.dirpath,
-                file=key,
-                text_id=new_text_id,
-                title=title,
-                metadata={
-                    "file": path,
-                    "resourcetype": resourcetype,
-                },
-            )
+                base_filename = f"{content.filename}_{suffix}"
+                filename = _unique_filename(
+                    WebsiteContent, content.website, content.dirpath, base_filename
+                )
+                new_text_id = str(uuid.uuid4())
+                title = f"{content.title} {suffix}" if content.title else filename
+                resource = WebsiteContent.objects.create(
+                    website=content.website,
+                    type="resource",
+                    is_page_content=True,
+                    filename=filename,
+                    dirpath=content.dirpath,
+                    file=key,
+                    text_id=new_text_id,
+                    title=title,
+                    metadata={
+                        "file": path,
+                        "resourcetype": resourcetype,
+                    },
+                )
 
             existing = video_files.get(resource_field)
             existing_ids = []

--- a/websites/migrations/0076_backfill_orphaned_caption_transcript_files.py
+++ b/websites/migrations/0076_backfill_orphaned_caption_transcript_files.py
@@ -11,15 +11,21 @@ Two cases handled per video:
    was ever set for this video. The key is simply removed -- there is nothing to
    back-fill.
 
-2. Non-empty orphan _file path: the referenced S3 object may still exist even
-   though no WebsiteContent record was ever created for it (e.g. content
-   uploaded directly to S3 outside of the GDrive/3Play pipelines, using a
-   Google Drive file ID as the filename). If the object exists in S3, a new
-   WebsiteContent resource is created for it, named after the video's own
-   filename (``{video.filename}_captions`` / ``{video.filename}_transcript``)
-   rather than the orphan path's filename, since the orphan path is often an
-   opaque identifier. If the S3 object no longer exists, the _file path is left
-   in place for manual inspection, matching migration 0074's philosophy.
+2. Non-empty orphan _file path: if a WebsiteContent resource already points at
+   this exact S3 key (e.g. created by a later sync or manual remediation after
+   migration 0074 ran), that resource is reused rather than creating a
+   duplicate. Otherwise, the referenced S3 object may still exist even though
+   no WebsiteContent record was ever created for it (e.g. content uploaded
+   directly to S3 outside of the GDrive/3Play pipelines, using a Google Drive
+   file ID as the filename); if so, a new WebsiteContent resource is created
+   for it, named after the video's own filename (``{video.filename}_captions``
+   / ``{video.filename}_transcript``) rather than the orphan path's filename,
+   since the orphan path is often an opaque identifier. If the S3 object no
+   longer exists, the _file path is left in place for manual inspection,
+   matching migration 0074's philosophy. Either way, the resolved resource's
+   id is appended to the resource field's existing ``content`` list without
+   dropping an already-linked id, whether that existing value is a list or a
+   legacy scalar string.
 
 IMPORTANT: this migration must not run in production until the
 `remove_uuid_from_filenames` management command has been run against
@@ -145,10 +151,18 @@ def _backfill_orphaned_files(apps, schema_editor):  # noqa: ARG001
 
             existing = video_files.get(resource_field)
             existing_ids = []
-            if isinstance(existing, dict) and isinstance(existing.get("content"), list):
-                existing_ids = existing["content"]
+            if isinstance(existing, dict) and existing.get("content"):
+                existing_content = existing["content"]
+                existing_ids = (
+                    [existing_content]
+                    if isinstance(existing_content, str)
+                    else list(existing_content)
+                )
+            resource_text_id = str(resource.text_id)
+            if resource_text_id not in existing_ids:
+                existing_ids = [*existing_ids, resource_text_id]
             video_files[resource_field] = {
-                "content": [*existing_ids, str(resource.text_id)],
+                "content": existing_ids,
                 "website": content.website.name,
             }
             video_files.pop(file_field)

--- a/websites/migrations/0076_backfill_orphaned_caption_transcript_files.py
+++ b/websites/migrations/0076_backfill_orphaned_caption_transcript_files.py
@@ -78,6 +78,7 @@ def _backfill_orphaned_files(apps, schema_editor):  # noqa: ARG001
     bucket_name = settings.AWS_STORAGE_BUCKET_NAME
 
     updated_website_ids = set()
+    objects_to_update = []
 
     for content in (
         WebsiteContent.objects.filter(
@@ -146,8 +147,11 @@ def _backfill_orphaned_files(apps, schema_editor):  # noqa: ARG001
             changed = True
 
         if changed:
-            content.save(update_fields=["metadata"])
+            objects_to_update.append(content)
             updated_website_ids.add(content.website_id)
+
+    if objects_to_update:
+        WebsiteContent.objects.bulk_update(objects_to_update, ["metadata"])
 
     if updated_website_ids:
         Website.objects.filter(pk__in=updated_website_ids).update(

--- a/websites/models.py
+++ b/websites/models.py
@@ -27,9 +27,7 @@ from safedelete.queryset import SafeDeleteQueryset
 
 from content_sync.constants import VERSION_LIVE
 from main.settings import (
-    YT_FIELD_CAPTIONS,
     YT_FIELD_CAPTIONS_RESOURCES,
-    YT_FIELD_TRANSCRIPT,
     YT_FIELD_TRANSCRIPT_RESOURCES,
 )
 from main.utils import uuid_string
@@ -420,7 +418,7 @@ class WebsiteContent(TimestampedModel, SafeDeleteModel):
         ).hexdigest()
 
     @property
-    def full_metadata(self) -> dict:  # noqa: C901, PLR0912
+    def full_metadata(self) -> dict:
         """Return the metadata field with file upload included"""
         file_field = self.get_config_file_field()
         s3_path = self.website.s3_path
@@ -475,30 +473,6 @@ class WebsiteContent(TimestampedModel, SafeDeleteModel):
                     set_dict_field(full_metadata, resource_field, resolved)
                     modified = True
 
-        # Update video transcript/caption paths in _file fields if they exist.
-        # Handles both the legacy scalar string format and the new
-        # multi-language array-of-objects format.
-        if full_metadata:
-            for field in (YT_FIELD_TRANSCRIPT, YT_FIELD_CAPTIONS):
-                value = get_dict_field(full_metadata, field)
-                if not value or not url_path:
-                    continue
-                if isinstance(value, str):
-                    # Legacy scalar — a single URL path string.
-                    set_dict_field(
-                        full_metadata, field, value.replace(s3_path, url_path, 1)
-                    )
-                    modified = True
-                elif isinstance(value, list):
-                    # Multi-language format — list of {"file": ..., "language": ...}.
-                    updated = [
-                        {**entry, "file": entry["file"].replace(s3_path, url_path, 1)}
-                        if isinstance(entry, dict) and entry.get("file")
-                        else entry
-                        for entry in value
-                    ]
-                    set_dict_field(full_metadata, field, updated)
-                    modified = True
         return full_metadata if modified else self.metadata
 
     def get_config_file_field(self) -> dict:

--- a/websites/models_test.py
+++ b/websites/models_test.py
@@ -58,12 +58,8 @@ def test_websitecontent_calculate_checksum(metadata, markdown, dirpath, exp_chec
 
 @pytest.mark.parametrize("has_file_widget", [True, False])
 @pytest.mark.parametrize("has_file", [True, False])
-@pytest.mark.parametrize("is_video", [True, False])
 @pytest.mark.parametrize("has_metadata", [True, False])
-@pytest.mark.parametrize("transcript_value", [None, "", "transcript.pdf"])
-def test_websitecontent_full_metadata(
-    has_file_widget, has_file, is_video, has_metadata, transcript_value
-):
+def test_websitecontent_full_metadata(has_file_widget, has_file, has_metadata):
     """WebsiteContent.full_metadata returns expected file field in metadata when appropriate"""
     file = SimpleUploadedFile("test.txt", b"content")
     title = ("Test Title",)
@@ -73,37 +69,7 @@ def test_websitecontent_full_metadata(
         {"label": "My File", "name": "my_file", "widget": "file", "required": False},
     ]
     fields = config_fields if has_file_widget else config_fields[0:1]
-    if is_video and has_metadata:
-        fields.append(
-            {
-                "fields": [
-                    {
-                        "label": "Video Captions (WebVTT) URL",
-                        "name": "video_captions_file",
-                        "widget": "string",
-                    },
-                    {
-                        "label": "Video Transcript (PDF) URL",
-                        "name": "video_transcript_file",
-                        "widget": "string",
-                    },
-                ],
-                "label": "Video Files",
-                "name": "video_files",
-                "widget": "object",
-            }
-        )
     metadata = {"title": title, "description": description}
-    meta_val = (
-        f"/sites/mysite/{transcript_value}.webvtt"
-        if transcript_value
-        else transcript_value
-    )
-    if is_video and has_metadata:
-        metadata["video_files"] = {
-            "video_captions_file": meta_val,
-            "video_transcript_file": meta_val,
-        }
     content = WebsiteContentFactory.build(
         type="resource",
         metadata=metadata if has_metadata else None,
@@ -128,11 +94,6 @@ def test_websitecontent_full_metadata(
             name="mysite",
         ),
     )
-    expected_val = (
-        f"/{content.website.url_path}/{transcript_value}.webvtt"
-        if transcript_value
-        else transcript_value
-    )
 
     full_metadata = content.full_metadata
     if has_metadata:
@@ -148,59 +109,8 @@ def test_websitecontent_full_metadata(
     elif has_metadata:
         assert "my_file" not in full_metadata
 
-    if is_video and has_metadata:
-        assert full_metadata["video_files"]["video_captions_file"] == expected_val
-        assert full_metadata["video_files"]["video_transcript_file"] == expected_val
     if not has_metadata and not has_file_widget:
         assert full_metadata is None
-
-
-def test_websitecontent_full_metadata_video_files_array_format():
-    """full_metadata replaces s3_path with url_path inside video_files array entries."""
-    website = WebsiteFactory(
-        starter=WebsiteStarterFactory.create(
-            config={
-                "content-dir": "content",
-                "root-url-path": "sites",
-                "collections": [
-                    {
-                        "name": "resource",
-                        "label": "Resource",
-                        "category": "Content",
-                        "folder": "content/resource",
-                        "fields": [
-                            {"label": "Title", "name": "title", "widget": "string"},
-                        ],
-                    }
-                ],
-            }
-        ),
-        url_path="sites/mysite-fall-2008",
-        name="mysite",
-    )
-    content = WebsiteContentFactory.build(
-        type="resource",
-        metadata={
-            "video_files": {
-                "video_captions_file": [
-                    {"file": "/sites/mysite/captions.vtt", "language": "en"}
-                ],
-                "video_transcript_file": [
-                    {"file": "/sites/mysite/transcript.pdf", "language": "en"}
-                ],
-            }
-        },
-        website=website,
-    )
-
-    full_metadata = content.full_metadata
-
-    assert full_metadata["video_files"]["video_captions_file"] == [
-        {"file": "/sites/mysite-fall-2008/captions.vtt", "language": "en"}
-    ]
-    assert full_metadata["video_files"]["video_transcript_file"] == [
-        {"file": "/sites/mysite-fall-2008/transcript.pdf", "language": "en"}
-    ]
 
 
 def test_website_starter_unpublished():
@@ -476,75 +386,6 @@ def test_website_collaborators_with_missing_groups():
     collaborators = website.collaborators
     assert len(collaborators) == 1
     assert owner in collaborators
-
-
-@pytest.mark.django_db
-def test_websitecontent_full_metadata_array_captions():
-    """full_metadata applies s3_path->url_path substitution on multi-language array _file values."""
-    content = WebsiteContentFactory.build(
-        type="resource",
-        metadata={
-            "video_files": {
-                "video_captions_file": [
-                    {"file": "/sites/mysite/lecture1_captions.vtt", "language": "en"},
-                    {
-                        "file": "/sites/mysite/lecture1_captions_es.vtt",
-                        "language": "es",
-                    },
-                ],
-                "video_transcript_file": [
-                    {
-                        "file": "/sites/mysite/lecture1_transcript.pdf",
-                        "language": "en",
-                    },
-                ],
-            }
-        },
-        file=None,
-        website=WebsiteFactory(
-            starter=WebsiteStarterFactory.create(
-                config={
-                    "content-dir": "content",
-                    "root-url-path": "sites",
-                    "collections": [
-                        {
-                            "name": "resource",
-                            "label": "Resource",
-                            "category": "Content",
-                            "folder": "content/resource",
-                            "fields": [
-                                {"label": "Title", "name": "title", "widget": "string"}
-                            ],
-                        }
-                    ],
-                }
-            ),
-            url_path="sites/mysite-fall-2008",
-            name="mysite",
-        ),
-    )
-
-    full = content.full_metadata
-
-    captions = full["video_files"]["video_captions_file"]
-    assert isinstance(captions, list)
-    assert len(captions) == 2
-    assert captions[0] == {
-        "file": "/sites/mysite-fall-2008/lecture1_captions.vtt",
-        "language": "en",
-    }
-    assert captions[1] == {
-        "file": "/sites/mysite-fall-2008/lecture1_captions_es.vtt",
-        "language": "es",
-    }
-
-    transcripts = full["video_files"]["video_transcript_file"]
-    assert isinstance(transcripts, list)
-    assert len(transcripts) == 1
-    assert transcripts[0] == {
-        "file": "/sites/mysite-fall-2008/lecture1_transcript.pdf",
-        "language": "en",
-    }
 
 
 def test_websitecontent_full_metadata_resolves_resources_relation():

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -5,7 +5,6 @@ from types import SimpleNamespace
 
 import pytest
 from dateutil.parser import parse as parse_date
-from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.db.models import CharField, Value
 from django.utils.text import slugify
@@ -55,7 +54,6 @@ from websites.serializers import (
     WebsiteUrlSerializer,
 )
 from websites.site_config_api import SiteConfig
-from websites.utils import get_dict_field, set_dict_field
 
 pytestmark = pytest.mark.django_db
 # pylint:disable=redefined-outer-name
@@ -936,58 +934,3 @@ def test_update_page_url_on_title_change_legacy_index_behavior(
     page.refresh_from_db()
     assert page.filename == expected_filename
     assert page.title == "New Title"
-
-
-def test_website_content_detail_serializer_leaves_file_fields_untouched(
-    mocker, mocked_website_funcs
-):
-    """Saving _resources relations stores them as-is and never derives _file fields."""
-    mocker.patch("websites.serializers.update_youtube_thumbnail")
-    video_metadata = {
-        settings.FIELD_RESOURCETYPE: RESOURCE_TYPE_VIDEO,
-        "video_files": {
-            # Legacy scalar _file values must survive the save untouched
-            "video_captions_file": "/old/captions.vtt",
-            "video_transcript_file": "/old/transcript.pdf",
-        },
-    }
-
-    video = WebsiteContentFactory.create(
-        type=CONTENT_TYPE_RESOURCE,
-        metadata=video_metadata,
-    )
-    caption = WebsiteContentFactory.create(
-        type=CONTENT_TYPE_RESOURCE, is_page_content=True
-    )
-
-    metadata_patch = {"video_files": video.metadata["video_files"].copy()}
-    relation_value = {
-        "content": [str(caption.text_id)],
-        "website": video.website.name,
-    }
-    set_dict_field(metadata_patch, settings.YT_FIELD_CAPTIONS_RESOURCES, relation_value)
-
-    serializer = WebsiteContentDetailSerializer(
-        instance=video,
-        data={"metadata": metadata_patch},
-        partial=True,
-        context={"request": mocker.Mock(user=UserFactory.create())},
-    )
-    serializer.is_valid(raise_exception=True)
-    serializer.save()
-    video.refresh_from_db()
-
-    # The relation is stored exactly as sent
-    assert (
-        get_dict_field(video.metadata, settings.YT_FIELD_CAPTIONS_RESOURCES)
-        == relation_value
-    )
-    # The legacy scalar _file values are untouched
-    assert (
-        get_dict_field(video.metadata, settings.YT_FIELD_CAPTIONS)
-        == "/old/captions.vtt"
-    )
-    assert (
-        get_dict_field(video.metadata, settings.YT_FIELD_TRANSCRIPT)
-        == "/old/transcript.pdf"
-    )

--- a/websites/utils.py
+++ b/websites/utils.py
@@ -2,7 +2,6 @@
 
 import logging
 import re
-from pathlib import Path
 from typing import Any
 
 from django.apps import apps
@@ -328,40 +327,29 @@ def resolve_course_list_referenced_content_ids(content) -> set[int]:
 
 
 def resolve_video_file_referenced_content_ids(content) -> set[int]:
-    """Resolve video_captions_file/video_transcript_file paths to WebsiteContent ids.
-
-    Handles both the legacy scalar string format and the new multi-language
-    array-of-objects format (``[{"file": "/path/...", "language": "en"}, ...]``).
-    """
+    """Resolve video_captions/transcript_resources content to WebsiteContent ids."""
     WebsiteContent = apps.get_model("websites", "WebsiteContent")
     referenced_ids = set()
 
-    for field_path in (settings.YT_FIELD_CAPTIONS, settings.YT_FIELD_TRANSCRIPT):
-        value = get_dict_field(content.metadata, field_path)
-        if not value:
+    for field_path in (
+        settings.YT_FIELD_CAPTIONS_RESOURCES,
+        settings.YT_FIELD_TRANSCRIPT_RESOURCES,
+    ):
+        relation = get_dict_field(content.metadata, field_path)
+        if not isinstance(relation, dict):
+            continue
+        text_ids = relation.get("content")
+        if isinstance(text_ids, str):
+            text_ids = [text_ids] if text_ids else []
+        elif not isinstance(text_ids, list):
+            continue
+        if not text_ids:
             continue
 
-        if isinstance(value, str):
-            # Legacy scalar format — a single URL path string.
-            keys = [value]
-        elif isinstance(value, list):
-            # Multi-language format — list of {"file": ..., "language": ...}.
-            keys = [
-                entry["file"]
-                for entry in value
-                if isinstance(entry, dict) and entry.get("file")
-            ]
-        else:
-            continue
-
-        for key in keys:
-            base_name = Path(key).stem
-            related_ids = (
-                WebsiteContent.objects.filter(website=content.website)
-                .filter(Q(file=key) | Q(file=key.strip("/")) | Q(filename=base_name))
-                .values_list("id", flat=True)
-            )
-            referenced_ids.update(related_ids)
+        related_ids = WebsiteContent.objects.filter(
+            website=content.website, text_id__in=text_ids
+        ).values_list("id", flat=True)
+        referenced_ids.update(related_ids)
 
     return referenced_ids
 

--- a/websites/utils.py
+++ b/websites/utils.py
@@ -71,6 +71,24 @@ def get_dict_query_field(dict_field_name: str, sub_field: str):
     return dict_field_name + "__" + sub_field.replace(".", "__")
 
 
+def query_field_is_empty(
+    field_path: str,
+    empty_values: tuple = (None, ""),
+    *,
+    include_isnull: bool = True,
+) -> Q:
+    """
+    Build a Q object matching a metadata field that is null/missing (if
+    ``include_isnull`` is True) or equal to any of the given ``empty_values``.
+    """
+    query_field = get_dict_query_field("metadata", field_path)
+    q = Q(**{f"{query_field}__isnull": True}) if include_isnull else None
+    for value in empty_values:
+        empty_q = Q(**{query_field: value})
+        q = empty_q if q is None else q | empty_q
+    return q
+
+
 def get_valid_base_filename(filename: str, content_type: str) -> str:
     """Avoid forbidden filenames that could confuse hugo"""
     if filename in constants.CONTENT_FILENAMES_FORBIDDEN:

--- a/websites/utils_test.py
+++ b/websites/utils_test.py
@@ -1275,21 +1275,17 @@ def test_resolve_referenced_content_ids_scopes_course_list_sitemetadata():
 
 
 @pytest.mark.django_db
-def test_resolve_referenced_content_ids_video_file_paths():
-    """resolve_referenced_content_ids resolves video_captions_file and video_transcript_file by file path."""
+def test_resolve_referenced_content_ids_video_resources():
+    """resolve_referenced_content_ids resolves video_captions_resources and video_transcript_resources content."""
     website = WebsiteFactory.create()
 
     captions_content = WebsiteContentFactory.create(
         website=website,
         type=constants.CONTENT_TYPE_RESOURCE,
-        filename="nXyqvKrQGZ8_captions",
-        file=f"courses/{website.name}/nXyqvKrQGZ8_captions.webvtt",
     )
     transcript_content = WebsiteContentFactory.create(
         website=website,
         type=constants.CONTENT_TYPE_RESOURCE,
-        filename="pdf_testpage",
-        file=f"courses/{website.name}/pdf_testpage.pdf",
     )
 
     video_resource = WebsiteContentFactory.create(
@@ -1298,8 +1294,8 @@ def test_resolve_referenced_content_ids_video_file_paths():
         metadata={
             "resourcetype": "Video",
             "video_files": {
-                "video_captions_file": f"/courses/{website.name}/nXyqvKrQGZ8_captions.webvtt",
-                "video_transcript_file": f"/courses/{website.name}/pdf_testpage.pdf",
+                "video_captions_resources": {"content": captions_content.text_id},
+                "video_transcript_resources": {"content": transcript_content.text_id},
             },
         },
     )
@@ -1310,8 +1306,8 @@ def test_resolve_referenced_content_ids_video_file_paths():
 
 
 @pytest.mark.django_db
-def test_resolve_referenced_content_ids_video_file_empty_strings():
-    """resolve_referenced_content_ids handles empty-string video file paths gracefully."""
+def test_resolve_referenced_content_ids_video_resources_empty_strings():
+    """resolve_referenced_content_ids handles empty-string video resource content gracefully."""
     website = WebsiteFactory.create()
 
     video_resource = WebsiteContentFactory.create(
@@ -1320,8 +1316,6 @@ def test_resolve_referenced_content_ids_video_file_empty_strings():
         metadata={
             "resourcetype": "Video",
             "video_files": {
-                "video_captions_file": "",
-                "video_transcript_file": "",
                 "video_captions_resources": "",
                 "video_transcript_resources": "",
             },
@@ -1333,27 +1327,21 @@ def test_resolve_referenced_content_ids_video_file_empty_strings():
 
 
 @pytest.mark.django_db
-def test_resolve_referenced_content_ids_video_file_paths_array_format():
-    """resolve_referenced_content_ids resolves multi-language array-of-objects _file format."""
+def test_resolve_referenced_content_ids_video_resources_multiple_content_ids():
+    """resolve_referenced_content_ids resolves multiple text_ids in a video resources relation."""
     website = WebsiteFactory.create()
 
     captions_en = WebsiteContentFactory.create(
         website=website,
         type=constants.CONTENT_TYPE_RESOURCE,
-        filename="lecture1_captions_vtt",
-        file=f"courses/{website.name}/lecture1_captions.vtt",
     )
     captions_es = WebsiteContentFactory.create(
         website=website,
         type=constants.CONTENT_TYPE_RESOURCE,
-        filename="lecture1_captions_es_vtt",
-        file=f"courses/{website.name}/lecture1_captions_es.vtt",
     )
     transcript_en = WebsiteContentFactory.create(
         website=website,
         type=constants.CONTENT_TYPE_RESOURCE,
-        filename="lecture1_transcript_pdf",
-        file=f"courses/{website.name}/lecture1_transcript.pdf",
     )
 
     video_resource = WebsiteContentFactory.create(
@@ -1362,22 +1350,10 @@ def test_resolve_referenced_content_ids_video_file_paths_array_format():
         metadata={
             "resourcetype": "Video",
             "video_files": {
-                "video_captions_file": [
-                    {
-                        "file": f"/courses/{website.name}/lecture1_captions.vtt",
-                        "language": "en",
-                    },
-                    {
-                        "file": f"/courses/{website.name}/lecture1_captions_es.vtt",
-                        "language": "es",
-                    },
-                ],
-                "video_transcript_file": [
-                    {
-                        "file": f"/courses/{website.name}/lecture1_transcript.pdf",
-                        "language": "en",
-                    },
-                ],
+                "video_captions_resources": {
+                    "content": [captions_en.text_id, captions_es.text_id]
+                },
+                "video_transcript_resources": {"content": [transcript_en.text_id]},
             },
         },
     )

--- a/websites/utils_test.py
+++ b/websites/utils_test.py
@@ -11,6 +11,7 @@ from websites.factories import (
     WebsiteFactory,
     WebsiteStarterFactory,
 )
+from websites.models import WebsiteContent
 from websites.utils import (
     compile_referencing_content,
     get_dict_field,
@@ -18,6 +19,7 @@ from websites.utils import (
     get_metadata_content_key,
     parse_resource_uuid,
     permissions_group_name_for_role,
+    query_field_is_empty,
     resolve_referenced_content_ids,
     set_dict_field,
 )
@@ -66,6 +68,51 @@ def test_get_dict_query_field():
         get_dict_query_field("metadata", "video_files.video_captions_file")
         == "metadata__video_files__video_captions_file"
     )
+
+
+@pytest.mark.parametrize(
+    ("metadata", "matches"),
+    [
+        ({"video_files": {"video_id": None}}, True),
+        ({"video_files": {}}, True),
+        ({"video_files": {"video_id": ""}}, True),
+        ({"video_files": {"video_id": "abc123"}}, False),
+    ],
+)
+@pytest.mark.django_db
+def test_query_field_is_empty_default(metadata, matches):
+    """query_field_is_empty should match null/missing/empty-string metadata fields by default"""
+    website = WebsiteFactory.create()
+    content = WebsiteContentFactory.create(website=website, metadata=metadata)
+    result = WebsiteContent.objects.filter(pk=content.pk).filter(
+        query_field_is_empty("video_files.video_id")
+    )
+    assert result.exists() is matches
+
+
+@pytest.mark.parametrize(
+    ("metadata", "matches"),
+    [
+        ({"video_files": {"captions": []}}, True),
+        ({"video_files": {"captions": None}}, True),
+        ({"video_files": {"captions": ""}}, True),
+        ({"video_files": {"captions": ["a"]}}, False),
+        ({"video_files": {}}, False),
+    ],
+)
+@pytest.mark.django_db
+def test_query_field_is_empty_custom_values_no_isnull(metadata, matches):
+    """query_field_is_empty should support custom empty_values and skip the isnull check"""
+    website = WebsiteFactory.create()
+    content = WebsiteContentFactory.create(website=website, metadata=metadata)
+    result = WebsiteContent.objects.filter(pk=content.pk).filter(
+        query_field_is_empty(
+            "video_files.captions",
+            empty_values=(None, [], ""),
+            include_isnull=False,
+        )
+    )
+    assert result.exists() is matches
 
 
 def test_get_dict_field():


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/7378

### Description (What does it do?)
Stacked on top of draft #3086 (auto-link). Two related pieces of cleanup:

**Migration 0076 — backfill orphaned caption/transcript files**
- `websites/migrations/0076_backfill_orphaned_caption_transcript_files.py`: creates `WebsiteContent` resources for videos whose captions/transcripts only ever existed as a `video_captions_file`/`video_transcript_file` path and were never linked via the `_resources` relation (migration 0074 only handled videos where a matching resource already existed), and cleans up leftover empty-string values.

**Remove `video_captions_file`/`video_transcript_file` fields entirely**
`video_captions_resources`/`video_transcript_resources` (the relation fields) are now the only fields — the derived `_file` fields and their backing settings are fully removed:
- `websites/serializers.py`: remove `sync_video_relation_urls` (no longer derives `_file`)
- `websites/api.py`: stop writing `_file` in `auto_link_video_captions_transcript`/`videos_missing_captions`
- `gdrive_sync/api.py`, `videos/threeplay_sync.py`, `videos/tasks.py`: stop writing `_file`
- `websites/models.py`: remove the dead `full_metadata()` `_file` substitution block
- `websites/utils.py`: `resolve_video_file_referenced_content_ids` now reads `_resources.content` directly instead of the removed `_file` fields
- `main/settings.py`: remove `YT_FIELD_CAPTIONS`/`YT_FIELD_TRANSCRIPT` settings
- Management commands (`sync_transcripts`, `clear_webvtt_files`, `detect_unrelated_content`, `backpopulate_referencing_content`) updated to match

Also fixes a bug found in code review: `videos_missing_captions()` used `include_isnull=False`, which missed videos where `video_captions_resources`/`video_files` was absent from metadata entirely (the common case for videos that never had captions linked) rather than explicitly null.

### How can this be tested?
1. Switch to `umar/7378-multi-language-cleanup` branch
2. **GDrive path:** upload a video and matching caption/transcript files (e.g. `lecture1.mp4`, `lecture1_captions-en-US.vtt`) to a course's GDrive folder and sync. Confirm the video's `video_captions_resources`/`video_transcript_resources` get populated automatically, including multiple language variants if present.
3. **3Play path:** trigger a 3Play transcript job for a video with no existing captions/transcripts. Confirm real caption/transcript `WebsiteContent` resources are created and linked via `_resources` (not just raw files with no resource).
4. **Manual unlink sticks:** remove a linked caption/transcript from the relation widget in Studio and save. Confirm it stays removed on subsequent saves (including saves unrelated to captions/transcripts).
5. **Delete cleanup:** delete a linked caption/transcript resource directly. Confirm it's automatically removed from the video's related content.

**Deploy ordering matters:** `umar/5790-normalize-s3-keys-and-export-csv` must ship and its `remove_uuid_from_filenames` command must run in production *before* migration 0076 runs (otherwise stale UUID-prefixed S3 keys get baked into new resources). Migration 0076 must then run in production *before* the companion ocw-hugo-themes PR deploys.