### PR TITLE
fix: publish an empty array when no caption/transcript resource resolves

### DIFF
--- a/content_sync/serializers_test.py
+++ b/content_sync/serializers_test.py
@@ -142,18 +142,25 @@ def test_hugo_file_serialize(tmp_path, markdown, exp_sections):
         assert len(md_file_sections) == exp_sections
         front_matter = md_file_sections[0]
         front_matter_lines = list(filter(None, sorted(front_matter.split("\n"))))
+        image_line = (
+            f"image: /media/{content.website.get_url_path()}/"
+            f"{content.file.name.split('/')[-1]}"
+        )
+        # The file field is stated explicitly rather than read back out of
+        # `metadata`: full_metadata adds it to the *published* front matter
+        # only, and must not write it back onto the stored metadata.
         assert front_matter_lines == sorted(
             [
                 f"title: {content.title}",
                 f"content_type: {content.type}",
                 f"uid: {content.text_id}",
+                image_line,
             ]
             + [f"{k}: {v}" for k, v in metadata.items()]
         )
-        assert (
-            f"image: /media/{content.website.get_url_path()}/{content.file.name.split('/')[-1]}"
-            in front_matter_lines
-        )
+        assert image_line in front_matter_lines
+        # Serializing left the stored metadata alone
+        assert set(content.metadata) == {"metadata1", "metadata2"}
         if exp_sections > 1:
             assert md_file_sections[1] == markdown
 

--- a/websites/models.py
+++ b/websites/models.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import re
+from copy import deepcopy
 from hashlib import sha256
 from typing import TYPE_CHECKING
 from urllib.parse import urljoin, urlparse
@@ -424,8 +425,16 @@ class WebsiteContent(TimestampedModel, SafeDeleteModel):
         file_field = self.get_config_file_field()
         s3_path = self.website.s3_path
         url_path = self.website.url_path
+        # Deep-copied rather than aliased: everything below rewrites keys into
+        # their *published* form, which must not leak back onto the stored
+        # metadata. Aliasing meant merely reading this property replaced an
+        # editor's {"content": [...]} relation with a resolved file list on the
+        # instance, so any later save() persisted that and lost the links, and
+        # calculate_checksum() returned a different value before and after.
         full_metadata = (
-            self.metadata if (self.metadata and isinstance(self.metadata, dict)) else {}
+            deepcopy(self.metadata)
+            if (self.metadata and isinstance(self.metadata, dict))
+            else {}
         )
         modified = False
         if file_field:

--- a/websites/models.py
+++ b/websites/models.py
@@ -451,28 +451,44 @@ class WebsiteContent(TimestampedModel, SafeDeleteModel):
                 YT_FIELD_TRANSCRIPT_RESOURCES,
             ):
                 resource_data = get_dict_field(full_metadata, resource_field)
-                if not resource_data or not isinstance(resource_data, dict):
+                if not isinstance(resource_data, dict):
+                    # Already a resolved list, or the field isn't set at all.
                     continue
-                text_ids = resource_data.get("content", [])
-                if not text_ids:
-                    continue
-                # self.__class__ is WebsiteContent — no circular import needed
-                related_contents = list(
-                    self.__class__.objects.filter(
-                        website=self.website,
-                        text_id__in=text_ids,
+                content = resource_data.get("content") or []
+                # A single-select relation predating the multi-select widget
+                # stores content as a bare string. Without this, text_id__in
+                # would iterate it character by character.
+                text_ids = [content] if isinstance(content, str) else list(content)
+                text_ids = [text_id for text_id in text_ids if text_id]
+                resolved = []
+                if text_ids:
+                    # self.__class__ is WebsiteContent — no circular import needed
+                    related_contents = list(
+                        self.__class__.objects.filter(
+                            website=self.website,
+                            text_id__in=text_ids,
+                        )
                     )
-                )
-                resolved = resource_file_paths(related_contents)
-                # Apply URL path substitution if s3 and url paths differ
-                if resolved and url_path and s3_path != url_path:
-                    resolved = [
-                        {**entry, "file": entry["file"].replace(s3_path, url_path, 1)}
-                        for entry in resolved
-                    ]
-                if resolved:
-                    set_dict_field(full_metadata, resource_field, resolved)
-                    modified = True
+                    resolved = resource_file_paths(related_contents)
+                    # Apply URL path substitution if s3 and url paths differ
+                    if resolved and url_path and s3_path != url_path:
+                        resolved = [
+                            {
+                                **entry,
+                                "file": entry["file"].replace(s3_path, url_path, 1),
+                            }
+                            for entry in resolved
+                        ]
+                # Always replace, even when nothing resolved. Leaving the raw
+                # {"content": ..., "website": ...} relation dict in place would
+                # publish the CMS's internal storage shape into Hugo
+                # frontmatter, where video_caption_tracks.html iterates it and
+                # fails on `.language` (a map yields its values, not objects).
+                # An empty list is what "no caption/transcript for this video"
+                # has to look like, and it keeps the field's published contract
+                # honest: always an array of {file, language} objects.
+                set_dict_field(full_metadata, resource_field, resolved)
+                modified = True
 
         return full_metadata if modified else self.metadata
 

--- a/websites/models_test.py
+++ b/websites/models_test.py
@@ -463,3 +463,102 @@ def test_websitecontent_full_metadata_resolves_resources_relation():
         "language": "es",
         "locale": "MX",
     } in resolved
