### PR TITLE
fix: gdrive resourcetype misclassification and transcript pdf titles

### DIFF
--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -567,7 +567,8 @@ def create_gdrive_resource_content(drive_file: DriveFile, user_pk=None):
             # metadata doesn't, so use the filename directly for those instead.
             resource_title = (
                 get_pdf_title(drive_file)
-                if extension.lower() == ".pdf" and "_transcript" not in drive_file.name
+                if extension.lower() == ".pdf"
+                and "_transcript" not in drive_file.name.lower()
                 else drive_file.name
             )
 
@@ -602,7 +603,10 @@ def create_gdrive_resource_content(drive_file: DriveFile, user_pk=None):
             resource.file = drive_file.s3_key
             if resource.metadata.get("file_size") != drive_file.size:
                 resource.metadata["file_size"] = drive_file.size
-            if extension.lower() == ".pdf" and "_transcript" not in drive_file.name:
+            if (
+                extension.lower() == ".pdf"
+                and "_transcript" not in drive_file.name.lower()
+            ):
                 # update resource title if PDF metadata contains title
                 pdf_title = get_pdf_title(drive_file)
                 if pdf_title != drive_file.name:

--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -43,7 +43,7 @@ from gdrive_sync.models import DriveFile
 from main.s3_utils import get_boto3_resource
 from main.utils import get_base_filename, get_dirpath_and_filename
 from videos.api import create_media_convert_job
-from videos.constants import VideoJobStatus, VideoStatus
+from videos.constants import CAPTION_FILE_EXTENSIONS, VideoJobStatus, VideoStatus
 from videos.models import Video, VideoJob
 from websites.api import (
     auto_link_video_captions_transcript,
@@ -403,6 +403,10 @@ def get_resource_type(drive_file: DriveFile) -> str:
         and DRIVE_FOLDER_VIDEOS_FINAL in drive_file.drive_path
     ):
         return RESOURCE_TYPE_VIDEO
+    # WebVTT captions get an S3 content_type starting with "text", which would
+    # otherwise match the generic document check below and misclassify them.
+    if extension.lstrip(".").lower() in CAPTION_FILE_EXTENSIONS:
+        return RESOURCE_TYPE_OTHER
     if content_type.startswith("text") or extension in VALID_TEXT_FILE_TYPES:
         return RESOURCE_TYPE_DOCUMENT
     return RESOURCE_TYPE_OTHER
@@ -558,9 +562,12 @@ def create_gdrive_resource_content(drive_file: DriveFile, user_pk=None):
                 **dict.fromkeys(settings.RESOURCE_TYPE_FIELDS, resource_type),
             }
 
+            # Transcript filenames carry language/locale info (e.g.
+            # "lecture1_transcript-fr.pdf") that a PDF's own internal title
+            # metadata doesn't, so use the filename directly for those instead.
             resource_title = (
                 get_pdf_title(drive_file)
-                if extension.lower() == ".pdf"
+                if extension.lower() == ".pdf" and "_transcript" not in drive_file.name
                 else drive_file.name
             )
 
@@ -595,7 +602,7 @@ def create_gdrive_resource_content(drive_file: DriveFile, user_pk=None):
             resource.file = drive_file.s3_key
             if resource.metadata.get("file_size") != drive_file.size:
                 resource.metadata["file_size"] = drive_file.size
-            if extension.lower() == ".pdf":
+            if extension.lower() == ".pdf" and "_transcript" not in drive_file.name:
                 # update resource title if PDF metadata contains title
                 pdf_title = get_pdf_title(drive_file)
                 if pdf_title != drive_file.name:

