### PR TITLE
chore: added environment variables to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,6 +231,7 @@ env = [
     "OCW_COURSE_STARTER_SLUG=course",
     "DRIVE_SHARED_ID=",
     "DRIVE_SERVICE_ACCOUNT_CREDS=",
+    "AWS_ENDPOINT_URL=",
 ]
 
 [tool.bumpversion]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,6 +229,8 @@ env = [
     "OCW_STUDIO_USE_S3=False",
     "OCW_IMPORT_STARTER_SLUG=course",
     "OCW_COURSE_STARTER_SLUG=course",
+    "DRIVE_SHARED_ID=",
+    "DRIVE_SERVICE_ACCOUNT_CREDS=",
 ]
 
 [tool.bumpversion]


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
Running tests locally always fails with `test_websites_endpoint_list_create` running forever. Commit `006dfd93` added `mock_gdrive_build` to `conftest.py`, which patches `gdrive_sync.api.build`. With`DRIVE_SHARED_ID` empty in `.env`, `is_gdrive_enabled()` returned False and `create_gdrive_folders.delay()` was a no-op in tests. The `build` mock was added for unrelated YouTube code paths.

With real `DRIVE_SHARED_ID` and `DRIVE_SERVICE_ACCOUNT_CREDS` (development credentials), this:
   - `is_gdrive_enabled()` → `True`
   - `create_gdrive_folders.delay()` now runs `api.create_gdrive_folders()` instead of returning early
   - `query_files()` calls `get_drive_service()`, which returns a `MagicMock` (because `build` is patched)
   - `MagicMock().files().list().execute().get("nextPageToken", None)` returns a **Mock object** (truthy, not `None`)
   - The `while next_token is not None:` loop in `query_files` runs **forever**

The `mock_gdrive_build` fixture correctly blocked the network discovery-doc download, but it wasn't designed for a code path where `is_gdrive_enabled()` returns `True`.

### How can this be tested?
Run the test suite locally and verify that `test_websites_endpoint_list_create` does not hang