### PR TITLE
fix: reject invalid characters in external resource URLs

### DIFF
--- a/websites/management/commands/fix_external_resource_urls.py
+++ b/websites/management/commands/fix_external_resource_urls.py
@@ -6,7 +6,7 @@ import re
 from django.conf import settings
 from mitol.common.utils import now_in_utc
 
-from content_sync.tasks import sync_unsynced_websites
+from content_sync.tasks import sync_website_content
 from main.management.commands.filter import WebsiteFilterCommand
 from websites.constants import CONTENT_TYPE_EXTERNAL_RESOURCE
 from websites.models import WebsiteContent
@@ -43,7 +43,7 @@ class Command(WebsiteFilterCommand):
             dest="skip_sync",
             action="store_true",
             default=False,
-            help="Whether to skip running the sync_unsynced_websites task",
+            help="Whether to skip syncing affected websites to the backend",
         )
 
     def handle(self, *args, **options):
@@ -92,11 +92,14 @@ class Command(WebsiteFilterCommand):
             and modified_content
             and not options["skip_sync"]
         ):
-            self.stdout.write("Syncing all unsynced content to the designated backend")
+            website_names = sorted({row["website_name"] for row in modified_content})
+            self.stdout.write(
+                f"Syncing {len(website_names)} affected website(s) to the backend"
+            )
             start = now_in_utc()
-            task = sync_unsynced_websites.delay(create_backends=True)
-            self.stdout.write(f"Starting task {task}...")
-            task.get()
+            for website_name in website_names:
+                task = sync_website_content.delay(website_name)
+                task.get()
             total_seconds = (now_in_utc() - start).total_seconds()
             self.stdout.write(f"Backend sync finished, took {total_seconds} seconds")
 

--- a/websites/management/commands/fix_external_resource_urls.py
+++ b/websites/management/commands/fix_external_resource_urls.py
@@ -1,0 +1,114 @@
+"""Strip control characters (e.g. stray newlines) from external_url values"""  # noqa: INP001
+
+import csv
+import re
+
+from django.conf import settings
+from mitol.common.utils import now_in_utc
+
+from content_sync.tasks import sync_unsynced_websites
+from main.management.commands.filter import WebsiteFilterCommand
+from websites.constants import CONTENT_TYPE_EXTERNAL_RESOURCE
+from websites.models import WebsiteContent
+
+CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+class Command(WebsiteFilterCommand):
+    """Strip control characters (e.g. stray newlines) from external_url values"""
+
+    help = __doc__
+
+    def add_arguments(self, parser):
+        """Add command-specific arguments."""
+        super().add_arguments(parser)
+        parser.add_argument(
+            "-o",
+            "--out",
+            dest="out",
+            default=None,
+            help="If provided, a CSV file of affected WebsiteContent objects will be written.",  # noqa: E501
+        )
+        parser.add_argument(
+            "-c",
+            "--commit",
+            dest="commit",
+            action="store_true",
+            default=False,
+            help="Whether the cleaned external_url values should be saved to the database/backend.",  # noqa: E501
+        )
+        parser.add_argument(
+            "-ss",
+            "--skip-sync",
+            dest="skip_sync",
+            action="store_true",
+            default=False,
+            help="Whether to skip running the sync_unsynced_websites task",
+        )
+
+    def handle(self, *args, **options):
+        """Find and optionally fix external-resource URLs with control characters."""
+        super().handle(*args, **options)
+        commit_changes = options["commit"]
+        csv_output = options["out"]
+
+        candidates = WebsiteContent.objects.filter(
+            type=CONTENT_TYPE_EXTERNAL_RESOURCE
+        ).exclude(metadata__external_url__isnull=True)
+        candidates = self.filter_website_contents(website_contents=candidates)
+
+        modified_content = []
+        for content in candidates.iterator():
+            url = content.metadata.get("external_url")
+            if not url or not CONTROL_CHAR_RE.search(url):
+                continue
+            cleaned_url = CONTROL_CHAR_RE.sub("", url)
+            modified_content.append(
+                {
+                    "pk_id": content.pk,
+                    "text_id": content.text_id,
+                    "website_name": content.website.name,
+                    "original_url": url,
+                    "cleaned_url": cleaned_url,
+                }
+            )
+            if commit_changes:
+                content.metadata["external_url"] = cleaned_url
+                content.save()
+
+        self.stdout.write(
+            f"Found {len(modified_content)} external-resource(s) with control "
+            "characters in external_url"
+        )
+
+        if csv_output and modified_content:
+            self.stdout.write(f"Writing affected content to csv file {csv_output}")
+            self.write_to_csv(csv_output, modified_content)
+
+        if (
+            settings.CONTENT_SYNC_BACKEND
+            and commit_changes
+            and modified_content
+            and not options["skip_sync"]
+        ):
+            self.stdout.write("Syncing all unsynced content to the designated backend")
+            start = now_in_utc()
+            task = sync_unsynced_websites.delay(create_backends=True)
+            self.stdout.write(f"Starting task {task}...")
+            task.get()
+            total_seconds = (now_in_utc() - start).total_seconds()
+            self.stdout.write(f"Backend sync finished, took {total_seconds} seconds")
+
+        self.stdout.write(f"Finished with commit={commit_changes}")
+
+    def write_to_csv(self, path: str, modified_content: list[dict]):
+        """Write modified contents to csv."""
+
+        with open(path, "w", newline="") as csvfile:  # noqa: PTH123
+            if not modified_content:
+                return
+            fieldnames = modified_content[0].keys()
+            writer = csv.DictWriter(csvfile, fieldnames, quoting=csv.QUOTE_ALL)
+            writer.writeheader()
+            for content in modified_content:
+                writer.writerow(content)

