### PR TITLE
fix: skip 3Play sync when an English caption/transcript is already linked under another naming convention

### DIFF
--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -33,14 +33,11 @@ from gdrive_sync.utils import get_gdrive_file, get_resource_name
 from main.celery import app
 from main.constants import STATUS_CREATED
 from main.s3_utils import get_boto3_resource
-from main.utils import get_file_extension
 from videos import threeplay_api
 from videos.constants import (
     ARCHIVE_URL_FILESIZE_TASK_RATE_LIMIT,
-    CAPTION_FILE_EXTENSIONS,
     DESTINATION_YOUTUBE,
     S3_FILESIZE_TASK_RATE_LIMIT,
-    TRANSCRIPT_FILE_EXTENSIONS,
     YT_THUMBNAIL_IMG,
     YTAGS_BATCH_LOCK_TTL,
     VideoFileStatus,
@@ -330,25 +327,6 @@ def delete_s3_objects(
             obj.delete()
 
 
-def _find_by_filename_prefix(website, prefix, extensions):
-    """Find WebsiteContent resources by filename prefix and real file extension.
-
-    Matches Video.caption_transcript_resources()'s own candidate search: the
-    real uploaded file's extension is used rather than the filename's tail,
-    since find_available_name can append a bare digit to a colliding
-    filename (e.g. "..._vtt" -> "..._vtt2"), which would defeat an exact
-    suffix match.
-    """
-    candidates = WebsiteContent.objects.filter(
-        website=website, filename__startswith=prefix
-    )
-    return [
-        r
-        for r in candidates
-        if r.file and get_file_extension(r.file.name) in extensions
-    ]
-
-
 def _has_english_resource(resources):
     """Return True if any resource resolves to English via its real file path.
 
@@ -385,28 +363,18 @@ def update_transcripts_for_video(video_id: int):  # noqa: C901, PLR0912
         )
         video_resources = list(website.websitecontent_set.filter(**search_fields))
 
-    # A one-off backfill command can create/link resources named after the
-    # video's own (unstripped) filename rather than the base-stem convention
-    # caption_transcript_resources() searches for -- search that convention
-    # too, so such a resource is visible to the English-availability check
-    # below, without being folded into captions_list/transcripts_list
-    # themselves (those still drive the _resources sync further down, which
-    # should stay scoped to the base-stem convention it already understands).
-    backfill_captions = []
-    backfill_transcripts = []
-    for video_resource in video_resources:
-        backfill_captions += _find_by_filename_prefix(
-            website, f"{video_resource.filename}_captions", CAPTION_FILE_EXTENSIONS
-        )
-        backfill_transcripts += _find_by_filename_prefix(
-            website, f"{video_resource.filename}_transcript", TRANSCRIPT_FILE_EXTENSIONS
-        )
-
+    # Only the language check is new here: every process that creates a
+    # caption/transcript resource (GDrive ingestion, 3Play's own sync, the
+    # one-off orphan backfill) names it with the "{base_stem}_captions" /
+    # "{base_stem}_transcript" convention that caption_transcript_resources()
+    # already searches, so no extra lookup is needed to see them. A
+    # French/Spanish/etc resource must not count as coverage, though, since
+    # 3Play only ever supplies English.
     has_threeplay_update = (
         False
         if (
-            _has_english_resource([*captions_list, *backfill_captions])
-            or _has_english_resource([*transcripts_list, *backfill_transcripts])
+            _has_english_resource(captions_list)
+            or _has_english_resource(transcripts_list)
         )
         else threeplay_api.update_transcripts_for_video(video)
     )

--- a/videos/tasks.py
+++ b/videos/tasks.py
@@ -33,11 +33,14 @@ from gdrive_sync.utils import get_gdrive_file, get_resource_name
 from main.celery import app
 from main.constants import STATUS_CREATED
 from main.s3_utils import get_boto3_resource
+from main.utils import get_file_extension
 from videos import threeplay_api
 from videos.constants import (
     ARCHIVE_URL_FILESIZE_TASK_RATE_LIMIT,
+    CAPTION_FILE_EXTENSIONS,
     DESTINATION_YOUTUBE,
     S3_FILESIZE_TASK_RATE_LIMIT,
+    TRANSCRIPT_FILE_EXTENSIONS,
     YT_THUMBNAIL_IMG,
     YTAGS_BATCH_LOCK_TTL,
     VideoFileStatus,
@@ -54,6 +57,7 @@ from videos.threeplay_sync import link_threeplay_files_as_resources
 from videos.utils import (
     create_new_content,
     fetch_youtube_snippets,
+    parse_caption_language_locale,
     process_video_tags,
 )
 from videos.youtube import (
@@ -326,6 +330,40 @@ def delete_s3_objects(
             obj.delete()
 
 
+def _find_by_filename_prefix(website, prefix, extensions):
+    """Find WebsiteContent resources by filename prefix and real file extension.
+
+    Matches Video.caption_transcript_resources()'s own candidate search: the
+    real uploaded file's extension is used rather than the filename's tail,
+    since find_available_name can append a bare digit to a colliding
+    filename (e.g. "..._vtt" -> "..._vtt2"), which would defeat an exact
+    suffix match.
+    """
+    candidates = WebsiteContent.objects.filter(
+        website=website, filename__startswith=prefix
+    )
+    return [
+        r
+        for r in candidates
+        if r.file and get_file_extension(r.file.name) in extensions
+    ]
+
+
+def _has_english_resource(resources):
+    """Return True if any resource resolves to English via its real file path.
+
+    3Play only ever provides an English transcript/caption (see
+    videos.threeplay_sync.link_threeplay_files_as_resources), so only an
+    existing English resource should gate a 3Play fetch -- an existing
+    French/Spanish/etc resource must not block fetching the English one.
+    """
+    return any(
+        parse_caption_language_locale(r.file.name)[0] == "en"
+        for r in resources
+        if r.file
+    )
+
+
 @app.task(acks_late=True)
 @single_task(
     timeout=settings.UPDATE_TAGGED_3PLAY_TRANSCRIPT_FREQUENCY, raise_block=False
@@ -334,9 +372,42 @@ def update_transcripts_for_video(video_id: int):  # noqa: C901, PLR0912
     """Update transcripts for a video"""
     video = Video.objects.get(id=video_id)
     captions_list, transcripts_list = video.caption_transcript_resources()
+
+    website = video.website
+    video_resources = []
+    if is_ocw_site(website):
+        search_fields = {}
+        search_fields[get_dict_query_field("metadata", settings.FIELD_RESOURCETYPE)] = (
+            RESOURCE_TYPE_VIDEO
+        )
+        search_fields[get_dict_query_field("metadata", settings.YT_FIELD_ID)] = (
+            video.youtube_id()
+        )
+        video_resources = list(website.websitecontent_set.filter(**search_fields))
+
+    # A one-off backfill command can create/link resources named after the
+    # video's own (unstripped) filename rather than the base-stem convention
+    # caption_transcript_resources() searches for -- search that convention
+    # too, so such a resource is visible to the English-availability check
+    # below, without being folded into captions_list/transcripts_list
+    # themselves (those still drive the _resources sync further down, which
+    # should stay scoped to the base-stem convention it already understands).
+    backfill_captions = []
+    backfill_transcripts = []
+    for video_resource in video_resources:
+        backfill_captions += _find_by_filename_prefix(
+            website, f"{video_resource.filename}_captions", CAPTION_FILE_EXTENSIONS
+        )
+        backfill_transcripts += _find_by_filename_prefix(
+            website, f"{video_resource.filename}_transcript", TRANSCRIPT_FILE_EXTENSIONS
+        )
+
     has_threeplay_update = (
         False
-        if captions_list or transcripts_list
+        if (
+            _has_english_resource([*captions_list, *backfill_captions])
+            or _has_english_resource([*transcripts_list, *backfill_transcripts])
+        )
         else threeplay_api.update_transcripts_for_video(video)
     )
     if not captions_list and not transcripts_list and not has_threeplay_update:
@@ -350,17 +421,8 @@ def update_transcripts_for_video(video_id: int):  # noqa: C901, PLR0912
         if has_threeplay_update:
             first_transcript_download = True
 
-    website = video.website
-    if is_ocw_site(website):  # pylint: disable=too-many-nested-blocks
-        search_fields = {}
-        search_fields[get_dict_query_field("metadata", settings.FIELD_RESOURCETYPE)] = (
-            RESOURCE_TYPE_VIDEO
-        )
-        search_fields[get_dict_query_field("metadata", settings.YT_FIELD_ID)] = (
-            video.youtube_id()
-        )
-
-        for video_resource in website.websitecontent_set.filter(**search_fields):
+    if video_resources:  # pylint: disable=too-many-nested-blocks
+        for video_resource in video_resources:
             if has_threeplay_update:
                 # Create resources from the downloaded 3Play files and link
                 # them via the _resources relation fields. The legacy _file

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -912,17 +912,14 @@ def test_update_transcripts_for_video_no_3play(
 
 
 def test_update_transcripts_for_video_no_3play_for_backfill_naming_convention(mocker):
-    """Avoid calling 3play when an English resource matches the backfill's
-    own naming convention, even though caption_transcript_resources()'s
-    filename-prefix search (base-stem convention) doesn't find it.
+    """Avoid calling 3play when the orphan backfill already created an English
+    transcript for the video.
 
-    Regression test: a one-off backfill command names created resources
-    after the video's own (unstripped) filename plus a suffix -- e.g. a
-    video named "lecture1_mp4" gets a resource "lecture1_mp4_transcript" --
-    which does not match the base-stem prefix "lecture1_transcript" that
-    caption_transcript_resources() searches for. update_transcripts_for_video
-    must search that second convention directly to recognize this and skip
-    the redundant 3Play fetch.
+    Regression test for the duplicate-resource bug: the backfill names what
+    it creates with the same "{base_stem}_transcript_{ext}" convention GDrive
+    ingestion uses, so caption_transcript_resources() discovers it and 3Play
+    is skipped. Naming it any other way (e.g. off the video's full, unstripped
+    filename) made it invisible here and produced a second English transcript.
     """
     mocker.patch("videos.tasks.is_ocw_site", return_value=True)
 
@@ -933,12 +930,13 @@ def test_update_transcripts_for_video_no_3play_for_backfill_naming_convention(mo
     resource = WebsiteContentFactory.create(website=video.website, metadata={})
     metadata = resource.metadata
 
-    # Matches {resource.filename}_transcript -- the backfill command's own
-    # naming convention -- not {get_base_filename(resource.filename)}_transcript.
+    # What the backfill creates: named off the video's base stem, while the
+    # file itself keeps the orphan's opaque S3 key.
+    base_stem = get_base_filename(resource.filename)
     linked_transcript = WebsiteContentFactory.create(
         website=video.website,
-        filename=f"{resource.filename}_transcript_pdf",
-        file=f"{resource.website.s3_path}/{resource.filename}_transcript.pdf",
+        filename=f"{base_stem}_transcript_pdf",
+        file=f"{resource.website.s3_path}/1AbCdEf_transcript.pdf",
     )
 
     set_dict_field(metadata, settings.FIELD_RESOURCETYPE, RESOURCE_TYPE_VIDEO)
@@ -953,11 +951,10 @@ def test_update_transcripts_for_video_no_3play_for_backfill_naming_convention(mo
     )
     resource.save()
 
-    # Confirm the base-stem filename-prefix search alone would NOT find it
-    # (the gap this test exists for).
-    captions_list, transcripts_list = video.caption_transcript_resources()
-    assert captions_list == []
-    assert transcripts_list == []
+    # The base-stem search finds it, which is the point of matching the
+    # convention rather than teaching the gate about a second one.
+    _, transcripts_list = video.caption_transcript_resources()
+    assert transcripts_list == [linked_transcript]
 
     mock_3play = mocker.patch("videos.tasks.threeplay_api.update_transcripts_for_video")
 

--- a/videos/tasks_test.py
+++ b/videos/tasks_test.py
@@ -911,6 +911,107 @@ def test_update_transcripts_for_video_no_3play(
     )
 
 
+def test_update_transcripts_for_video_no_3play_for_backfill_naming_convention(mocker):
+    """Avoid calling 3play when an English resource matches the backfill's
+    own naming convention, even though caption_transcript_resources()'s
+    filename-prefix search (base-stem convention) doesn't find it.
+
+    Regression test: a one-off backfill command names created resources
+    after the video's own (unstripped) filename plus a suffix -- e.g. a
+    video named "lecture1_mp4" gets a resource "lecture1_mp4_transcript" --
+    which does not match the base-stem prefix "lecture1_transcript" that
+    caption_transcript_resources() searches for. update_transcripts_for_video
+    must search that second convention directly to recognize this and skip
+    the redundant 3Play fetch.
+    """
+    mocker.patch("videos.tasks.is_ocw_site", return_value=True)
+
+    videofile = VideoFileFactory.create(
+        destination=DESTINATION_YOUTUBE, destination_id="expected_id"
+    )
+    video = videofile.video
+    resource = WebsiteContentFactory.create(website=video.website, metadata={})
+    metadata = resource.metadata
+
+    # Matches {resource.filename}_transcript -- the backfill command's own
+    # naming convention -- not {get_base_filename(resource.filename)}_transcript.
+    linked_transcript = WebsiteContentFactory.create(
+        website=video.website,
+        filename=f"{resource.filename}_transcript_pdf",
+        file=f"{resource.website.s3_path}/{resource.filename}_transcript.pdf",
+    )
+
+    set_dict_field(metadata, settings.FIELD_RESOURCETYPE, RESOURCE_TYPE_VIDEO)
+    set_dict_field(metadata, settings.YT_FIELD_ID, "expected_id")
+    set_dict_field(
+        metadata,
+        settings.YT_FIELD_TRANSCRIPT_RESOURCES,
+        {
+            "content": [str(linked_transcript.text_id)],
+            "website": video.website.name,
+        },
+    )
+    resource.save()
+
+    # Confirm the base-stem filename-prefix search alone would NOT find it
+    # (the gap this test exists for).
+    captions_list, transcripts_list = video.caption_transcript_resources()
+    assert captions_list == []
+    assert transcripts_list == []
+
+    mock_3play = mocker.patch("videos.tasks.threeplay_api.update_transcripts_for_video")
+
+    update_transcripts_for_video(video.id)
+
+    mock_3play.assert_not_called()
+
+
+def test_update_transcripts_for_video_still_fetches_english_when_only_french_linked(
+    mocker,
+):
+    """A French-only _resources entry must not block fetching the English one.
+
+    Regression test for a stricter, over-eager version of the "already
+    linked" check that treated any existing entry -- regardless of language
+    -- as reason to skip 3Play. 3Play only ever supplies an English
+    transcript/caption, so an existing French one must not prevent it.
+    """
+    mocker.patch("videos.tasks.is_ocw_site", return_value=True)
+
+    videofile = VideoFileFactory.create(
+        destination=DESTINATION_YOUTUBE, destination_id="expected_id"
+    )
+    video = videofile.video
+    resource = WebsiteContentFactory.create(website=video.website, metadata={})
+    metadata = resource.metadata
+
+    french_transcript = WebsiteContentFactory.create(
+        website=video.website,
+        filename=f"{resource.filename}_transcript-fr_pdf",
+        file=f"{resource.website.s3_path}/{resource.filename}_transcript-fr.pdf",
+    )
+
+    set_dict_field(metadata, settings.FIELD_RESOURCETYPE, RESOURCE_TYPE_VIDEO)
+    set_dict_field(metadata, settings.YT_FIELD_ID, "expected_id")
+    set_dict_field(
+        metadata,
+        settings.YT_FIELD_TRANSCRIPT_RESOURCES,
+        {
+            "content": [str(french_transcript.text_id)],
+            "website": video.website.name,
+        },
+    )
+    resource.save()
+
+    mock_3play = mocker.patch(
+        "videos.tasks.threeplay_api.update_transcripts_for_video", return_value=False
+    )
+
+    update_transcripts_for_video(video.id)
+
+    mock_3play.assert_called_once_with(video)
+
+
 @pytest.mark.django_db
 def test_update_transcripts_for_video_multi_language_with_locale(mocker):
     """All language variants matching the dash convention are linked via _resources."""

--- a/videos/threeplay_sync.py
+++ b/videos/threeplay_sync.py
@@ -11,7 +11,11 @@ from main.s3_utils import get_boto3_resource
 from main.utils import get_base_filename, get_dirpath_and_filename, get_file_extension
 from videos.constants import PDF_FORMAT_ID, WEBVTT_FORMAT_ID
 from videos.threeplay_api import fetch_file, threeplay_transcript_api_request
-from videos.utils import generate_s3_path, get_content_dirpath
+from videos.utils import (
+    generate_s3_path,
+    get_content_dirpath,
+    parse_caption_language_locale,
+)
 from websites.api import sync_website_content_references
 from websites.models import WebsiteContent
 
@@ -70,21 +74,39 @@ def _append_resource_to_video_files(
         vf[resource_field] = {"content": [text_id], "website": video.website.name}
 
 
+def _resolved_language(resource: WebsiteContent) -> str | None:
+    """Return a linked resource's resolved language, or None if unresolvable.
+
+    Prefers the resource's real uploaded file path (immune to a
+    find_available_name collision suffix on the filename field), falling
+    back to the filename when no file has been set yet.
+    """
+    file_name = resource.file.name if resource.file else resource.filename
+    return parse_caption_language_locale(file_name)[0] if file_name else None
+
+
 def _threeplay_resource_already_linked(
-    video: WebsiteContent, resource_field: str, filename_prefix: str
+    video: WebsiteContent, resource_field: str
 ) -> bool:
-    """Return True if the 3Play-generated resource is already in the content list."""
+    """Return True if an English resource is already linked in the content list.
+
+    Checked by resolved language rather than by filename convention, so a
+    resource linked by GDrive, a one-off backfill command, or 3Play's own
+    youtube-id-based naming are all recognized equally -- only the language
+    actually matters here, since 3Play only ever supplies an English
+    transcript/caption. An existing French/Spanish/etc entry must not block
+    fetching the English one.
+    """
     existing_content = (
         video.metadata["video_files"].get(resource_field, {}).get("content") or []
     )
-    return bool(
-        isinstance(existing_content, list)
-        and existing_content
-        and WebsiteContent.objects.filter(
-            website=video.website,
-            text_id__in=existing_content,
-            filename__startswith=filename_prefix,
-        ).exists()
+    if not isinstance(existing_content, list) or not existing_content:
+        return False
+    return any(
+        _resolved_language(resource) == "en"
+        for resource in WebsiteContent.objects.filter(
+            website=video.website, text_id__in=existing_content
+        )
     )
 
 
@@ -99,9 +121,7 @@ def _attach_transcript_if_missing(
     Attach transcript to video if it does not exist.
     Fetches from 3Play API and updates the video metadata.
     """
-    if _threeplay_resource_already_linked(
-        video, "video_transcript_resources", f"{youtube_id}_transcript"
-    ):
+    if _threeplay_resource_already_linked(video, "video_transcript_resources"):
         return
 
     pdf_url = base_url + f"&format_id={PDF_FORMAT_ID}"
@@ -140,9 +160,7 @@ def _attach_captions_if_missing(
     Attach captions to video if it does not exist.
     Fetches from 3Play API and updates the video metadata.
     """
-    if _threeplay_resource_already_linked(
-        video, "video_captions_resources", f"{youtube_id}_captions"
-    ):
+    if _threeplay_resource_already_linked(video, "video_captions_resources"):
         return
 
     webvtt_url = base_url + f"&format_id={WEBVTT_FORMAT_ID}"

--- a/videos/threeplay_sync.py
+++ b/videos/threeplay_sync.py
@@ -100,6 +100,8 @@ def _threeplay_resource_already_linked(
     existing_content = (
         video.metadata["video_files"].get(resource_field, {}).get("content") or []
     )
+    if isinstance(existing_content, str):
+        existing_content = [existing_content]
     if not isinstance(existing_content, list) or not existing_content:
         return False
     return any(

--- a/videos/threeplay_sync_test.py
+++ b/videos/threeplay_sync_test.py
@@ -118,22 +118,22 @@ def test_sync_video_captions_and_transcripts_skips_for_non_3play_naming_conventi
     even if it doesn't match 3Play's own {youtube_id}_transcript/_captions
     filename convention.
 
-    Regression test: a resource created by a one-off backfill command (or
-    GDrive) uses a different naming convention than 3Play's own
-    youtube-id-based one. The guard must recognize it by resolved language,
-    not by filename pattern, or it would fetch and link a redundant second
-    English resource.
+    Regression test: a resource created by GDrive ingestion (or by the
+    orphan backfill, which follows the same convention) is named after the
+    video's base stem, not 3Play's youtube id. The guard must recognize it
+    by resolved language, not by filename pattern, or it would fetch and
+    link a redundant second English resource.
     """
     starter = WebsiteStarterFactory.create(slug="ocw-course-v2")
     website = WebsiteFactory.create(starter=starter)
     transcript_resource = WebsiteContentFactory.create(
         website=website,
-        filename="lecture1_mp4_transcript",
+        filename="lecture1_transcript_pdf",
         file=f"courses/{website.name}/1AbCdEf_transcript.pdf",
     )
     captions_resource = WebsiteContentFactory.create(
         website=website,
-        filename="lecture1_mp4_captions",
+        filename="lecture1_captions_vtt",
         file=f"courses/{website.name}/1AbCdEf_captions.vtt",
     )
     video = WebsiteContentFactory.create(
@@ -181,12 +181,12 @@ def test_sync_video_captions_and_transcripts_skips_for_scalar_string_content(
     website = WebsiteFactory.create(starter=starter)
     transcript_resource = WebsiteContentFactory.create(
         website=website,
-        filename="lecture1_mp4_transcript",
+        filename="lecture1_transcript_pdf",
         file=f"courses/{website.name}/1AbCdEf_transcript.pdf",
     )
     captions_resource = WebsiteContentFactory.create(
         website=website,
-        filename="lecture1_mp4_captions",
+        filename="lecture1_captions_vtt",
         file=f"courses/{website.name}/1AbCdEf_captions.vtt",
     )
     video = WebsiteContentFactory.create(

--- a/videos/threeplay_sync_test.py
+++ b/videos/threeplay_sync_test.py
@@ -111,21 +111,77 @@ def test_sync_video_captions_and_transcripts_skips_if_resource_exists(mocker):
     fetch_file_mock.assert_not_called()
 
 
+def test_sync_video_captions_and_transcripts_skips_for_non_3play_naming_convention(
+    mocker,
+):
+    """3Play sync skips fetching when an English resource is already linked,
+    even if it doesn't match 3Play's own {youtube_id}_transcript/_captions
+    filename convention.
+
+    Regression test: a resource created by a one-off backfill command (or
+    GDrive) uses a different naming convention than 3Play's own
+    youtube-id-based one. The guard must recognize it by resolved language,
+    not by filename pattern, or it would fetch and link a redundant second
+    English resource.
+    """
+    starter = WebsiteStarterFactory.create(slug="ocw-course-v2")
+    website = WebsiteFactory.create(starter=starter)
+    transcript_resource = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_mp4_transcript",
+        file=f"courses/{website.name}/1AbCdEf_transcript.pdf",
+    )
+    captions_resource = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_mp4_captions",
+        file=f"courses/{website.name}/1AbCdEf_captions.vtt",
+    )
+    video = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        metadata={
+            "resourcetype": "Video",
+            "video_metadata": {"youtube_id": "yt789"},
+            "video_files": {
+                "video_captions_resources": {
+                    "content": [str(captions_resource.text_id)],
+                    "website": website.name,
+                },
+                "video_transcript_resources": {
+                    "content": [str(transcript_resource.text_id)],
+                    "website": website.name,
+                },
+            },
+        },
+    )
+
+    mocker.patch(
+        "videos.threeplay_sync.threeplay_transcript_api_request",
+        return_value={"data": [{"status": "complete", "id": 11, "media_file_id": 22}]},
+    )
+    fetch_file_mock = mocker.patch("videos.threeplay_sync.fetch_file")
+
+    sync_video_captions_and_transcripts(video)
+
+    fetch_file_mock.assert_not_called()
+
+
 def test_sync_video_captions_and_transcripts_appends_english_when_other_languages_exist(
     mocker,
 ):
     """3Play adds English even when other-language entries already exist from GDrive."""
     starter = WebsiteStarterFactory.create(slug="ocw-course-v2")
     website = WebsiteFactory.create(starter=starter)
-    # Simulate GDrive having already linked French caption/transcript resources.
-    # These use filenames that don't match the 3Play pattern, so the guard won't fire.
+    # Simulate GDrive having already linked French caption/transcript
+    # resources. The "-fr" suffix resolves to French, not English, so the
+    # guard must not treat these as already covering the 3Play fetch.
     fr_caption = WebsiteContentFactory.create(
         website=website,
-        filename="lecture1_captions_fr_vtt",
+        filename="lecture1_captions-fr_vtt",
     )
     fr_transcript = WebsiteContentFactory.create(
         website=website,
-        filename="lecture1_transcript_fr_pdf",
+        filename="lecture1_transcript-fr_pdf",
     )
     video = WebsiteContentFactory.create(
         website=website,
@@ -228,11 +284,11 @@ def test_sync_video_captions_and_transcripts_appends_to_scalar_string_content(mo
     website = WebsiteFactory.create(starter=starter)
     fr_caption = WebsiteContentFactory.create(
         website=website,
-        filename="lecture1_captions_fr_vtt",
+        filename="lecture1_captions-fr_vtt",
     )
     fr_transcript = WebsiteContentFactory.create(
         website=website,
-        filename="lecture1_transcript_fr_pdf",
+        filename="lecture1_transcript-fr_pdf",
     )
     video = WebsiteContentFactory.create(
         website=website,

--- a/videos/threeplay_sync_test.py
+++ b/videos/threeplay_sync_test.py
@@ -166,6 +166,59 @@ def test_sync_video_captions_and_transcripts_skips_for_non_3play_naming_conventi
     fetch_file_mock.assert_not_called()
 
 
+def test_sync_video_captions_and_transcripts_skips_for_scalar_string_content(
+    mocker,
+):
+    """3Play sync skips fetching when an already-linked English resource is
+    stored as legacy scalar-string content, not just a single-item list.
+
+    Regression test: _append_resource_to_video_files explicitly supports a
+    bare string content value (pre-10982 single-select relation data). The
+    guard must recognize a linked resource in that shape too, or it will
+    fetch and link a redundant second English resource.
+    """
+    starter = WebsiteStarterFactory.create(slug="ocw-course-v2")
+    website = WebsiteFactory.create(starter=starter)
+    transcript_resource = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_mp4_transcript",
+        file=f"courses/{website.name}/1AbCdEf_transcript.pdf",
+    )
+    captions_resource = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_mp4_captions",
+        file=f"courses/{website.name}/1AbCdEf_captions.vtt",
+    )
+    video = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        metadata={
+            "resourcetype": "Video",
+            "video_metadata": {"youtube_id": "yt789"},
+            "video_files": {
+                "video_captions_resources": {
+                    "content": str(captions_resource.text_id),
+                    "website": website.name,
+                },
+                "video_transcript_resources": {
+                    "content": str(transcript_resource.text_id),
+                    "website": website.name,
+                },
+            },
+        },
+    )
+
+    mocker.patch(
+        "videos.threeplay_sync.threeplay_transcript_api_request",
+        return_value={"data": [{"status": "complete", "id": 11, "media_file_id": 22}]},
+    )
+    fetch_file_mock = mocker.patch("videos.threeplay_sync.fetch_file")
+
+    sync_video_captions_and_transcripts(video)
+
+    fetch_file_mock.assert_not_called()
+
+
 def test_sync_video_captions_and_transcripts_appends_english_when_other_languages_exist(
     mocker,
 ):

--- a/websites/management/commands/backfill_orphaned_caption_transcript_files.py
+++ b/websites/management/commands/backfill_orphaned_caption_transcript_files.py
@@ -5,6 +5,7 @@ from django.conf import settings
 
 from main.management.commands.filter import WebsiteFilterCommand
 from main.s3_utils import get_boto3_resource
+from videos.utils import parse_caption_language_locale
 from websites.api import get_valid_new_filename
 from websites.constants import CONTENT_FILENAME_MAX_LEN, CONTENT_TITLE_MAX_LEN
 from websites.models import Website, WebsiteContent
@@ -40,31 +41,45 @@ class Command(WebsiteFilterCommand):
     empty-string _file leftovers from the pre-relation-widget string field,
     which 0074's falsy-value guard correctly skipped but never cleaned up.
 
-    Two cases handled per video:
+    Three cases handled per video:
 
     1. Empty-string _file value (e.g. video_captions_file == ""): no
        caption/transcript was ever set for this video. The key is simply
        removed, there is nothing to back-fill.
 
-    2. Non-empty orphan _file path: the stored path is relative to the
-       *publish* bucket (prefixed by the website's url_path), while
-       WebsiteContent.file and the storage bucket are keyed relative to the
-       website's s3_path (site_config.root_url_path + website.name). When
-       url_path differs from s3_path, the path is converted to its storage
-       key before any lookup, mirroring the same swap WebsiteContent.
-       full_metadata does in reverse when generating the published path. If
-       a WebsiteContent resource already points at that storage key (e.g.
-       created by a later sync or manual remediation after migration 0074
-       ran), that resource is reused rather than creating a duplicate.
-       Otherwise, the referenced S3 object may still exist even though no
-       WebsiteContent record was ever created for it (e.g. content uploaded
-       directly to S3 outside of the GDrive/3Play pipelines, using a Google
-       Drive file ID as the filename); if so, a new WebsiteContent resource
-       is created for it, named after the video's own filename (truncated as
-       needed to fit the filename length limit) rather than the orphan
-       path's filename, since the orphan path is often an opaque identifier.
-       If the S3 object no longer exists under the storage key, the _file
-       path is left in place for manual inspection. Either way, the resolved
+    2. A resource in the same language is already linked in the
+       corresponding _resources field: GDrive's filename-convention
+       auto-link and the scheduled 3Play sync both populate _resources
+       independently of this command and never clean up the legacy _file
+       key afterward, so a video can already have a current, correctly-
+       linked resource while _file is still sitting there stale. Since
+       legacy _file values predate per-language suffixes and always resolve
+       to "en", such a case means the field is already resolved -- the _file
+       key is dropped without creating or linking anything, rather than
+       adding a same-language duplicate. A different-language existing
+       entry (e.g. an "fr" caption) does not block this: the orphan is
+       still linked alongside it.
+
+    3. Non-empty orphan _file path, no same-language resource linked yet:
+       the stored path is relative to the *publish* bucket (prefixed by the
+       website's url_path), while WebsiteContent.file and the storage
+       bucket are keyed relative to the website's s3_path
+       (site_config.root_url_path + website.name). When url_path differs
+       from s3_path, the path is converted to its storage key before any
+       lookup, mirroring the same swap WebsiteContent.full_metadata does in
+       reverse when generating the published path. If a WebsiteContent
+       resource already points at that storage key (e.g. created by a later
+       sync or manual remediation after migration 0074 ran), that resource
+       is reused rather than creating a duplicate. Otherwise, the
+       referenced S3 object may still exist even though no WebsiteContent
+       record was ever created for it (e.g. content uploaded directly to S3
+       outside of the GDrive/3Play pipelines, using a Google Drive file ID
+       as the filename); if so, a new WebsiteContent resource is created
+       for it, named after the video's own filename (truncated as needed to
+       fit the filename length limit) rather than the orphan path's
+       filename, since the orphan path is often an opaque identifier. If
+       the S3 object no longer exists under the storage key, the _file path
+       is left in place for manual inspection. Either way, the resolved
        resource's id is appended to the resource field's existing content
        list without dropping an already-linked id, whether that existing
        value is a list or a legacy scalar string.
@@ -175,6 +190,35 @@ class Command(WebsiteFilterCommand):
             "website": website_name,
         }
 
+    @staticmethod
+    def _existing_resource_languages(video_files, resource_field, website_id):
+        """Return the set of languages already linked for resource_field.
+
+        Videos, GDrive's filename-convention auto-link, and the scheduled
+        3Play sync can all populate this field independently of this
+        command, and none of them clean up the legacy _file key afterward.
+        """
+        existing = video_files.get(resource_field)
+        if not isinstance(existing, dict):
+            return set()
+        content = existing.get("content")
+        if isinstance(content, str):
+            text_ids = [content] if content else []
+        elif isinstance(content, list):
+            text_ids = content
+        else:
+            return set()
+        if not text_ids:
+            return set()
+
+        return {
+            parse_caption_language_locale(file_name)[0]
+            for file_name in WebsiteContent.objects.filter(
+                website_id=website_id, text_id__in=text_ids
+            ).values_list("file", flat=True)
+            if file_name
+        }
+
     def _backfill_video(self, content):
         """Back-fill one video's orphaned _file fields. Returns True if changed."""
         video_files = content.metadata.get("video_files")
@@ -194,12 +238,31 @@ class Command(WebsiteFilterCommand):
                 changed = True
                 continue
 
-            # Case 2: real orphan path. Reuse a resource already pointing at
-            # this exact S3 key if one exists (e.g. created by a later sync
-            # or manual remediation after migration 0074 ran) instead of
-            # creating a duplicate; otherwise verify the object still exists
-            # in S3 and create a new resource for it.
             key = self._to_storage_key(content.website, path)
+
+            # Case 1b: a resource is already linked for the same language
+            # this orphan would resolve to. It was linked by something
+            # other than this command (legacy _file values predate
+            # language suffixes, so they always resolve to "en" by
+            # convention) -- that link is authoritative for this language,
+            # so drop the stale _file value rather than adding a duplicate.
+            # A different-language existing entry (e.g. an "fr" caption) is
+            # left alone and the orphan is still linked alongside it.
+            orphan_language, _ = parse_caption_language_locale(key)
+            existing_languages = self._existing_resource_languages(
+                video_files, resource_field, content.website_id
+            )
+            if orphan_language in existing_languages:
+                video_files.pop(file_field)
+                changed = True
+                continue
+
+            # Case 2: real orphan path, no same-language resource linked
+            # yet. Reuse a resource already pointing at this exact S3 key
+            # if one exists (e.g. created by a later sync or manual
+            # remediation after migration 0074 ran) instead of creating a
+            # duplicate; otherwise verify the object still exists in S3 and
+            # create a new resource for it.
             resource = self._resolve_or_create_resource(
                 content, key, path, suffix, resourcetype
             )

--- a/websites/management/commands/backfill_orphaned_caption_transcript_files.py
+++ b/websites/management/commands/backfill_orphaned_caption_transcript_files.py
@@ -7,6 +7,7 @@ from django.conf import settings
 
 from main.management.commands.filter import WebsiteFilterCommand
 from main.s3_utils import get_boto3_resource
+from main.utils import get_base_filename, get_file_extension
 from videos.utils import parse_caption_language_locale
 from websites.api import get_valid_new_filename
 from websites.constants import (
@@ -99,9 +100,17 @@ class Command(WebsiteFilterCommand):
        record was ever created for it (e.g. content uploaded directly to S3
        outside of the GDrive/3Play pipelines, using a Google Drive file ID
        as the filename); if so, a new WebsiteContent resource is created
-       for it, named after the video's own filename (truncated as needed to
-       fit the filename length limit) rather than the orphan path's
-       filename, since the orphan path is often an opaque identifier. If
+       for it, named with the same convention GDrive ingestion uses --
+       the video's base stem plus the caption/transcript suffix plus the
+       real file extension, e.g. "lecture1_captions_vtt" for a video named
+       "lecture1_mp4" (truncated as needed to fit the filename length
+       limit). The orphan path's own filename is not used, since it is
+       often an opaque identifier. Matching GDrive's convention matters:
+       auto_link_video_captions_transcript and
+       Video.caption_transcript_resources() both discover resources by the
+       "{base_stem}_captions" / "{base_stem}_transcript" prefix, so a
+       resource named any other way is invisible to them and gets
+       re-fetched from 3Play as a duplicate. If
        the S3 object no longer exists under the storage key, the _file path
        is left in place for manual inspection. Either way, the resolved
        resource's id is appended to the resource field's existing content
@@ -161,12 +170,26 @@ class Command(WebsiteFilterCommand):
             )
             return None
 
-        # Truncate the video's own filename so the suffixed base never
-        # exceeds the filename length limit on its own, before
-        # get_valid_new_filename handles any additional numbered-suffix
-        # truncation needed for a collision.
+        # Name the created resource exactly as GDrive ingestion and
+        # link_threeplay_files_as_resources would: the video's *base stem*
+        # (get_base_filename strips the trailing format tag, e.g.
+        # "lecture1_mp4" -> "lecture1") plus the caption/transcript suffix
+        # plus the real file extension, giving "lecture1_captions_vtt".
+        # auto_link_video_captions_transcript and
+        # Video.caption_transcript_resources() both search the
+        # "{base_stem}_captions" / "{base_stem}_transcript" prefix, so
+        # anything named off the *full* filename would be invisible to them
+        # and get re-fetched from 3Play as a duplicate. The orphan path's own
+        # filename is not used because it is often an opaque identifier.
+        #
+        # Truncated so the suffixed base never exceeds the filename length
+        # limit on its own, before get_valid_new_filename handles any
+        # additional numbered-suffix truncation needed for a collision.
+        suffix = f"_{field_config.suffix}"
+        if extension := get_file_extension(key):
+            suffix = f"{suffix}_{extension}"
         base_filename = self._truncate_with_suffix(
-            content.filename, f"_{field_config.suffix}", CONTENT_FILENAME_MAX_LEN
+            get_base_filename(content.filename), suffix, CONTENT_FILENAME_MAX_LEN
         )
         filename = get_valid_new_filename(
             website_pk=content.website_id,

--- a/websites/management/commands/backfill_orphaned_caption_transcript_files.py
+++ b/websites/management/commands/backfill_orphaned_caption_transcript_files.py
@@ -1,5 +1,7 @@
 """Back-populate video_captions_resources / video_transcript_resources for orphaned legacy caption/transcript files"""  # noqa: E501, INP001
 
+from collections import namedtuple
+
 from botocore.exceptions import ClientError
 from django.conf import settings
 
@@ -7,13 +9,34 @@ from main.management.commands.filter import WebsiteFilterCommand
 from main.s3_utils import get_boto3_resource
 from videos.utils import parse_caption_language_locale
 from websites.api import get_valid_new_filename
-from websites.constants import CONTENT_FILENAME_MAX_LEN, CONTENT_TITLE_MAX_LEN
+from websites.constants import (
+    CONTENT_FILENAME_MAX_LEN,
+    CONTENT_TITLE_MAX_LEN,
+    CONTENT_TYPE_RESOURCE,
+)
 from websites.models import Website, WebsiteContent
+from websites.site_config_api import SiteConfig
 
-# Each entry: file_field, resource_field, filename_suffix, resourcetype.
+FieldConfig = namedtuple(  # noqa: PYI024
+    "FieldConfig",
+    ["file_field", "resource_field", "suffix", "resourcetype", "file_type"],
+)
+
 _FIELD_CONFIG = (
-    ("video_captions_file", "video_captions_resources", "captions", "Other"),
-    ("video_transcript_file", "video_transcript_resources", "transcript", "Document"),
+    FieldConfig(
+        file_field="video_captions_file",
+        resource_field="video_captions_resources",
+        suffix="captions",
+        resourcetype="Other",
+        file_type="application/x-subrip",
+    ),
+    FieldConfig(
+        file_field="video_transcript_file",
+        resource_field="video_transcript_resources",
+        suffix="transcript",
+        resourcetype="Document",
+        file_type="application/pdf",
+    ),
 )
 
 # Flushed periodically rather than once at the end, so a crash partway
@@ -22,15 +45,16 @@ _FIELD_CONFIG = (
 _BULK_UPDATE_BATCH_SIZE = 500
 
 
-def _object_exists_in_s3(s3, bucket_name, key):
-    """Return True if the S3 object exists."""
+def _load_s3_object(s3, bucket_name, key):
+    """Return the loaded S3 object, or None if it doesn't exist."""
+    obj = s3.Object(bucket_name, key)
     try:
-        s3.Object(bucket_name, key).load()
+        obj.load()
     except ClientError as exc:
         if exc.response["Error"]["Code"] in ("404", "NoSuchKey"):
-            return False
+            return None
         raise
-    return True
+    return obj
 
 
 class Command(WebsiteFilterCommand):
@@ -116,7 +140,7 @@ class Command(WebsiteFilterCommand):
             key = s3_path + key[len(url_path) :]
         return key
 
-    def _resolve_or_create_resource(self, content, key, path, suffix, resourcetype):
+    def _resolve_or_create_resource(self, content, key, path, field_config):
         """Find a resource already pointing at this S3 key, or create one.
 
         Returns None if the S3 object no longer exists (the orphan path is
@@ -129,7 +153,8 @@ class Command(WebsiteFilterCommand):
             return resource
 
         bucket_name = settings.AWS_STORAGE_BUCKET_NAME
-        if not _object_exists_in_s3(self.s3, bucket_name, key):
+        s3_object = _load_s3_object(self.s3, bucket_name, key)
+        if s3_object is None:
             self.stdout.write(
                 f"Skipping missing S3 object for "
                 f"{content.website.name}/{content.filename}: {path}"
@@ -141,7 +166,7 @@ class Command(WebsiteFilterCommand):
         # get_valid_new_filename handles any additional numbered-suffix
         # truncation needed for a collision.
         base_filename = self._truncate_with_suffix(
-            content.filename, f"_{suffix}", CONTENT_FILENAME_MAX_LEN
+            content.filename, f"_{field_config.suffix}", CONTENT_FILENAME_MAX_LEN
         )
         filename = get_valid_new_filename(
             website_pk=content.website_id,
@@ -150,11 +175,32 @@ class Command(WebsiteFilterCommand):
         )
         title = (
             self._truncate_with_suffix(
-                content.title, f" {suffix}", CONTENT_TITLE_MAX_LEN
+                content.title, f" {field_config.suffix}", CONTENT_TITLE_MAX_LEN
             )
             if content.title
             else filename
         )
+        # Same schema-defaulted metadata GDrive sync uses (draft,
+        # learning_resource_types, gdrive_url, etc. all get their configured
+        # defaults), instead of a bare {file, resourcetype} dict. Falls back
+        # to the bare shape if there's no starter to read a schema from.
+        resource_type_fields = {
+            "file_type": field_config.file_type,
+            "file_size": s3_object.content_length,
+            **dict.fromkeys(settings.RESOURCE_TYPE_FIELDS, field_config.resourcetype),
+        }
+        if content.website.starter is not None:
+            metadata = {
+                **SiteConfig(content.website.starter.config).generate_item_metadata(
+                    CONTENT_TYPE_RESOURCE,
+                    cls=WebsiteContent,
+                    use_defaults=True,
+                    values=resource_type_fields,
+                ),
+                "file": path,
+            }
+        else:
+            metadata = {"file": path, **resource_type_fields}
         return WebsiteContent.objects.create(
             website_id=content.website_id,
             type="resource",
@@ -163,10 +209,7 @@ class Command(WebsiteFilterCommand):
             dirpath=content.dirpath,
             file=key,
             title=title,
-            metadata={
-                "file": path,
-                "resourcetype": resourcetype,
-            },
+            metadata=metadata,
         )
 
     def _merge_resource_into_video_files(
@@ -227,14 +270,14 @@ class Command(WebsiteFilterCommand):
 
         changed = False
 
-        for file_field, resource_field, suffix, resourcetype in _FIELD_CONFIG:
-            path = video_files.get(file_field)
+        for field_config in _FIELD_CONFIG:
+            path = video_files.get(field_config.file_field)
             if not isinstance(path, str):
                 continue
 
             # Case 1: empty-string leftover, nothing to back-fill, just drop it.
             if not path:
-                video_files.pop(file_field)
+                video_files.pop(field_config.file_field)
                 changed = True
                 continue
 
@@ -250,10 +293,10 @@ class Command(WebsiteFilterCommand):
             # left alone and the orphan is still linked alongside it.
             orphan_language, _ = parse_caption_language_locale(key)
             existing_languages = self._existing_resource_languages(
-                video_files, resource_field, content.website_id
+                video_files, field_config.resource_field, content.website_id
             )
             if orphan_language in existing_languages:
-                video_files.pop(file_field)
+                video_files.pop(field_config.file_field)
                 changed = True
                 continue
 
@@ -264,15 +307,15 @@ class Command(WebsiteFilterCommand):
             # duplicate; otherwise verify the object still exists in S3 and
             # create a new resource for it.
             resource = self._resolve_or_create_resource(
-                content, key, path, suffix, resourcetype
+                content, key, path, field_config
             )
             if resource is None:
                 continue
 
             self._merge_resource_into_video_files(
-                video_files, resource_field, resource, content.website.name
+                video_files, field_config.resource_field, resource, content.website.name
             )
-            video_files.pop(file_field)
+            video_files.pop(field_config.file_field)
             changed = True
 
         return changed

--- a/websites/management/commands/backfill_orphaned_caption_transcript_files_test.py
+++ b/websites/management/commands/backfill_orphaned_caption_transcript_files_test.py
@@ -88,7 +88,11 @@ def test_creates_resource_for_existing_s3_object(mock_s3):
     assert len(resources["content"]) == 1
 
     created = WebsiteContent.objects.get(text_id=resources["content"][0])
-    assert created.filename == "lecture1_mp4_captions"
+    # Named with GDrive's convention: the video's base stem ("lecture1_mp4" ->
+    # "lecture1") plus the suffix plus the real extension. This is what makes
+    # the resource discoverable by the auto-link and 3Play gate lookups, which
+    # both search the "{base_stem}_captions" prefix.
+    assert created.filename == "lecture1_captions_webvtt"
     assert created.dirpath == "content/resources"
     assert created.file.name == caption_key
     assert created.metadata["resourcetype"] == "Other"
@@ -151,7 +155,7 @@ def test_reuses_existing_resource_via_corrected_storage_key(mock_s3):
     storage_key = f"{website.s3_path}/1AbCdEf_transcript.webvtt"
     already_linked = WebsiteContentFactory.create(
         website=website,
-        filename="lecture1_mp4_captions",
+        filename="lecture1_captions_webvtt",
         file=storage_key,
     )
 
@@ -372,7 +376,7 @@ def test_reuses_existing_resource_for_same_s3_key(mock_s3):
     key = f"courses/{website.name}/1AbCdEf_transcript.webvtt"
     already_linked = WebsiteContentFactory.create(
         website=website,
-        filename="lecture1_mp4_captions",
+        filename="lecture1_captions_webvtt",
         file=key,
     )
 
@@ -490,7 +494,9 @@ def test_deduplicates_filename_collision(mock_s3):
     """Filename collisions in the same (website, dirpath) get a numeric suffix."""
     website = WebsiteFactory.create()
     WebsiteContentFactory.create(
-        website=website, filename="lecture1_mp4_captions", dirpath="content/resources"
+        website=website,
+        filename="lecture1_captions_webvtt",
+        dirpath="content/resources",
     )
     key = f"courses/{website.name}/1AbC_transcript.webvtt"
     mock_s3.put_object(Key=key, Body=b"WEBVTT")
@@ -510,7 +516,7 @@ def test_deduplicates_filename_collision(mock_s3):
     video.refresh_from_db()
     resources = video.metadata["video_files"]["video_captions_resources"]
     created = WebsiteContent.objects.get(text_id=resources["content"][0])
-    assert created.filename == "lecture1_mp4_captions2"
+    assert created.filename == "lecture1_captions_webvtt2"
 
 
 def test_skips_non_video_content(mock_s3):
@@ -563,8 +569,8 @@ def test_backfills_both_captions_and_transcript_for_same_video(mock_s3):
     transcript_resource = WebsiteContent.objects.get(
         text_id=vf["video_transcript_resources"]["content"][0]
     )
-    assert captions_resource.filename == "lecture1_mp4_captions"
-    assert transcript_resource.filename == "lecture1_mp4_transcript"
+    assert captions_resource.filename == "lecture1_captions_webvtt"
+    assert transcript_resource.filename == "lecture1_transcript_pdf"
     assert captions_resource.metadata["resourcetype"] == "Other"
     assert transcript_resource.metadata["resourcetype"] == "Document"
 
@@ -622,7 +628,7 @@ def test_truncates_long_video_filename_to_fit_length_limit(mock_s3):
     resources = video.metadata["video_files"]["video_captions_resources"]
     created = WebsiteContent.objects.get(text_id=resources["content"][0])
     assert len(created.filename) <= CONTENT_FILENAME_MAX_LEN
-    assert created.filename.endswith("_captions")
+    assert created.filename.endswith("_captions_webvtt")
 
 
 def test_truncates_long_video_title_to_fit_length_limit(mock_s3):

--- a/websites/management/commands/backfill_orphaned_caption_transcript_files_test.py
+++ b/websites/management/commands/backfill_orphaned_caption_transcript_files_test.py
@@ -93,6 +93,11 @@ def test_creates_resource_for_existing_s3_object(mock_s3):
     assert created.file.name == caption_key
     assert created.metadata["resourcetype"] == "Other"
     assert created.metadata["file"] == f"/{caption_key}"
+    # Schema-defaulted metadata (from the site config, same as GDrive sync
+    # uses), not just the bare {file, resourcetype} shape.
+    assert created.metadata["file_type"] == "application/x-subrip"
+    assert created.metadata["file_size"] == len(b"WEBVTT")
+    assert created.metadata["license"] == "default_license_specificed_in_config"
 
 
 def test_converts_url_path_relative_orphan_to_storage_key(mock_s3):
@@ -201,7 +206,9 @@ def test_no_key_swap_when_starter_is_none(mock_s3):
     """The swap is skipped, not crashed, when the website has no starter.
 
     s3_path can't be computed without a starter's site config, so the raw
-    path is used as-is rather than raising.
+    path is used as-is rather than raising. Schema-defaulted metadata also
+    can't be computed without a starter, so it falls back to the bare
+    {file, resourcetype, ...} shape instead of crashing.
     """
     website = WebsiteFactory.create(starter=None, url_path="courses/some-path")
     raw_key = f"{website.url_path}/1AbCdEf_transcript.webvtt"
@@ -225,6 +232,10 @@ def test_no_key_swap_when_starter_is_none(mock_s3):
     resources = vf["video_captions_resources"]
     created = WebsiteContent.objects.get(text_id=resources["content"][0])
     assert created.file.name == raw_key
+    assert created.metadata["file"] == f"/{raw_key}"
+    assert created.metadata["resourcetype"] == "Other"
+    assert created.metadata["file_type"] == "application/x-subrip"
+    assert created.metadata["file_size"] == len(b"WEBVTT")
 
 
 def test_no_key_swap_when_url_path_not_a_prefix(mock_s3):
@@ -450,7 +461,7 @@ def test_partial_progress_persists_on_mid_run_failure(mock_s3, monkeypatch):
         )
         videos.append(video)
 
-    original_check = cmd_module._object_exists_in_s3  # noqa: SLF001
+    original_load = cmd_module._load_s3_object  # noqa: SLF001
     call_count = 0
 
     def _fail_on_third_call(s3, bucket_name, key):
@@ -458,9 +469,9 @@ def test_partial_progress_persists_on_mid_run_failure(mock_s3, monkeypatch):
         call_count += 1
         if call_count == 3:
             raise TransientS3Error
-        return original_check(s3, bucket_name, key)
+        return original_load(s3, bucket_name, key)
 
-    monkeypatch.setattr(cmd_module, "_object_exists_in_s3", _fail_on_third_call)
+    monkeypatch.setattr(cmd_module, "_load_s3_object", _fail_on_third_call)
 
     with pytest.raises(TransientS3Error):
         _run(filter=website.name)

--- a/websites/management/commands/backfill_orphaned_caption_transcript_files_test.py
+++ b/websites/management/commands/backfill_orphaned_caption_transcript_files_test.py
@@ -290,7 +290,7 @@ def test_appends_to_existing_resources(mock_s3):
     fr_caption = WebsiteContentFactory.create(
         website=website,
         filename="lecture1_captions_fr_vtt",
-        file=f"courses/{website.name}/lecture1_captions_fr.vtt",
+        file=f"courses/{website.name}/lecture1_captions-fr.vtt",
     )
     en_key = f"courses/{website.name}/1EnglishId_transcript.webvtt"
     mock_s3.put_object(Key=en_key, Body=b"WEBVTT")
@@ -325,7 +325,7 @@ def test_appends_to_existing_scalar_string_content(mock_s3):
     fr_caption = WebsiteContentFactory.create(
         website=website,
         filename="lecture1_captions_fr_vtt",
-        file=f"courses/{website.name}/lecture1_captions_fr.vtt",
+        file=f"courses/{website.name}/lecture1_captions-fr.vtt",
     )
     en_key = f"courses/{website.name}/1EnglishId_transcript.webvtt"
     mock_s3.put_object(Key=en_key, Body=b"WEBVTT")


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12532

Stacked on #3113. This branch is based on it and depends on it merging first.

### Description (What does it do?)
Fixes duplicate caption/transcript resources created when 3Play's scheduled or signal-triggered sync doesn't recognize a resource already linked under a different naming convention. Found while validating #3113 on staging.

Three separate processes can link `video_captions_resources`/`video_transcript_resources`: the backfill command, GDrive's auto-link, and 3Play's own sync. Each only recognized its own naming convention as "already linked," so a resource created by another path was invisible to it and got duplicated.

- `videos/tasks.py` and `videos/threeplay_sync.py`: gate on the resolved language of already-linked resources instead of a specific naming convention. Any English resource blocks the 3Play fetch, regardless of which process created it. A different-language entry (e.g. French) does not block it.
- `backfill_orphaned_caption_transcript_files.py`: drops a stale orphaned `_file` key instead of duplicating it when an existing linked resource already resolves to the same language. Created resources also get schema-defaulted metadata (via `SiteConfig.generate_item_metadata`, matching GDrive's convention) instead of a bare `{file: ...}` dict.

### How can this be tested?
1. Checkout `umar/12532-fix-3play-duplicate-resource-naming` (based on `umar/12436-fix-backfill-s3-key-prefix-mismatch`)
2. Run `docker compose run --rm web pytest videos/ websites/management/commands/backfill_orphaned_caption_transcript_files_test.py --no-cov -q`
3. On staging, backfill a video then trigger `update_transcripts_for_video` for it. Confirm no duplicate English resource is created.
4. Confirm a video with only a French caption/transcript linked still gets its English version fetched from 3Play.
