### PR TITLE
fix: store relation blanks in the widget's shape so new content stays editable

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -76,6 +76,21 @@ def omnibus_config(settings, db):  # noqa: ARG001
     return SiteConfig(parsed_config)
 
 
+@pytest.fixture
+def ocw_course_config(settings):
+    """Returns the parsed OCW course site config.
+
+    WebsiteStarterFactory's default config has no relation widgets, so tests
+    that care about relation fields build a starter from this instead.
+    """  # noqa: D401
+    with open(  # noqa: PTH123
+        os.path.join(  # noqa: PTH118
+            settings.BASE_DIR, "localdev/configs/ocw-course-site-config.yml"
+        )
+    ) as f:
+        return yaml.load(f.read().strip(), Loader=yaml.SafeLoader)
+
+
 def pytest_addoption(parser):
     """Pytest hook that adds command line parameters"""
     parser.addoption(

--- a/gdrive_sync/api.py
+++ b/gdrive_sync/api.py
@@ -595,6 +595,7 @@ def create_gdrive_resource_content(drive_file: DriveFile, user_pk=None):
                         cls=WebsiteContent,
                         use_defaults=True,
                         values=resource_type_fields,
+                        website_name=drive_file.website.name,
                     )
                 },
                 **ownership_fields,

--- a/gdrive_sync/api_test.py
+++ b/gdrive_sync/api_test.py
@@ -51,7 +51,11 @@ from websites.constants import (
     RESOURCE_TYPE_OTHER,
     RESOURCE_TYPE_VIDEO,
 )
-from websites.factories import WebsiteContentFactory, WebsiteFactory
+from websites.factories import (
+    WebsiteContentFactory,
+    WebsiteFactory,
+    WebsiteStarterFactory,
+)
 from websites.models import WebsiteContent
 
 pytestmark = pytest.mark.django_db
@@ -586,6 +590,32 @@ def test_create_gdrive_resource_content(mime_type, mock_get_s3_content_type, wit
         assert content.updated_by_id == user_pk
         drive_file.refresh_from_db()
         assert drive_file.resource == content
+
+
+def test_create_gdrive_resource_content_relation_fields_use_widget_shape(
+    ocw_course_config, mock_get_s3_content_type
+):
+    """An ingested resource's blank relation fields carry the widget's shape.
+
+    A bare [] here is not editable in the CMS: the content form's object
+    schema rejects it as a type error and reports it as a required-field
+    error on a field that is not required, blocking every save of that
+    resource until the value is replaced.
+    """
+    website = WebsiteFactory.create(
+        starter=WebsiteStarterFactory.create(config=ocw_course_config)
+    )
+    drive_file = DriveFileFactory.create(
+        website=website,
+        name="lecture1.mp4",
+        s3_key="test/path/lecture1_mp4.mp4",
+        mime_type="video/mp4",
+    )
+    create_gdrive_resource_content(drive_file)
+    drive_file.refresh_from_db()
+    video_files = drive_file.resource.metadata["video_files"]
+    for field in ("video_captions_resources", "video_transcript_resources"):
+        assert video_files[field] == {"content": [], "website": website.name}
 
 
 def test_create_gdrive_resource_content_forbidden_name(

--- a/websites/management/commands/backfill_orphaned_caption_transcript_files.py
+++ b/websites/management/commands/backfill_orphaned_caption_transcript_files.py
@@ -219,6 +219,7 @@ class Command(WebsiteFilterCommand):
                     cls=WebsiteContent,
                     use_defaults=True,
                     values=resource_type_fields,
+                    website_name=content.website.name,
                 ),
                 "file": path,
             }

--- a/websites/management/commands/backfill_orphaned_caption_transcript_files_test.py
+++ b/websites/management/commands/backfill_orphaned_caption_transcript_files_test.py
@@ -12,7 +12,11 @@ from moto import mock_aws
 from main.s3_utils import get_boto3_resource
 from videos.conftest import MOCK_BUCKET_NAME, setup_s3
 from websites.constants import CONTENT_FILENAME_MAX_LEN, CONTENT_TITLE_MAX_LEN
-from websites.factories import WebsiteContentFactory, WebsiteFactory
+from websites.factories import (
+    WebsiteContentFactory,
+    WebsiteFactory,
+    WebsiteStarterFactory,
+)
 from websites.models import WebsiteContent
 
 pytestmark = pytest.mark.django_db
@@ -102,6 +106,42 @@ def test_creates_resource_for_existing_s3_object(mock_s3):
     assert created.metadata["file_type"] == "application/x-subrip"
     assert created.metadata["file_size"] == len(b"WEBVTT")
     assert created.metadata["license"] == "default_license_specificed_in_config"
