### PR TITLE
feat: language and locale override for resources

### DIFF
--- a/videos/utils.py
+++ b/videos/utils.py
@@ -314,7 +314,22 @@ def parse_caption_language_locale(filename: str) -> tuple[str, str | None]:
     return "en", None
 
 
-def resolve_language_locale(resource) -> tuple[str, str | None]:
+def _normalized_code(value, *, upper: bool = False) -> str | None:
+    """Return a trimmed, case-normalized language or locale code, or None.
+
+    Anything that is not a usable string (wrong type, empty, whitespace-only)
+    is treated as unset rather than raising, because this runs in the publish
+    path where an exception would fail the whole site build.
+    """
+    if not isinstance(value, str):
+        return None
+    code = value.strip()
+    if not code:
+        return None
+    return code.upper() if upper else code.lower()
+
+
+def resolve_language_locale(resource: WebsiteContent) -> tuple[str, str | None]:
     """Return ``(language, locale)`` for a resource.
 
     An explicit metadata value wins.  Otherwise the value is parsed from the
@@ -325,13 +340,13 @@ def resolve_language_locale(resource) -> tuple[str, str | None]:
     explicit locale yields no locale, rather than inheriting a region parsed
     from a filename that the language no longer agrees with.
 
-    This is the single source of precedence.  Both the edit form and the
-    publish path go through it, so what an editor is shown cannot drift from
-    what actually gets published.
+    This is the single source of precedence.  The edit form and the publish
+    path are both intended to route through it, so what an editor is shown
+    cannot drift from what actually gets published.
     """
     metadata = resource.metadata if isinstance(resource.metadata, dict) else {}
-    language = metadata.get("language") or None
-    locale = metadata.get("locale") or None
+    language = _normalized_code(metadata.get("language"))
+    locale = _normalized_code(metadata.get("locale"), upper=True)
 
     if language:
         return language, locale

--- a/videos/utils.py
+++ b/videos/utils.py
@@ -363,9 +363,9 @@ def resource_file_paths(resources: list) -> list:
     resources.
 
     Language and optional locale come from :func:`resolve_language_locale`, so an
-    explicit value set in Studio wins over whatever the filename says.  Resources
-    without a resolvable file are omitted.  ``locale`` is only included in the
-    dict when present.
+    explicit value set in Studio wins over the language parsed from the resource's
+    real uploaded file path.  Resources without a resolvable file are omitted.
+    ``locale`` is only included in the dict when present.
     """
     result = []
     for resource in resources:

--- a/videos/utils.py
+++ b/videos/utils.py
@@ -314,6 +314,35 @@ def parse_caption_language_locale(filename: str) -> tuple[str, str | None]:
     return "en", None
 
 
+def resolve_language_locale(resource) -> tuple[str, str | None]:
+    """Return ``(language, locale)`` for a resource.
+
+    An explicit metadata value wins.  Otherwise the value is parsed from the
+    resource's real uploaded file path, which itself falls back to
+    ``("en", None)`` when the filename carries no language suffix.
+
+    Language and locale resolve independently: an explicit language with no
+    explicit locale yields no locale, rather than inheriting a region parsed
+    from a filename that the language no longer agrees with.
+
+    This is the single source of precedence.  Both the edit form and the
+    publish path go through it, so what an editor is shown cannot drift from
+    what actually gets published.
+    """
+    metadata = resource.metadata if isinstance(resource.metadata, dict) else {}
+    language = metadata.get("language") or None
+    locale = metadata.get("locale") or None
+
+    if language:
+        return language, locale
+
+    file_name = getattr(getattr(resource, "file", None), "name", None)
+    parsed_language, parsed_locale = (
+        parse_caption_language_locale(file_name) if file_name else ("en", None)
+    )
+    return parsed_language, locale or parsed_locale
+
+
 def resource_file_paths(resources: list) -> list:
     """Return a list of ``{file, language[, locale]}`` dicts for caption/transcript
     resources.

