### PR TITLE
Add viewable, editable image galleries to the Markdown editor (POC)

### DIFF
--- a/static/js/components/widgets/ImageGalleryWidget.tsx
+++ b/static/js/components/widgets/ImageGalleryWidget.tsx
@@ -1,0 +1,202 @@
+import React, { useCallback, useEffect, useState } from "react"
+import { createPortal } from "react-dom"
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from "@dnd-kit/core"
+import {
+  SortableContext,
+  arrayMove,
+  rectSortingStrategy,
+  sortableKeyboardCoordinates,
+  useSortable,
+} from "@dnd-kit/sortable"
+import { CSS } from "@dnd-kit/utilities"
+
+import { useWebsite } from "../../context/Website"
+import { useWebsiteContent } from "../../hooks/websites"
+import { siteContentRerouteUrl } from "../../lib/urls"
+import { ImageGalleryHandle } from "../../lib/ckeditor/plugins/constants"
+
+interface Props {
+  el: HTMLElement
+  handle: ImageGalleryHandle
+}
+
+/**
+ * Display and edit component for image galleries embedded in the Markdown
+ * editor.
+ *
+ * Like EmbeddedResource this renders into a raw element owned by CKEditor via a
+ * portal, but unlike EmbeddedResource it also *writes* — reordering and
+ * removing images go back into the CKEditor model through `handle`, so they
+ * participate in undo/redo and mark the form dirty.
+ *
+ * Per-image metadata (alt text, caption, credit) is deliberately not editable
+ * here. It lives on the image resource itself, which is the single source of
+ * truth; each thumbnail links out to that resource's form.
+ */
+export default function ImageGalleryWidget(props: Props): JSX.Element {
+  const { el, handle } = props
+
+  const [uuids, setUuids] = useState<string[]>(() => handle.getUuids())
+
+  /**
+   * The editingDowncast converter does not opt into reconversion, so this view
+   * is never rebuilt when the gallery changes. Subscribing to the model instead
+   * keeps the grid current — including after an undo — without remounting the
+   * React tree mid-drag.
+   */
+  useEffect(
+    () => handle.onModelChange(() => setUuids(handle.getUuids())),
+    [handle],
+  )
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  )
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event
+      if (!over || active.id === over.id) {
+        return
+      }
+      const oldIndex = uuids.indexOf(String(active.id))
+      const newIndex = uuids.indexOf(String(over.id))
+      if (oldIndex === -1 || newIndex === -1) {
+        return
+      }
+      handle.setUuids(arrayMove(uuids, oldIndex, newIndex))
+    },
+    [uuids, handle],
+  )
+
+  const removeImage = useCallback(
+    (uuid: string) => {
+      handle.setUuids(uuids.filter((item) => item !== uuid))
+    },
+    [uuids, handle],
+  )
+
+  return createPortal(
+    <div
+      className="image-gallery-editor"
+      /**
+       * CKEditor's widget layer binds mousedown on the widget in order to
+       * select it, which would otherwise swallow the drag handles and buttons
+       * below. The gallery's interior is ours, so keep those events local.
+       */
+      onMouseDown={(event) => event.stopPropagation()}
+    >
+      <div className="d-flex align-items-center justify-content-between mb-2">
+        <h3 className="m-0">Image Gallery</h3>
+        <button
+          type="button"
+          className="btn cyan-button"
+          onClick={handle.openPicker}
+        >
+          Add images
+        </button>
+      </div>
+      {uuids.length === 0 ? (
+        <div className="image-gallery-empty text-gray font-italic">
+          No images yet — use “Add images” to choose some.
+        </div>
+      ) : (
+        <DndContext
+          sensors={sensors}
+          collisionDetection={closestCenter}
+          onDragEnd={handleDragEnd}
+        >
+          <SortableContext items={uuids} strategy={rectSortingStrategy}>
+            <div className="image-gallery-grid">
+              {uuids.map((uuid) => (
+                <GalleryThumbnail
+                  key={uuid}
+                  uuid={uuid}
+                  removeImage={removeImage}
+                />
+              ))}
+            </div>
+          </SortableContext>
+        </DndContext>
+      )}
+    </div>,
+    el,
+  )
+}
+
+interface ThumbnailProps {
+  uuid: string
+  removeImage: (uuid: string) => void
+}
+
+function GalleryThumbnail(props: ThumbnailProps): JSX.Element {
+  const { uuid, removeImage } = props
+  const website = useWebsite()
+  const [resource] = useWebsiteContent(uuid)
+
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id: uuid })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+
+  const onRemove = useCallback(() => removeImage(uuid), [removeImage, uuid])
+
+  return (
+    <div
+      className="image-gallery-item"
+      ref={setNodeRef}
+      // @ts-expect-error unavoidable because of the library's types, as in SortableItem
+      style={style}
+    >
+      <div className="image-gallery-item-controls">
+        <span
+          className="material-icons drag-handle"
+          title="Drag to reorder"
+          {...attributes}
+          {...listeners}
+        >
+          drag_indicator
+        </span>
+        <span
+          className="material-icons gray-button hover ml-auto"
+          title="Remove from gallery"
+          onClick={onRemove}
+        >
+          remove_circle_outline
+        </span>
+      </div>
+      {resource?.file ? (
+        <img className="img-fluid" src={resource.file} alt="" />
+      ) : (
+        <div className="image-gallery-item-missing text-gray">
+          {resource ? "Not an image" : "Loading…"}
+        </div>
+      )}
+      <a
+        className="image-gallery-item-title"
+        href={siteContentRerouteUrl
+          .param({ name: website.name, uuid })
+          .toString()}
+        target="_blank"
+        rel="noopener noreferrer"
+        title="Edit this image's caption, credit and alt text"
+      >
+        {resource?.title ?? uuid}
+      </a>
+    </div>
+  )
+}