+
+
+def test_created_resource_relation_fields_use_widget_shape(mock_s3, ocw_course_config):
+    """A resource this command creates is editable in the CMS afterwards.
+
+    Its own blank relation fields have to carry the widget's shape, not a
+    bare container, or the content form rejects them as a type error and
+    reports a false required-field error that blocks every save.
+    """
+    website = WebsiteFactory.create(
+        starter=WebsiteStarterFactory.create(config=ocw_course_config)
+    )
+    caption_key = f"courses/{website.name}/1AbCdEf_transcript.webvtt"
+    mock_s3.put_object(Key=caption_key, Body=b"WEBVTT")
+    video = WebsiteContentFactory.create(
+        website=website,
+        filename="lecture1_mp4",
+        dirpath="content/resources",
+        title="Lecture 1",
+        metadata={
+            "resourcetype": "Video",
+            "video_files": {"video_captions_file": f"/{caption_key}"},
+        },
+    )
+
+    _run()
+
+    video.refresh_from_db()
+    created = WebsiteContent.objects.get(
+        text_id=video.metadata["video_files"]["video_captions_resources"]["content"][0]
+    )
+    for field in ("video_captions_resources", "video_transcript_resources"):
+        assert created.metadata["video_files"][field] == {
+            "content": [],
+            "website": website.name,
+        }
 
 
 def test_converts_url_path_relative_orphan_to_storage_key(mock_s3):