--- a/videos/utils.py
+++ b/videos/utils.py
@@ -362,16 +362,16 @@ def resource_file_paths(resources: list) -> list:
     """Return a list of ``{file, language[, locale]}`` dicts for caption/transcript
     resources.
 
-    Language and optional locale are parsed from each resource's real
-    uploaded file path (immune to the filename-uniqueness suffix described in
-    :func:`parse_caption_language_locale`).  Resources without a resolvable
-    file are omitted.  ``locale`` is only included in the dict when present.
+    Language and optional locale come from :func:`resolve_language_locale`, so an
+    explicit value set in Studio wins over whatever the filename says.  Resources
+    without a resolvable file are omitted.  ``locale`` is only included in the
+    dict when present.
     """
     result = []
     for resource in resources:
         file_name = getattr(getattr(resource, "file", None), "name", None)
         if file_name:
-            lang, locale = parse_caption_language_locale(file_name)
+            lang, locale = resolve_language_locale(resource)
             entry: dict = {
                 "file": f"/{file_name.lstrip('/')}",
                 "language": lang,

--- a/videos/utils_test.py
+++ b/videos/utils_test.py
@@ -13,6 +13,7 @@ from videos.utils import (
     get_tags_with_course,
     parse_caption_language_locale,
     resolve_language_locale,
+    resource_file_paths,
     update_metadata,
 )
 from websites.factories import (
@@ -249,3 +250,38 @@ def test_resolve_language_locale_non_dict_metadata(metadata):
         metadata=metadata, file="courses/s/l1_captions-fr.vtt"
     )
     assert resolve_language_locale(resource) == ("fr", None)
+
+
+def test_resource_file_paths_honors_metadata_override():
+    """An explicit language overrides what the filename says."""
+    resource = WebsiteContentFactory.build(
+        metadata={"language": "es", "locale": "MX"},
+        file="courses/s/lecture1_captions-fr.vtt",
+    )
+    assert resource_file_paths([resource]) == [
+        {
+            "file": "/courses/s/lecture1_captions-fr.vtt",
+            "language": "es",
+            "locale": "MX",
+        }
+    ]
+
+
+def test_resource_file_paths_falls_back_to_filename():
+    """With no metadata language, output is unchanged from before this feature."""
+    resource = WebsiteContentFactory.build(
+        metadata={}, file="courses/s/lecture1_captions-fr.vtt"
+    )
+    assert resource_file_paths([resource]) == [
+        {"file": "/courses/s/lecture1_captions-fr.vtt", "language": "fr"}
+    ]
+
+
+def test_resource_file_paths_omits_locale_when_absent():
+    """The locale key is only present when there is a locale to publish."""
+    resource = WebsiteContentFactory.build(
+        metadata={"language": "de"}, file="courses/s/lecture1_captions.vtt"
+    )
+    assert resource_file_paths([resource]) == [
+        {"file": "/courses/s/lecture1_captions.vtt", "language": "de"}
+    ]

--- a/videos/utils_test.py
+++ b/videos/utils_test.py
@@ -12,6 +12,7 @@ from videos.utils import (
     get_content_dirpath,
     get_tags_with_course,
     parse_caption_language_locale,
+    resolve_language_locale,
     update_metadata,
 )
 from websites.factories import (
@@ -199,3 +200,46 @@ def test_get_tags_with_course_whitespace_handling():
 def test_parse_caption_language_locale(filename, expected):
     """parse_caption_language_locale returns (language, locale) from slugified filename."""
     assert parse_caption_language_locale(filename) == expected
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    ("metadata", "file_name", "expected"),
+    [
+        # explicit metadata wins over the filename
+        ({"language": "es"}, "courses/s/l1_captions-fr.vtt", ("es", None)),
+        # explicit language with no locale does not inherit the parsed region
+        ({"language": "es"}, "courses/s/l1_captions-fr-CA.vtt", ("es", None)),
+        # explicit locale wins while language still comes from the filename
+        ({"locale": "BR"}, "courses/s/l1_captions-pt.vtt", ("pt", "BR")),
+        # both explicit
+        ({"language": "pt", "locale": "BR"}, "courses/s/l1_captions.vtt", ("pt", "BR")),
+        # no metadata: parsed from the filename
+        ({}, "courses/s/l1_captions-fr.vtt", ("fr", None)),
+        ({}, "courses/s/l1_captions-en-US.vtt", ("en", "US")),
+        # no metadata and no language suffix: the "en" default
+        ({}, "courses/s/l1_captions.vtt", ("en", None)),
+        # empty-string metadata is treated as unset, not as a language
+        ({"language": "", "locale": ""}, "courses/s/l1_captions-fr.vtt", ("fr", None)),
+    ],
+)
+def test_resolve_language_locale(metadata, file_name, expected):
+    """Explicit metadata wins, otherwise the filename is parsed, otherwise 'en'."""
+    resource = WebsiteContentFactory.build(metadata=metadata, file=file_name)
+    assert resolve_language_locale(resource) == expected
+
+
+@pytest.mark.django_db
+def test_resolve_language_locale_without_file():
+    """A resource with no uploaded file falls back to the 'en' default."""
+    resource = WebsiteContentFactory.build(metadata={}, file=None)
+    assert resolve_language_locale(resource) == ("en", None)
+
+
+@pytest.mark.django_db
+def test_resolve_language_locale_non_dict_metadata():
+    """Metadata that is not a dict is treated as absent rather than raising."""
+    resource = WebsiteContentFactory.build(
+        metadata=None, file="courses/s/l1_captions-fr.vtt"
+    )
+    assert resolve_language_locale(resource) == ("fr", None)

--- a/videos/utils_test.py
+++ b/videos/utils_test.py
@@ -202,7 +202,6 @@ def test_parse_caption_language_locale(filename, expected):
     assert parse_caption_language_locale(filename) == expected
 
 
-@pytest.mark.django_db
 @pytest.mark.parametrize(
     ("metadata", "file_name", "expected"),
     [
@@ -212,6 +211,7 @@ def test_parse_caption_language_locale(filename, expected):
         ({"language": "es"}, "courses/s/l1_captions-fr-CA.vtt", ("es", None)),
         # explicit locale wins while language still comes from the filename
         ({"locale": "BR"}, "courses/s/l1_captions-pt.vtt", ("pt", "BR")),
+        ({"locale": "BR"}, "courses/s/l1_captions-pt-PT.vtt", ("pt", "BR")),
         # both explicit
         ({"language": "pt", "locale": "BR"}, "courses/s/l1_captions.vtt", ("pt", "BR")),
         # no metadata: parsed from the filename
@@ -221,6 +221,13 @@ def test_parse_caption_language_locale(filename, expected):
         ({}, "courses/s/l1_captions.vtt", ("en", None)),
         # empty-string metadata is treated as unset, not as a language
         ({"language": "", "locale": ""}, "courses/s/l1_captions-fr.vtt", ("fr", None)),
+        # explicit codes are normalized to match what the filename parse yields
+        ({"language": "EN"}, "courses/s/l1_captions-fr.vtt", ("en", None)),
+        ({"language": "pt", "locale": "br"}, "courses/s/l1_captions.vtt", ("pt", "BR")),
+        # unusable values are unset, never a crash and never published as-is
+        ({"language": "   "}, "courses/s/l1_captions-fr.vtt", ("fr", None)),
+        ({"language": 5}, "courses/s/l1_captions-fr.vtt", ("fr", None)),
+        ({"language": ["fr"]}, "courses/s/l1_captions-fr.vtt", ("fr", None)),
     ],
 )
 def test_resolve_language_locale(metadata, file_name, expected):
@@ -229,17 +236,16 @@ def test_resolve_language_locale(metadata, file_name, expected):
     assert resolve_language_locale(resource) == expected
 
 
-@pytest.mark.django_db
 def test_resolve_language_locale_without_file():
     """A resource with no uploaded file falls back to the 'en' default."""
     resource = WebsiteContentFactory.build(metadata={}, file=None)
     assert resolve_language_locale(resource) == ("en", None)
 
 
-@pytest.mark.django_db
-def test_resolve_language_locale_non_dict_metadata():
+@pytest.mark.parametrize("metadata", [None, "en", ["en"], 42])
+def test_resolve_language_locale_non_dict_metadata(metadata):
     """Metadata that is not a dict is treated as absent rather than raising."""
     resource = WebsiteContentFactory.build(
-        metadata=None, file="courses/s/l1_captions-fr.vtt"
+        metadata=metadata, file="courses/s/l1_captions-fr.vtt"
     )
     assert resolve_language_locale(resource) == ("fr", None)

--- a/videos/utils_test.py
+++ b/videos/utils_test.py
@@ -277,6 +277,16 @@ def test_resource_file_paths_falls_back_to_filename():
     ]
 
 
