### PR TITLE
Bump redis to >=5.0.1 to fix django-health-check redis probe 500s

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "pypdf>=6.0.0,<7",
     "python-magic>=0.4.27,<0.5",
     "pyyaml>=6.0.1,<7",
-    "redis>=4.5.5,<5",
+    "redis>=5.0.1,<6",
     "requests==2.33.1",
     "sentry-sdk==2.60.0",
     "smart-open[s3]>=7.0.0,<8",

--- a/uv.lock
+++ b/uv.lock
@@ -1531,7 +1531,7 @@ requires-dist = [
     { name = "pypdf", specifier = ">=6.0.0,<7" },
     { name = "python-magic", specifier = ">=0.4.27,<0.5" },
     { name = "pyyaml", specifier = ">=6.0.1,<7" },
-    { name = "redis", specifier = ">=4.5.5,<5" },
+    { name = "redis", specifier = ">=5.0.1,<6" },
     { name = "requests", specifier = "==2.33.1" },
     { name = "sentry-sdk", specifier = "==2.60.0" },
     { name = "smart-open", extras = ["s3"], specifier = ">=7.0.0,<8" },
@@ -2105,11 +2105,14 @@ wheels = [
 
 [[package]]
 name = "redis"
-version = "4.6.0"
+version = "5.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/88/63d802c2b18dd9eaa5b846cbf18917c6b2882f20efda398cc16a7500b02c/redis-4.6.0.tar.gz", hash = "sha256:585dc516b9eb042a619ef0a39c3d7d55fe81bdb4df09a52c9cdde0d07bf1aa7d", size = 4561721, upload-time = "2023-06-25T13:13:57.139Z" }
+dependencies = [
+    { name = "pyjwt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6a/cf/128b1b6d7086200c9f387bd4be9b2572a30b90745ef078bd8b235042dc9f/redis-5.3.1.tar.gz", hash = "sha256:ca49577a531ea64039b5a36db3d6cd1a0c7a60c34124d46924a45b956e8cf14c", size = 4626200, upload-time = "2025-07-25T08:06:27.778Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/2e/409703d645363352a20c944f5d119bdae3eb3034051a53724a7c5fee12b8/redis-4.6.0-py3-none-any.whl", hash = "sha256:e2b03db868160ee4591de3cb90d40ebb50a90dd302138775937f6a42b7ed183c", size = 241149, upload-time = "2023-06-25T13:13:54.563Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/26/5c5fa0e83c3621db835cfc1f1d789b37e7fa99ed54423b5f519beb931aa7/redis-5.3.1-py3-none-any.whl", hash = "sha256:dc1909bd24669cc31b5f67a039700b16ec30571096c5f1f0d9d2324bff31af97", size = 272833, upload-time = "2025-07-25T08:06:26.317Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### What are the relevant tickets?
N/A

### Description (What does it do?)
After #3083 added django-health-check and mounted it at `/health/{startup,liveness,readiness,full}/`, and infra pointed k8s probes at those endpoints, the `startup`/`readiness`/`full` checks started 500ing constantly, crash-looping the app in QA (ocw-studio pods stuck in `CrashLoopBackOff`).

Root cause: `django-health-check`'s Redis contrib check (`health_check/contrib/redis.py`) creates a `redis.asyncio.Redis` client via `client_factory` and calls `await client.aclose()` on it when done. `redis-py` didn't add `aclose()` until 5.0.1 (added as a standardized alias so both sync and async clients could be closed via `contextlib.aclosing`). This repo's `pyproject.toml` pins `redis>=4.5.5,<5`, which predates that method, so every health check probe raised:

```
AttributeError: 'Redis' object has no attribute 'aclose'. Did you mean: 'close'?
```

The fix is a version bump only — `redis>=4.5.5,<5` → `redis>=5.0.1,<6`. Nothing else in the app touches the `redis` client directly; it's only used via `django-redis` (cache backend, already pinned to `django-redis==6.0.0` which supports redis-py 5.x) and Celery's broker URL (a connection string, not a client object), so there's no other code that needs updating for this bump.

### Screenshots (if appropriate):
N/A

### How can this be tested?
1. Run a local Redis instance, e.g. `docker run -d --rm -p 6379:6379 redis:8.4.0`.
2. Confirm the bug reproduces on the old pin: check out `redis==4.6.0` (`uv add "redis>=4.5.5,<5"`, `uv sync`) and exercise the exact check config the app registers in `main/urls_healthcheck.py`:
   ```python
   import asyncio, django, os
   os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'main.settings')
   django.setup()
   from health_check.contrib.redis import Redis as RedisCheck
   from redis.asyncio import Redis as RedisClient
   from django.conf import settings
   check = RedisCheck(client_factory=lambda: RedisClient.from_url(settings.CELERY_BROKER_URL))
   asyncio.run(check.run())  # raises AttributeError: 'Redis' object has no attribute 'aclose'
   ```
3. Apply this PR's change (`uv sync`) and rerun the same snippet — it completes with no exception.
4. Alternatively, hit `/health/startup/` (or `/health/full/`) on a running instance before/after the bump; it should go from a 500 to a 200 (assuming DB/cache/celery are also reachable).

Full test suite (4577 tests) passes at the same rate as unmodified `master` under identical local conditions (real Postgres + Redis, outside Docker) — 4549 passed / 28 failed both before and after this change, where all 28 failures are pre-existing local-environment issues unrelated to redis (Python 3.14 + `mock.MagicMock(spec=...)` NameErrors on `TYPE_CHECKING`-only imports in a few files, and `/var/media` permission errors from running tests outside the Docker container).

### Additional Context
This was surfaced by a linked infra change in `ol-infrastructure` that pointed ocw-studio's k8s liveness/readiness/startup probes at these `/health/*` endpoints instead of `/nginx-health`. That infra change has been reverted for ocw-studio in the meantime to stop the crash loop in QA; once this fix is merged and released, the infra probes can be re-pointed at `/health/*` again.