### PR TITLE
Add AskTIM vars to theme assets pipeline

### DIFF
--- a/content_sync/conftest.py
+++ b/content_sync/conftest.py
@@ -87,6 +87,7 @@ def required_concourse_settings(settings):
     settings.SEARCH_API_URL = "http://test.edu/api/v0/search"
     settings.COURSE_SEARCH_API_URL = "http://test.edu/api/v1/learning_resources_search"
     settings.CONTENT_FILE_SEARCH_API_URL = "http://test.edu/api/v1/content_file_search"
+    settings.LEARN_AI_SYLLABUS_ENDPOINT = "http://test.edu/api/v1/syllabus"
     settings.OCW_GTM_ACCOUNT_ID = "abc123"
     settings.OCW_EXTRA_THEMES_GTM_IDS = {}
     settings.OCW_EXTRA_THEMES_BASE_URLS = {}

--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline.py
@@ -85,6 +85,7 @@ class ThemeAssetsPipelineDefinition(Pipeline):
             "CONTENT_FILE_SEARCH_API_URL": settings.CONTENT_FILE_SEARCH_API_URL,
             "MIT_LEARN_BASE_URL": settings.MIT_LEARN_BASE_URL,
             "MIT_LEARN_API_BASE_URL": settings.MIT_LEARN_API_BASE_URL,
+            "LEARN_AI_SYLLABUS_ENDPOINT": settings.LEARN_AI_SYLLABUS_ENDPOINT,
             "SENTRY_DSN": settings.OCW_HUGO_THEMES_SENTRY_DSN,
             "SENTRY_ENV": settings.ENVIRONMENT,
             "POSTHOG_ENABLED": str(settings.PUBLISH_POSTHOG_ENABLED).lower(),

--- a/content_sync/pipelines/definitions/concourse/theme_assets_pipeline_test.py
+++ b/content_sync/pipelines/definitions/concourse/theme_assets_pipeline_test.py
@@ -58,6 +58,10 @@ def test_generate_theme_assets_pipeline_definition(mock_environments):
     assert OCW_HUGO_THEMES_GIT_IDENTIFIER in build_ocw_hugo_themes_command
     build_ocw_hugo_themes_params = build_ocw_hugo_themes_task["config"]["params"]
     assert (
+        build_ocw_hugo_themes_params["LEARN_AI_SYLLABUS_ENDPOINT"]
+        == settings.LEARN_AI_SYLLABUS_ENDPOINT
+    )
+    assert (
         build_ocw_hugo_themes_params["POSTHOG_UI_HOST"]
         == settings.PUBLISH_POSTHOG_UI_HOST
     )

--- a/main/settings.py
+++ b/main/settings.py
@@ -1452,3 +1452,9 @@ MIT_LEARN_API_BASE_URL = get_string(
     description="URL to an instance of the MIT Learn API",
     required=False,
 )
+LEARN_AI_SYLLABUS_ENDPOINT = get_string(
+    name="LEARN_AI_SYLLABUS_ENDPOINT",
+    default=None,
+    description="The AskTIM syllabus endpoint to inject into the theme assets build",
+    required=False,
+)


### PR DESCRIPTION
### What are the relevant tickets?
Part of https://github.com/mitodl/hq/issues/12848.

### Description (What does it do?)
This PR adds the `LEARN_AI_SYLLABUS_ENDPOINT` to OCW Studio, which allows for it to be injected into the theme assets build. This, in turn, allows for AskTIM to be enabled in v3 courses when the PostHog feature flag is enabled.

### How can this be tested?
First, set the following variables in the OCW Studio `.env` file:

```
OCW_STUDIO_ENVIRONMENT=dev
OCW_EXTRA_COURSE_THEMES=ocw-course-v3
LEARN_AI_SYLLABUS_ENDPOINT=https://api.rc.learn.mit.edu/ai/http/syllabus_agent/
PUBLISH_POSTHOG_ENABLED=True
PUBLISH_POSTHOG_PROJECT_API_KEY=<key from OCW project in PostHog>
```
Alternatively to using the OCW project PostHog key, use a different PostHog key and make sure that the `ocw-course-v3-ask-tim` feature flag is enabled for the test user.

Then, upsert a theme assets build with `docker compose exec web ./manage.py upsert_theme_assets_pipeline`, unpause, and trigger the build. Once the build completes, publish any course using the OCW Studio UI, either to draft or live. Then, navigate to `http://<OCW_STUDIO_DRAFT_URL or OCW_STUDIO_LIVE_URL>/ocw-course-v3/courses/<course name>/` and verify that the AskTIM button appears and that interaction with the model works as expected.