--- a/websites/management/commands/fix_external_resource_urls.py
+++ b/websites/management/commands/fix_external_resource_urls.py
@@ -80,6 +80,7 @@ class Command(WebsiteFilterCommand):
             f"Found {len(modified_content)} external-resource(s) with control "
             "characters in external_url"
         )
+        self.print_affected_content(modified_content)
 
         if csv_output and modified_content:
             self.stdout.write(f"Writing affected content to csv file {csv_output}")
@@ -100,6 +101,17 @@ class Command(WebsiteFilterCommand):
             self.stdout.write(f"Backend sync finished, took {total_seconds} seconds")
 
         self.stdout.write(f"Finished with commit={commit_changes}")
+
+    def print_affected_content(self, modified_content: list[dict]):
+        """Print affected content to stdout, e.g. to inspect production in a dry run."""
+        if not modified_content:
+            return
+        self.stdout.write("pk_id,text_id,website_name,external_link")
+        for content in modified_content:
+            self.stdout.write(
+                f"{content['pk_id']},{content['text_id']},"
+                f"{content['website_name']},{content['original_url']}"
+            )
 
     def write_to_csv(self, path: str, modified_content: list[dict]):
         """Write modified contents to csv."""

--- a/websites/management/commands/fix_external_resource_urls_test.py
+++ b/websites/management/commands/fix_external_resource_urls_test.py
@@ -1,6 +1,7 @@
 """Tests for the fix_external_resource_urls management command."""  # noqa: INP001
 
 import csv
+from io import StringIO
 
 import pytest
 from django.core.management import call_command
@@ -152,6 +153,41 @@ def test_dry_run_writes_csv_plan(tmp_path, mock_sync_task):
     # dry run: DB itself is untouched even though the plan was written
     content.refresh_from_db()
     assert content.metadata["external_url"] == original_url
+
+
+def test_dry_run_prints_affected_content_list(mock_sync_task):
+    """Without --commit, the affected content prints to stdout for inspection (e.g. on production)."""
+    website = WebsiteFactory.create()
+    original_url = "http://www.gutenberg.org/etext/141\n"
+    content = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_EXTERNAL_RESOURCE,
+        metadata={"external_url": original_url},
+    )
+    out = StringIO()
+
+    call_command("fix_external_resource_urls", stdout=out)
+
+    output = out.getvalue()
+    assert "pk_id,text_id,website_name,external_link" in output
+    assert f"{content.pk},{content.text_id},{website.name},{original_url}" in output
+    content.refresh_from_db()
+    assert content.metadata["external_url"] == original_url
+
+
+def test_dry_run_prints_nothing_when_no_content_affected(mock_sync_task):
+    """When nothing is affected, no affected-content list is printed."""
+    website = WebsiteFactory.create()
+    WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_EXTERNAL_RESOURCE,
+        metadata={"external_url": "http://example.com/already-clean"},
+    )
+    out = StringIO()
+
+    call_command("fix_external_resource_urls", stdout=out)
+
+    assert "pk_id,text_id,website_name,external_link" not in out.getvalue()
 
 
 def test_filter_limits_to_specified_website(mock_sync_task):

