### PR TITLE
chore: add the COURSE_V3_CANONICAL_DOMAIN variable to site pipelines

### DIFF
--- a/content_sync/conftest.py
+++ b/content_sync/conftest.py
@@ -90,6 +90,7 @@ def required_concourse_settings(settings):
     settings.OCW_GTM_ACCOUNT_ID = "abc123"
     settings.OCW_EXTRA_THEMES_GTM_IDS = {}
     settings.OCW_EXTRA_THEMES_BASE_URLS = {}
+    settings.COURSE_V3_CANONICAL_DOMAIN = "learn-test.mit.edu"
     settings.TEST_ROOT_WEBSITE_NAME = "ocw-ci-test-www"
     settings.OCW_TEST_SITE_SLUGS = ["ocw-ci-test-www", "ocw-ci-test-course"]
     return settings

--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline.py
@@ -320,6 +320,7 @@ class EndToEndTestPipelineDefinition(Pipeline):
                         "POSTHOG_ENV": "development",
                         "RESOURCE_BASE_URL": static_api_base_url,
                         "SITEMAP_DOMAIN": sitemap_domain,
+                        "COURSE_V3_CANONICAL_DOMAIN": settings.COURSE_V3_CANONICAL_DOMAIN,  # noqa: E501
                         "SEARCH_API_URL": "https://discussions-rc.odl.mit.edu/api/v0/search/",
                         "COURSE_SEARCH_API_URL": "https://mit-open-rc.odl.mit.edu/api/v1/learning_resources_search/",
                         "CONTENT_FILE_SEARCH_API_URL": "https://mit-open-rc.odl.mit.edu/api/v1/content_file_search/",

