### PR TITLE
fix: clarify youtube tags help text is per-tag not total

### DIFF
--- a/localdev/configs/ocw-course-site-config.yml
+++ b/localdev/configs/ocw-course-site-config.yml
@@ -157,8 +157,7 @@ collections:
     - label: Youtube Speakers
       name: video_speakers
       widget: string
-    - label: Youtube Tags (comma separated; max 100 characters per tag, max 500 characters
-        total)
+    - label: Youtube Tags (comma separated; max 100 chars/tag, 500 total)
       name: video_tags
       widget: text
   - label: Video Files

--- a/localdev/configs/ocw-course-site-config.yml
+++ b/localdev/configs/ocw-course-site-config.yml
@@ -157,7 +157,8 @@ collections:
     - label: Youtube Speakers
       name: video_speakers
       widget: string
-    - label: Youtube Tags (comma separated; max 100 characters)
+    - label: Youtube Tags (comma separated; max 100 characters per tag, max 500 characters
+        total)
       name: video_tags
       widget: text
   - label: Video Files

--- a/localdev/configs/ocw-course-site-config.yml
+++ b/localdev/configs/ocw-course-site-config.yml
@@ -157,9 +157,10 @@ collections:
     - label: Youtube Speakers
       name: video_speakers
       widget: string
-    - label: Youtube Tags (comma separated; max 100 chars/tag, 500 total)
+    - label: Youtube Tags (comma separated)
       name: video_tags
       widget: text
+      help: Maximum 100 characters per tag, 500 characters total.
   - label: Video Files
     name: video_files
     widget: object

--- a/static/js/resources/ocw-course-site-config.json
+++ b/static/js/resources/ocw-course-site-config.json
@@ -197,7 +197,7 @@
               "widget": "string"
             },
             {
-              "label": "Youtube Tags (comma separated; max 100 characters per tag, max 500 characters total)",
+              "label": "Youtube Tags (comma separated; max 100 chars/tag, 500 total)",
               "name": "video_tags",
               "widget": "text"
             }

--- a/static/js/resources/ocw-course-site-config.json
+++ b/static/js/resources/ocw-course-site-config.json
@@ -197,7 +197,7 @@
               "widget": "string"
             },
             {
-              "label": "Youtube Tags (comma separated; max 100 characters)",
+              "label": "Youtube Tags (comma separated; max 100 characters per tag, max 500 characters total)",
               "name": "video_tags",
               "widget": "text"
             }

--- a/static/js/resources/ocw-course-site-config.json
+++ b/static/js/resources/ocw-course-site-config.json
@@ -197,7 +197,8 @@
               "widget": "string"
             },
             {
-              "label": "Youtube Tags (comma separated; max 100 chars/tag, 500 total)",
+              "help": "Maximum 100 characters per tag, 500 characters total.",
+              "label": "Youtube Tags (comma separated)",
               "name": "video_tags",
               "widget": "text"
             }


### PR DESCRIPTION
### What are the relevant tickets?
Closes mitodl/hq#13052

Paired with mitodl/ocw-hugo-projects#404, which holds the actual production config for this field.

### Description (What does it do?)
The Youtube Tags label read as a 100 character limit total, but YouTube allows 100 characters per tag and 500 total across all tags. This confused the team during a retrospective.

- `localdev/configs/ocw-course-site-config.yml`: added a `help` line stating both limits, keeping the label itself short, matching the companion PR.

### How can this be tested?
1. Checkout `umar/13052-studio-youtube-tags-help-text`, run `python manage.py override_site_config`, and confirm the Youtube Tags field under Video Metadata shows the new help text.