### PR TITLE
fix: convert url_path-relative orphan paths to their s3_path storage key

### DIFF
--- a/websites/management/commands/backfill_orphaned_caption_transcript_files.py
+++ b/websites/management/commands/backfill_orphaned_caption_transcript_files.py
@@ -46,17 +46,24 @@ class Command(WebsiteFilterCommand):
        caption/transcript was ever set for this video. The key is simply
        removed, there is nothing to back-fill.
 
-    2. Non-empty orphan _file path: if a WebsiteContent resource already
-       points at this exact S3 key (e.g. created by a later sync or manual
-       remediation after migration 0074 ran), that resource is reused rather
-       than creating a duplicate. Otherwise, the referenced S3 object may
-       still exist even though no WebsiteContent record was ever created for
-       it (e.g. content uploaded directly to S3 outside of the GDrive/3Play
-       pipelines, using a Google Drive file ID as the filename); if so, a new
-       WebsiteContent resource is created for it, named after the video's own
-       filename (truncated as needed to fit the filename length limit)
-       rather than the orphan path's filename, since the orphan path is often
-       an opaque identifier. If the S3 object no longer exists, the _file
+    2. Non-empty orphan _file path: the stored path is relative to the
+       *publish* bucket (prefixed by the website's url_path), while
+       WebsiteContent.file and the storage bucket are keyed relative to the
+       website's s3_path (site_config.root_url_path + website.name). When
+       url_path differs from s3_path, the path is converted to its storage
+       key before any lookup, mirroring the same swap WebsiteContent.
+       full_metadata does in reverse when generating the published path. If
+       a WebsiteContent resource already points at that storage key (e.g.
+       created by a later sync or manual remediation after migration 0074
+       ran), that resource is reused rather than creating a duplicate.
+       Otherwise, the referenced S3 object may still exist even though no
+       WebsiteContent record was ever created for it (e.g. content uploaded
+       directly to S3 outside of the GDrive/3Play pipelines, using a Google
+       Drive file ID as the filename); if so, a new WebsiteContent resource
+       is created for it, named after the video's own filename (truncated as
+       needed to fit the filename length limit) rather than the orphan
+       path's filename, since the orphan path is often an opaque identifier.
+       If the S3 object no longer exists under the storage key, the _file
        path is left in place for manual inspection. Either way, the resolved
        resource's id is appended to the resource field's existing content
        list without dropping an already-linked id, whether that existing
@@ -74,6 +81,25 @@ class Command(WebsiteFilterCommand):
         """Truncate base so f"{base}{suffix}" fits within max_length."""
         max_base_len = max_length - len(suffix)
         return f"{base[:max_base_len]}{suffix}"
