### PR TITLE
fix: clean up orphaned backend files when content is hard-deleted

### DIFF
--- a/content_sync/apis/github.py
+++ b/content_sync/apis/github.py
@@ -420,12 +420,21 @@ class GithubApiWrapper:
         return commit
 
     @retry_on_failure
-    def delete_content_file(self, content: WebsiteContent) -> Commit | None:
+    def delete_content_file(
+        self, content: WebsiteContent, filepath: str | None = None
+    ) -> Commit | None:
         """
         Delete a file from git. Returns None if the file is already gone.
+
+        `filepath` overrides the path computed from `content`'s current
+        fields, for callers that already know the path the file was last
+        actually synced to (e.g. a hard-deleted WebsiteContent whose current
+        fields could reflect a rename that was never resynced).
         """
         repo = self.get_repo()
-        filepath = get_destination_filepath(content, self.site_config)
+        filepath = filepath or get_destination_filepath(content, self.site_config)
+        if not filepath:
+            return None
         try:
             sha = repo.get_contents(filepath).sha
         except GithubException as ge:

--- a/content_sync/apis/github.py
+++ b/content_sync/apis/github.py
@@ -420,13 +420,18 @@ class GithubApiWrapper:
         return commit
 
     @retry_on_failure
-    def delete_content_file(self, content: WebsiteContent) -> Commit:
+    def delete_content_file(self, content: WebsiteContent) -> Commit | None:
         """
-        Delete a file from git
+        Delete a file from git. Returns None if the file is already gone.
         """
         repo = self.get_repo()
         filepath = get_destination_filepath(content, self.site_config)