--- a/websites/management/commands/fix_external_resource_urls_test.py
+++ b/websites/management/commands/fix_external_resource_urls_test.py
@@ -1,0 +1,244 @@
+"""Tests for the fix_external_resource_urls management command."""  # noqa: INP001
+
+import csv
+
+import pytest
+from django.core.management import call_command
+
+from websites.constants import CONTENT_TYPE_EXTERNAL_RESOURCE, CONTENT_TYPE_RESOURCE
+from websites.factories import WebsiteContentFactory, WebsiteFactory
+from websites.models import Website
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def mock_sync_task(mocker):
+    """Mock the sync_unsynced_websites task used by the command."""
+    mock_delay = mocker.patch(
+        "websites.management.commands.fix_external_resource_urls"
+        ".sync_unsynced_websites.delay"
+    )
+    mock_delay.return_value.get.return_value = None
+    return mock_delay
+
+
+def _reset_dirty_flags(website):
+    """Content creation itself dirties the website via signals; reset for a clean assertion."""
+    Website.objects.filter(uuid=website.uuid).update(
+        has_unpublished_live=False, has_unpublished_draft=False
+    )
+
+
+@pytest.mark.parametrize(
+    ("label", "original_url", "expected_cleaned"),
+    [
+        (
+            "trailing newline",
+            "http://www.gutenberg.org/browse/BIBREC/BR6960.HTM\n",
+            "http://www.gutenberg.org/browse/BIBREC/BR6960.HTM",
+        ),
+        (
+            "leading newline",
+            "\nhttp://books.google.com/books?id=K3V1juIGhXYC&pg=Pafrontcover",
+            "http://books.google.com/books?id=K3V1juIGhXYC&pg=Pafrontcover",
+        ),
+        (
+            "newline mid-URL",
+            "http://books.google.com/books?\nid=TzJ2L9ZmlQUC&pg=PAfrontcover",
+            "http://books.google.com/books?id=TzJ2L9ZmlQUC&pg=PAfrontcover",
+        ),
+    ],
+)
+def test_cleans_control_characters(
+    mock_sync_task, label, original_url, expected_cleaned
+):
+    """Control characters are stripped regardless of where they appear in the URL."""
+    website = WebsiteFactory.create()
+    content = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_EXTERNAL_RESOURCE,
+        metadata={"external_url": original_url},
+    )
+
+    call_command("fix_external_resource_urls", commit=True)
+
+    content.refresh_from_db()
+    assert content.metadata["external_url"] == expected_cleaned, label
+
+
+def test_leaves_clean_url_untouched(mock_sync_task):
+    """A URL with no control characters is left exactly as-is and not reported."""
+    website = WebsiteFactory.create()
+    clean_url = "http://books.google.com/books?id=CLEAN123&pg=Pafrontcover"
+    content = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_EXTERNAL_RESOURCE,
+        metadata={"external_url": clean_url},
+    )
+
+    call_command("fix_external_resource_urls", commit=True)
+
+    content.refresh_from_db()
+    assert content.metadata["external_url"] == clean_url
+
+
+def test_ignores_non_external_resource_content_type(mock_sync_task):
+    """Only type=external-resource content is considered, even if another type has a similar field."""
+    website = WebsiteFactory.create()
+    content = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_RESOURCE,
+        metadata={"external_url": "http://example.com/\n"},
+    )
+
+    call_command("fix_external_resource_urls", commit=True)
+
+    content.refresh_from_db()
+    assert content.metadata["external_url"] == "http://example.com/\n"
+
+
+def test_ignores_missing_external_url(mock_sync_task):
+    """Content with no external_url key in metadata is skipped without error."""
+    website = WebsiteFactory.create()
+    WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_EXTERNAL_RESOURCE,
+        metadata={"has_external_license_warning": False},
+    )
+
+    call_command("fix_external_resource_urls", commit=True)  # must not raise
+
+
+def test_dry_run_makes_no_changes(mock_sync_task):
+    """Without --commit, the database is not modified."""
+    website = WebsiteFactory.create()
+    original_url = "http://www.gutenberg.org/etext/4217\n"
+    content = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_EXTERNAL_RESOURCE,
+        metadata={"external_url": original_url},
+    )
+
+    call_command("fix_external_resource_urls")
+
+    content.refresh_from_db()
+    assert content.metadata["external_url"] == original_url
+    mock_sync_task.assert_not_called()
+
+
+def test_dry_run_writes_csv_plan(tmp_path, mock_sync_task):
+    """Even without --commit, the CSV plan reports what would change."""
+    website = WebsiteFactory.create()
+    original_url = "http://www.gutenberg.org/etext/98\n"
+    content = WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_EXTERNAL_RESOURCE,
+        metadata={"external_url": original_url},
+    )
+    output_file = tmp_path / "plan.csv"
+
+    call_command("fix_external_resource_urls", out=str(output_file))
+
+    assert output_file.exists()
+    with output_file.open("r", newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    assert len(rows) == 1
+    assert rows[0]["pk_id"] == str(content.pk)
+    assert rows[0]["text_id"] == str(content.text_id)
+    assert rows[0]["website_name"] == website.name
+    assert rows[0]["original_url"] == original_url
+    assert rows[0]["cleaned_url"] == "http://www.gutenberg.org/etext/98"
+    # dry run: DB itself is untouched even though the plan was written
+    content.refresh_from_db()
+    assert content.metadata["external_url"] == original_url
+
+
+def test_filter_limits_to_specified_website(mock_sync_task):
+    """The --filter argument restricts processing to the named website only."""
+    website_a = WebsiteFactory.create()
+    website_b = WebsiteFactory.create()
+    content_a = WebsiteContentFactory.create(
+        website=website_a,
+        type=CONTENT_TYPE_EXTERNAL_RESOURCE,
+        metadata={"external_url": "http://example.com/a\n"},
+    )
+    content_b = WebsiteContentFactory.create(
+        website=website_b,
+        type=CONTENT_TYPE_EXTERNAL_RESOURCE,
+        metadata={"external_url": "http://example.com/b\n"},
+    )
+
+    call_command("fix_external_resource_urls", commit=True, filter=website_a.name)
+
+    content_a.refresh_from_db()
+    content_b.refresh_from_db()
+    assert content_a.metadata["external_url"] == "http://example.com/a"
+    assert content_b.metadata["external_url"] == "http://example.com/b\n"
+
+
+def test_marks_website_dirty_after_fix(mock_sync_task):
+    """Saving the cleaned content marks the website as having unpublished changes.
+
+    This exercises the real post_save -> ContentSyncState signal chain rather than
+    assuming it fires (content_sync/signals.py:upsert_content_sync_state).
+    """
+    website = WebsiteFactory.create()
+    WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_EXTERNAL_RESOURCE,
+        metadata={"external_url": "http://www.gutenberg.org/etext/6688\n"},
+    )
+    _reset_dirty_flags(website)
+
+    call_command("fix_external_resource_urls", commit=True)
+
+    website.refresh_from_db()
+    assert website.has_unpublished_live is True
+    assert website.has_unpublished_draft is True
+
+
+def test_triggers_sync_when_committed(settings, mock_sync_task):
+    """A committed run with affected content triggers sync_unsynced_websites."""
+    # pytest overrides CONTENT_SYNC_BACKEND to "" globally (pyproject.toml) to keep
+    # the suite from touching a real backend; restore a truthy value to exercise
+    # the branch that's actually gated on it.
+    settings.CONTENT_SYNC_BACKEND = "content_sync.backends.github.GithubBackend"
+    website = WebsiteFactory.create()
+    WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_EXTERNAL_RESOURCE,
+        metadata={"external_url": "http://www.gutenberg.org/etext/768\n"},
+    )
+
+    call_command("fix_external_resource_urls", commit=True)
+
+    mock_sync_task.assert_called_once_with(create_backends=True)
+
+
+def test_skip_sync_flag_prevents_sync(mock_sync_task):
+    """--skip-sync prevents the sync_unsynced_websites task from running."""
+    website = WebsiteFactory.create()
+    WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_EXTERNAL_RESOURCE,
+        metadata={"external_url": "http://www.jstor.org/stable/3985060\n"},
+    )
+
+    call_command("fix_external_resource_urls", commit=True, skip_sync=True)
+
+    mock_sync_task.assert_not_called()
+
+
+def test_no_sync_when_nothing_modified(mock_sync_task):
+    """A committed run with no affected content does not trigger a sync."""
+    website = WebsiteFactory.create()
+    WebsiteContentFactory.create(
+        website=website,
+        type=CONTENT_TYPE_EXTERNAL_RESOURCE,
+        metadata={"external_url": "http://example.com/already-clean"},
+    )
+
+    call_command("fix_external_resource_urls", commit=True)
+
+    mock_sync_task.assert_not_called()

