### PR TITLE
Add PostHog UI host var to theme assets pipeline

### DIFF
--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
@@ -91,9 +91,6 @@ class ThemeAssetsPipelineDefinition(Pipeline):
             "POSTHOG_API_HOST": settings.PUBLISH_POSTHOG_API_HOST,
             "POSTHOG_UI_HOST": settings.PUBLISH_POSTHOG_UI_HOST,
             "POSTHOG_ENV": settings.ENVIRONMENT,
-            "POSTHOG_COURSE_V3_ENABLED": str(
-                settings.PUBLISH_POSTHOG_COURSE_V3_ENABLED
-            ).lower(),
         }
         if (
             settings.PUBLISH_POSTHOG_ENABLED

--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
@@ -89,7 +89,11 @@ class ThemeAssetsPipelineDefinition(Pipeline):
             "SENTRY_ENV": settings.ENVIRONMENT,
             "POSTHOG_ENABLED": str(settings.PUBLISH_POSTHOG_ENABLED).lower(),
             "POSTHOG_API_HOST": settings.PUBLISH_POSTHOG_API_HOST,
+            "POSTHOG_UI_HOST": settings.PUBLISH_POSTHOG_UI_HOST,
             "POSTHOG_ENV": settings.ENVIRONMENT,
+            "POSTHOG_COURSE_V3_ENABLED": str(
+                settings.PUBLISH_POSTHOG_COURSE_V3_ENABLED
+            ).lower(),
         }
         if (
             settings.PUBLISH_POSTHOG_ENABLED
@@ -100,6 +104,13 @@ class ThemeAssetsPipelineDefinition(Pipeline):
             ).lower()
             themes_env["POSTHOG_PROJECT_API_KEY"] = (
                 settings.PUBLISH_POSTHOG_PROJECT_API_KEY
+            )
+        if (
+            settings.PUBLISH_POSTHOG_COURSE_V3_ENABLED
+            and settings.PUBLISH_POSTHOG_COURSE_V3_PROJECT_API_KEY
+        ):
+            themes_env["POSTHOG_COURSE_V3_PROJECT_API_KEY"] = (
+                settings.PUBLISH_POSTHOG_COURSE_V3_PROJECT_API_KEY
             )
         tasks = [
             GetStep(

--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
@@ -105,13 +105,6 @@ class ThemeAssetsPipelineDefinition(Pipeline):
             themes_env["POSTHOG_PROJECT_API_KEY"] = (
                 settings.PUBLISH_POSTHOG_PROJECT_API_KEY
             )
-        if (
-            settings.PUBLISH_POSTHOG_COURSE_V3_ENABLED
-            and settings.PUBLISH_POSTHOG_COURSE_V3_PROJECT_API_KEY
-        ):
-            themes_env["POSTHOG_COURSE_V3_PROJECT_API_KEY"] = (
-                settings.PUBLISH_POSTHOG_COURSE_V3_PROJECT_API_KEY
-            )
         tasks = [
             GetStep(
                 get=OCW_HUGO_THEMES_GIT_IDENTIFIER,

--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline_test.py
@@ -56,6 +56,20 @@ def test_generate_theme_assets_pipeline_definition(mock_environments):
         build_ocw_hugo_themes_task["config"]["run"]["args"]
     )
     assert OCW_HUGO_THEMES_GIT_IDENTIFIER in build_ocw_hugo_themes_command
+    build_ocw_hugo_themes_params = build_ocw_hugo_themes_task["config"]["params"]
+    assert (
+        build_ocw_hugo_themes_params["POSTHOG_UI_HOST"]
+        == settings.PUBLISH_POSTHOG_UI_HOST
+    )
+    assert build_ocw_hugo_themes_params["POSTHOG_COURSE_V3_ENABLED"] == (
+        str(settings.PUBLISH_POSTHOG_COURSE_V3_ENABLED).lower()
+    )
+    assert (
+        "POSTHOG_COURSE_V3_PROJECT_API_KEY" in build_ocw_hugo_themes_params
+    ) == bool(
+        settings.PUBLISH_POSTHOG_COURSE_V3_ENABLED
+        and settings.PUBLISH_POSTHOG_COURSE_V3_PROJECT_API_KEY
+    )
     upload_theme_assets_tasks = [
         task
         for task in build_theme_assets_job["plan"]

--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline_test.py
@@ -64,12 +64,6 @@ def test_generate_theme_assets_pipeline_definition(mock_environments):
     assert build_ocw_hugo_themes_params["POSTHOG_COURSE_V3_ENABLED"] == (
         str(settings.PUBLISH_POSTHOG_COURSE_V3_ENABLED).lower()
     )
-    assert (
-        "POSTHOG_COURSE_V3_PROJECT_API_KEY" in build_ocw_hugo_themes_params
-    ) == bool(
-        settings.PUBLISH_POSTHOG_COURSE_V3_ENABLED
-        and settings.PUBLISH_POSTHOG_COURSE_V3_PROJECT_API_KEY
-    )
     upload_theme_assets_tasks = [
         task
         for task in build_theme_assets_job["plan"]

--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline_test.py
@@ -61,9 +61,6 @@ def test_generate_theme_assets_pipeline_definition(mock_environments):
         build_ocw_hugo_themes_params["POSTHOG_UI_HOST"]
         == settings.PUBLISH_POSTHOG_UI_HOST
     )
-    assert build_ocw_hugo_themes_params["POSTHOG_COURSE_V3_ENABLED"] == (
-        str(settings.PUBLISH_POSTHOG_COURSE_V3_ENABLED).lower()
-    )
     upload_theme_assets_tasks = [
         task
         for task in build_theme_assets_job["plan"]

--- a/main/settings.py
+++ b/main/settings.py
@@ -1400,12 +1400,6 @@ PUBLISH_POSTHOG_COURSE_V3_ENABLED = get_bool(
     default=False,
     description="Whether PostHog is enabled for course v3",
 )
-PUBLISH_POSTHOG_COURSE_V3_PROJECT_API_KEY = get_string(
-    name="PUBLISH_POSTHOG_COURSE_V3_PROJECT_API_KEY",
-    default=None,
-    description="API token for communicating with PostHog for course v3",
-    required=False,
-)
 PUBLISH_POSTHOG_ENABLED = get_bool(
     name="PUBLISH_POSTHOG_ENABLED",
     default=False,

--- a/main/settings.py
+++ b/main/settings.py
@@ -1395,6 +1395,17 @@ PUBLISH_POSTHOG_API_HOST = get_string(
     description="API host for PostHog, published to pipelines",
     required=False,
 )
+PUBLISH_POSTHOG_COURSE_V3_ENABLED = get_bool(
+    name="PUBLISH_POSTHOG_COURSE_V3_ENABLED",
+    default=False,
+    description="Whether PostHog is enabled for course v3",
+)
+PUBLISH_POSTHOG_COURSE_V3_PROJECT_API_KEY = get_string(
+    name="PUBLISH_POSTHOG_COURSE_V3_PROJECT_API_KEY",
+    default=None,
+    description="API token for communicating with PostHog for course v3",
+    required=False,
+)
 PUBLISH_POSTHOG_ENABLED = get_bool(
     name="PUBLISH_POSTHOG_ENABLED",
     default=False,
@@ -1422,6 +1433,12 @@ PUBLISH_POSTHOG_PROJECT_API_KEY = get_string(
     name="PUBLISH_POSTHOG_PROJECT_API_KEY",
     default=None,
     description="API token for communicating with PostHog, published to pipelines",
+    required=False,
+)
+PUBLISH_POSTHOG_UI_HOST = get_string(
+    name="PUBLISH_POSTHOG_UI_HOST",
+    default="https://app.posthog.com",
+    description="UI host for PostHog, published to pipelines",
     required=False,
 )
 OCW_STUDIO_DELETABLE_CONTENT_TYPES = get_delimited_list(

--- a/main/settings.py
+++ b/main/settings.py
@@ -1395,11 +1395,6 @@ PUBLISH_POSTHOG_API_HOST = get_string(
     description="API host for PostHog, published to pipelines",
     required=False,
 )
-PUBLISH_POSTHOG_COURSE_V3_ENABLED = get_bool(
-    name="PUBLISH_POSTHOG_COURSE_V3_ENABLED",
-    default=False,
-    description="Whether PostHog is enabled for course v3",
-)
 PUBLISH_POSTHOG_ENABLED = get_bool(
     name="PUBLISH_POSTHOG_ENABLED",
     default=False,


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12194

### Description (What does it do?)
Publishes the `POSTHOG_UI_HOST` environment variable to the theme assets Concourse pipeline so the `ocw-hugo-themes` Webpack build can pick it up.


### How can this be tested?
- Upsert the theme assets pipeline
- Get the pipeline yaml with `fly -t local get-pipeline <theme_assets_pipeline>`
- Verify the pipeline configuration contains `POSTHOG_UI_HOST`


🤖 Generated with [Claude Code](https://claude.com/claude-code)