-        sha = repo.get_contents(filepath).sha
+        try:
+            sha = repo.get_contents(filepath).sha
+        except GithubException as ge:
+            if ge.status == 404:  # noqa: PLR2004
+                return None
+            raise
         return repo.delete_file(
             filepath,
             f"Delete {filepath}",

--- a/content_sync/apis/github_test.py
+++ b/content_sync/apis/github_test.py
@@ -573,16 +573,42 @@ def test_delete_content_file_already_gone(
     mock_repo.delete_file.assert_not_called()
 
 
+def test_delete_content_file_uses_explicit_filepath_override(
+    mocker, mock_api_wrapper, patched_destination_filepath
+):
+    """An explicit filepath should be used instead of the content's current computed path."""
+    content = mock_api_wrapper.website.websitecontent_set.first()
+    mock_repo = mock_api_wrapper.org.get_repo.return_value
+    mock_repo.get_contents.return_value.sha.return_value = sha1(  # noqa: S324
+        b"fake_sha"
+    )
+    override_path = "path/to/a-previously-synced-file.md"
+
+    mock_api_wrapper.delete_content_file(content, filepath=override_path)
+
+    mock_repo.get_contents.assert_called_once_with(override_path)
+    mock_repo.delete_file.assert_called_once_with(
+        override_path,
+        f"Delete {override_path}",
+        mock_repo.get_contents.return_value.sha,
+        committer=mocker.ANY,
+        **{},
+    )
+
+
 def test_hard_delete_signal_redundant_call_is_safe(
-    settings, mock_api_wrapper, patched_destination_filepath
+    settings,
+    mock_api_wrapper,
+    patched_destination_filepath,
+    django_capture_on_commit_callbacks,
 ):
     """
     GithubBackend.delete_content_in_backend deletes a content's backend file
     and then hard-deletes the row. That hard-delete also fires
-    websites.signals' safety-net receiver, which tries to delete the same,
-    now-already-gone file again. That redundant second call must be a
-    silent no-op rather than a retried failure that surfaces as a raised
-    exception here.
+    websites.signals' safety-net receiver (deferred to a background task via
+    transaction.on_commit), which tries to delete the same, now-already-gone
+    file again. That redundant second call must be a silent no-op rather
+    than a retried failure that surfaces as a raised exception here.
     """
     settings.CONTENT_SYNC_BACKEND = "content_sync.backends.github.GithubBackend"
     content = mock_api_wrapper.website.websitecontent_set.first()
@@ -593,7 +619,10 @@ def test_hard_delete_signal_redundant_call_is_safe(
     ]
 
     mock_api_wrapper.delete_content_file(content)  # the explicit, sanctioned delete
-    content.delete(force_policy=HARD_DELETE)  # fires the signal; must not retry-storm
+    with django_capture_on_commit_callbacks(execute=True):
+        content.delete(
+            force_policy=HARD_DELETE
+        )  # fires the signal; must not retry-storm
 
     # Exactly one get_contents call per delete_content_file invocation: the
     # redundant second call must be recognized as "already gone" on its

--- a/content_sync/apis/github_test.py
+++ b/content_sync/apis/github_test.py
@@ -13,6 +13,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from github import Auth, GithubException, GithubIntegration
 from requests import HTTPError
+from safedelete.models import HARD_DELETE
 
 from content_sync.apis.github import (
     GIT_DATA_FILEPATH,
@@ -556,6 +557,52 @@ def test_delete_content_file(mocker, mock_api_wrapper, patched_destination_filep
         committer=mocker.ANY,
         **{},
     )
+
+
+def test_delete_content_file_already_gone(
+    mock_api_wrapper, patched_destination_filepath
+):
+    """delete_content_file should treat an already-deleted file as a no-op, not an error"""
+    content = mock_api_wrapper.website.websitecontent_set.first()
+    mock_repo = mock_api_wrapper.org.get_repo.return_value
+    mock_repo.get_contents.side_effect = GithubException(404)
+
+    result = mock_api_wrapper.delete_content_file(content)
+
+    assert result is None
+    mock_repo.delete_file.assert_not_called()
+
+
+def test_hard_delete_signal_redundant_call_is_safe(
+    settings, mock_api_wrapper, patched_destination_filepath
+):
+    """
+    GithubBackend.delete_content_in_backend deletes a content's backend file
+    and then hard-deletes the row. That hard-delete also fires
+    websites.signals' safety-net receiver, which tries to delete the same,
+    now-already-gone file again. That redundant second call must be a
+    silent no-op rather than a retried failure that surfaces as a raised
+    exception here.
+    """
+    settings.CONTENT_SYNC_BACKEND = "content_sync.backends.github.GithubBackend"
+    content = mock_api_wrapper.website.websitecontent_set.first()
+    mock_repo = mock_api_wrapper.org.get_repo.return_value
+    mock_repo.get_contents.side_effect = [
+        SimpleNamespace(sha=sha1(b"fake_sha").hexdigest()),  # noqa: S324
+        GithubException(404),
+    ]
+
+    mock_api_wrapper.delete_content_file(content)  # the explicit, sanctioned delete
+    content.delete(force_policy=HARD_DELETE)  # fires the signal; must not retry-storm
+
+    # Exactly one get_contents call per delete_content_file invocation: the
+    # redundant second call must be recognized as "already gone" on its
+    # first attempt, not exhaust retry_on_failure's retries (which would
+    # also silently vanish into the signal's own try/except, masking a
+    # regression here if this test only asserted "does not raise").
+    assert mock_repo.get_contents.call_count == 2
+    assert mock_repo.delete_file.call_count == 1
+    assert WebsiteContent.objects.filter(id=content.id).first() is None
 
 
 def test_merge_branches(mock_api_wrapper):

--- a/content_sync/tasks.py
+++ b/content_sync/tasks.py
@@ -22,6 +22,7 @@ from content_sync.models import ContentSyncState
 from content_sync.utils import get_publishable_sites
 from main.celery import app
 from main.s3_utils import get_boto3_resource
+from users.models import User
 from websites.api import (
     get_website_in_root_website_metadata,
     reset_publishing_fields,
@@ -50,6 +51,41 @@ def sync_content(content_sync_id: str):
         )
     else:
         api.sync_content(sync_state)
+
+
+@app.task(acks_late=True)
+def delete_orphaned_content_file(
+    website_pk: str, filepath: str, updated_by_pk: int | None
+):
+    """
+    Delete a single file from a website's git backend, for content that was
+    hard-deleted outside the normal sync flow. See
+    websites.signals.delete_content_from_backend_on_hard_delete, which
+    defers to this task rather than calling the backend inline so a bulk
+    hard-delete doesn't turn into a blocking network call per row.
+    """
+    try:
+        website = Website.objects.get(pk=website_pk)
+    except Website.DoesNotExist:
+        log.debug(
+            "Attempted to clean up backend file for Website that no longer "
+            "exists: pk=%s",
+            website_pk,
+        )
+        return
+    updated_by = (
+        User.objects.filter(pk=updated_by_pk).first() if updated_by_pk else None
+    )
+    content_stub = WebsiteContent(updated_by=updated_by)
+    try:
+        backend = api.get_sync_backend(website)
+        backend.api.delete_content_file(content_stub, filepath=filepath)
+    except Exception:  # pylint:disable=broad-except
+        log.exception(
+            "Failed to delete orphaned backend file %s for website %s",
+            filepath,
+            website.name,
+        )
 
 
 @app.task(acks_late=True)

--- a/content_sync/tasks_test.py
+++ b/content_sync/tasks_test.py
@@ -22,6 +22,7 @@ from content_sync.pipelines.base import (
     BaseUnpublishedSiteRemovalPipeline,
 )
 from main.s3_utils import get_boto3_resource
+from users.factories import UserFactory
 from websites.constants import (
     PUBLISH_STATUS_ABORTED,
     PUBLISH_STATUS_ERRORED,
@@ -72,6 +73,62 @@ def test_sync_content_not_exists(api_mock, log_mock):
         12354,
     )
     api_mock.sync_content.assert_not_called()
+
+
+def test_delete_orphaned_content_file(mocker, api_mock, log_mock):
+    """The task fetches the website and user then calls delete_content_file with the given filepath"""
+    website = WebsiteFactory.create()
+    user = UserFactory.create()
+
+    tasks.delete_orphaned_content_file.delay(
+        str(website.pk), "path/to/file.md", user.id
+    )
+
+    log_mock.debug.assert_not_called()
+    api_mock.get_sync_backend.assert_called_once_with(website)
+    backend = api_mock.get_sync_backend.return_value
+    backend.api.delete_content_file.assert_called_once_with(
+        mocker.ANY, filepath="path/to/file.md"
+    )
+    stub = backend.api.delete_content_file.call_args.args[0]
+    assert stub.updated_by == user
+
+
+def test_delete_orphaned_content_file_no_updated_by(api_mock, log_mock):
+    """The task works when there's no updated_by user to attribute the deletion to"""
+    website = WebsiteFactory.create()
+
+    tasks.delete_orphaned_content_file.delay(str(website.pk), "path/to/file.md", None)
+
+    backend = api_mock.get_sync_backend.return_value
+    backend.api.delete_content_file.assert_called_once()
+    stub = backend.api.delete_content_file.call_args.args[0]
+    assert stub.updated_by is None
+
+
+def test_delete_orphaned_content_file_website_missing(api_mock, log_mock):
+    """The task no-ops without error if the website no longer exists"""
+    missing_pk = "11111111-1111-1111-1111-111111111111"
+
+    tasks.delete_orphaned_content_file.delay(missing_pk, "path/to/file.md", None)
+
+    log_mock.debug.assert_called_once_with(
+        "Attempted to clean up backend file for Website that no longer exists: pk=%s",
+        missing_pk,
+    )
+    api_mock.get_sync_backend.assert_not_called()
+
+
+def test_delete_orphaned_content_file_backend_error_logged(api_mock, log_mock):
+    """A backend failure is logged, not raised"""
+    website = WebsiteFactory.create()
+    api_mock.get_sync_backend.return_value.api.delete_content_file.side_effect = (
+        Exception("backend unavailable")
+    )
+
+    tasks.delete_orphaned_content_file.delay(str(website.pk), "path/to/file.md", None)
+
+    log_mock.exception.assert_called_once()
 
 
 def test_create_website_backend(api_mock, log_mock):

--- a/docs/production-to-rc-data-cloning.md
+++ b/docs/production-to-rc-data-cloning.md
@@ -179,6 +179,33 @@ batch.update(synced_checksum=None)
 3. Trigger github sync for this batch by publishing through the UI. Verify from the github content repo that the sync completed.
 4. Repeat for remaining batches
 
+### 3.4 Clean Up Orphaned Backend Files
+
+The steps above only push whatever content currently exists in the database. They never remove a file from a site's GitHub repo whose corresponding row didn't survive the restore, for example RC-only test content that isn't in production, or content whose destination path changed. Those files stay in the repo and Hugo keeps building them.
+
+For each site (excluding `ocw-www`, which needs the same batching consideration as step 3.3), run:
+
+```bash
+./manage.py sync_website_to_backend --filter-json /path/to/site_names.json --delete
+```
+
+`site_names.json` should be a JSON array of the same site names published in step 3.2. You can generate it in a Django shell:
+
+```python
+import json
+from websites.constants import STARTER_SOURCE_GITHUB
+from websites.models import Website
+
+names = list(
+    Website.objects.filter(starter__source=STARTER_SOURCE_GITHUB)
+    .exclude(name="ocw-www")
+    .values_list("name", flat=True)
+)
+json.dump(names, open("/tmp/site_names.json", "w"))
+```
+
+**Warning:** `--delete` permanently removes files from the GitHub repo. Only run this after step 3.2's mass publish has finished successfully, so the database and the repo are in sync before reconciling.
+
 ## Step 4: Pipeline Management and Mass build
 
 ### 4.1 Refresh Pipeline Definitions

--- a/websites/signals.py
+++ b/websites/signals.py
@@ -1,11 +1,15 @@
 """Signals for websites"""
 
+import logging
+
 from django.db import transaction
-from django.db.models.signals import post_save, pre_save
+from django.db.models.signals import post_delete, post_save, pre_save
 from django.dispatch import receiver
 from django.utils.text import slugify
 from safedelete.signals import post_softdelete
 
+from content_sync.api import get_sync_backend
+from content_sync.decorators import is_sync_enabled
 from websites.api import unlink_deleted_resource_from_videos
 from websites.constants import (
     CONTENT_TYPE_NAVMENU,
@@ -15,6 +19,8 @@ from websites.constants import (
 )
 from websites.models import Website, WebsiteContent
 from websites.permissions import setup_website_groups_permissions
+
+log = logging.getLogger(__name__)
 
 
 @receiver(
@@ -90,3 +96,39 @@ def unlink_deleted_resource_on_softdelete(
     if not instance.referencing_content.exists():
         return
     unlink_deleted_resource_from_videos(instance)
+
+
+@receiver(
+    post_delete,
+    sender=WebsiteContent,
+    dispatch_uid="delete_content_from_backend_on_hard_delete",
+)
+@is_sync_enabled
+def delete_content_from_backend_on_hard_delete(
+    sender,  # noqa: ARG001
+    instance,
+    **kwargs,  # noqa: ARG001
+):
+    """
+    Safety net for hard-deletes that bypass the normal managed sync flow
+    (e.g. a management command or shell session calling
+    `.delete(force_policy=HARD_DELETE)` directly): removes the content's
+    file from the git backend so it doesn't stay orphaned forever.
+
+    Hard-deletes that already go through the normal flow (GithubBackend's
+    delete_content_in_backend / sync_all_content_to_db /
+    upsert_content_files_for_user) have already removed the backend file by
+    the time this fires; the resulting redundant call is a cheap no-op
+    because delete_content_file treats an already-missing file as success
+    rather than an error.
+    """
+    website = instance.website
+    try:
+        backend = get_sync_backend(website)
+        backend.api.delete_content_file(instance)
+    except Exception:  # pylint:disable=broad-except
+        log.exception(
+            "Failed to delete backend file for hard-deleted content %s (%s)",
+            instance.text_id,
+            website.name,
+        )

--- a/websites/signals.py
+++ b/websites/signals.py
@@ -3,13 +3,16 @@
 import logging
 
 from django.db import transaction
-from django.db.models.signals import post_delete, post_save, pre_save
+from django.db.models.signals import post_save, pre_delete, pre_save
 from django.dispatch import receiver
 from django.utils.text import slugify
 from safedelete.signals import post_softdelete
 
-from content_sync.api import get_sync_backend
+from content_sync.apis.github import GIT_DATA_FILEPATH
 from content_sync.decorators import is_sync_enabled
+from content_sync.models import ContentSyncState
+from content_sync.tasks import delete_orphaned_content_file
+from content_sync.utils import get_destination_filepath
 from websites.api import unlink_deleted_resource_from_videos
 from websites.constants import (
     CONTENT_TYPE_NAVMENU,
@@ -19,6 +22,7 @@ from websites.constants import (
 )
 from websites.models import Website, WebsiteContent
 from websites.permissions import setup_website_groups_permissions
+from websites.site_config_api import SiteConfig
 
 log = logging.getLogger(__name__)
 
@@ -99,7 +103,7 @@ def unlink_deleted_resource_on_softdelete(
 
 
 @receiver(
-    post_delete,
+    pre_delete,
     sender=WebsiteContent,
     dispatch_uid="delete_content_from_backend_on_hard_delete",
 )
@@ -115,20 +119,38 @@ def delete_content_from_backend_on_hard_delete(
     `.delete(force_policy=HARD_DELETE)` directly): removes the content's
     file from the git backend so it doesn't stay orphaned forever.
 
-    Hard-deletes that already go through the normal flow (GithubBackend's
-    delete_content_in_backend / sync_all_content_to_db /
-    upsert_content_files_for_user) have already removed the backend file by
-    the time this fires; the resulting redundant call is a cheap no-op
-    because delete_content_file treats an already-missing file as success
-    rather than an error.
+    Runs on pre_delete, not post_delete, so the content's ContentSyncState
+    (cascade-deleted along with it) can still be read here to recover the
+    path it was last actually synced to. Recomputing the path fresh from the
+    row's current fields would target the wrong file for content that was
+    renamed but never resynced before being hard-deleted.
+
+    The actual backend call is deferred via transaction.on_commit into a
+    background task rather than made inline: inline, it would run inside
+    the same transaction as the delete (so a later rollback couldn't undo an
+    already-made GitHub API call), and for a bulk hard-delete it would turn
+    every row into a blocking, synchronous network request even though the
+    sanctioned bulk-delete flows already remove their own backend files.
     """
     website = instance.website
+    filepath = None
     try:
-        backend = get_sync_backend(website)
-        backend.api.delete_content_file(instance)
-    except Exception:  # pylint:disable=broad-except
-        log.exception(
-            "Failed to delete backend file for hard-deleted content %s (%s)",
-            instance.text_id,
-            website.name,
+        sync_state = instance.content_sync_state
+    except ContentSyncState.DoesNotExist:
+        sync_state = None
+    if sync_state and sync_state.data:
+        filepath = sync_state.data.get(GIT_DATA_FILEPATH)
+    if not filepath:
+        site_config = SiteConfig(website.starter.config)
+        filepath = get_destination_filepath(instance, site_config)
+    if not filepath:
+        return
+
+    website_pk = website.pk
+    updated_by_pk = instance.updated_by_id
+
+    transaction.on_commit(
+        lambda: delete_orphaned_content_file.delay(
+            str(website_pk), filepath, updated_by_pk
         )
+    )

--- a/websites/signals_test.py
+++ b/websites/signals_test.py
@@ -1,12 +1,14 @@
 """Tests for signals"""
 
 import pytest
+from safedelete.models import HARD_DELETE
 
 from users.factories import UserFactory
 from websites import constants
 from websites.api import sync_website_content_references
-from websites.constants import RESOURCE_TYPE_VIDEO
+from websites.constants import CONTENT_TYPE_EXTERNAL_RESOURCE, RESOURCE_TYPE_VIDEO
 from websites.factories import WebsiteContentFactory, WebsiteFactory
+from websites.models import WebsiteContent
 from websites.serializers import WebsiteContentDetailSerializer
 
 
@@ -87,3 +89,58 @@ def test_deleting_linked_resource_unlinks_it_from_video():
 
     video.refresh_from_db()
     assert video.metadata["video_files"]["video_captions_resources"]["content"] == []
+
+
+@pytest.mark.django_db
+def test_hard_delete_removes_content_from_backend(settings, mocker):
+    """Hard-deleting a WebsiteContent should delete its file from the git backend"""
+    settings.CONTENT_SYNC_BACKEND = "content_sync.backends.github.GithubBackend"
+    mock_get_backend = mocker.patch("websites.signals.get_sync_backend")
+    content = WebsiteContentFactory.create(type=CONTENT_TYPE_EXTERNAL_RESOURCE)
+
+    content.delete(force_policy=HARD_DELETE)
+
+    mock_get_backend.assert_called_once_with(content.website)
+    mock_get_backend.return_value.api.delete_content_file.assert_called_once_with(
+        content
+    )
+
+
+@pytest.mark.django_db
+def test_hard_delete_skips_backend_when_sync_disabled(settings, mocker):
+    """No backend call should be made when CONTENT_SYNC_BACKEND isn't configured"""
+    settings.CONTENT_SYNC_BACKEND = ""
+    mock_get_backend = mocker.patch("websites.signals.get_sync_backend")
+    content = WebsiteContentFactory.create(type=CONTENT_TYPE_EXTERNAL_RESOURCE)
+
+    content.delete(force_policy=HARD_DELETE)
+
+    mock_get_backend.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_soft_delete_does_not_touch_backend(settings, mocker):
+    """A regular (soft) delete should not trigger the hard-delete backend cleanup"""
+    settings.CONTENT_SYNC_BACKEND = "content_sync.backends.github.GithubBackend"
+    mock_get_backend = mocker.patch("websites.signals.get_sync_backend")
+    content = WebsiteContentFactory.create(type=CONTENT_TYPE_EXTERNAL_RESOURCE)
+
+    content.delete()
+
+    mock_get_backend.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_hard_delete_backend_error_does_not_block_deletion(settings, mocker):
+    """A backend failure while cleaning up should be logged, not raised"""
+    settings.CONTENT_SYNC_BACKEND = "content_sync.backends.github.GithubBackend"
+    mock_get_backend = mocker.patch("websites.signals.get_sync_backend")
+    mock_get_backend.return_value.api.delete_content_file.side_effect = Exception(
+        "backend unavailable"
+    )
+    content = WebsiteContentFactory.create(type=CONTENT_TYPE_EXTERNAL_RESOURCE)
+    content_id = content.id
+
+    content.delete(force_policy=HARD_DELETE)  # must not raise
+
+    assert not WebsiteContent.all_objects.filter(id=content_id).exists()

--- a/websites/signals_test.py
+++ b/websites/signals_test.py
@@ -3,6 +3,7 @@
 import pytest
 from safedelete.models import HARD_DELETE
 
+from content_sync.apis.github import GIT_DATA_FILEPATH
 from users.factories import UserFactory
 from websites import constants
 from websites.api import sync_website_content_references
@@ -92,55 +93,111 @@ def test_deleting_linked_resource_unlinks_it_from_video():
 
 
 @pytest.mark.django_db
-def test_hard_delete_removes_content_from_backend(settings, mocker):
-    """Hard-deleting a WebsiteContent should delete its file from the git backend"""
+def test_hard_delete_enqueues_cleanup_with_last_synced_path(
+    settings, mocker, django_capture_on_commit_callbacks
+):
+    """Hard-deleting content enqueues backend cleanup using its last-synced path"""
     settings.CONTENT_SYNC_BACKEND = "content_sync.backends.github.GithubBackend"
-    mock_get_backend = mocker.patch("websites.signals.get_sync_backend")
+    mock_task = mocker.patch("websites.signals.delete_orphaned_content_file")
     content = WebsiteContentFactory.create(type=CONTENT_TYPE_EXTERNAL_RESOURCE)
+    content.content_sync_state.data = {GIT_DATA_FILEPATH: "path/to/synced-file.md"}
+    content.content_sync_state.save()
+    website_pk = content.website.pk
+    updated_by_id = content.updated_by_id
 
-    content.delete(force_policy=HARD_DELETE)
+    with django_capture_on_commit_callbacks(execute=True):
+        content.delete(force_policy=HARD_DELETE)
 
-    mock_get_backend.assert_called_once_with(content.website)
-    mock_get_backend.return_value.api.delete_content_file.assert_called_once_with(
-        content
+    mock_task.delay.assert_called_once_with(
+        str(website_pk), "path/to/synced-file.md", updated_by_id
     )
 
 
 @pytest.mark.django_db
-def test_hard_delete_skips_backend_when_sync_disabled(settings, mocker):
-    """No backend call should be made when CONTENT_SYNC_BACKEND isn't configured"""
-    settings.CONTENT_SYNC_BACKEND = ""
-    mock_get_backend = mocker.patch("websites.signals.get_sync_backend")
+def test_hard_delete_falls_back_to_computed_path_when_never_synced(
+    settings, mocker, django_capture_on_commit_callbacks
+):
+    """Content with no recorded synced path falls back to a freshly computed one"""
+    settings.CONTENT_SYNC_BACKEND = "content_sync.backends.github.GithubBackend"
+    mock_task = mocker.patch("websites.signals.delete_orphaned_content_file")
+    mocker.patch(
+        "websites.signals.get_destination_filepath",
+        return_value="path/to/computed-file.md",
+    )
     content = WebsiteContentFactory.create(type=CONTENT_TYPE_EXTERNAL_RESOURCE)
+    website_pk = content.website.pk
+    updated_by_id = content.updated_by_id
 
-    content.delete(force_policy=HARD_DELETE)
+    with django_capture_on_commit_callbacks(execute=True):
+        content.delete(force_policy=HARD_DELETE)
 
-    mock_get_backend.assert_not_called()
+    mock_task.delay.assert_called_once_with(
+        str(website_pk), "path/to/computed-file.md", updated_by_id
+    )
 
 
 @pytest.mark.django_db
-def test_soft_delete_does_not_touch_backend(settings, mocker):
+def test_hard_delete_skips_cleanup_when_path_cannot_be_determined(
+    settings, mocker, django_capture_on_commit_callbacks
+):
+    """No task is enqueued when neither a synced path nor a computed one is available"""
+    settings.CONTENT_SYNC_BACKEND = "content_sync.backends.github.GithubBackend"
+    mock_task = mocker.patch("websites.signals.delete_orphaned_content_file")
+    mocker.patch("websites.signals.get_destination_filepath", return_value=None)
+    content = WebsiteContentFactory.create(type=CONTENT_TYPE_EXTERNAL_RESOURCE)
+
+    with django_capture_on_commit_callbacks(execute=True):
+        content.delete(force_policy=HARD_DELETE)
+
+    mock_task.delay.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_hard_delete_skips_backend_when_sync_disabled(
+    settings, mocker, django_capture_on_commit_callbacks
+):
+    """No cleanup should be enqueued when CONTENT_SYNC_BACKEND isn't configured"""
+    settings.CONTENT_SYNC_BACKEND = ""
+    mock_task = mocker.patch("websites.signals.delete_orphaned_content_file")
+    content = WebsiteContentFactory.create(type=CONTENT_TYPE_EXTERNAL_RESOURCE)
+
+    with django_capture_on_commit_callbacks(execute=True):
+        content.delete(force_policy=HARD_DELETE)
+
+    mock_task.delay.assert_not_called()
+
+
+@pytest.mark.django_db
+def test_soft_delete_does_not_touch_backend(
+    settings, mocker, django_capture_on_commit_callbacks
+):
     """A regular (soft) delete should not trigger the hard-delete backend cleanup"""
     settings.CONTENT_SYNC_BACKEND = "content_sync.backends.github.GithubBackend"
-    mock_get_backend = mocker.patch("websites.signals.get_sync_backend")
+    mock_task = mocker.patch("websites.signals.delete_orphaned_content_file")
     content = WebsiteContentFactory.create(type=CONTENT_TYPE_EXTERNAL_RESOURCE)
 
-    content.delete()
+    with django_capture_on_commit_callbacks(execute=True):
+        content.delete()
 
-    mock_get_backend.assert_not_called()
+    mock_task.delay.assert_not_called()
 
 
 @pytest.mark.django_db
-def test_hard_delete_backend_error_does_not_block_deletion(settings, mocker):
-    """A backend failure while cleaning up should be logged, not raised"""
+def test_hard_delete_backend_error_does_not_block_deletion(
+    settings, mocker, django_capture_on_commit_callbacks
+):
+    """A backend failure while cleaning up (end-to-end, task included) is logged, not raised"""
     settings.CONTENT_SYNC_BACKEND = "content_sync.backends.github.GithubBackend"
-    mock_get_backend = mocker.patch("websites.signals.get_sync_backend")
+    mock_get_backend = mocker.patch("content_sync.tasks.api.get_sync_backend")
     mock_get_backend.return_value.api.delete_content_file.side_effect = Exception(
         "backend unavailable"
     )
     content = WebsiteContentFactory.create(type=CONTENT_TYPE_EXTERNAL_RESOURCE)
+    content.content_sync_state.data = {GIT_DATA_FILEPATH: "path/to/synced-file.md"}
+    content.content_sync_state.save()
     content_id = content.id
 
-    content.delete(force_policy=HARD_DELETE)  # must not raise
+    with django_capture_on_commit_callbacks(execute=True):
+        content.delete(force_policy=HARD_DELETE)  # must not raise
 
     assert not WebsiteContent.all_objects.filter(id=content_id).exists()


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/12963

### Description (What does it do?)
Hard-deleting a `WebsiteContent` row didn't reliably clean up its file in the git backend, and the production-to-RC database cloning runbook never checked for or removed files left behind by the clone. Both leave a file in git with no corresponding database row, which Hugo keeps building.

- `websites/signals.py`: new `post_delete` signal on `WebsiteContent` that removes the corresponding backend file as a safety net for hard-deletes outside the existing managed paths.
- `content_sync/apis/github.py`: `delete_content_file` now treats an already-missing file as a no-op instead of raising, so the signal's call against a path that already cleaned up the file doesn't retry and log an error.
- `docs/production-to-rc-data-cloning.md`: added a step to reconcile GitHub against the database after a clone, using the existing `sync_website_to_backend --delete` command.

Automating the reconciliation step instead of relying on the documented runbook step is a possible follow-up, not included here.

### How can this be tested?
1. Checkout `umar/12963-orphaned-backend-files-on-hard-delete`
2. In a Django shell, hard-delete a `WebsiteContent` that has a file synced to its backend outside the normal delete flow (e.g. `content.delete(force_policy=HARD_DELETE)`) and confirm the file is removed from the repo.
3. Read through the new step 3.4 in the updated doc for accuracy.