--- a/websites/management/commands/fix_external_resource_urls_test.py
+++ b/websites/management/commands/fix_external_resource_urls_test.py
@@ -15,10 +15,10 @@ pytestmark = pytest.mark.django_db
 
 @pytest.fixture
 def mock_sync_task(mocker):
-    """Mock the sync_unsynced_websites task used by the command."""
+    """Mock the sync_website_content task used by the command."""
     mock_delay = mocker.patch(
         "websites.management.commands.fix_external_resource_urls"
-        ".sync_unsynced_websites.delay"
+        ".sync_website_content.delay"
     )
     mock_delay.return_value.get.return_value = None
     return mock_delay
@@ -235,7 +235,7 @@ def test_marks_website_dirty_after_fix(mock_sync_task):
 
 
 def test_triggers_sync_when_committed(settings, mock_sync_task):
-    """A committed run with affected content triggers sync_unsynced_websites."""
+    """A committed run with affected content syncs that content's website."""
     # pytest overrides CONTENT_SYNC_BACKEND to "" globally (pyproject.toml) to keep
     # the suite from touching a real backend; restore a truthy value to exercise
     # the branch that's actually gated on it.
@@ -249,7 +249,28 @@ def test_triggers_sync_when_committed(settings, mock_sync_task):
 
     call_command("fix_external_resource_urls", commit=True)
 