--- a/static/js/components/widgets/MarkdownEditor.test.tsx
+++ b/static/js/components/widgets/MarkdownEditor.test.tsx
@@ -57,6 +57,7 @@ jest.mock("@ckeditor/ckeditor5-react", () => ({
 let lastResourcePickerProps: any = null
 jest.mock("../../components/widgets/ResourcePickerDialog", () => ({
   __esModule: true,
+  ...jest.requireActual("../../components/widgets/ResourcePickerDialog"),
   default: (props: any) => {
     lastResourcePickerProps = props
     return props.isOpen ? <div data-testid="resource-picker" /> : null

--- a/static/js/components/widgets/MarkdownEditor.tsx
+++ b/static/js/components/widgets/MarkdownEditor.tsx
@@ -20,15 +20,21 @@ import {
   RESOURCE_EMBED_COMMAND,
   ResourceDialogMode,
   ADD_RESOURCE_EMBED,
+  RESOURCE_EMBED,
   RESOURCE_LINK,
   MARKDOWN_CONFIG_KEY,
   RESOURCE_LINK_CONFIG_KEY,
   WEBSITE_NAME,
   MINIMAL_WITH_MATH,
+  IMAGE_GALLERY_COMMAND,
+  ImageGalleryHandle,
+  RenderGalleryFunc,
 } from "../../lib/ckeditor/plugins/constants"
-import ResourcePickerDialog from "./ResourcePickerDialog"
+import ResourcePickerDialog, { TabIds } from "./ResourcePickerDialog"
+import ImageGalleryWidget from "./ImageGalleryWidget"
 import useThrowSynchronously from "../../hooks/useAsyncError"
 import { useWebsite } from "../../context/Website"
+import { ContentType } from "../../constants"
 import { siteContentRerouteUrl } from "../../lib/urls"
 import { useFeatureFlag } from "../../lib/util"
 import { FEATURE_FLAG_CUSTOM_LINKUI } from "../../common/feature_flags"
@@ -46,6 +52,8 @@ export interface Props {
 }
 
 type RenderQueueEntry = [string, HTMLElement]
+
+type GalleryQueueEntry = [HTMLElement, ImageGalleryHandle]
 
 /**
  * A component for editing Markdown using CKEditor.
@@ -111,10 +119,57 @@ export default function MarkdownEditor(props: Props): JSX.Element {
 
   const openResourcePicker = useCallback(
     (resourceDialogType: CKEResourceNodeType) => {
+      setIsGalleryPicker(false)
       setResourcePickerMode(resourceDialogType)
       setIsResourcePickerOpen(true)
     },
     [setResourcePickerMode, setIsResourcePickerOpen],
+  )
+
+  const [galleryQueue, setGalleryQueue] = useState<GalleryQueueEntry[]>([])
+
+  const renderImageGallery: RenderGalleryFunc = useCallback(
+    (el: HTMLElement, handle: ImageGalleryHandle) => {
+      setGalleryQueue((xs) => [...xs, [el, handle]])
+    },
+    [setGalleryQueue],
+  )
+
+  /**
+   * The gallery being added to, or null when the picker's selection should
+   * become a brand new gallery.
+   */
+  const [galleryHandle, setGalleryHandle] = useState<ImageGalleryHandle | null>(
+    null,
+  )
+  const [isGalleryPicker, setIsGalleryPicker] = useState(false)
+
+  const openImageGalleryPicker = useCallback(
+    (handle: ImageGalleryHandle | null) => {
+      setGalleryHandle(handle)
+      setIsGalleryPicker(true)
+      setResourcePickerMode(RESOURCE_EMBED)
+      setIsResourcePickerOpen(true)
+    },
+    [],
+  )
+
+  const addGalleryImages = useCallback(
+    (uuids: string[]) => {
+      if (galleryHandle) {
+        // Appending to an existing gallery. Skip anything already present so a
+        // re-pick cannot duplicate an image.
+        const existing = galleryHandle.getUuids()
+        galleryHandle.setUuids([
+          ...existing,
+          ...uuids.filter((uuid) => !existing.includes(uuid)),
+        ])
+      } else {
+        editor.current?.execute(IMAGE_GALLERY_COMMAND, uuids)
+      }
+      editor.current?.editing.view.focus()
+    },
+    [galleryHandle],
   )
 
   const editorConfig = useMemo(() => {
@@ -163,6 +218,8 @@ export default function MarkdownEditor(props: Props): JSX.Element {
       [CKEDITOR_RESOURCE_UTILS]: {
         renderResource,
         openResourcePicker,
+        renderImageGallery,
+        openImageGalleryPicker,
       },
       toolbar: {
         ...baseConfig.toolbar,
@@ -177,6 +234,8 @@ export default function MarkdownEditor(props: Props): JSX.Element {
     minimal,
     renderResource,
     openResourcePicker,
+    renderImageGallery,
+    openImageGalleryPicker,
     link,
     embed,
     allowedHtml,
@@ -204,8 +263,11 @@ export default function MarkdownEditor(props: Props): JSX.Element {
       setRenderQueue((xs) =>
         xs.filter((entry) => document.body.contains(entry[1])),
       )
+      setGalleryQueue((xs) =>
+        xs.filter((entry) => document.body.contains(entry[0])),
+      )
     },
-    [onChange, setRenderQueue, name],
+    [onChange, setRenderQueue, setGalleryQueue, name],
   )
 
   const closeResourcePicker = useCallback(() => {
@@ -224,17 +286,31 @@ export default function MarkdownEditor(props: Props): JSX.Element {
           onError={throwSynchronously}
         />
       </div>
-      {(link.length > 0 || embed.length > 0) && (
+      {(link.length > 0 || embed.length > 0 || isGalleryPicker) && (
         <ResourcePickerDialog
           isOpen={isResourcePickerOpen}
           mode={resourcePickerMode}
-          contentNames={resourcePickerMode === RESOURCE_LINK ? link : embed}
+          contentNames={
+            isGalleryPicker
+              ? [ContentType.Resource]
+              : resourcePickerMode === RESOURCE_LINK
+                ? link
+                : embed
+          }
           closeDialog={closeResourcePicker}
           insertEmbed={addResourceEmbed}
+          multiple={isGalleryPicker}
+          insertMultiple={addGalleryImages}
+          restrictToTabIds={isGalleryPicker ? [TabIds.Images] : undefined}
+          dialogTitle={isGalleryPicker ? "Add Images to Gallery" : undefined}
+          acceptLabel={isGalleryPicker ? "Add images" : undefined}
         />
       )}
       {renderQueue.map(([uuid, el], idx) => (
         <EmbeddedResource key={`${uuid}_${idx}`} uuid={uuid} el={el} />
+      ))}
+      {galleryQueue.map(([el, handle], idx) => (
+        <ImageGalleryWidget key={`gallery_${idx}`} el={el} handle={handle} />
       ))}
     </>
   )

--- a/static/js/components/widgets/ResourcePickerDialog.tsx
+++ b/static/js/components/widgets/ResourcePickerDialog.tsx
@@ -27,6 +27,18 @@ interface Props {
   closeDialog: () => void
   insertEmbed: (id: string, title: string, variant: CKEResourceNodeType) => void
   contentNames: string[]
+  /**
+   * Opt in to selecting several resources at once. Existing callers leave this
+   * unset and keep the original single-selection behavior.
+   */
+  multiple?: boolean
+  /** Required when `multiple` is set. Receives the uuids in selection order. */
+  insertMultiple?: (uuids: string[]) => void
+  /** Restrict the visible tabs, e.g. to images only. */
+  restrictToTabIds?: string[]
+  /** Overrides the dialog heading and accept button label. */
+  dialogTitle?: string
+  acceptLabel?: string
 }
 
 interface TabSettings {
@@ -107,7 +119,18 @@ const modeText = {
 }
 
 export default function ResourcePickerDialog(props: Props): JSX.Element {
-  const { mode, isOpen, closeDialog, insertEmbed, contentNames } = props
+  const {
+    mode,
+    isOpen,
+    closeDialog,
+    insertEmbed,
+    contentNames,
+    multiple = false,
+    insertMultiple,
+    restrictToTabIds,
+    dialogTitle,
+    acceptLabel,
+  } = props
   const website = useWebsite()
   const definedCategories = useMemo(() => {
     const contentCollections =
@@ -131,8 +154,11 @@ export default function ResourcePickerDialog(props: Props): JSX.Element {
             ]
           } else return []
         })
-        .filter((tab) => tab && (mode !== RESOURCE_EMBED || tab.embeddable)),
-    [contentNames, definedCategories, mode],
+        .filter((tab) => tab && (mode !== RESOURCE_EMBED || tab.embeddable))
+        .filter(
+          (tab) => !restrictToTabIds || restrictToTabIds.includes(tab.id),
+        ),
+    [contentNames, definedCategories, mode, restrictToTabIds],
   )
 
   const [activeTabId, setActiveTabId] = useState(tabs[0].id)
@@ -159,6 +185,31 @@ export default function ResourcePickerDialog(props: Props): JSX.Element {
     null,
   )
 
+  const [selectedUuids, setSelectedUuids] = useState<string[]>([])
+
+  // Start from a clean selection every time the dialog is opened.
+  useEffect(() => {
+    if (isOpen) {
+      setSelectedUuids([])
+      setFocusedResource(null)
+    }
+  }, [isOpen])
+
+  const toggleResource = useCallback((item: WebsiteContent) => {
+    setSelectedUuids((current) =>
+      current.includes(item.text_id)
+        ? current.filter((uuid) => uuid !== item.text_id)
+        : [...current, item.text_id],
+    )
+  }, [])
+
+  const addSelectedResources = useCallback(() => {
+    if (selectedUuids.length > 0 && isOpen) {
+      insertMultiple?.(selectedUuids)
+      closeDialog()
+    }
+  }, [insertMultiple, selectedUuids, closeDialog, isOpen])
+
   const addResource = useCallback(() => {
     if (focusedResource && isOpen) {
       insertEmbed(
@@ -172,14 +223,22 @@ export default function ResourcePickerDialog(props: Props): JSX.Element {
 
   const { acceptText, title } = modeText[mode]
 
+  const hasSelection = multiple
+    ? selectedUuids.length > 0
+    : focusedResource !== null
+  const onAccept = multiple ? addSelectedResources : addResource
+  const resolvedAcceptText = multiple
+    ? `${acceptLabel ?? acceptText} (${selectedUuids.length})`
+    : acceptText
+
   return (
     <Dialog
       open={isOpen}
       onCancel={closeDialog}
       wrapClassName="resource-picker-dialog"
-      headerContent={title}
-      onAccept={focusedResource ? addResource : undefined}
-      acceptText={focusedResource ? acceptText : undefined}
+      headerContent={dialogTitle ?? title}
+      onAccept={hasSelection ? onAccept : undefined}
+      acceptText={hasSelection ? resolvedAcceptText : undefined}
       bodyContent={
         <>
           <Nav tabs>
@@ -211,8 +270,11 @@ export default function ResourcePickerDialog(props: Props): JSX.Element {
                     resourcetype={tab.resourcetype}
                     contentType={tab.contentType}
                     filter={filter ?? null}
-                    focusResource={setFocusedResource}
+                    focusResource={
+                      multiple ? toggleResource : setFocusedResource
+                    }
                     focusedResource={focusedResource}
+                    selectedUuids={multiple ? selectedUuids : undefined}
                     singleColumn={tab.singleColumn}
                   />
                 ) : null}

--- a/static/js/components/widgets/ResourcePickerListing.tsx
+++ b/static/js/components/widgets/ResourcePickerListing.tsx
@@ -23,6 +23,11 @@ interface Props {
   focusedResource: WebsiteContent | null
   sourceWebsiteName?: string
   singleColumn: boolean
+  /**
+   * When the picker is in multi-select mode, the uuids chosen so far. Items in
+   * this list are highlighted the same way a focused item is.
+   */
+  selectedUuids?: string[]
 }
 
 export default function ResourcePickerListing(
@@ -36,6 +41,7 @@ export default function ResourcePickerListing(
     contentType,
     sourceWebsiteName,
     singleColumn,
+    selectedUuids,
   } = props
   const website = useWebsite()
 
@@ -82,7 +88,10 @@ export default function ResourcePickerListing(
             isWholeRow={singleColumn}
             websiteContent={item}
             onClick={focusItem}
-            isFocused={item.text_id === focusedResource?.text_id}
+            isFocused={
+              item.text_id === focusedResource?.text_id ||
+              (selectedUuids?.includes(item.text_id) ?? false)
+            }
           />
         )
       })}

--- a/static/js/lib/ckeditor/CKEditor.ts
+++ b/static/js/lib/ckeditor/CKEditor.ts
@@ -23,12 +23,17 @@ import MathSyntax from "./plugins/MathSyntax"
 import Markdown from "./plugins/Markdown"
 import ResourceEmbed from "./plugins/ResourceEmbed"
 import ResourcePicker from "./plugins/ResourcePicker"
-import { ADD_RESOURCE_EMBED, ADD_RESOURCE_LINK } from "./plugins/constants"
+import {
+  ADD_IMAGE_GALLERY,
+  ADD_RESOURCE_EMBED,
+  ADD_RESOURCE_LINK,
+} from "./plugins/constants"
 import ResourceLink from "./plugins/ResourceLink"
 import DisallowNestedTables from "./plugins/DisallowNestedTables"
 import TableMarkdownSyntax from "./plugins/TableMarkdownSyntax"
 import MarkdownListSyntax from "./plugins/MarkdownListSyntax"
 import LegacyShortcodes from "./plugins/LegacyShortcodes"
+import ImageGallery from "./plugins/ImageGallery"
 
 /**
  * Programming languages we support in CKEditor code blocks
@@ -86,6 +91,7 @@ export const FullEditorConfig = {
     TableMarkdownSyntax,
     MathSyntax, // Needs to go before MarkdownListSyntax
     MarkdownListSyntax,
+    ImageGallery,
     LegacyShortcodes,
     Mathematics,
     Markdown,
@@ -111,6 +117,7 @@ export const FullEditorConfig = {
       "redo",
       ADD_RESOURCE_LINK,
       ADD_RESOURCE_EMBED,
+      ADD_IMAGE_GALLERY,
     ],
   },
   image: {
@@ -153,6 +160,7 @@ export const MinimalEditorConfig = {
     ResourceLink,
     MarkdownListSyntax,
     Markdown,
+    ImageGallery,
     LegacyShortcodes,
   ],
   toolbar: {
@@ -191,6 +199,7 @@ export const MinimalWithMathEditorConfig = {
     MarkdownListSyntax,
     Mathematics,
     Markdown,
+    ImageGallery,
     LegacyShortcodes,
   ],
   toolbar: {

--- a/static/js/lib/ckeditor/plugins/ImageGallery.test.ts
+++ b/static/js/lib/ckeditor/plugins/ImageGallery.test.ts
@@ -1,0 +1,80 @@
+import ImageGallery from "./ImageGallery"
+import Markdown from "./Markdown"
+import { createTestEditor, markdownTest } from "./test_util"
+import { turndownService } from "../turndown"
+
+const getEditor = createTestEditor([ImageGallery, Markdown])
+
+describe("ImageGallery plugin", () => {
+  afterEach(() => {
+    turndownService.rules.array = turndownService.rules.array.filter(
+      (rule: any) => rule.filter !== "figure" && rule.filter !== "section",
+    )
+  })
+
+  it("round-trips a gallery with a single image", async () => {
+    const editor = await getEditor("")
+    markdownTest(
+      editor,
+      [
+        "{{< image-gallery >}}",
+        '{{< image-gallery-item uuid="uuid-one" >}}',
+        "{{< /image-gallery >}}",
+      ].join("\n"),
+      '<div class="image-gallery" data-uuids="uuid-one"></div>',
+    )
+  })
+
+  it("round-trips a gallery with several images, preserving order", async () => {
+    const editor = await getEditor("")
+    markdownTest(
+      editor,
+      [
+        "{{< image-gallery >}}",
+        '{{< image-gallery-item uuid="ccc" >}}',
+        '{{< image-gallery-item uuid="aaa" >}}',
+        '{{< image-gallery-item uuid="bbb" >}}',
+        "{{< /image-gallery >}}",
+      ].join("\n"),
+      '<div class="image-gallery" data-uuids="ccc,aaa,bbb"></div>',
+    )
+  })
+
+  it("keeps surrounding prose intact", async () => {
+    const editor = await getEditor("")
+    markdownTest(
+      editor,
+      [
+        "Here is a gallery.",
+        "",
+        "{{< image-gallery >}}",
+        '{{< image-gallery-item uuid="aaa" >}}',
+        "{{< /image-gallery >}}",
+        "",
+        "And some text after it.",
+      ].join("\n"),
+      [
+        "<p>Here is a gallery.</p>",
+        '<div class="image-gallery" data-uuids="aaa"></div>',
+        "<p>And some text after it.</p>",
+      ].join("\n"),
+    )
+  })
+
+  it("loads a gallery into the editor and writes it back unchanged", async () => {
+    const markdown = [
+      "{{< image-gallery >}}",
+      '{{< image-gallery-item uuid="aaa" >}}',
+      '{{< image-gallery-item uuid="bbb" >}}',
+      "{{< /image-gallery >}}",
+    ].join("\n")
+    const editor = await getEditor(markdown)
+    expect(editor.getData()).toBe(markdown)
+  })
+
+  it("drops an empty gallery rather than writing a broken shortcode", async () => {
+    const editor = await getEditor("")
+    const { html2md } = editor.data.processor as any
+    expect(html2md('<div class="image-gallery" data-uuids=""></div>')).toBe("")
+  })
+})

--- a/static/js/lib/ckeditor/plugins/ImageGallery.ts
+++ b/static/js/lib/ckeditor/plugins/ImageGallery.ts
@@ -1,0 +1,313 @@
+import CKEPlugin from "@ckeditor/ckeditor5-core/src/plugin"
+import Command from "@ckeditor/ckeditor5-core/src/command"
+import Showdown from "showdown"
+import Turndown from "turndown"
+import { Editor } from "@ckeditor/ckeditor5-core"
+import { toWidget } from "@ckeditor/ckeditor5-widget/src/utils"
+import ButtonView from "@ckeditor/ckeditor5-ui/src/button/buttonview"
+
+import MarkdownSyntaxPlugin from "./MarkdownSyntaxPlugin"
+import { TurndownRule } from "../../../types/ckeditor_markdown"
+import {
+  ADD_IMAGE_GALLERY,
+  CKEDITOR_RESOURCE_UTILS,
+  IMAGE_GALLERY,
+  IMAGE_GALLERY_COMMAND,
+  ImageGalleryHandle,
+  RenderGalleryFunc,
+} from "./constants"
+
+const GALLERY_CLASS = "image-gallery"
+const DATA_UUIDS = "data-uuids"
+const UUIDS = "uuids"
+
+/**
+ * Matches a whole `image-gallery` block, capturing everything between the
+ * opening and closing shortcodes.
+ *
+ * Unlike most of our shortcode handling this cannot use `Shortcode.regex`,
+ * which matches a single tag at a time. A gallery is inherently a paired
+ * shortcode, so the whole block has to be consumed at once — otherwise the
+ * opening tag, the items and the closing tag would be converted independently
+ * and there would be nothing tying them together in the editor.
+ *
+ * Both `{{< /image-gallery >}}` and `{{</ image-gallery >}}` are accepted for
+ * the closing tag, since both appear in the wild.
+ */
+const GALLERY_BLOCK_REGEX =
+  /\{\{<\s*image-gallery\s*>\}\}([\s\S]*?)\{\{<\s*\/\s*image-gallery\s*>\}\}/g
+
+const GALLERY_ITEM_REGEX =
+  /\{\{<\s*image-gallery-item\s+uuid="(?<uuid>[^"]*)"\s*\/?\s*>\}\}/g
+
+const parseUuids = (blockInterior: string): string[] =>
+  [...blockInterior.matchAll(GALLERY_ITEM_REGEX)]
+    .map((match) => match.groups?.uuid ?? "")
+    .filter(Boolean)
+
+const serializeUuids = (uuids: string[]): string =>
+  [
+    "{{< image-gallery >}}",
+    ...uuids.map((uuid) => `{{< image-gallery-item uuid="${uuid}" >}}`),
+    "{{< /image-gallery >}}",
+  ].join("\n")
+
+/**
+ * Markdown conversion rules for image galleries.
+ *
+ * A whole gallery becomes a single `div.image-gallery` carrying its ordered
+ * uuids in one attribute. Keeping the items out of the HTML (and out of the
+ * CKEditor schema) is deliberate: an item has no authored content of its own
+ * any more — description, caption and credit all live on the image resource —
+ * so there is nothing for the user to edit per item, and a flat node avoids a
+ * nested schema entirely.
+ */
+class ImageGalleryMarkdownSyntax extends MarkdownSyntaxPlugin {
+  static get pluginName(): string {
+    return "ImageGalleryMarkdownSyntax"
+  }
+
+  get showdownExtension() {
+    return function imageGalleryExtension(): Showdown.ShowdownExtension[] {
+      return [
+        {
+          type: "lang",
+          regex: GALLERY_BLOCK_REGEX,
+          replace: (_match: string, interior: string) =>
+            `<div class="${GALLERY_CLASS}" ${DATA_UUIDS}="${parseUuids(
+              interior,
+            ).join(",")}"></div>`,
+        },
+      ]
+    }
+  }
+
+  get turndownRules(): TurndownRule[] {
+    return [
+      {
+        name: "imageGallery",
+        rule: {
+          // Filtering on the class rather than the tag name matters: `div` is
+          // far too broad, and ResourceEmbed already claims `section`.
+          filter: (node: Turndown.Node): boolean =>
+            node.nodeName === "DIV" &&
+            (node as HTMLElement).classList.contains(GALLERY_CLASS),
+          replacement: (_content: string, node: Turndown.Node): string => {
+            if (!(node instanceof HTMLElement)) {
+              throw new Error("Node should be HTMLElement")
+            }
+            const uuids = (node.getAttribute(DATA_UUIDS) ?? "")
+              .split(",")
+              .filter(Boolean)
+            // An empty gallery is not worth writing to the repo, and a bare
+            // pair of shortcodes would render as an empty div on the site.
+            if (uuids.length === 0) {
+              return ""
+            }
+            return `${serializeUuids(uuids)}\n`
+          },
+        },
+      },
+    ]
+  }
+}
+
+/**
+ * Inserts a new gallery, or replaces the uuids of the selected one.
+ */
+class InsertImageGalleryCommand extends Command {
+  constructor(editor: Editor) {
+    super(editor)
+  }
+
+  execute(uuids: string[]) {
+    this.editor.model.change((writer: any) => {
+      const gallery = writer.createElement(IMAGE_GALLERY, {
+        [UUIDS]: uuids.join(","),
+      })
+      this.editor.model.insertContent(gallery)
+    })
+  }
+
+  refresh() {
+    const model = this.editor.model
+    const selection = model.document.selection
+    const allowedIn = model.schema.findAllowedParent(
+      selection.getFirstPosition(),
+      IMAGE_GALLERY,
+    )
+    this.isEnabled = allowedIn !== null
+  }
+}
+
+class ImageGalleryEditing extends CKEPlugin {
+  static get pluginName(): string {
+    return "ImageGalleryEditing"
+  }
+
+  constructor(editor: Editor) {
+    super(editor)
+  }
+
+  init() {
+    this._defineSchema()
+    this._defineConverters()
+
+    this.editor.commands.add(
+      IMAGE_GALLERY_COMMAND,
+      new InsertImageGalleryCommand(this.editor),
+    )
+  }
+
+  _defineSchema() {
+    this.editor.model.schema.register(IMAGE_GALLERY, {
+      isObject: true,
+      allowWhere: "$block",
+      // Stored as a comma-joined string rather than an array. CKEditor treats
+      // attribute values as opaque and compares them by identity in places, so
+      // a primitive keeps change detection and undo/redo predictable.
+      allowAttributes: [UUIDS],
+    })
+  }
+
+  _defineConverters() {
+    const conversion = this.editor.conversion
+    const editor = this.editor
+
+    conversion.for("upcast").elementToElement({
+      view: {
+        name: "div",
+        classes: [GALLERY_CLASS],
+      },
+      model: (viewElement: any, { writer: modelWriter }: any) =>
+        modelWriter.createElement(IMAGE_GALLERY, {
+          [UUIDS]: viewElement.getAttribute(DATA_UUIDS) ?? "",
+        }),
+    })
+
+    conversion.for("dataDowncast").elementToElement({
+      model: IMAGE_GALLERY,
+      view: (modelElement: any, { writer: viewWriter }: any) =>
+        viewWriter.createEmptyElement("div", {
+          class: GALLERY_CLASS,
+          [DATA_UUIDS]: modelElement.getAttribute(UUIDS) ?? "",
+        }),
+    })
+
+    const { renderImageGallery, openImageGalleryPicker } = (editor.config.get(
+      CKEDITOR_RESOURCE_UTILS,
+    ) ?? {}) as {
+      renderImageGallery?: RenderGalleryFunc
+      openImageGalleryPicker?: (handle: ImageGalleryHandle) => void
+    }
+
+    conversion.for("editingDowncast").elementToElement({
+      model: IMAGE_GALLERY,
+      view: (modelElement: any, { writer: viewWriter }: any) => {
+        const container = viewWriter.createContainerElement("div", {
+          class: "image-gallery-widget",
+        })
+
+        /**
+         * The handle closes over this gallery's model element, so every
+         * mutation the React layer makes goes through `model.change()` and
+         * therefore participates in undo/redo and marks the form dirty.
+         *
+         * Note there is deliberately no reconversion configured for the
+         * `uuids` attribute. Reconversion would rebuild this view element on
+         * every change, destroying the raw element's DOM node and remounting
+         * the React tree mid-drag. Instead React subscribes to model changes
+         * and re-renders in place.
+         */
+        const handle: ImageGalleryHandle = {
+          getUuids: () =>
+            (modelElement.getAttribute(UUIDS) ?? "").split(",").filter(Boolean),
+          setUuids: (uuids: string[]) =>
+            editor.model.change((writer: any) =>
+              writer.setAttribute(UUIDS, uuids.join(","), modelElement),
+            ),
+          onModelChange: (cb: () => void) => {
+            const listener = () => cb()
+            editor.model.document.on("change:data", listener)
+            return () => editor.model.document.off("change:data", listener)
+          },
+          openPicker: () => openImageGalleryPicker?.(handle),
+        }
+
+        const reactWrapper = viewWriter.createRawElement(
+          "div",
+          { class: "image-gallery-react-wrapper" },
+          function (el: HTMLElement) {
+            renderImageGallery?.(el, handle)
+          },
+        )
+
+        viewWriter.insert(
+          viewWriter.createPositionAt(container, 0),
+          reactWrapper,
+        )
+
+        return toWidget(container, viewWriter, { label: "Image Gallery" })
+      },
+    })
+  }
+}
+
+/**
+ * Toolbar button which opens the resource picker and inserts whatever the user
+ * chooses as a new gallery.
+ */
+class ImageGalleryToolbar extends CKEPlugin {
+  static get pluginName(): string {
+    return "ImageGalleryToolbar"
+  }
+
+  init(): void {
+    const editor = this.editor
+    const { openImageGalleryPicker } = (editor.config.get(
+      CKEDITOR_RESOURCE_UTILS,
+    ) ?? {}) as {
+      openImageGalleryPicker?: (handle: ImageGalleryHandle | null) => void
+    }
+
+    editor.ui.componentFactory.add(ADD_IMAGE_GALLERY, (locale: any) => {
+      const view = new ButtonView(locale)
+
+      view.set({
+        label: "Image gallery",
+        withText: true,
+      })
+
+      view.on("execute", () => {
+        // No handle: the picker's selection becomes a brand new gallery.
+        openImageGalleryPicker?.(null)
+      })
+
+      return view
+    })
+  }
+}
+
+/**
+ * CKEditor plugin providing viewable, reorderable image galleries.
+ *
+ * Galleries are stored in Markdown as a paired Hugo shortcode whose items
+ * reference image resources by uuid:
+ *
+ *   {{< image-gallery >}}
+ *   {{< image-gallery-item uuid="..." >}}
+ *   {{< /image-gallery >}}
+ */
+export default class ImageGallery extends CKEPlugin {
+  static get pluginName(): string {
+    return "ImageGallery"
+  }
+
+  static get requires(): (typeof CKEPlugin)[] {
+    return [
+      ImageGalleryEditing,
+      ImageGalleryMarkdownSyntax,
+      ImageGalleryToolbar,
+    ]
+  }
+}

--- a/static/js/lib/ckeditor/plugins/constants.ts
+++ b/static/js/lib/ckeditor/plugins/constants.ts
@@ -12,6 +12,12 @@ export const RESOURCE_LINK = "resourceLink"
 
 export const RESOURCE_EMBED_COMMAND = "insertResourceEmbed"
 
+export const IMAGE_GALLERY = "imageGallery"
+
+export const IMAGE_GALLERY_COMMAND = "insertImageGallery"
+
+export const ADD_IMAGE_GALLERY = "addImageGallery"
+
 export const MARKDOWN_CONFIG_KEY = "markdown-config"
 
 export const RESOURCE_LINK_CONFIG_KEY = "resource-link-config"
@@ -38,6 +44,33 @@ export type CKEResourceNodeType = typeof RESOURCE_LINK | typeof RESOURCE_EMBED
  */
 export interface RenderResourceFunc {
   (uuid: string, el: HTMLElement): void
+}
+
+/**
+ * A handle passed to the React layer for a single image gallery widget.
+ *
+ * The gallery widget needs to *write* to the CKEditor model, not just read
+ * from it like `RenderResourceFunc` does. These callbacks are built in the
+ * editingDowncast converter, where the model element for this particular
+ * gallery is in scope, so React never has to know about CKEditor internals.
+ */
+export interface ImageGalleryHandle {
+  getUuids(): string[]
+  setUuids(uuids: string[]): void
+  /** Subscribe to model changes. Returns an unsubscribe function. */
+  onModelChange(cb: () => void): () => void
+  /** Open the resource picker to append more images to this gallery. */
+  openPicker(): void
+}
+
+/**
+ * A 'gallery renderer', analogous to RenderResourceFunc.
+ *
+ * Passed from the React component wrapping CKEditor into the editor config,
+ * then called in the editingDowncast handler for image galleries.
+ */
+export interface RenderGalleryFunc {
+  (el: HTMLElement, handle: ImageGalleryHandle): void
 }
 
 export type ResourceDialogMode = typeof RESOURCE_LINK | typeof RESOURCE_EMBED
@@ -81,8 +114,6 @@ export const LEGACY_SHORTCODES = [
   "div-with-class",
   "fullwidth-cell",
   "h",
-  "image-gallery-item",
-  "image-gallery",
   "quote",
   "simplecast",
   "sub",

--- a/static/js/lib/ckeditor/turndown.ts
+++ b/static/js/lib/ckeditor/turndown.ts
@@ -77,9 +77,31 @@ turndownService.rules.blankRule.replacement = (
   if (matchingRules.length === 1) {
     const [rule] = matchingRules
     return rule.replacement?.(content, node as HTMLElement, options)
-  } else {
-    return "\n\n"
   }
+
+  /**
+   * Fall back to rules whose filter is a function or an array rather than a
+   * plain tag name. The string comparison above cannot see those, so without
+   * this a blank node handled by such a rule would be silently dropped.
+   *
+   * This is only reached when no string-filter rule matched, so it cannot
+   * change the behavior of any rule that already worked.
+   */
+  const functionMatchedRules = turndownService.rules.array.filter(
+    (rule) =>
+      typeof rule.filter !== "string" && ruleMatches(rule, node as HTMLElement),
+  )
+
+  if (functionMatchedRules.length > 1) {
+    throw new Error("should only be a single matching rule")
+  }
+
+  if (functionMatchedRules.length === 1) {
+    const [rule] = functionMatchedRules
+    return rule.replacement?.(content, node as HTMLElement, options)
+  }
+
+  return "\n\n"
 }
 
 // fix for the default behavior in turndown which, for some reason, adds

--- a/static/scss/image-gallery-widget.scss
+++ b/static/scss/image-gallery-widget.scss
@@ -1,0 +1,57 @@
+.ck-editor {
+  .image-gallery-widget {
+    border: 1px solid $studio-gray;
+    padding: 0.75rem;
+    margin: 0.5rem 0;
+  }
+
+  .image-gallery-empty {
+    padding: 1rem 0;
+  }
+
+  .image-gallery-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: 0.75rem;
+  }
+
+  .image-gallery-item {
+    border: 1px solid $form-control-gray;
+    border-radius: 0.25rem;
+    padding: 0.25rem;
+    background: white;
+    display: flex;
+    flex-direction: column;
+
+    img {
+      // CKEditor sets a min-width on images which breaks the grid.
+      min-width: initial !important;
+      max-width: 100% !important;
+      height: 100px;
+      object-fit: cover;
+    }
+  }
+
+  .image-gallery-item-controls {
+    display: flex;
+    align-items: center;
+
+    .drag-handle {
+      cursor: grab;
+    }
+  }
+
+  .image-gallery-item-missing {
+    height: 100px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+  }
+
+  .image-gallery-item-title {
+    font-size: 12px;
+    overflow-wrap: anywhere;
+    margin-top: 0.25rem;
+  }
+}

--- a/static/scss/layout.scss
+++ b/static/scss/layout.scss
@@ -14,6 +14,7 @@
 @import "list";
 @import "ckeditor";
 @import "resource-embed-widget";
+@import "image-gallery-widget";
 @import "resource-picker-dialog";
 @import "content-listing";
 


### PR DESCRIPTION
Image galleries were stored as `image-gallery`/`image-gallery-item` shortcodes handled by LegacyShortcodes, so CKEditor rendered them as inert spans printing the shortcode name. Authors could neither see nor edit them.

Galleries are now a first-class CKEditor widget. A gallery is stored as a paired shortcode whose items reference image resources by uuid:

    {{< image-gallery >}}
    {{< image-gallery-item uuid="..." >}}
    {{< /image-gallery >}}

Items carry no authored content of their own. Description, caption and credit all live on the image resource, which is the single source of truth, so there is nothing to edit per item and the CKEditor schema stays flat -- one atomic node with the ordered uuids in a single attribute. Each thumbnail links out to its resource form for metadata editing.

The editing view is a React thumbnail grid rendered into a raw element via a portal, following the ResourceEmbed pattern. Unlike ResourceEmbed it also writes: reordering and removal go back through `editor.model.change()`, so they participate in undo/redo and mark the form dirty. The downcast deliberately does not opt into reconversion -- that would rebuild the view element on every change, destroying the raw element's DOM node and remounting React mid-drag. React subscribes to model changes instead and re-renders in place.

ResourcePickerDialog gains an opt-in multi-select mode so a gallery can be populated in one pass. Existing embed and link callers are unaffected.

Also fixes a latent bug in the shared turndown setup: the blank-node interception matched rules by string filter only, silently dropping any blank node whose rule uses a function filter (which is why ResourceEmbed must use `filter: "section"`). Function and array filters are now tried as a fallback, only when no string filter matched, so no existing rule changes behavior.

Scoped as a POC: existing legacy-format galleries are untouched, and the corresponding ocw-hugo-themes change to resolve items by uuid is not included, so these galleries do not render on a built site yet.

### What are the relevant tickets?
<!--- If it fixes an open issue, please link to the issue here. -->
<!--- Closes # --->
<!--- Fixes # --->
<!--- N/A --->

### Description (What does it do?)
<!--- Describe your changes in detail -->

### Screenshots (if appropriate):
<!--- optional - delete if empty --->
- [ ] Desktop screenshots
- [ ] Mobile width screenshots

### How can this be tested?
<!---
Please describe in detail how your changes have been tested.
Include details of your testing environment, any set-up required
(e.g. data entry required for validation) and the tests you ran to
see how your change affects other areas of the code, etc.
Please also include instructions for how your reviewer can validate your changes.
--->

### Additional Context
<!--- optional - delete if empty --->
<!--- Please add any reviewer questions, details worth noting, etc. that will help in
assessing this change.  --->


<!--- Uncomment and add steps to be completed before merging this PR if necessary
### Checklist:
- [ ] e.g. Update secret values in Vault before merging
--->