+def test_resource_file_paths_skips_fileless_resource_with_language():
+    """A metadata language alone is not enough to publish an entry.
+
+    There is no file to point at, so the resource is omitted exactly as it was
+    before the language override existed.
+    """
+    resource = WebsiteContentFactory.build(metadata={"language": "es"}, file="")
+    assert resource_file_paths([resource]) == []
+
+
 def test_resource_file_paths_omits_locale_when_absent():
     """The locale key is only present when there is a locale to publish."""
     resource = WebsiteContentFactory.build(

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -24,6 +24,7 @@ from gdrive_sync.tasks import create_gdrive_folders
 from main.posthog import is_feature_enabled
 from main.serializers import RequestUserSerializerMixin
 from users.models import User
+from videos.utils import resolve_language_locale
 from websites import constants
 from websites.api import (
     detect_mime_type,
@@ -525,6 +526,21 @@ class WebsiteContentSerializer(
         fields = read_only_fields
 
 
+def _declared_field_names(instance) -> set:
+    """Return the top-level field names the starter declares for this content type.
+
+    Used to gate derived-value injection so it only happens where the form
+    actually has a matching widget.
+    """
+    starter = instance.website.starter
+    if starter is None:
+        return set()
+    item = SiteConfig(starter.config).find_item_by_name(instance.type)
+    if item is None:
+        return set()
+    return {field.get("name") for field in item.fields}
+
+
 class WebsiteContentDetailSerializer(
     serializers.ModelSerializer,
     RequestUserSerializerMixin,
@@ -670,6 +686,19 @@ class WebsiteContentDetailSerializer(
         drivefile = instance.drivefile_set.first()  # noqa: ORM002
         if drivefile:
             result["gdrive_url"] = DRIVE_FILE_VIEW_URL.format(file_id=drivefile.file_id)
+
+        declared = _declared_field_names(instance)
+        if declared & {"language", "locale"}:
+            # Copied, never mutated in place: result["metadata"] can be the
+            # same dict as instance.metadata, and writing a derived value onto
+            # the instance would let a later save persist it.
+            metadata = dict(result.get("metadata") or {})
+            language, locale = resolve_language_locale(instance)
+            if "language" in declared and not metadata.get("language"):
+                metadata["language"] = language
+            if "locale" in declared and locale and not metadata.get("locale"):
+                metadata["locale"] = locale
+            result["metadata"] = metadata
 
         return result
 

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -693,10 +693,17 @@ class WebsiteContentDetailSerializer(
             # same dict as instance.metadata, and writing a derived value onto
             # the instance would let a later save persist it.
             metadata = dict(result.get("metadata") or {})
+            # Assigned unconditionally rather than only when absent.
+            # resolve_language_locale already gives a stored value precedence,
+            # so re-checking here would only serve to echo a stored value back
+            # *unnormalized* -- showing "ES" in the form while "es" publishes.
+            # Writing what the resolver returns keeps the form and the publish
+            # path identical for every input, which is the whole point of both
+            # routing through it.
             language, locale = resolve_language_locale(instance)
-            if "language" in declared and not metadata.get("language"):
+            if "language" in declared:
                 metadata["language"] = language
-            if "locale" in declared and locale and not metadata.get("locale"):
+            if "locale" in declared and locale:
                 metadata["locale"] = locale
             result["metadata"] = metadata
 

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -16,6 +16,7 @@ from main.constants import ISO_8601_FORMAT
 from users.factories import UserFactory
 from users.models import User
 from videos.constants import YT_THUMBNAIL_IMG
+from videos.utils import resource_file_paths
 from websites.constants import (
     CONTENT_TYPE_INSTRUCTOR,
     CONTENT_TYPE_METADATA,
@@ -934,3 +935,141 @@ def test_update_page_url_on_title_change_legacy_index_behavior(
     page.refresh_from_db()
     assert page.filename == expected_filename
     assert page.title == "New Title"
+
+
+LANGUAGE_FIELD_CONFIG = {
+    "collections": [
+        {
+            "name": "resource",
+            "label": "Resource",
+            "category": "Content",
+            "folder": "content/resources",
+            "fields": [
+                {"label": "Title", "name": "title", "widget": "string"},
+                {"label": "Language", "name": "language", "widget": "select"},
+                {"label": "Locale", "name": "locale", "widget": "select"},
+            ],
+        }
+    ],
+}
+
+
+@pytest.mark.django_db
+def test_detail_serializer_fills_language_from_filename():
+    """An unset language is shown as the value that would publish."""
+    website = WebsiteFactory.create(
+        starter=WebsiteStarterFactory.create(config=LANGUAGE_FIELD_CONFIG)
+    )
+    content = WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        metadata={},
+        file="courses/s/lecture1_captions-fr.vtt",
+    )
+
+    data = WebsiteContentDetailSerializer(instance=content).data
+
+    assert data["metadata"]["language"] == "fr"
+
+
+@pytest.mark.django_db
+def test_detail_serializer_defaults_language_to_english():
+    """A filename with no language suffix resolves to English."""
+    website = WebsiteFactory.create(
+        starter=WebsiteStarterFactory.create(config=LANGUAGE_FIELD_CONFIG)
+    )
+    content = WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        metadata={},
+        file="courses/s/lecture1_captions.vtt",
+    )
+
+    data = WebsiteContentDetailSerializer(instance=content).data
+
+    assert data["metadata"]["language"] == "en"
+
+
+@pytest.mark.django_db
+def test_detail_serializer_keeps_explicit_language():
+    """A stored value is never overwritten by the derived one."""
+    website = WebsiteFactory.create(
+        starter=WebsiteStarterFactory.create(config=LANGUAGE_FIELD_CONFIG)
+    )
+    content = WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        metadata={"language": "es"},
+        file="courses/s/lecture1_captions-fr.vtt",
+    )
+
+    data = WebsiteContentDetailSerializer(instance=content).data
+
+    assert data["metadata"]["language"] == "es"
+
+
+@pytest.mark.django_db
+def test_detail_serializer_skips_when_starter_lacks_the_field():
+    """Nothing is injected for a starter that does not declare the field.
+
+    This keeps ocw-studio inert until the starter ships, and stops the keys
+    appearing on content types that have no such form field.
+    """
+    content = WebsiteContentFactory.create(
+        type="resource", metadata={}, file="courses/s/lecture1_captions-fr.vtt"
+    )
+
+    data = WebsiteContentDetailSerializer(instance=content).data
+
+    assert "language" not in data["metadata"]
+
+
+@pytest.mark.django_db
+def test_detail_serializer_does_not_mutate_stored_metadata():
+    """Serializing must not write the derived value onto the instance.
+
+    to_representation's result can alias instance.metadata. Mutating it in
+    place would let a derived guess be persisted by any later save, which is
+    the failure mode fixed in full_metadata under hq#12635.
+    """
+    website = WebsiteFactory.create(
+        starter=WebsiteStarterFactory.create(config=LANGUAGE_FIELD_CONFIG)
+    )
+    content = WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        metadata={},
+        file="courses/s/lecture1_captions-fr.vtt",
+    )
+
+    WebsiteContentDetailSerializer(instance=content).data  # noqa: B018
+
+    assert content.metadata == {}
+    content.save()
+    content.refresh_from_db()
+    assert content.metadata == {}
+
+
+@pytest.mark.django_db
+def test_detail_serializer_agrees_with_what_gets_published():
+    """The form and the publish path must never disagree.
+
+    Both route through resolve_language_locale precisely so an editor cannot
+    be shown one language while a different one ships.  This pins that
+    invariant from the form side; resource_file_paths pins the publish side.
+    """
+    website = WebsiteFactory.create(
+        starter=WebsiteStarterFactory.create(config=LANGUAGE_FIELD_CONFIG)
+    )
+    content = WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        metadata={},
+        file="courses/s/lecture1_captions-pt-BR.vtt",
+    )
+
+    shown = WebsiteContentDetailSerializer(instance=content).data["metadata"]
+    published = resource_file_paths([content])[0]
+
+    assert shown["language"] == published["language"] == "pt"
+    assert shown["locale"] == published["locale"] == "BR"

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -1029,8 +1029,8 @@ def test_detail_serializer_does_not_mutate_stored_metadata():
     """Serializing must not write the derived value onto the instance.
 
     to_representation's result can alias instance.metadata. Mutating it in
-    place would let a derived guess be persisted by any later save, which is
-    the failure mode fixed in full_metadata under hq#12635.
+    place would let a derived guess be persisted by any later save, as if the
+    editor had chosen it.
     """
     website = WebsiteFactory.create(
         starter=WebsiteStarterFactory.create(config=LANGUAGE_FIELD_CONFIG)

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -1050,26 +1050,84 @@ def test_detail_serializer_does_not_mutate_stored_metadata():
     assert content.metadata == {}
 
 
+@pytest.mark.parametrize(
+    ("metadata", "file_name", "exp_language", "exp_locale"),
+    [
+        # No metadata: both sides parse the filename identically.
+        ({}, "courses/s/l1_captions-pt-BR.vtt", "pt", "BR"),
+        # The distinguishing case: an explicit language against a filename that
+        # carries a region. A direct parse in the serializer would show locale
+        # "BR" here while publishing none, so this is what actually pins both
+        # callers to the shared resolver.
+        ({"language": "es"}, "courses/s/l1_captions-pt-BR.vtt", "es", None),
+        # A stored value is echoed back normalized, not raw.
+        ({"language": "ES"}, "courses/s/l1_captions.vtt", "es", None),
+    ],
+)
 @pytest.mark.django_db
-def test_detail_serializer_agrees_with_what_gets_published():
+def test_detail_serializer_agrees_with_what_gets_published(
+    metadata, file_name, exp_language, exp_locale
+):
     """The form and the publish path must never disagree.
 
     Both route through resolve_language_locale precisely so an editor cannot
-    be shown one language while a different one ships.  This pins that
-    invariant from the form side; resource_file_paths pins the publish side.
+    be shown one language while a different one ships.
     """
     website = WebsiteFactory.create(
         starter=WebsiteStarterFactory.create(config=LANGUAGE_FIELD_CONFIG)
     )
     content = WebsiteContentFactory.create(
-        website=website,
-        type="resource",
-        metadata={},
-        file="courses/s/lecture1_captions-pt-BR.vtt",
+        website=website, type="resource", metadata=metadata, file=file_name
     )
 
     shown = WebsiteContentDetailSerializer(instance=content).data["metadata"]
     published = resource_file_paths([content])[0]
 
-    assert shown["language"] == published["language"] == "pt"
-    assert shown["locale"] == published["locale"] == "BR"
+    assert shown["language"] == published["language"] == exp_language
+    assert shown.get("locale") == published.get("locale") == exp_locale
+
+
+@pytest.mark.parametrize(
+    ("declared_fields", "expect_language", "expect_locale"),
+    [
+        (["language", "locale"], True, True),
+        (["language"], True, False),
+        (["locale"], False, True),
+    ],
+)
+@pytest.mark.django_db
+def test_detail_serializer_injects_only_declared_fields(
+    declared_fields, expect_language, expect_locale
+):
+    """A key is injected only when the starter declares that specific field.
+
+    Collapsing this to "inject both when either is declared" would put a
+    locale onto a starter with no locale widget, which a later save would
+    then persist.
+    """
+    config = {
+        "collections": [
+            {
+                "name": "resource",
+                "label": "Resource",
+                "category": "Content",
+                "folder": "content/resources",
+                "fields": [
+                    {"label": name.title(), "name": name, "widget": "select"}
+                    for name in declared_fields
+                ],
+            }
+        ],
+    }
+    website = WebsiteFactory.create(starter=WebsiteStarterFactory.create(config=config))
+    content = WebsiteContentFactory.create(
+        website=website,
+        type="resource",
+        metadata={},
+        file="courses/s/l1_captions-pt-BR.vtt",
+    )
+
+    shown = WebsiteContentDetailSerializer(instance=content).data["metadata"]
+
+    assert ("language" in shown) is expect_language
+    assert ("locale" in shown) is expect_locale


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12685

Paired with mitodl/ocw-hugo-projects#400, which declares the two form fields. The two can merge in either order. Until the starter ships, this branch finds no metadata value and behaves exactly as today.

### Description (What does it do?)
A caption or transcript's language is currently derived only from its uploaded filename, which has to follow the `_captions-<lang>[-<locale>]` convention. A file that does not follow it cannot be labeled, and correcting a language means renaming the file. This lets an editor set the language from the resource form instead.

- `videos/utils.py`: new `resolve_language_locale`, the single source of precedence (explicit metadata, then the parsed filename, then `en`). Language and locale resolve independently, so an explicit language does not inherit a region parsed from a filename it no longer agrees with. Non-string or whitespace-only metadata is treated as unset rather than raising, since this runs in the publish path where an exception fails a whole site build.
- `videos/utils.py`: `resource_file_paths` now goes through the resolver, which is what makes an override reach published frontmatter.
- `websites/serializers.py`: `WebsiteContentDetailSerializer.to_representation` fills both keys from the resolver, so the form always shows the value that will publish and saving materializes it. An incorrect detection is then visible and correctable.

No change is needed in ocw-hugo-themes. Its partials already consume `{file, language, locale}`.

### How can this be tested?

**Load the starter from the linked branch.** `import_website_starters` refuses to sync unless the commit you pass matches the head of `GITHUB_WEBHOOK_BRANCH`, and it prints "Successfully updated" either way, so both have to be set or the import silently does nothing.

```bash
BRANCH=umar/12685-resource-language-locale-fields
SHA=$(git ls-remote https://github.com/mitodl/ocw-hugo-projects "refs/heads/$BRANCH" | cut -f1)
docker compose run --rm -e GITHUB_WEBHOOK_BRANCH="$BRANCH" web \
  python manage.py import_website_starters https://github.com/mitodl/ocw-hugo-projects -c "$SHA"
```

Confirm the output lists the config files rather than "No ocw-studio.yaml files found", then check the fields actually landed:

```bash
docker compose run --rm web python manage.py shell -c "
from websites.models import WebsiteStarter
from websites.site_config_api import SiteConfig
item = SiteConfig(WebsiteStarter.objects.get(slug='ocw-course-v2').config).find_item_by_name('resource')
print([f['name'] for f in item.fields if f['name'] in ('language', 'locale')])
"
```

Expected: `['language', 'locale']`.

**Then in the editor:**

1. Open a caption resource whose filename carries a language, for example `..._captions-fr.vtt`. Language is pre-selected as French rather than blank. A file with no language suffix shows English.
2. Change it to Spanish and save. The published frontmatter for the video that links it shows `language: es` rather than the `fr` in the filename.
3. Confirm a resource on a starter without these fields is unaffected, with no `language` key added to its metadata.