-    mock_sync_task.assert_called_once_with(create_backends=True)
+    mock_sync_task.assert_called_once_with(website.name)
+
+
+def test_sync_scoped_to_affected_websites_only(settings, mock_sync_task):
+    """A committed run only syncs websites it actually modified, not every unsynced site."""
+    settings.CONTENT_SYNC_BACKEND = "content_sync.backends.github.GithubBackend"
+    affected_website = WebsiteFactory.create()
+    unaffected_website = WebsiteFactory.create()
+    WebsiteContentFactory.create(
+        website=affected_website,
+        type=CONTENT_TYPE_EXTERNAL_RESOURCE,
+        metadata={"external_url": "http://example.com/bad\n"},
+    )
+    WebsiteContentFactory.create(
+        website=unaffected_website,
+        type=CONTENT_TYPE_EXTERNAL_RESOURCE,
+        metadata={"external_url": "http://example.com/already-clean"},
+    )
+
+    call_command("fix_external_resource_urls", commit=True)
+
+    mock_sync_task.assert_called_once_with(affected_website.name)
 
 
 def test_skip_sync_flag_prevents_sync(mock_sync_task):

--- a/websites/management/commands/markdown_cleaning/link_parser.py
+++ b/websites/management/commands/markdown_cleaning/link_parser.py
@@ -25,6 +25,17 @@ from websites.management.commands.markdown_cleaning.parsing_utils import (
     unescape_quoted_string,
 )
 
+# Characters that must never be silently absorbed into a link destination:
+# space/tab (existing separator logic), ASCII control characters (Go's
+# net/url.Parse rejects these outright with "invalid control character in
+# URL"), and backslash (Go's net/url.Parse rejects it specifically with
+# "invalid character \"\\\\\" in host name"). A source markdown link with one
+# of these inside its `(destination)` most likely comes from a hard-wrapped
+# or otherwise mangled URL, not a deliberate one.
+_DESTINATION_FORBIDDEN_CHARS = (
+    " " + "".join(chr(c) for c in range(0x20)) + "\x7f" + "\\"
+)
+
 
 @dataclass
 class MarkdownLink:
@@ -200,7 +211,7 @@ class LinkParser(WrappedParser):
             ZeroOrMore(
                 original_text_for(nested_expr(opener=R"{{<", closer=">}}"))
                 | original_text_for(nested_expr(opener=R"{{%", closer="%}}"))
-                | CharsNotIn(" \t", exact=1)
+                | CharsNotIn(_DESTINATION_FORBIDDEN_CHARS, exact=1)
             )
         ).set_results_name("destination")
 

--- a/websites/management/commands/markdown_cleaning/link_parser_test.py
+++ b/websites/management/commands/markdown_cleaning/link_parser_test.py
@@ -139,6 +139,12 @@ def test_link_parser_with_shortcodes_in_destination():
         "[text] (dest)",
         "[text]\n(dest)",
         "[text] \n (dest)",
+        "[some text](http://example.com/page\n)",
+        "[some text](\nhttp://example.com/page)",
+        "[some text](http://example.com/\npage)",
+        "[some text](http://example.com\\page)",
+        "[some text](http://example.com/page\r)",
+        "[some text](http://example.com/pa\x00ge)",
     ],
 )
 def test_link_parser_rejects_bad_links(markdown):

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -8,6 +8,7 @@ from urllib.parse import urljoin, urlparse
 
 from django.conf import settings
 from django.contrib.auth.models import Group
+from django.core.validators import URLValidator
 from django.db import transaction
 from django.db.models import Q
 from django.utils.text import slugify