--- a/gdrive_sync/api_test.py
+++ b/gdrive_sync/api_test.py
@@ -314,6 +314,8 @@ def test_create_gdrive_folders(  # pylint:disable=too-many-locals,too-many-argum
         ["file.mp4", False, "video/mp4", RESOURCE_TYPE_VIDEO],  # noqa: PT007
         ["file.jpeg", True, "image/jpeg", RESOURCE_TYPE_IMAGE],  # noqa: PT007
         ["file.py", True, "application/python", RESOURCE_TYPE_OTHER],  # noqa: PT007
+        ["file_captions-en-US.vtt", True, "text/vtt", RESOURCE_TYPE_OTHER],  # noqa: PT007
+        ["file_captions-en-US.webvtt", True, "text/vtt", RESOURCE_TYPE_OTHER],  # noqa: PT007
     ],
 )
 def test_get_resource_type(
@@ -723,6 +725,26 @@ def test_create_gdrive_pdf_no_metadata(mock_get_s3_content_type, mocker):
     create_gdrive_resource_content(drive_file)
     drive_file.refresh_from_db()
     assert drive_file.resource.title == drive_file.name
+
+
+def test_create_gdrive_transcript_pdf_ignores_metadata_title(
+    mock_get_s3_content_type, mocker
+):
+    """
+    Transcript PDFs should use the file name for the resource title even when
+    the PDF has its own metadata title, since the file name carries language/
+    locale info (e.g. "-fr") that the PDF's own title metadata doesn't.
+    """
+    mock_get_pdf_title = mocker.patch("gdrive_sync.api.get_pdf_title")
+    drive_file = DriveFileFactory.create(
+        name="lecture1_transcript-fr.pdf",
+        s3_key="test/path/lecture1_transcript-fr.pdf",
+        mime_type="application/pdf",
+    )
+    create_gdrive_resource_content(drive_file)
+    drive_file.refresh_from_db()
+    assert drive_file.resource.title == drive_file.name
+    mock_get_pdf_title.assert_not_called()
 
 
 def test_create_gdrive_resource_content_update(mock_get_s3_content_type):

--- a/gdrive_sync/api_test.py
+++ b/gdrive_sync/api_test.py
@@ -747,6 +747,26 @@ def test_create_gdrive_transcript_pdf_ignores_metadata_title(
     mock_get_pdf_title.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "name",
+    ["lecture1_Transcript-fr.pdf", "lecture1_TRANSCRIPT-fr.pdf"],
+)
+def test_create_gdrive_transcript_pdf_ignores_metadata_title_mixed_case(
+    mock_get_s3_content_type, mocker, name
+):
+    """The transcript filename check is case-insensitive."""
+    mock_get_pdf_title = mocker.patch("gdrive_sync.api.get_pdf_title")
+    drive_file = DriveFileFactory.create(
+        name=name,
+        s3_key=f"test/path/{name}",
+        mime_type="application/pdf",
+    )
+    create_gdrive_resource_content(drive_file)
+    drive_file.refresh_from_db()
+    assert drive_file.resource.title == drive_file.name
+    mock_get_pdf_title.assert_not_called()
+
+
 def test_create_gdrive_resource_content_update(mock_get_s3_content_type):
     """create_resource_from_gdrive should update a WebsiteContent object linked to a DriveFile object"""
     content = WebsiteContentFactory.create(file="test/path/old.doc")
@@ -759,6 +779,28 @@ def test_create_gdrive_resource_content_update(mock_get_s3_content_type):
     drive_file.refresh_from_db()
     assert content.file == drive_file.s3_key
     assert drive_file.resource == content
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["lecture1_transcript-fr.pdf", "lecture1_Transcript-fr.pdf"],
+)
+def test_create_gdrive_resource_content_update_transcript_pdf_ignores_metadata_title(
+    mock_get_s3_content_type, mocker, name
+):
+    """Updating a transcript PDF resource should not pick up its metadata title, case-insensitively."""
+    mock_get_pdf_title = mocker.patch("gdrive_sync.api.get_pdf_title")
+    content = WebsiteContentFactory.create(file="test/path/old.pdf", title="Old Title")
+    drive_file = DriveFileFactory.create(
+        website=content.website,
+        name=name,
+        s3_key=f"test/path/{name}",
+        resource=content,
+    )
+    create_gdrive_resource_content(drive_file)
+    content.refresh_from_db()
+    assert content.title == "Old Title"
+    mock_get_pdf_title.assert_not_called()
 
 
 def test_create_gdrive_resource_content_error(mocker):


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12336

### Description (What does it do?)
Fixes two related metadata bugs found while manually testing Studio's resource listing and video resource drawer against a real course, both traced to `gdrive_sync/api.py` (not `ocw-hugo-projects`, whose relation widget config is already correct).

**`get_resource_type()` misclassified `.vtt`/`.webvtt` as `Document` instead of `Other`.** Their S3 content_type starts with `"text"`, matching the generic document check before any caption-specific handling existed. The `ocw-hugo-projects` widget config filters `video_captions_resources` by `resourcetype=Other` and `video_transcript_resources` by `resourcetype=Document` server-side, so a misclassified caption was excluded from its own field's fetched options (the frontend can't resolve a title for it and falls back to displaying the raw UUID) while incorrectly matching the transcript field's filter (so vtt files showed up in the transcript list instead of captions).

**`create_gdrive_resource_content()` preferred a PDF's own internal `/Title` metadata over the Drive filename, for all PDFs.** Transcript PDFs across languages are frequently exported from the same source/template and share the same generic internal title, discarding the language/locale info the Drive filename carries. This was also why the resource listing page showed no file extension for PDF resources (the internal title has none) while mp4/vtt titles, which are the raw Drive filename, did.

This only fixes newly-synced files going forward. Existing data already has real breakage: 229 caption resources in local seeded content alone already carry the wrong `resourcetype`, and an unknown number of transcript PDFs already have generic non-distinguishing titles. A backfill migration to correct existing data is a separate follow-up, documented in the linked ticket but not yet scoped.

- `gdrive_sync/api.py`: `get_resource_type()` special-cases caption extensions before the generic document check; `create_gdrive_resource_content()` skips the internal-PDF-metadata title lookup for transcript-named files

### How can this be tested?
1. Switch to `umar/12336-gdrive-resource-metadata-fixes` branch
2. Upload a caption file (e.g. `lecture1_captions-en-US.vtt`) and a transcript file (e.g. `lecture1_transcript-en-US.pdf`) to a course's GDrive folder and sync
3. Open the video resource's edit drawer in Studio, confirm the caption appears under Video Captions Resources (not Transcript Resources) and displays its real title, not a UUID
4. Open the resource listing page, confirm the transcript resource's title includes the language (e.g. `lecture1_transcript-en-US.pdf`), not a generic title with no extension
5. Upload a second-language transcript for the same video (e.g. `lecture1_transcript-fr.pdf`) and confirm it gets a distinct title from the English one
