### PR TITLE
feat: add image dimension help text to promo image field

### DIFF
--- a/localdev/configs/ocw-www.yml
+++ b/localdev/configs/ocw-www.yml
@@ -110,6 +110,7 @@ collections:
     multiple: false
     min: 1
     max: 1
+    help: Image dimensions should be 1920x1080 (16:9 aspect ratio) for best results.
     filter:
       field: "filetype"
       filter_type: "equals"

--- a/localdev/configs/ocw-www.yml
+++ b/localdev/configs/ocw-www.yml
@@ -110,7 +110,7 @@ collections:
     multiple: false
     min: 1
     max: 1
-    help: Image dimensions should be 1920x1080 (16:9 aspect ratio) for best results.
+    help: Recommended image size is 1920x1080 (16:9 aspect ratio).
     filter:
       field: "filetype"
       filter_type: "equals"

--- a/static/js/resources/ocw-www.json
+++ b/static/js/resources/ocw-www.json
@@ -133,7 +133,7 @@
             "filter_type": "equals",
             "value": "Image"
           },
-          "help": "Image dimensions should be 1920x1080 (16:9 aspect ratio) for best results.",
+          "help": "Recommended image size is 1920x1080 (16:9 aspect ratio).",
           "label": "Image",
           "max": 1,
           "min": 1,

--- a/static/js/resources/ocw-www.json
+++ b/static/js/resources/ocw-www.json
@@ -133,6 +133,7 @@
             "filter_type": "equals",
             "value": "Image"
           },
+          "help": "Image dimensions should be 1920x1080 (16:9 aspect ratio) for best results.",
           "label": "Image",
           "max": 1,
           "min": 1,


### PR DESCRIPTION
### What are the relevant tickets?
Closes mitodl/hq#3594

Paired with mitodl/ocw-hugo-projects#405, which holds the actual production config for this field.

### Description (What does it do?)
The Promo Image field had no guidance on ideal dimensions, so authors had no way to know what worked well in the homepage carousel. Added a help line recommending 1920x1080 (16:9), which matches the carousel's fixed aspect ratio and comfortably fits Fastly's optimizer limits.

- `localdev/configs/ocw-www.yml`: added `help` text to the Promo collection's Image field, matching the companion PR.

### How can this be tested?
1. Checkout `umar/3594-promo-image-help-text`, run `python manage.py override_site_config --starter=ocw-www --config-path=localdev/configs/ocw-www.yml`, and confirm the new help text shows under the Image field when editing a Promo.