+
+
+@pytest.mark.parametrize(
+    ("stored_content", "reason"),
+    [
+        ("", "site-config initialises a relation widget to an empty string"),
+        ([], "empty multi-select list"),
+        (["no-such-text-id"], "dangling text_id matching no resource"),
+    ],
+)
+def test_websitecontent_full_metadata_normalizes_unresolvable_resources(
+    stored_content, reason
+):
+    """An unresolvable _resources relation is published as [], never as the raw dict.
+
+    full_metadata used to leave the stored {"content": ..., "website": ...}
+    relation dict untouched whenever resolution produced nothing, so the CMS's
+    internal storage shape reached Hugo frontmatter. There
+    video_caption_tracks.html treats a non-empty map as truthy, ranges it (which
+    yields the map's *values*), and dies on `.language` with "can't evaluate
+    field language in type interface {}", breaking the whole site build.
+    """
+    website = WebsiteFactory.create(name="mysite", url_path="sites/mysite-fall-2008")
+    video = WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        metadata={
+            "video_files": {
+                "video_captions_resources": {
+                    "content": stored_content,
+                    "website": website.name,
+                },
+            }
+        },
+        file=None,
+    )
+
+    published = video.full_metadata["video_files"]["video_captions_resources"]
+
+    assert published == [], f"{reason}: got {published!r}"
+
+
+def test_websitecontent_full_metadata_normalizes_unresolved_when_resource_has_no_file():
+    """A linked resource with no uploaded file resolves to [], not the raw dict."""
+    website = WebsiteFactory.create(name="mysite", url_path="sites/mysite-fall-2008")
+    no_file = WebsiteContentFactory.create(
+        website=website, filename="lecture1_captions_vtt", type="resource", file=None
+    )
+    video = WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        metadata={
+            "video_files": {
+                "video_captions_resources": {
+                    "content": [str(no_file.text_id)],
+                    "website": website.name,
+                },
+            }
+        },
+        file=None,
+    )
+
+    published = video.full_metadata["video_files"]["video_captions_resources"]
+
+    assert published == []
+
+
+def test_websitecontent_full_metadata_resolves_scalar_string_content():
+    """A legacy single-select relation stores content as a bare string.
+
+    Without normalizing it to a list first, text_id__in would iterate the
+    string character by character and match nothing.
+    """
+    website = WebsiteFactory.create(name="mysite", url_path="sites/mysite-fall-2008")
+    captions = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_captions_vtt",
+        file="sites/mysite/lecture1_captions.vtt",
+        type="resource",
+    )
+    video = WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        metadata={
+            "video_files": {
+                "video_captions_resources": {
+                    "content": str(captions.text_id),
+                    "website": website.name,
+                },
+            }
+        },
+        file=None,
+    )
+
+    published = video.full_metadata["video_files"]["video_captions_resources"]
+
+    assert published == [
+        {"file": "/sites/mysite-fall-2008/lecture1_captions.vtt", "language": "en"}
+    ]