--- a/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/e2e_test_site_pipeline_test.py
@@ -178,6 +178,9 @@ def test_generate_e2e_test_site_pipeline_definition(  # noqa: PLR0913, PLR0915, 
     assert www_values["ocw_hugo_themes_branch"] == ocw_hugo_themes_branch
     assert www_values["ocw_hugo_projects_branch"] == ocw_hugo_projects_branch
     assert www_values["sitemap_domain"] == sitemap_domain
+    assert (
+        www_values["course_v3_canonical_domain"] == settings.COURSE_V3_CANONICAL_DOMAIN
+    )
     course_values = next(
         values
         for values in across_values
@@ -191,6 +194,10 @@ def test_generate_e2e_test_site_pipeline_definition(  # noqa: PLR0913, PLR0915, 
     assert course_values["ocw_hugo_themes_branch"] == ocw_hugo_themes_branch
     assert course_values["ocw_hugo_projects_branch"] == ocw_hugo_projects_branch
     assert course_values["sitemap_domain"] == sitemap_domain
+    assert (
+        course_values["course_v3_canonical_domain"]
+        == settings.COURSE_V3_CANONICAL_DOMAIN
+    )
     across_step_build_steps = across_steps[0]["do"]
     cdn_cache_clear_steps = [
         step
@@ -249,6 +256,10 @@ def test_generate_e2e_test_site_pipeline_definition(  # noqa: PLR0913, PLR0915, 
     assert playwright_task_params["RESOURCE_BASE_URL"] == static_api_base_url
     assert (
         playwright_task_params["SITEMAP_DOMAIN"] == urlparse(static_api_base_url).netloc
+    )
+    assert (
+        playwright_task_params["COURSE_V3_CANONICAL_DOMAIN"]
+        == settings.COURSE_V3_CANONICAL_DOMAIN
     )
     assert playwright_task_params["WEBPACK_WATCH_MODE"] == "false"
     assert playwright_task_params["SENTRY_ENV"] == ""

--- a/content_sync/pipelines/definitions/concourse/mass_build_sites_test.py
+++ b/content_sync/pipelines/definitions/concourse/mass_build_sites_test.py
@@ -290,6 +290,10 @@ def test_generate_mass_build_sites_definition(  # noqa: C901, PLR0913, PLR0912, 
                         == site_config.hugo_args_offline
                     )
                     assert across_values["prefix"] == site_config.prefix
+                    assert (
+                        across_values["course_v3_canonical_domain"]
+                        == settings.COURSE_V3_CANONICAL_DOMAIN
+                    )
                 build_steps = step["do"]
                 site_content_git_step = get_dict_list_item_by_field(
                     items=build_steps,

--- a/content_sync/pipelines/definitions/concourse/site_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline.py
@@ -93,6 +93,7 @@ def get_site_pipeline_definition_vars(namespace: str):
         "pipeline_name": f"(({namespace}pipeline_name))",
         "instance_vars": f"(({namespace}instance_vars))",
         "sitemap_domain": f"(({namespace}sitemap_domain))",
+        "course_v3_canonical_domain": f"(({namespace}course_v3_canonical_domain))",
         "static_api_url": f"(({namespace}static_api_url))",
         "storage_bucket": f"(({namespace}storage_bucket))",
         "artifacts_bucket": f"(({namespace}artifacts_bucket))",
@@ -150,6 +151,7 @@ class SitePipelineDefinitionConfig:
         ocw_hugo_themes_branch(str): The branch of ocw-hugo-themes to use
         ocw_hugo_projects_branch(str): The branch of ocw-hugo-projects to use
         hugo_override_args(str): (Optional) Arguments to override in the hugo command
+        course_v3_canonical_domain(str): (Optional) The domain to use for canonical URLs on ocw-course-v3 sites
         prefix(str): (Optional) A prefix to deploy the site at
         namespace(str): The Concourse vars namespace to use
     """  # noqa: E501
@@ -170,6 +172,7 @@ class SitePipelineDefinitionConfig:
         ocw_hugo_projects_branch: str,
         hugo_override_args: str | None = "",
         sitemap_domain: str | None = settings.SITEMAP_DOMAIN,
+        course_v3_canonical_domain: str | None = None,
         prefix: str = "",
         namespace: str = "site:",
         noindex: bool | None = None,  # noqa: FBT001
@@ -189,6 +192,13 @@ class SitePipelineDefinitionConfig:
         self.offline_bucket = offline_bucket
         self.static_api_url = static_api_url
         self.sitemap_domain = sitemap_domain
+        # Resolved here rather than as a kwarg default so that the setting is read at
+        # pipeline generation time instead of at module import time.
+        self.course_v3_canonical_domain = (
+            course_v3_canonical_domain
+            if course_v3_canonical_domain is not None
+            else settings.COURSE_V3_CANONICAL_DOMAIN
+        )
         self.prefix = prefix.strip("/") if prefix else ""
         self.url_path = site.get_url_path()
         self.resource_base_url = resource_base_url
@@ -286,6 +296,7 @@ class SitePipelineDefinitionConfig:
             "pipeline_name": pipeline_name,
             "instance_vars": instance_vars,
             "sitemap_domain": self.sitemap_domain,
+            "course_v3_canonical_domain": self.course_v3_canonical_domain,
             "static_api_url": self.static_api_url,
             "storage_bucket": storage_bucket,
             "artifacts_bucket": artifacts_bucket,
@@ -587,6 +598,9 @@ class SitePipelineOnlineTasks(list[StepModifierMixin]):
                     "OCW_COURSE_STARTER_SLUG": settings.OCW_COURSE_STARTER_SLUG,
                     "RESOURCE_BASE_URL": pipeline_vars["resource_base_url"],
                     "SITEMAP_DOMAIN": pipeline_vars["sitemap_domain"],
+                    "COURSE_V3_CANONICAL_DOMAIN": pipeline_vars[
+                        "course_v3_canonical_domain"
+                    ],
                     "SENTRY_DSN": settings.OCW_HUGO_THEMES_SENTRY_DSN,
                     "NOINDEX": pipeline_vars["noindex"],
                 },
@@ -809,6 +823,9 @@ class SitePipelineOfflineTasks(list[StepModifierMixin]):
                     "OCW_COURSE_STARTER_SLUG": settings.OCW_COURSE_STARTER_SLUG,
                     "RESOURCE_BASE_URL": pipeline_vars["resource_base_url"] or "",
                     "SITEMAP_DOMAIN": pipeline_vars["sitemap_domain"],
+                    "COURSE_V3_CANONICAL_DOMAIN": pipeline_vars[
+                        "course_v3_canonical_domain"
+                    ],
                     "SENTRY_DSN": settings.OCW_HUGO_THEMES_SENTRY_DSN,
                     "NOINDEX": pipeline_vars["noindex"],
                     "IS_ROOT_WEBSITE": pipeline_vars["is_root_website"],
@@ -1039,6 +1056,9 @@ class SitePipelineDefinition(Pipeline):
                     "pipeline_name": config.values["pipeline_name"],
                     "instance_vars": config.values["instance_vars"],
                     "sitemap_domain": config.values["sitemap_domain"],
+                    "course_v3_canonical_domain": config.values[
+                        "course_v3_canonical_domain"
+                    ],
                     "static_api_url": config.values["static_api_url"],
                     "storage_bucket": config.values["storage_bucket"],
                     "artifacts_bucket": config.values["artifacts_bucket"],

--- a/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/site_pipeline_test.py
@@ -386,6 +386,7 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
         "OCW_IMPORT_STARTER_SLUG": settings.OCW_COURSE_STARTER_SLUG,
         "OCW_COURSE_STARTER_SLUG": settings.OCW_COURSE_STARTER_SLUG,
         "SITEMAP_DOMAIN": settings.SITEMAP_DOMAIN,
+        "COURSE_V3_CANONICAL_DOMAIN": settings.COURSE_V3_CANONICAL_DOMAIN,
         "SENTRY_DSN": settings.OCW_HUGO_THEMES_SENTRY_DSN,
         "NOINDEX": config.noindex,
     }
@@ -403,6 +404,10 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
     assert (
         build_online_site_task["params"]["GTM_ACCOUNT_ID"]
         == config.vars["gtm_account_id"]
+    )
+    assert (
+        build_online_site_task["params"]["COURSE_V3_CANONICAL_DOMAIN"]
+        == config.vars["course_v3_canonical_domain"]
     )
     upload_online_build_task = get_dict_list_item_by_field(
         items=online_site_tasks, field="task", value=UPLOAD_ONLINE_BUILD_IDENTIFIER
@@ -607,6 +612,7 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
         "OCW_IMPORT_STARTER_SLUG": settings.OCW_COURSE_STARTER_SLUG,
         "OCW_COURSE_STARTER_SLUG": settings.OCW_COURSE_STARTER_SLUG,
         "SITEMAP_DOMAIN": settings.SITEMAP_DOMAIN,
+        "COURSE_V3_CANONICAL_DOMAIN": settings.COURSE_V3_CANONICAL_DOMAIN,
         "SENTRY_DSN": settings.OCW_HUGO_THEMES_SENTRY_DSN,
         "NOINDEX": config.noindex,
     }
@@ -624,6 +630,10 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
     assert (
         build_offline_site_task["params"]["GTM_ACCOUNT_ID"]
         == config.vars["gtm_account_id"]
+    )
+    assert (
+        build_offline_site_task["params"]["COURSE_V3_CANONICAL_DOMAIN"]
+        == config.vars["course_v3_canonical_domain"]
     )
     upload_offline_build_task = get_dict_list_item_by_field(
         offline_site_tasks, "task", UPLOAD_OFFLINE_BUILD_IDENTIFIER
@@ -736,6 +746,9 @@ def test_generate_theme_assets_pipeline_definition(  # noqa: C901, PLR0912, PLR0
     assert dummy_vars["noindex"] == config.noindex
     assert dummy_vars["pipeline_name"] == branch_vars["pipeline_name"]
     assert dummy_vars["instance_vars"] == instance_vars
+    assert (
+        dummy_vars["course_v3_canonical_domain"] == settings.COURSE_V3_CANONICAL_DOMAIN
+    )
     assert dummy_vars["static_api_url"] == branch_vars["static_api_url"]
     assert dummy_vars["storage_bucket"] == storage_bucket
     assert dummy_vars["artifacts_bucket"] == artifacts_bucket

--- a/main/settings.py
+++ b/main/settings.py
@@ -1348,6 +1348,11 @@ SITEMAP_DOMAIN = get_string(
     default="ocw.mit.edu",
     description="The domain to be used in Hugo builds for fully qualified URLs in the sitemap",  # noqa: E501
 )
+COURSE_V3_CANONICAL_DOMAIN = get_string(
+    name="COURSE_V3_CANONICAL_DOMAIN",
+    default="learn.mit.edu",
+    description="The domain to be used in Hugo builds for canonical URLs on ocw-course-v3 sites",  # noqa: E501
+)
 OCW_HUGO_THEMES_SENTRY_DSN = get_string(
     name="OCW_HUGO_THEMES_SENTRY_DSN",
     required=False,


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12410

### Description (What does it do?)
Adds the COURSE_V3_CANONICAL_DOMAIN variable to site pipelines


### How can this be tested?
1. Set the COURSE_V3_CANONICAL_DOMAIN setting to any value of your choice (e.g learn.mit.edu)
2. Upsert a mass build pipeline and some site pipeline
3. Verify that the pipeline config contains the COURSE_V3_CANONICAL_DOMAIN param `fly -t local get-pipeline -p <name>`
4. Try running the mass build pipeline and site pipeline. Verify that they run to completion as expected