--- a/websites/management/commands/markdown_cleaning/rules/link_to_external_resource.py
+++ b/websites/management/commands/markdown_cleaning/rules/link_to_external_resource.py
@@ -60,7 +60,7 @@ def build_external_resource(
     This does not save the object to the database.
     """
     metadata = site_config.generate_item_metadata(
-        CONTENT_TYPE_EXTERNAL_RESOURCE, use_defaults=True
+        CONTENT_TYPE_EXTERNAL_RESOURCE, use_defaults=True, website_name=website.name
     )
     metadata["external_url"] = url
     metadata["has_external_license_warning"] = (

--- a/websites/site_config_api.py
+++ b/websites/site_config_api.py
@@ -81,6 +81,48 @@ class ConfigField:
     parent_field: dict | None = None
 
 
+def _blank_relation_value(field: dict, website_name: str | None) -> dict:
+    """Return a relation field's blank value in the widget's own shape.
+
+    A relation stores {"content": [...], "website": name}, unlike every other
+    widget, whose blank value is a bare container. A bare [] or "" fails the
+    content form's object schema as a type error, which the form reports as a
+    false "is a required field", blocking every save of the item.
+
+    List-vs-scalar content and the site name both mirror what the widget
+    itself writes: multiple or sortable means a list, and a field-level
+    website overrides the site being edited. The website key is omitted when
+    no site is known, which still validates, and the widget attaches it on
+    the first edit.
+    """
+    is_list = field.get("multiple") or field.get("sortable")
+    blank = {"content": [] if is_list else ""}
+    website = field.get("website") or website_name
+    if website:
+        blank["website"] = website
+    return blank
+
+
+def _leaf_field_value(
+    field: dict,
+    values: dict,
+    *,
+    use_defaults: bool,
+    website_name: str | None,
+):
+    """Return the blank or default value for a field with no subfields."""
+    key = field["name"]
+    if values.get(key) is not None:
+        return values.get(key)
+    if use_defaults and field.get("default") is not None:
+        return field.get("default")
+    if field.get("widget") == "relation":
+        return _blank_relation_value(field, website_name)
+    if field.get("multiple"):
+        return []
+    return ""
+
+
 class SiteConfig:
     """Utility class for parsing and introspecting site configs"""
 
@@ -151,24 +193,17 @@ class SiteConfig:
         cls: object = None,
         use_defaults=False,  # noqa: FBT002
         values: dict | None = None,
+        website_name: str | None = None,
     ) -> dict:
         """Generate a metadata dict with blank keys for the specified item. If
         use_defaults is True, fill the keys with default values from config.
+
+        Pass website_name when the metadata is being generated for a known
+        site so relation fields carry it, matching what the CMS form writes.
         """
         values = values or {}
         item_dict = {}
         item = self.find_item_by_name(name)
-
-        def get_leaf_field_value(config_field: ConfigField):
-            key = config_field.field["name"]
-            if values.get(key) is not None:
-                return values.get(key)
-            if use_defaults and config_field.field.get("default") is not None:
-                return config_field.field.get("default")
-            if config_field.field.get("multiple"):
-                return []
-            return ""
-
         if not item:
             return item_dict
         for config_field in self.iter_item_fields(item):
@@ -179,7 +214,12 @@ class SiteConfig:
                 if subfields:
                     item_dict[key] = {}
                 else:
-                    value = get_leaf_field_value(config_field)
+                    value = _leaf_field_value(
+                        config_field.field,
+                        values,
+                        use_defaults=use_defaults,
+                        website_name=website_name,
+                    )
                     if config_field.parent_field is None:
                         item_dict[key] = value
                     else:

--- a/websites/site_config_api_test.py
+++ b/websites/site_config_api_test.py
@@ -7,7 +7,7 @@ from websites.constants import (
     WEBSITE_CONFIG_DEFAULT_CONTENT_DIR,
 )
 from websites.models import WebsiteContent
-from websites.site_config_api import ConfigItem, SiteConfig
+from websites.site_config_api import ConfigItem, SiteConfig, _blank_relation_value
 
 # pylint:disable=redefined-outer-name
 
@@ -185,8 +185,8 @@ def test_generate_item_metadata(  # pylint: disable=too-many-arguments  # noqa: 
         "video_metadata": {"youtube_id": "", "video_speakers": "", "video_tags": ""},
         "video_files": {
             "video_thumbnail_file": "",
-            "video_captions_resources": [],
-            "video_transcript_resources": [],
+            "video_captions_resources": {"content": []},
+            "video_transcript_resources": {"content": []},
         },
         **class_data,
     }
@@ -198,3 +198,61 @@ def test_generate_item_metadata(  # pylint: disable=too-many-arguments  # noqa: 
         )
         == expected_data
     )
+
+
+def test_generate_item_metadata_relation_blank_carries_website(parsed_site_config):
+    """A blank relation value carries the site name when one is supplied.
+
+    The CMS relation widget stores {"content": [...], "website": name}, and the
+    content form binds to the nested "content" key, so a bare [] fails the
+    form's object schema as a type error and surfaces as a false "is a
+    required field" on a field that is not required.
+    """
+    metadata = SiteConfig(parsed_site_config).generate_item_metadata(
+        "resource", WebsiteContent, website_name="test-site"
+    )
+    assert metadata["video_files"]["video_captions_resources"] == {
+        "content": [],
+        "website": "test-site",
+    }
+    assert metadata["video_files"]["video_transcript_resources"] == {
+        "content": [],
+        "website": "test-site",
+    }
+
+
+@pytest.mark.parametrize(
+    ("field_props", "expected"),
+    [
+        ({"multiple": True}, {"content": [], "website": "test-site"}),
+        # sortable alone also means a list. The content form decides on
+        # "multiple || sortable", so a scalar here fails its object schema
+        # exactly the way a bare [] does.
+        ({"sortable": True}, {"content": [], "website": "test-site"}),
+        ({"multiple": True, "sortable": True}, {"content": [], "website": "test-site"}),
+        (
+            {"cross_site": True, "sortable": True},
+            {"content": [], "website": "test-site"},
+        ),
+        ({}, {"content": "", "website": "test-site"}),
+        ({"multiple": False}, {"content": "", "website": "test-site"}),
+        # A field-level website targets another site, and the widget stores
+        # that rather than the site being edited.
+        (
+            {"multiple": True, "website": "ocw-www"},
+            {"content": [], "website": "ocw-www"},
+        ),
+    ],
+)
+def test_blank_relation_value(field_props, expected):
+    """A blank relation matches the shape the CMS widget itself writes."""
+    assert (
+        _blank_relation_value({"name": "rel", **field_props}, "test-site") == expected
+    )
+
+
+def test_blank_relation_value_without_website():
+    """With no site known the website key is left out, which still validates."""
+    assert _blank_relation_value({"name": "rel", "multiple": True}, None) == {
+        "content": []
+    }


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12926

### Description (What does it do?)
`SiteConfig.generate_item_metadata()` builds blank metadata for a new item from the site config schema, but its leaf-value logic didn't know the relation widget's own shape. It returned a bare `[]`/`""` for a relation field instead of `{"content": [] or "", "website": <site name>}`. The content form's relation schema requires the `content` key, so the bare value failed as a type error and displayed as a false "is a required field" message, blocking every save on the resource until the value was replaced.

- `websites/site_config_api.py`: `generate_item_metadata()` gives relation fields their own blank-value branch, respecting `multiple`/`sortable` and a field-level `website` override, and accepts a `website_name` to fill in.
- `gdrive_sync/api.py`, `backfill_orphaned_caption_transcript_files.py`: pass the site name through, since both create resources via this generator.

### How can this be tested?
1. Check out `umar/12926-empty-captions-transcript-field-cant-be-saved`
2. Sync a video from GDrive with no caption/transcript files present. Confirm the resulting resource's edit drawer saves cleanly with no error.