+
+    @staticmethod
+    def _to_storage_key(website, path):
+        """Convert a url_path-relative orphan path to its s3_path storage key.
+
+        Mirrors WebsiteContent.full_metadata's equivalent swap in reverse.
+        Leaves the path unchanged if the swap can't be determined (no
+        starter, so s3_path can't be computed) or doesn't apply (no
+        url_path, prefixes already match, or the path doesn't actually
+        start with url_path).
+        """
+        key = path.lstrip("/")
+        url_path = website.url_path
+        if not url_path or website.starter is None:
+            return key
+        s3_path = website.s3_path
+        if s3_path != url_path and key.startswith(url_path):
+            key = s3_path + key[len(url_path) :]
+        return key
 
     def _resolve_or_create_resource(self, content, key, path, suffix, resourcetype):
         """Find a resource already pointing at this S3 key, or create one.
@@ -173,7 +199,7 @@ class Command(WebsiteFilterCommand):
             # or manual remediation after migration 0074 ran) instead of
             # creating a duplicate; otherwise verify the object still exists
             # in S3 and create a new resource for it.
-            key = path.lstrip("/")
+            key = self._to_storage_key(content.website, path)
             resource = self._resolve_or_create_resource(
                 content, key, path, suffix, resourcetype
             )
@@ -214,8 +240,17 @@ class Command(WebsiteFilterCommand):
                 metadata__resourcetype="Video",
                 metadata__video_files__isnull=False,
             )
-            .select_related("website")
-            .only("id", "filename", "dirpath", "title", "metadata", "website__name")
+            .select_related("website", "website__starter")
+            .only(
+                "id",
+                "filename",
+                "dirpath",
+                "title",
+                "metadata",
+                "website__name",
+                "website__url_path",
+                "website__starter__config",
+            )
         )
 
         # Not a small, curated set: this matches every video with a

--- a/websites/management/commands/backfill_orphaned_caption_transcript_files_test.py
+++ b/websites/management/commands/backfill_orphaned_caption_transcript_files_test.py
@@ -95,6 +95,172 @@ def test_creates_resource_for_existing_s3_object(mock_s3):
     assert created.metadata["file"] == f"/{caption_key}"
 
 
+def test_converts_url_path_relative_orphan_to_storage_key(mock_s3):
+    """An orphan path stored relative to url_path is looked up via s3_path.
+
+    Regression test for hq#12436: the legacy _file path is relative to the
+    publish bucket (prefixed by url_path), not the storage bucket (prefixed
+    by s3_path). When the two differ, the raw path must be converted before
+    any S3 lookup or resource creation, or an object that genuinely exists
+    gets reported as missing and left orphaned.
+    """
+    website = WebsiteFactory.create()
+    assert website.url_path != website.s3_path  # sanity: factory defaults differ
+
+    storage_key = f"{website.s3_path}/1AbCdEf_transcript.webvtt"
+    mock_s3.put_object(Key=storage_key, Body=b"WEBVTT")
+
+    orphan_path = f"/{website.url_path}/1AbCdEf_transcript.webvtt"
+    video = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_mp4",
+        dirpath="content/resources",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {"video_captions_file": orphan_path},
+        },
+    )
+
+    output = _run()
+
+    assert "Skipping missing S3 object" not in output
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    assert "video_captions_file" not in vf
+    resources = vf["video_captions_resources"]
+    assert len(resources["content"]) == 1
+
+    created = WebsiteContent.objects.get(text_id=resources["content"][0])
+    assert created.file.name == storage_key
+    assert created.metadata["file"] == orphan_path
+
+
+def test_reuses_existing_resource_via_corrected_storage_key(mock_s3):
+    """An orphan path resolves to an existing resource keyed by s3_path.
+
+    Same hq#12436 scenario as above, but the resource already exists (e.g.
+    created by a prior GDrive sync, which always keys new uploads by
+    s3_path) rather than needing to be created fresh.
+    """
+    website = WebsiteFactory.create()
+    storage_key = f"{website.s3_path}/1AbCdEf_transcript.webvtt"
+    already_linked = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_mp4_captions",
+        file=storage_key,
+    )
+
+    orphan_path = f"/{website.url_path}/1AbCdEf_transcript.webvtt"
+    video = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_mp4",
+        dirpath="content/resources",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {"video_captions_file": orphan_path},
+        },
+    )
+
+    _run()
+
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    assert "video_captions_file" not in vf
+    resources = vf["video_captions_resources"]
+    assert resources["content"] == [str(already_linked.text_id)]
+    assert WebsiteContent.objects.filter(website=website, file=storage_key).count() == 1
+
+
+def test_no_key_swap_when_url_path_unset(mock_s3):
+    """No prefix swap is attempted when the website has no url_path set."""
+    website = WebsiteFactory.create(url_path=None)
+    storage_key = f"{website.s3_path}/1AbCdEf_transcript.webvtt"
+    mock_s3.put_object(Key=storage_key, Body=b"WEBVTT")
+
+    video = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_mp4",
+        dirpath="content/resources",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {"video_captions_file": f"/{storage_key}"},
+        },
+    )
+
+    _run()
+
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    assert "video_captions_file" not in vf
+    resources = vf["video_captions_resources"]
+    created = WebsiteContent.objects.get(text_id=resources["content"][0])
+    assert created.file.name == storage_key
+
+
+def test_no_key_swap_when_starter_is_none(mock_s3):
+    """The swap is skipped, not crashed, when the website has no starter.
+
+    s3_path can't be computed without a starter's site config, so the raw
+    path is used as-is rather than raising.
+    """
+    website = WebsiteFactory.create(starter=None, url_path="courses/some-path")
+    raw_key = f"{website.url_path}/1AbCdEf_transcript.webvtt"
+    mock_s3.put_object(Key=raw_key, Body=b"WEBVTT")
+
+    video = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_mp4",
+        dirpath="content/resources",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {"video_captions_file": f"/{raw_key}"},
+        },
+    )
+
+    _run()
+
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    assert "video_captions_file" not in vf
+    resources = vf["video_captions_resources"]
+    created = WebsiteContent.objects.get(text_id=resources["content"][0])
+    assert created.file.name == raw_key
+
+
+def test_no_key_swap_when_url_path_not_a_prefix(mock_s3):
+    """The swap only applies when url_path is the actual leading prefix.
+
+    Regression test: a naive substring replace could corrupt a path where
+    url_path's value happens to appear later in the string (e.g. embedded in
+    an opaque legacy filename) even though the path is already s3_path-
+    relative and was never url_path-relative to begin with.
+    """
+    website = WebsiteFactory.create()
+    storage_key = (
+        f"{website.s3_path}/backup-of-{website.url_path}-file_transcript.webvtt"
+    )
+    mock_s3.put_object(Key=storage_key, Body=b"WEBVTT")
+
+    video = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_mp4",
+        dirpath="content/resources",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {"video_transcript_file": f"/{storage_key}"},
+        },
+    )
+
+    _run()
+
+    video.refresh_from_db()
+    vf = video.metadata["video_files"]
+    assert "video_transcript_file" not in vf
+    resources = vf["video_transcript_resources"]
+    created = WebsiteContent.objects.get(text_id=resources["content"][0])
+    assert created.file.name == storage_key
+
+
 def test_skips_missing_s3_object(mock_s3):
     """A real orphan path whose S3 object no longer exists is left untouched."""
     website = WebsiteFactory.create()


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12436

### Description (What does it do?)
Fixes a bucket-prefix mismatch in `backfill_orphaned_caption_transcript_files`: the legacy `video_captions_file`/`video_transcript_file` paths stored on video resources are relative to the *publish* bucket (prefixed by the website's `url_path`), but the command looked them up directly against the *storage* bucket (`settings.AWS_STORAGE_BUCKET_NAME`), which is keyed by `website.s3_path` (`site_config.root_url_path + website.name`) instead. Whenever `url_path != s3_path` for a site, the raw lookup used the wrong prefix, the S3 existence check failed, and a file that genuinely existed got reported as "missing" and left orphaned.

Confirmed against a local clone of real data that this isn't an edge case: 227 of 2906 websites have `url_path != s3_path`, and those sites account for 1570 of 2044 (77%) currently-orphaned caption/transcript entries, concentrated in 44 sites. Also confirmed the fix direction against real data: sampled 15 already-linked (working) caption/transcript resources across 3 different mismatched sites, all keyed by `s3_path`, none by `url_path`.

- `websites/management/commands/backfill_orphaned_caption_transcript_files.py`: new `Command._to_storage_key(website, path)` converts the orphan path's prefix from `url_path` to `s3_path` (mirroring `WebsiteContent.full_metadata`'s equivalent swap in reverse) before the S3 existence check, the existing-resource lookup, and the new resource's `file` field, while `metadata["file"]` (what gets published) keeps the original `url_path`-relative path. Falls back to the raw path unchanged if the site has no `starter` (so `s3_path` can't be computed) or the path doesn't actually start with `url_path` (avoids a naive substring replace corrupting an already-correct key that happens to contain `url_path`'s value elsewhere, e.g. in an opaque legacy filename). Widened the main queryset's `select_related`/`.only()` to include `website__starter__config`/`website__url_path`, verified no extra query added at scale.
- `websites/management/commands/backfill_orphaned_caption_transcript_files_test.py`: 5 new tests covering the mismatch conversion, reuse via the corrected key, no swap when `url_path` is unset, no crash when `starter` is `None`, and no corruption when `url_path`'s value isn't actually the path's prefix.

### How can this be tested?
1. Switch to `umar/12436-fix-backfill-s3-key-prefix-mismatch` branch
2. Run `docker compose exec web python manage.py backfill_orphaned_caption_transcript_files` against a database with a video resource whose `url_path` differs from its `s3_path`, with an orphaned `video_captions_file`/`video_transcript_file` path pointing at a real S3 object stored under the `s3_path` prefix. Confirm it's no longer reported as "missing" and the resource is correctly created/linked, with `metadata["file"]` still showing the original `url_path`-relative path.
3. Run against a site with no `url_path`/`s3_path` mismatch and confirm behavior is unchanged from before.
4. Run with `--filter <website-name>` and confirm only that website's videos are processed.

Note: this only fixes the lookup going forward. Any site already affected by a prior run of this command should also have `backpopulate_referencing_content` run afterward, to repair `referencing_content` for anything that command's earlier (pre-existing, unrelated to this PR) run already created.