--- a/websites/models_test.py
+++ b/websites/models_test.py
@@ -466,6 +466,10 @@ def test_websitecontent_full_metadata_resolves_resources_relation():
 
 
 @pytest.mark.parametrize(
+    "field",
+    ["video_captions_resources", "video_transcript_resources"],
+)
+@pytest.mark.parametrize(
     ("stored_content", "reason"),
     [
         ("", "site-config initialises a relation widget to an empty string"),
@@ -474,7 +478,7 @@ def test_websitecontent_full_metadata_resolves_resources_relation():
     ],
 )
 def test_websitecontent_full_metadata_normalizes_unresolvable_resources(
-    stored_content, reason
+    stored_content, reason, field
 ):
     """An unresolvable _resources relation is published as [], never as the raw dict.
 
@@ -491,7 +495,7 @@ def test_websitecontent_full_metadata_normalizes_unresolvable_resources(
         type="resource",
         metadata={
             "video_files": {
-                "video_captions_resources": {
+                field: {
                     "content": stored_content,
                     "website": website.name,
                 },
@@ -500,9 +504,9 @@ def test_websitecontent_full_metadata_normalizes_unresolvable_resources(
         file=None,
     )
 
-    published = video.full_metadata["video_files"]["video_captions_resources"]
+    published = video.full_metadata["video_files"][field]
 
-    assert published == [], f"{reason}: got {published!r}"
+    assert published == [], f"{field} / {reason}: got {published!r}"
 
 
 def test_websitecontent_full_metadata_normalizes_unresolved_when_resource_has_no_file():
@@ -528,6 +532,111 @@ def test_websitecontent_full_metadata_normalizes_unresolved_when_resource_has_no
     published = video.full_metadata["video_files"]["video_captions_resources"]
 
     assert published == []
+
+
+def test_websitecontent_full_metadata_does_not_mutate_stored_metadata():
+    """Reading full_metadata must leave the stored metadata untouched.
+
+    full_metadata rewrites keys into their published form. It used to alias
+    self.metadata, so merely reading the property replaced an editor's
+    {"content": [...]} relation with a resolved file list on the instance. Any
+    later save() then persisted that and the links were gone.
+    """
+    website = WebsiteFactory.create(name="mysite", url_path="sites/mysite-fall-2008")
+    captions = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_captions_vtt",
+        file="sites/mysite/lecture1_captions.vtt",
+        type="resource",
+    )
+    stored = {"content": [str(captions.text_id)], "website": website.name}
+    video = WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        metadata={"video_files": {"video_captions_resources": dict(stored)}},
+        file=None,
+    )
+
+    published = video.full_metadata["video_files"]["video_captions_resources"]
+
+    # The published form resolved, and the stored form is still the relation
+    assert isinstance(published, list)
+    assert video.metadata["video_files"]["video_captions_resources"] == stored
+
+    # ...and it survives a round trip through the database
+    video.save()
+    video.refresh_from_db()
+    assert video.metadata["video_files"]["video_captions_resources"] == stored
+
+
+def test_websitecontent_full_metadata_leaves_checksum_stable():
+    """calculate_checksum must not depend on whether full_metadata was read.
+
+    content_sync computes the checksum on both sides of serialization. If
+    reading full_metadata mutates the instance, the two never agree and the
+    content looks perpetually unsynced.
+    """
+    website = WebsiteFactory.create(name="mysite", url_path="sites/mysite-fall-2008")
+    captions = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_captions_vtt",
+        file="sites/mysite/lecture1_captions.vtt",
+        type="resource",
+    )
+    video = WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        metadata={
+            "video_files": {
+                "video_captions_resources": {
+                    "content": [str(captions.text_id)],
+                    "website": website.name,
+                }
+            }
+        },
+        file=None,
+    )
+
+    before = video.calculate_checksum()
+    video.full_metadata  # noqa: B018
+    assert video.calculate_checksum() == before
+
+
+def test_websitecontent_full_metadata_resolves_partially_resolvable_content():
+    """Entries that resolve are published; unresolvable ones are dropped."""
+    website = WebsiteFactory.create(name="mysite", url_path="sites/mysite-fall-2008")
+    resolvable = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_captions_vtt",
+        file="sites/mysite/lecture1_captions.vtt",
+        type="resource",
+    )
+    no_file = WebsiteContentFactory.create(
+        website=website, filename="lecture1_captions-fr_vtt", type="resource", file=None
+    )
+    video = WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        metadata={
+            "video_files": {
+                "video_captions_resources": {
+                    "content": [
+                        str(resolvable.text_id),
+                        str(no_file.text_id),
+                        "does-not-exist",
+                    ],
+                    "website": website.name,
+                }
+            }
+        },
+        file=None,
+    )
+
+    published = video.full_metadata["video_files"]["video_captions_resources"]
+
+    assert published == [
+        {"file": "/sites/mysite-fall-2008/lecture1_captions.vtt", "language": "en"}
+    ]
 
 
 def test_websitecontent_full_metadata_resolves_scalar_string_content():


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12635

Paired with mitodl/ocw-hugo-themes#1843. Either side stops the build failing on its own, and both are worth having: this one keeps the shape out of new frontmatter, the themes one covers content that is already published.

### Description (What does it do?)
`full_metadata()` only replaced `video_captions_resources` / `video_transcript_resources` when resolution produced a non-empty list. When it produced nothing, the stored relation object `{"content": ..., "website": ...}` was published to Hugo frontmatter as-is, and the caption partials aborted the whole site build on it.

Two situations reach it, both verified against a clone of production data:

1. The field was never linked, so `content` is empty. This is the default the CMS gives a new relation field, so it applies to newly created video resources, not just old data.
2. The field links a resource with no uploaded file, so there is no path to publish.

- `websites/models.py`: always write the resolved list, including when it is empty, so the field is an array in frontmatter. Also normalizes a legacy scalar-string `content` to a list first, which `text_id__in` would otherwise iterate character by character.

Blast radius: 9 video resources across 6 websites, 5 of them published.

### How can this be tested?
1. Checkout `umar/12635-empty-caption-transcript-breaks-build`
2. Run `docker compose run --rm web pytest websites/models_test.py -k full_metadata --no-cov -q`
3. Create a video resource and link no caption to it. Confirm `full_metadata` publishes `video_captions_resources: []` rather than a `content`/`website` object.
4. Confirm a video with captions linked still publishes the resolved `[{file, language}]` array, including its language and locale suffixes.
