### PR TITLE
Add setting for SESSION_COOKIE_NAME

### DIFF
--- a/main/settings.py
+++ b/main/settings.py
@@ -190,6 +190,11 @@ if DEBUG:
     INSTALLED_APPS.append("nplusone.ext.django")
     MIDDLEWARE.append("nplusone.ext.django.NPlusOneMiddleware")
 
+SESSION_COOKIE_NAME = get_string(
+    name="SESSION_COOKIE_NAME",
+    default="sessionid",
+    description="Name of the Django session cookie",
+)
 SESSION_ENGINE = "django.contrib.sessions.backends.signed_cookies"
 
 LOGIN_REDIRECT_URL = "/"


### PR DESCRIPTION
### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->
Related to https://github.com/mitodl/ol-infrastructure/issues/5005

### Description (What does it do?)
<!--- Describe your changes in detail -->
This adds an environment variable setting for `SESSION_COOKIE_NAME` so that we can set it to a non-default value as a best-guess effort to fix the aforementioned issue.

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->
Set the variable and ensure your session is set on a cookie of that name