@@ -52,6 +53,7 @@ ROLE_ERROR_MESSAGES = {"invalid_choice": "Invalid role", "required": "Role is re
 
 _URL_CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
 _INVALID_PERCENT_ENCODING_RE = re.compile(r"%(?![0-9A-Fa-f]{2})")
+_validate_url_format = URLValidator()
 
 
 def validate_external_resource_metadata(metadata):
@@ -83,17 +85,7 @@ def validate_external_resource_metadata(metadata):
     if _INVALID_PERCENT_ENCODING_RE.search(url):
         msg = "External URL contains a malformed percent-encoded character."
         raise serializers.ValidationError(msg)
-    try:
-        parsed = urlparse(url)
-    except ValueError:
-        msg = "External URL could not be parsed."
-        raise serializers.ValidationError(msg) from None
-    if not parsed.scheme or not parsed.netloc:
-        msg = (
-            "External URL must be a complete, absolute URL "
-            "(e.g. https://example.com/page)."
-        )
-        raise serializers.ValidationError(msg)
+    _validate_url_format(url)
     metadata["external_url"] = url
     return metadata
 

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -33,6 +33,7 @@ from websites.api import (
     update_youtube_thumbnail,
 )
 from websites.constants import (
+    CONTENT_TYPE_EXTERNAL_RESOURCE,
     CONTENT_TYPE_METADATA,
     CONTENT_TYPE_PAGE,
     CONTENT_TYPE_RESOURCE,
@@ -48,6 +49,41 @@ log = logging.getLogger(__name__)
 
 
 ROLE_ERROR_MESSAGES = {"invalid_choice": "Invalid role", "required": "Role is required"}
+
+_URL_CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def validate_external_resource_metadata(metadata):
+    """
+    Validate and normalize an external-resource's `external_url`, raising a
+    ValidationError for characters known to make Hugo's Go url.Parse reject
+    the URL at build time (see link_parser.py's _DESTINATION_FORBIDDEN_CHARS
+    for the same underlying set of characters).
+    """
+    if not isinstance(metadata, dict) or not metadata.get("external_url"):
+        return metadata
+    if not isinstance(metadata["external_url"], str):
+        msg = "External URL must be a string."
+        raise serializers.ValidationError(msg)
+    url = metadata["external_url"].strip()
+    if _URL_CONTROL_CHAR_RE.search(url):
+        msg = (
+            "External URL contains an invalid control character "
+            "(e.g. a stray newline or tab)."
+        )
+        raise serializers.ValidationError(msg)
+    if "\\" in url:
+        msg = "External URL contains a backslash, which is not a valid URL character."
+        raise serializers.ValidationError(msg)
+    parsed = urlparse(url)
+    if not parsed.scheme or not parsed.netloc:
+        msg = (
+            "External URL must be a complete, absolute URL "
+            "(e.g. https://example.com/page)."
+        )
+        raise serializers.ValidationError(msg)
+    metadata["external_url"] = url
+    return metadata
 
 
 class WebsiteStarterSerializer(serializers.ModelSerializer):
@@ -551,6 +587,15 @@ class WebsiteContentDetailSerializer(
     content_context = serializers.SerializerMethodField()
     url_path = serializers.SerializerMethodField()
 
+    def validate_metadata(self, value):
+        """Validate metadata contents that need cross-field/content-type context"""
+        content_type = (
+            self.instance.type if self.instance else self.initial_data.get("type")
+        )
+        if content_type == CONTENT_TYPE_EXTERNAL_RESOURCE:
+            value = validate_external_resource_metadata(value)
+        return value
+
     def update(self, instance, validated_data):
         """Update WebsiteContent, handling filename and metadata."""
         title = validated_data.get("title", instance.title)
@@ -733,6 +778,12 @@ class WebsiteContentCreateSerializer(
     serializers.ModelSerializer, RequestUserSerializerMixin
 ):
     """Serializer which creates a new WebsiteContent"""
+
+    def validate_metadata(self, value):
+        """Validate metadata contents that need cross-field/content-type context"""
+        if self.initial_data.get("type") == CONTENT_TYPE_EXTERNAL_RESOURCE:
+            value = validate_external_resource_metadata(value)
+        return value
 
     def create(self, validated_data):
         user = self.user_from_request()

--- a/websites/serializers.py
+++ b/websites/serializers.py
@@ -51,6 +51,7 @@ log = logging.getLogger(__name__)
 ROLE_ERROR_MESSAGES = {"invalid_choice": "Invalid role", "required": "Role is required"}
 
 _URL_CONTROL_CHAR_RE = re.compile(r"[\x00-\x1f\x7f]")
+_INVALID_PERCENT_ENCODING_RE = re.compile(r"%(?![0-9A-Fa-f]{2})")
 
 
 def validate_external_resource_metadata(metadata):
@@ -60,12 +61,16 @@ def validate_external_resource_metadata(metadata):
     the URL at build time (see link_parser.py's _DESTINATION_FORBIDDEN_CHARS
     for the same underlying set of characters).
     """
-    if not isinstance(metadata, dict) or not metadata.get("external_url"):
+    if not isinstance(metadata, dict) or "external_url" not in metadata:
         return metadata
-    if not isinstance(metadata["external_url"], str):
+    value = metadata["external_url"]
+    if not isinstance(value, str):
         msg = "External URL must be a string."
         raise serializers.ValidationError(msg)
-    url = metadata["external_url"].strip()
+    url = value.strip()
+    if not url:
+        msg = "External URL is required."
+        raise serializers.ValidationError(msg)
     if _URL_CONTROL_CHAR_RE.search(url):
         msg = (
             "External URL contains an invalid control character "
@@ -75,7 +80,14 @@ def validate_external_resource_metadata(metadata):
     if "\\" in url:
         msg = "External URL contains a backslash, which is not a valid URL character."
         raise serializers.ValidationError(msg)
-    parsed = urlparse(url)
+    if _INVALID_PERCENT_ENCODING_RE.search(url):
+        msg = "External URL contains a malformed percent-encoded character."
+        raise serializers.ValidationError(msg)
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        msg = "External URL could not be parsed."
+        raise serializers.ValidationError(msg) from None
     if not parsed.scheme or not parsed.netloc:
         msg = (
             "External URL must be a complete, absolute URL "

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -18,6 +18,7 @@ from users.models import User
 from videos.constants import YT_THUMBNAIL_IMG
 from videos.utils import resource_file_paths
 from websites.constants import (
+    CONTENT_TYPE_EXTERNAL_RESOURCE,
     CONTENT_TYPE_INSTRUCTOR,
     CONTENT_TYPE_METADATA,
     CONTENT_TYPE_PAGE,
@@ -643,6 +644,127 @@ def test_website_content_detail_serializer_save_null_metadata(
     assert content.metadata == {"meta": "data"}
     assert content.updated_by == user
     mocked_website_funcs.update_website_backend.assert_called_once_with(content.website)
+
+
+@pytest.mark.parametrize(
+    ("bad_url", "expected_message"),
+    [
+        (
+            "http://example.com/pa\x00ge",
+            (
+                "External URL contains an invalid control character "
+                "(e.g. a stray newline or tab)."
+            ),
+        ),
+        (
+            "http://example.com\\page",
+            "External URL contains a backslash, which is not a valid URL character.",
+        ),
+        (
+            "not a url",
+            (
+                "External URL must be a complete, absolute URL "
+                "(e.g. https://example.com/page)."
+            ),
+        ),
+        (12345, "External URL must be a string."),
+        (["http://example.com"], "External URL must be a string."),
+    ],
+)
+def test_website_content_detail_serializer_rejects_bad_external_url(
+    mocker, bad_url, expected_message
+):
+    """WebsiteContentDetailSerializer should reject external_url values that would break Hugo's build"""
+    content = WebsiteContentFactory.create(
+        type=CONTENT_TYPE_EXTERNAL_RESOURCE,
+        metadata={"external_url": "https://example.com/original"},
+    )
+    serializer = WebsiteContentDetailSerializer(
+        instance=content,
+        data={"metadata": {"external_url": bad_url}},
+        partial=True,
+        context={
+            "view": mocker.Mock(kwargs={"parent_lookup_website": content.website.name}),
+            "request": mocker.Mock(user=UserFactory.create()),
+        },
+    )
+    assert serializer.is_valid() is False
+    assert serializer.errors.get("metadata") == [expected_message]
+
+
+@pytest.mark.parametrize(
+    "raw_url",
+    [
+        " https://example.com/page ",
+        "https://example.com/page\n",
+        "\nhttps://example.com/page",
+        "\thttps://example.com/page",
+    ],
+)
+def test_website_content_detail_serializer_strips_external_url_whitespace(
+    mocker, mocked_website_funcs, raw_url
+):
+    """WebsiteContentDetailSerializer should strip leading/trailing whitespace from external_url"""
+    content = WebsiteContentFactory.create(
+        type=CONTENT_TYPE_EXTERNAL_RESOURCE,
+        metadata={"external_url": "https://example.com/original"},
+    )
+    serializer = WebsiteContentDetailSerializer(
+        instance=content,
+        data={"metadata": {"external_url": raw_url}},
+        partial=True,
+        context={
+            "view": mocker.Mock(kwargs={"parent_lookup_website": content.website.name}),
+            "request": mocker.Mock(user=UserFactory.create()),
+        },
+    )
+    serializer.is_valid(raise_exception=True)
+    serializer.save()
+    content.refresh_from_db()
+    assert content.metadata["external_url"] == "https://example.com/page"
+
+
+def test_website_content_detail_serializer_ignores_backslash_for_other_types(mocker):
+    """The external_url guard should not apply to non-external-resource content"""
+    content = WebsiteContentFactory.create(
+        type=CONTENT_TYPE_RESOURCE,
+        metadata={"external_url": "http://example.com\\page"},
+    )
+    serializer = WebsiteContentDetailSerializer(
+        instance=content,
+        data={"metadata": {"external_url": "http://example.com\\page"}},
+        partial=True,
+        context={
+            "view": mocker.Mock(kwargs={"parent_lookup_website": content.website.name}),
+            "request": mocker.Mock(user=UserFactory.create()),
+        },
+    )
+    assert serializer.is_valid() is True
+
+
+def test_website_content_create_serializer_rejects_bad_external_url(mocker):
+    """WebsiteContentCreateSerializer should reject an external_url that would break Hugo's build"""
+    website = WebsiteFactory.create()
+    payload = {
+        "website_id": website.pk,
+        "text_id": "my-text-id",
+        "title": "a title",
+        "type": CONTENT_TYPE_EXTERNAL_RESOURCE,
+        "metadata": {"external_url": "http://example.com\\page"},
+        "is_page_content": False,
+        "dirpath": "content/external-resources",
+        "filename": "myfile",
+    }
+    context = {
+        "view": mocker.Mock(kwargs={"parent_lookup_website": website.name}),
+        "request": mocker.Mock(user=UserFactory.create()),
+        "website_id": website.pk,
+    }
+    serializer = WebsiteContentCreateSerializer(data=payload, context=context)
+    assert serializer.is_valid() is False
+    assert serializer.errors.get("metadata") == [
+        "External URL contains a backslash, which is not a valid URL character."
+    ]
 
 
 @pytest.mark.parametrize("add_context_data", [True, False])

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -662,10 +662,7 @@ def test_website_content_detail_serializer_save_null_metadata(
         ),
         (
             "not a url",
-            (
-                "External URL must be a complete, absolute URL "
-                "(e.g. https://example.com/page)."
-            ),
+            "Enter a valid URL.",
         ),
         (12345, "External URL must be a string."),
         (["http://example.com"], "External URL must be a string."),
@@ -673,7 +670,7 @@ def test_website_content_detail_serializer_save_null_metadata(
         ("   ", "External URL is required."),
         (
             "http://[::1",
-            "External URL could not be parsed.",
+            "Enter a valid URL.",
         ),
         (
             "https://example.com/%zz",

--- a/websites/serializers_test.py
+++ b/websites/serializers_test.py
@@ -669,6 +669,16 @@ def test_website_content_detail_serializer_save_null_metadata(
         ),
         (12345, "External URL must be a string."),
         (["http://example.com"], "External URL must be a string."),
+        ("", "External URL is required."),
+        ("   ", "External URL is required."),
+        (
+            "http://[::1",
+            "External URL could not be parsed.",
+        ),
+        (
+            "https://example.com/%zz",
+            "External URL contains a malformed percent-encoded character.",
+        ),
     ],
 )
 def test_website_content_detail_serializer_rejects_bad_external_url(


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12941

### Description (What does it do?)
External resource links saved with a stray newline, tab, or other control character broke Hugo's build with a URL parsing error. Two places let that through: the markdown link parser absorbed the bad character straight into the link destination, and nothing checked `external_url` again when it was saved directly through the API.

- `websites/management/commands/markdown_cleaning/link_parser.py`: the link destination grammar now excludes control characters and backslashes, not just spaces and tabs.
- `websites/serializers.py`: `external_url` is now validated on save, rejecting control characters and backslashes and requiring a complete URL, while trimming harmless leading and trailing whitespace.
- `websites/management/commands/fix_external_resource_urls.py`: one-off command to find and clean up existing `external_url` values with control characters. Defaults to a dry run that prints the affected content (id, text id, website, url) so it is safe to run against production just to see what is there, with `--commit` to apply changes and an optional CSV report.

Confirmed on RC: 21 external resource links across 14 sites were found and already cleaned up. Production not yet checked.

### How can this be tested?
1. Checkout `umar/12941-reject-invalid-external-resource-urls`
2. Try saving an external resource with a URL containing a newline or backslash through Studio. Confirm it is rejected with a clear error instead of saving.
3. Run `./manage.py fix_external_resource_urls` without `--commit` to preview affected content, then with `--commit` to clean it up.