### PR TITLE
feat: add backfill_mit_learn_topics management command

### DIFF
--- a/websites/management/commands/backfill_mit_learn_topics.py
+++ b/websites/management/commands/backfill_mit_learn_topics.py
@@ -1,0 +1,363 @@
+"""Backfill mit_learn_topics metadata from OCW topics via topics.yaml"""  # noqa: INP001
+
+import csv
+from collections import Counter
+from pathlib import Path
+
+import yaml
+from django.db import transaction
+
+from main.management.commands.filter import WebsiteFilterCommand
+from websites.constants import CONTENT_TYPE_METADATA
+from websites.models import WebsiteContent, WebsiteStarter
+from websites.site_config_api import SiteConfig
+
+OCW_TOPICS_FIELD = "topics"
+LEARN_TOPICS_FIELD = "mit_learn_topics"
+OFFEROR_CODE = "ocw"
+
+UPDATED = "updated"
+UNCHANGED = "unchanged"
+SKIPPED_CURATED = "skipped: mit_learn_topics already set"
+SKIPPED_NO_TOPICS = "skipped: no ocw topics"
+SKIPPED_NO_FIELD = "skipped: starter has no mit_learn_topics field"
+NOTHING_MAPPED = "skipped: ocw topics map to nothing"
+INVALID_PATHS = "skipped: mapped topic is not a config option"
+
+
+class TopicTaxonomy:
+    """
+    topics.yaml reduced to what the OCW mapping needs.
+
+    Mirrors MIT Learn's own pipeline: _walk_topic_map builds the topic tree and
+    the offeror mapping rows, transform_topics resolves a name against them, and
+    load_topics adds each resolved topic's ancestors.
+    """
+
+    def __init__(self, parents: dict[str, str | None], mappings: dict[str, list[str]]):
+        self.parents = parents
+        self.mappings = mappings
+        self.topic_names = set(parents)
+
+    @classmethod
+    def from_yaml(  # noqa: C901
+        cls, path: str, offeror_code: str = OFFEROR_CODE
+    ) -> TopicTaxonomy:
+        """Build a taxonomy from a topics.yaml file"""
+        document = yaml.safe_load(Path(path).read_text())
+        roots = document["topics"]
+
+        uuids: dict[str, str] = {}
+
+        def index(nodes):
+            for node in nodes or []:
+                if node and node.get("id"):
+                    uuids[str(node["id"])] = node["name"]
+                if node:
+                    index(node.get("children"))
+
+        index(roots)
+
+        parents: dict[str, str | None] = {}
+        per_topic: dict[str, list[str]] = {}
+        order: list[str] = []
+
+        def walk(nodes, parent=None):
+            for node in nodes or []:
+                if not node:
+                    continue
+                name = node["name"]
+                resolved = parent
+                # An explicit `parent:` UUID applies only to un-nested nodes,
+                # matching _walk_topic_map.
+                if parent is None and node.get("parent"):
+                    resolved = uuids.get(str(node["parent"]))
+                parents[name] = resolved
+                # Mapping rows are replaced, not merged: a repeated topic name
+                # keeps only the last node's names.
+                node_mappings = node.get("mappings") or {}
+                per_topic[name] = list(node_mappings.get(offeror_code) or [])
+                if name not in order:
+                    order.append(name)
+                walk(node.get("children"), name)
+
+        walk(roots)
+
+        mappings: dict[str, list[str]] = {}
+        for topic_name in order:
+            for source_name in per_topic[topic_name]:
+                targets = mappings.setdefault(source_name, [])
+                if topic_name not in targets:
+                    targets.append(topic_name)
+
+        return cls(parents, mappings)
+
+    def ancestors(self, name: str) -> list[str]:
+        """Walk a topic's parent chain upward"""
+        chain, seen = [], {name}
+        parent = self.parents.get(name)
+        while parent and parent not in seen:
+            chain.append(parent)
+            seen.add(parent)
+            parent = self.parents.get(parent)
+        return chain
+
+    def map_terms(self, terms: list[str]) -> list[str]:
+        """
+        Resolve OCW topic names to Learn topic names.
+
+        Exact match against the mapping rows first, fanning out to every mapped
+        topic; then a pass-through for names that are themselves Learn topics;
+        anything else is dropped.
+        """
+        resolved: set[str] = set()
+        for term in terms:
+            if term in self.mappings:
+                resolved.update(self.mappings[term])
+            elif term in self.topic_names:
+                resolved.add(term)
+        for name in list(resolved):
+            resolved.update(self.ancestors(name))
+        return sorted(resolved)
+
+    def studio_paths(self, topic_names: list[str]) -> list[list[str]]:
+        """
+        Render Learn topic names as hierarchical-select paths, [[topic, subtopic]].
+
+        A root path is dropped when a child path already implies it, since the
+        Learn ETL re-adds ancestors when it reads the field back.
+        """
+        paths: list[list[str]] = []
+        for name in sorted(set(topic_names)):
+            parent = self.parents.get(name)
+            path = [parent, name] if parent else [name]
+            if path not in paths:
+                paths.append(path)
+        implied = {path[0] for path in paths if len(path) > 1}
+        return [p for p in paths if len(p) > 1 or p[0] not in implied]
+
+
+def learn_topic_options(starter: WebsiteStarter) -> set[tuple[str, ...]] | None:
+    """
+    Return the selections the starter's mit_learn_topics field actually offers.
+
+    Returns None when the starter has no such field at all -- ocw-course-v3 and
+    the localdev course config define `topics` but not `mit_learn_topics`.
+    """
+    for config_field in SiteConfig(starter.config).iter_fields():
+        field = config_field.field
+        if field.get("name") != LEARN_TOPICS_FIELD:
+            continue
+        options_map = field.get("options_map") or {}
+        options = {(root,) for root in options_map}
+        for root, children in options_map.items():
+            for child in children or {}:
+                options.add((root, child))
+        return options
+    return None
+
+
+class Command(WebsiteFilterCommand):
+    """
+    Write mit_learn_topics into sitemetadata, mapped from each site's ocw topics.
+
+    Reads metadata['topics'], resolves it through a MIT Learn topics.yaml, and
+    stores the result in metadata['mit_learn_topics'] as [topic, subtopic] paths.
+    Saving marks each touched site as having unpublished draft and live changes,
+    so the sites need republishing for the change to reach the built output.
+    """
+
+    help = __doc__
+
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+        parser.add_argument(
+            "topics_yaml",
+            help="Path to MIT Learn's learning_resources/data/topics.yaml",
+        )
+        parser.add_argument(
+            "-s",
+            "--starter",
+            dest="starter",
+            default=None,
+            help="Only process sites built on this WebsiteStarter slug",
+        )
+        parser.add_argument(
+            "-o",
+            "--overwrite",
+            dest="overwrite",
+            action="store_true",
+            help="Replace mit_learn_topics values that are already set",
+        )
+        parser.add_argument(
+            "-d",
+            "--dry-run",
+            dest="dry_run",
+            action="store_true",
+            help="Report what would change without writing anything",
+        )
+        parser.add_argument(
+            "--ignore-config",
+            dest="ignore_config",
+            action="store_true",
+            help=(
+                "Write mapped topics even when the starter has no "
+                "mit_learn_topics field or does not offer the mapped option"
+            ),
+        )
+        parser.add_argument(
+            "-r",
+            "--report",
+            dest="report",
+            default=None,
+            help="Write a per-site CSV of the proposed values to this path",
+        )
+
+    def handle(self, *args, **options):
+        super().handle(*args, **options)
+
+        taxonomy = TopicTaxonomy.from_yaml(options["topics_yaml"])
+        dry_run = options["dry_run"]
+        overwrite = options["overwrite"]
+        ignore_config = options["ignore_config"]
+        verbose = options["verbosity"] > 1
+
+        contents = WebsiteContent.objects.filter(
+            type=CONTENT_TYPE_METADATA
+        ).select_related("website", "website__starter")
+        contents = self.filter_website_contents(website_contents=contents)
+        if options["starter"]:
+            contents = contents.filter(website__starter__slug=options["starter"])
+
+        options_cache: dict[int, set[tuple[str, ...]] | None] = {}
+        outcomes = Counter()
+        rows = []
+        to_save = []
+
+        for content in contents.iterator():
+            starter = content.website.starter
+            if starter and starter.id not in options_cache:
+                options_cache[starter.id] = learn_topic_options(starter)
+            allowed = options_cache.get(starter.id) if starter else None
+
+            outcome, proposed, existing, terms = self.evaluate(
+                content,
+                taxonomy,
+                allowed=allowed,
+                overwrite=overwrite,
+                ignore_config=ignore_config,
+            )
+            outcomes[outcome] += 1
+            rows.append(
+                {
+                    "website": content.website.name,
+                    "starter": starter.slug if starter else "",
+                    "ocw_topics": "; ".join(" / ".join(p) for p in terms),
+                    "existing_mit_learn_topics": "; ".join(
+                        " / ".join(p) for p in existing
+                    ),
+                    "proposed_mit_learn_topics": "; ".join(
+                        " / ".join(p) for p in proposed
+                    ),
+                    "outcome": outcome,
+                }
+            )
+            if outcome == UPDATED:
+                content.metadata[LEARN_TOPICS_FIELD] = proposed
+                to_save.append(content)
+                if verbose:
+                    self.stdout.write(
+                        f"{content.website.name}: "
+                        + "; ".join(" / ".join(p) for p in proposed)
+                    )
+            elif verbose and outcome != UNCHANGED:
+                self.stdout.write(f"{content.website.name}: {outcome}")
+
+        if to_save and not dry_run:
+            # One save() per object on purpose: the post_save receiver upserts
+            # ContentSyncState, and WebsiteContent.save() flags the site as having
+            # unpublished changes. bulk_update would skip both.
+            with transaction.atomic():
+                for content in to_save:
+                    content.save()
+
+        if options["report"]:
+            self.write_report(options["report"], rows)
+
+        self.write_summary(outcomes, len(to_save), dry_run=dry_run)
+
+    def evaluate(  # noqa: PLR0911
+        self,
+        content: WebsiteContent,
+        taxonomy: TopicTaxonomy,
+        *,
+        allowed: set[tuple[str, ...]] | None,
+        overwrite: bool,
+        ignore_config: bool,
+    ) -> tuple[str, list[list[str]], list[list[str]], list[list[str]]]:
+        """
+        Decide what this site's mit_learn_topics should become.
+
+        Returns the outcome plus the proposed value, the existing value, and the
+        site's ocw topics, so the caller can report on skipped sites too.
+        """
+        metadata = content.metadata or {}
+        # Legacy rows can carry nulls; the widget strips them on save.
+        ocw_topics = [
+            [term for term in path if term]
+            for path in metadata.get(OCW_TOPICS_FIELD) or []
+        ]
+        existing = metadata.get(LEARN_TOPICS_FIELD) or []
+
+        if allowed is None and not ignore_config:
+            return SKIPPED_NO_FIELD, [], existing, ocw_topics
+        if not any(ocw_topics):
+            return SKIPPED_NO_TOPICS, [], existing, ocw_topics
+        if existing and not overwrite:
+            return SKIPPED_CURATED, [], existing, ocw_topics
+
+        terms = sorted({term for path in ocw_topics for term in path})
+        proposed = taxonomy.studio_paths(taxonomy.map_terms(terms))
+        if not proposed:
+            return NOTHING_MAPPED, [], existing, ocw_topics
+        if allowed is not None and not ignore_config:
+            unusable = [p for p in proposed if tuple(p) not in allowed]
+            if unusable:
+                self.stderr.write(
+                    f"{content.website.name}: "
+                    + ", ".join(" / ".join(p) for p in unusable)
+                    + f" not offered by starter {content.website.starter.slug}"
+                )
+                return INVALID_PATHS, proposed, existing, ocw_topics
+        if proposed == existing:
+            return UNCHANGED, proposed, existing, ocw_topics
+        return UPDATED, proposed, existing, ocw_topics
+
+    def write_report(self, path: str, rows: list[dict]):
+        """Write the per-site CSV report"""
+        fieldnames = [
+            "website",
+            "starter",
+            "ocw_topics",
+            "existing_mit_learn_topics",
+            "proposed_mit_learn_topics",
+            "outcome",
+        ]
+        with Path(path).open("w", newline="") as report_file:
+            writer = csv.DictWriter(report_file, fieldnames=fieldnames)
+            writer.writeheader()
+            writer.writerows(rows)
+        self.stdout.write(f"Wrote report for {len(rows)} sites to {path}")
+
+    def write_summary(self, outcomes: Counter, saved: int, *, dry_run: bool):
+        """Write the run summary"""
+        total = sum(outcomes.values())
+        self.stdout.write(f"Examined {total} sitemetadata objects")
+        for outcome, count in outcomes.most_common():
+            self.stdout.write(f"  {count:>6}  {outcome}")
+        if dry_run:
+            self.stdout.write(
+                f"Dry run: {saved} sites would have mit_learn_topics written"
+            )
+        else:
+            self.stdout.write(f"Wrote mit_learn_topics for {saved} sites")

--- a/websites/management/commands/backfill_mit_learn_topics_test.py
+++ b/websites/management/commands/backfill_mit_learn_topics_test.py
@@ -1,0 +1,745 @@
+"""
+Tests for the backfill_mit_learn_topics management command.
+
+The command reads each site's OCW ``topics`` metadata, resolves it through a
+copy of MIT Learn's ``topics.yaml``, and writes the result into
+``metadata["mit_learn_topics"]`` as ``[topic, subtopic]`` paths.
+
+Learn's real topics.yaml is not checked in here, so these tests build a small
+one out of shapes taken from it: a root mapped by an OCW name of its own
+("Science & Math" <- "Science"), roots that Learn maps only for another offeror
+and which are therefore reachable only by pass-through ("Engineering",
+"Humanities"), and an OCW name claimed by two Learn topics under two different
+roots ("Climate" <- "Earth Science" and "Climate Science").
+
+The command tests drive the real command through ``call_command`` against
+factory-built sites, matching the repo convention.
+"""  # noqa: INP001
+
+import csv
+import re
+from io import StringIO
+from types import SimpleNamespace
+
+import pytest
+import yaml
+from django.core.management import call_command
+
+from content_sync.models import ContentSyncState
+from websites.constants import CONTENT_TYPE_METADATA, CONTENT_TYPE_PAGE
+from websites.factories import (
+    WebsiteContentFactory,
+    WebsiteFactory,
+    WebsiteStarterFactory,
+)
+from websites.management.commands.backfill_mit_learn_topics import (
+    INVALID_PATHS,
+    NOTHING_MAPPED,
+    SKIPPED_CURATED,
+    SKIPPED_NO_FIELD,
+    SKIPPED_NO_TOPICS,
+    UNCHANGED,
+    UPDATED,
+    TopicTaxonomy,
+    learn_topic_options,
+)
+from websites.models import Website
+
+pytestmark = pytest.mark.django_db
+
+SCIENCE_ID = "11111111-1111-1111-1111-111111111111"
+PHYSICS_ID = "11111111-1111-1111-1111-000000000002"
+ENERGY_ID = "22222222-2222-2222-2222-222222222222"
+ENGINEERING_ID = "33333333-3333-3333-3333-333333333333"
+HUMANITIES_ID = "44444444-4444-4444-4444-444444444444"
+
+# A marker for "let the helper build a starter", so that `starter=None` can keep
+# its literal meaning of a site with no starter at all.
+UNSET = object()
+
+
+def topic_node(name, node_id, *, mappings=None, children=(), parent=None):
+    """Build one topics.yaml node, shaped like the nodes in Learn's own file."""
+    node = {
+        "id": node_id,
+        "name": name,
+        "mappings": dict(mappings or {}),
+        "children": list(children),
+    }
+    if parent:
+        node["parent"] = parent
+    return node
+
+
+TAXONOMY_TOPICS = [
+    topic_node(
+        "Science & Math",
+        SCIENCE_ID,
+        mappings={"mitx": ["Science"], "ocw": ["Science"]},
+        children=[
+            topic_node(
+                "Earth Science",
+                "11111111-1111-1111-1111-000000000001",
+                mappings={
+                    "mitx": ["Environmental Studies"],
+                    "ocw": ["Climate", "Earth Science", "Geology"],
+                },
+            ),
+            topic_node(
+                "Physics",
+                PHYSICS_ID,
+                mappings={"ocw": ["Physics", "Quantum Mechanics"]},
+            ),
+        ],
+    ),
+    topic_node(
+        "Energy, Climate & Sustainability",
+        ENERGY_ID,
+        children=[
+            topic_node(
+                "Climate Science",
+                "22222222-2222-2222-2222-000000000001",
+                mappings={"ocw": ["Climate", "Sustainability"]},
+            )
+        ],
+    ),
+    topic_node(
+        "Engineering",
+        ENGINEERING_ID,
+        mappings={"mitx": ["Engineering"]},
+        children=[
+            topic_node(
+                "Computer Science",
+                "33333333-3333-3333-3333-000000000001",
+                mappings={
+                    "ocw": ["Computer Science", "Software Design and Engineering"]
+                },
+            )
+        ],
+    ),
+    topic_node("Humanities", HUMANITIES_ID, mappings={"mitx": ["Humanities"]}),
+]
+
+# What a starter's mit_learn_topics field offers: every path the taxonomy above
+# can produce, so tests opt into the options check by narrowing this.
+LEARN_OPTIONS_MAP = {
+    "Science & Math": {"Earth Science": [], "Physics": []},
+    "Energy, Climate & Sustainability": {"Climate Science": []},
+    "Engineering": {"Computer Science": []},
+    "Humanities": {},
+}
+
+OCW_TOPICS_FIELD_CONFIG = {
+    "label": "Topics",
+    "name": "topics",
+    "widget": "hierarchical-select",
+    "levels": [
+        {"label": "Topic", "name": "topic"},
+        {"label": "Subtopic", "name": "subtopic"},
+        {"label": "Speciality", "name": "speciality"},
+    ],
+    "options_map": {"Science": {"Physics": ["Quantum Mechanics"]}},
+}
+
+
+def learn_topics_field(options_map):
+    """Build the mit_learn_topics field a starter's config may define."""
+    return {
+        "label": "MIT Learn Topics",
+        "name": "mit_learn_topics",
+        "widget": "hierarchical-select",
+        "levels": [
+            {"label": "Topic", "name": "topic"},
+            {"label": "Subtopic", "name": "subtopic"},
+        ],
+        "options_map": options_map,
+    }
+
+
+def site_config(*fields):
+    """Build a minimal site config whose sitemetadata item carries `fields`."""
+    return {
+        "content-dir": "content",
+        "collections": [
+            {
+                "name": "metadata",
+                "label": "Metadata",
+                "category": "Settings",
+                "files": [
+                    {
+                        "file": "data/metadata.json",
+                        "name": "sitemetadata",
+                        "label": "Site Metadata",
+                        "fields": [OCW_TOPICS_FIELD_CONFIG, *fields],
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def make_starter(options_map=LEARN_OPTIONS_MAP, **kwargs):
+    """Create a starter offering `options_map`; None omits the field entirely."""
+    fields = [] if options_map is None else [learn_topics_field(options_map)]
+    return WebsiteStarterFactory.create(config=site_config(*fields), **kwargs)
+
+
+def make_site(*, topics=None, learn_topics=None, starter=UNSET, name=None):
+    """
+    Create a site and its sitemetadata content, and return the content.
+
+    `topics` and `learn_topics` are written into the metadata only when given,
+    so a site can be built with the keys genuinely absent. Creating content
+    dirties the site's republish flags, so they are cleared here -- the tests
+    need to see what the command itself changes.
+    """
+    website = WebsiteFactory.create(
+        starter=make_starter() if starter is UNSET else starter,
+        **({"name": name, "short_id": name} if name else {}),
+    )
+    metadata = {"course_title": website.title}
+    if topics is not None:
+        metadata["topics"] = topics
+    if learn_topics is not None:
+        metadata["mit_learn_topics"] = learn_topics
+    content = WebsiteContentFactory.create(
+        website=website, type=CONTENT_TYPE_METADATA, metadata=metadata
+    )
+    Website.objects.filter(pk=website.pk).update(
+        has_unpublished_draft=False, has_unpublished_live=False
+    )
+    return content
+
+
+def write_topics_yaml(tmp_path, topics, filename="topics.yaml"):
+    """Write `topics` out as a topics.yaml file and return its path."""
+    path = tmp_path / filename
+    path.write_text(yaml.safe_dump({"topics": topics}))
+    return str(path)
+
+
+SUMMARY_LINE = re.compile(r"^\s+(\d+)\s\s(\S.*)$")
+
+
+def summary_counts(output):
+    """Parse the `  <count>  <outcome>` lines of the command's run summary."""
+    return {
+        match.group(2): int(match.group(1))
+        for match in (SUMMARY_LINE.match(line) for line in output.splitlines())
+        if match
+    }
+
+
+def run_command(topics_yaml, **kwargs):
+    """Run the command, returning its output plus the parsed outcome counts."""
+    out, err = StringIO(), StringIO()
+    call_command(
+        "backfill_mit_learn_topics", topics_yaml, stdout=out, stderr=err, **kwargs
+    )
+    output = out.getvalue()
+    return SimpleNamespace(
+        out=output, err=err.getvalue(), outcomes=summary_counts(output)
+    )
+
+
+def website_flags(website):
+    """Read the site's (draft, live) unpublished-changes flags back from the db."""
+    website = Website.objects.get(pk=website.pk)
+    return website.has_unpublished_draft, website.has_unpublished_live
+
+
+def sync_checksum(content):
+    """Read the content's stored ContentSyncState checksum back from the db."""
+    return ContentSyncState.objects.get(content=content).current_checksum
+
+
+@pytest.fixture
+def topics_yaml(tmp_path):
+    """Write the fixture taxonomy out as a topics.yaml and return its path."""
+    return write_topics_yaml(tmp_path, TAXONOMY_TOPICS)
+
+
+@pytest.fixture
+def taxonomy(topics_yaml):
+    """Parse the fixture taxonomy."""
+    return TopicTaxonomy.from_yaml(topics_yaml)
+
+
+# ---------------------------------------------------------------------------
+# TopicTaxonomy: parsing topics.yaml and resolving OCW names through it
+# ---------------------------------------------------------------------------
+
+
+def test_map_terms_fans_out_and_adds_ancestors(taxonomy):
+    """An OCW name two Learn topics claim resolves to both, plus their ancestors."""
+    assert taxonomy.map_terms(["Climate"]) == [
+        "Climate Science",
+        "Earth Science",
+        "Energy, Climate & Sustainability",
+        "Science & Math",
+    ]
+
+
+def test_map_terms_passes_through_learn_topic_names(taxonomy):
+    """
+    A term that is itself a Learn topic resolves without a mapping row.
+
+    Learn maps "Engineering" only for mitx, so the OCW topic of the same name
+    survives only via the pass-through branch.
+    """
+    assert taxonomy.map_terms(["Engineering"]) == ["Engineering"]
+
+
+def test_map_terms_ignores_other_offerors_mappings(taxonomy):
+    """A name mapped only under another offeror is not an OCW mapping."""
+    assert taxonomy.map_terms(["Environmental Studies"]) == []
+
+
+def test_map_terms_drops_unmappable_terms(taxonomy):
+    """Terms that are neither mapped nor Learn topic names are dropped."""
+    assert taxonomy.map_terms(["Underwater Basket Weaving", "Geology"]) == [
+        "Earth Science",
+        "Science & Math",
+    ]
+
+
+def test_studio_paths_drops_a_root_implied_by_a_child(taxonomy):
+    """
+    A root path is dropped when a child path already implies it.
+
+    Learn's ETL re-adds ancestors when it reads the field back, so keeping the
+    root would only duplicate it.
+    """
+    assert taxonomy.studio_paths(["Science & Math", "Physics"]) == [
+        ["Science & Math", "Physics"]
+    ]
+
+
+def test_studio_paths_keeps_a_root_with_no_child_selected(taxonomy):
+    """A topic with no parent renders as a single-element path."""
+    assert taxonomy.studio_paths(["Humanities", "Engineering"]) == [
+        ["Engineering"],
+        ["Humanities"],
+    ]
+
+
+def test_explicit_parent_uuid_nests_an_unnested_node(tmp_path):
+    """A top-level node's `parent:` UUID resolves to that topic's name."""
+    topics = [
+        topic_node("Science & Math", SCIENCE_ID, mappings={"ocw": ["Science"]}),
+        topic_node(
+            "Physics", PHYSICS_ID, mappings={"ocw": ["Physics"]}, parent=SCIENCE_ID
+        ),
+    ]
+
+    taxonomy = TopicTaxonomy.from_yaml(write_topics_yaml(tmp_path, topics))
+
+    assert taxonomy.ancestors("Physics") == ["Science & Math"]
+    assert taxonomy.studio_paths(["Physics"]) == [["Science & Math", "Physics"]]
+
+
+def test_parent_uuid_is_ignored_on_a_nested_node(tmp_path):
+    """
+    Nesting wins over a nested node's own `parent:` UUID.
+
+    Mirrors Learn's _walk_topic_map, which consults `parent` only for nodes
+    that are not already nested under another topic.
+    """
+    topics = [
+        topic_node("Humanities", HUMANITIES_ID),
+        topic_node(
+            "Science & Math",
+            SCIENCE_ID,
+            children=[
+                topic_node(
+                    "Physics",
+                    PHYSICS_ID,
+                    mappings={"ocw": ["Physics"]},
+                    parent=HUMANITIES_ID,
+                )
+            ],
+        ),
+    ]
+
+    taxonomy = TopicTaxonomy.from_yaml(write_topics_yaml(tmp_path, topics))
+
+    assert taxonomy.ancestors("Physics") == ["Science & Math"]
+
+
+def test_from_yaml_tolerates_null_children_and_null_nodes(tmp_path):
+    """A null `children:` value and a null entry in a node list are skipped."""
+    topics = [
+        {
+            "id": SCIENCE_ID,
+            "name": "Science & Math",
+            "mappings": {"ocw": ["Science"]},
+            "children": None,
+        },
+        None,
+    ]
+
+    taxonomy = TopicTaxonomy.from_yaml(write_topics_yaml(tmp_path, topics))
+
+    assert taxonomy.map_terms(["Science"]) == ["Science & Math"]
+
+
+def test_repeated_topic_name_keeps_the_last_nodes_mappings(tmp_path):
+    """A topic name appearing twice keeps only the last node's mapping rows."""
+    topics = [
+        topic_node("Physics", PHYSICS_ID, mappings={"ocw": ["Mechanics"]}),
+        topic_node("Physics", PHYSICS_ID, mappings={"ocw": ["Quantum Mechanics"]}),
+    ]
+
+    taxonomy = TopicTaxonomy.from_yaml(write_topics_yaml(tmp_path, topics))
+
+    assert taxonomy.map_terms(["Quantum Mechanics"]) == ["Physics"]
+    assert taxonomy.map_terms(["Mechanics"]) == []
+
+
+def test_ancestors_stops_on_a_parent_cycle():
+    """A cyclic parent chain terminates instead of looping forever."""
+    taxonomy = TopicTaxonomy({"A": "B", "B": "A"}, {})
+
+    assert taxonomy.ancestors("A") == ["B"]
+
+
+# ---------------------------------------------------------------------------
+# learn_topic_options: what a starter's mit_learn_topics field actually offers
+# ---------------------------------------------------------------------------
+
+
+def test_learn_topic_options_returns_none_without_the_field():
+    """A starter defining no mit_learn_topics field yields None, not an empty set."""
+    assert learn_topic_options(make_starter(options_map=None)) is None
+
+
+def test_learn_topic_options_includes_roots_and_child_paths():
+    """
+    Both `(root,)` and `(root, child)` selections count as offered.
+
+    A root whose value is null (rather than a mapping of children) contributes
+    only itself.
+    """
+    starter = make_starter(
+        options_map={"Humanities": {"Language": []}, "Engineering": None}
+    )
+
+    assert learn_topic_options(starter) == {
+        ("Engineering",),
+        ("Humanities",),
+        ("Humanities", "Language"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# The command
+# ---------------------------------------------------------------------------
+
+
+def test_writes_mapped_topics(topics_yaml):
+    """Mapped OCW topics are written as mit_learn_topics paths."""
+    content = make_site(topics=[["Science", "Physics", "Quantum Mechanics"]])
+
+    result = run_command(topics_yaml)
+
+    content.refresh_from_db()
+    assert content.metadata["mit_learn_topics"] == [["Science & Math", "Physics"]]
+    assert result.outcomes == {UPDATED: 1}
+    assert "Wrote mit_learn_topics for 1 sites" in result.out
+
+
+def test_writes_every_topic_an_ocw_name_maps_to(topics_yaml):
+    """An OCW name claimed by topics under two roots writes both paths."""
+    content = make_site(topics=[["Energy", "Climate"]])
+
+    run_command(topics_yaml)
+
+    content.refresh_from_db()
+    assert content.metadata["mit_learn_topics"] == [
+        ["Energy, Climate & Sustainability", "Climate Science"],
+        ["Science & Math", "Earth Science"],
+    ]
+
+
+def test_null_segments_in_ocw_topics_are_stripped(topics_yaml):
+    """Legacy rows can carry nulls inside a topics path; they are ignored."""
+    content = make_site(topics=[["Science", None]])
+
+    run_command(topics_yaml)
+
+    content.refresh_from_db()
+    assert content.metadata["mit_learn_topics"] == [["Science & Math"]]
+
+
+@pytest.mark.parametrize("topics", [None, [], [[]], [[None]]])
+def test_sites_without_usable_ocw_topics_are_skipped(topics_yaml, topics):
+    """No usable OCW topics means nothing is written."""
+    content = make_site(topics=topics)
+
+    result = run_command(topics_yaml)
+
+    content.refresh_from_db()
+    assert "mit_learn_topics" not in content.metadata
+    assert result.outcomes == {SKIPPED_NO_TOPICS: 1}
+
+
+def test_existing_value_is_left_alone_by_default(topics_yaml):
+    """A curated mit_learn_topics value is not overwritten without --overwrite."""
+    curated = [["Humanities"]]
+    content = make_site(topics=[["Science", "Physics"]], learn_topics=curated)
+
+    result = run_command(topics_yaml)
+
+    content.refresh_from_db()
+    assert content.metadata["mit_learn_topics"] == curated
+    assert result.outcomes == {SKIPPED_CURATED: 1}
+
+
+def test_overwrite_replaces_an_existing_value(topics_yaml):
+    """--overwrite replaces a value that is already set."""
+    content = make_site(topics=[["Science", "Physics"]], learn_topics=[["Humanities"]])
+
+    result = run_command(topics_yaml, overwrite=True)
+
+    content.refresh_from_db()
+    assert content.metadata["mit_learn_topics"] == [["Science & Math", "Physics"]]
+    assert result.outcomes == {UPDATED: 1}
+
+
+def test_value_already_equal_to_the_mapping_is_left_unchanged(topics_yaml):
+    """An existing value equal to the mapped one is reported, not rewritten."""
+    content = make_site(
+        topics=[["Science", "Physics"]], learn_topics=[["Science & Math", "Physics"]]
+    )
+
+    result = run_command(topics_yaml, overwrite=True)
+
+    assert result.outcomes == {UNCHANGED: 1}
+    assert "Wrote mit_learn_topics for 0 sites" in result.out
+    assert website_flags(content.website) == (False, False)
+
+
+def test_topics_that_map_to_nothing_are_skipped(topics_yaml):
+    """OCW topics that resolve to no Learn topic write nothing."""
+    content = make_site(topics=[["Underwater Basket Weaving"]])
+
+    result = run_command(topics_yaml)
+
+    content.refresh_from_db()
+    assert "mit_learn_topics" not in content.metadata
+    assert result.outcomes == {NOTHING_MAPPED: 1}
+
+
+def test_starter_without_the_learn_field_is_skipped(topics_yaml):
+    """Some starters (ocw-course-v3) define `topics` but no mit_learn_topics."""
+    content = make_site(
+        topics=[["Science", "Physics"]], starter=make_starter(options_map=None)
+    )
+
+    result = run_command(topics_yaml)
+
+    content.refresh_from_db()
+    assert "mit_learn_topics" not in content.metadata
+    assert result.outcomes == {SKIPPED_NO_FIELD: 1}
+
+
+def test_site_without_a_starter_is_skipped(topics_yaml):
+    """A site with no starter has no field to validate the mapping against."""
+    content = make_site(topics=[["Science", "Physics"]], starter=None)
+
+    result = run_command(topics_yaml)
+
+    content.refresh_from_db()
+    assert "mit_learn_topics" not in content.metadata
+    assert result.outcomes == {SKIPPED_NO_FIELD: 1}
+
+
+@pytest.mark.parametrize("with_starter", [True, False])
+def test_ignore_config_writes_when_the_field_is_missing(topics_yaml, with_starter):
+    """--ignore-config writes even with no mit_learn_topics field to check against."""
+    starter = make_starter(options_map=None) if with_starter else None
+    content = make_site(topics=[["Science", "Physics"]], starter=starter)
+
+    result = run_command(topics_yaml, ignore_config=True)
+
+    content.refresh_from_db()
+    assert content.metadata["mit_learn_topics"] == [["Science & Math", "Physics"]]
+    assert result.outcomes == {UPDATED: 1}
+
+
+def test_path_the_starter_does_not_offer_is_skipped_and_reported(topics_yaml):
+    """A mapped path the starter's field does not offer is refused and named."""
+    starter = make_starter(options_map={"Engineering": {"Computer Science": []}})
+    content = make_site(
+        topics=[["Energy", "Climate"]], starter=starter, name="narrow-site"
+    )
+
+    result = run_command(topics_yaml)
+
+    content.refresh_from_db()
+    assert "mit_learn_topics" not in content.metadata
+    assert result.outcomes == {INVALID_PATHS: 1}
+    assert "narrow-site" in result.err
+    assert "Energy, Climate & Sustainability / Climate Science" in result.err
+    assert "Science & Math / Earth Science" in result.err
+    assert f"not offered by starter {starter.slug}" in result.err
+
+
+def test_ignore_config_writes_paths_the_starter_does_not_offer(topics_yaml):
+    """--ignore-config bypasses the starter options check entirely."""
+    starter = make_starter(options_map={"Engineering": {"Computer Science": []}})
+    content = make_site(topics=[["Energy", "Climate"]], starter=starter)
+
+    result = run_command(topics_yaml, ignore_config=True)
+
+    content.refresh_from_db()
+    assert content.metadata["mit_learn_topics"] == [
+        ["Energy, Climate & Sustainability", "Climate Science"],
+        ["Science & Math", "Earth Science"],
+    ]
+    assert result.err == ""
+
+
+def test_dry_run_changes_nothing(topics_yaml):
+    """--dry-run reports the update but leaves the database untouched."""
+    content = make_site(topics=[["Science", "Physics"]])
+    before = sync_checksum(content)
+
+    result = run_command(topics_yaml, dry_run=True)
+
+    content.refresh_from_db()
+    assert "mit_learn_topics" not in content.metadata
+    assert website_flags(content.website) == (False, False)
+    assert sync_checksum(content) == before
+    assert result.outcomes == {UPDATED: 1}
+    assert "Dry run: 1 sites would have mit_learn_topics written" in result.out
+
+
+def test_writing_marks_the_site_for_republish_and_resyncs_state(topics_yaml):
+    """
+    Each write goes through WebsiteContent.save() rather than bulk_update.
+
+    save() flags the site as having unpublished draft and live changes, and the
+    post_save receiver refreshes the ContentSyncState checksum; a bulk_update
+    would have skipped both, and the change would never reach the built site.
+    """
+    content = make_site(topics=[["Science", "Physics"]])
+    before = sync_checksum(content)
+
+    run_command(topics_yaml)
+
+    content.refresh_from_db()
+    assert website_flags(content.website) == (True, True)
+    assert sync_checksum(content) != before
+    assert sync_checksum(content) == content.calculate_checksum()
+
+
+def test_only_sitemetadata_content_is_considered(topics_yaml):
+    """Topics on other content types are not touched."""
+    page = WebsiteContentFactory.create(
+        website=WebsiteFactory.create(starter=make_starter()),
+        type=CONTENT_TYPE_PAGE,
+        metadata={"topics": [["Science", "Physics"]]},
+    )
+
+    result = run_command(topics_yaml)
+
+    page.refresh_from_db()
+    assert "mit_learn_topics" not in page.metadata
+    assert "Examined 0 sitemetadata objects" in result.out
+
+
+@pytest.mark.parametrize(
+    "options", [{"filter": "kept-site"}, {"exclude": "other-site"}]
+)
+def test_filter_options_scope_the_run(topics_yaml, options):
+    """--filter and --exclude restrict which sites are processed."""
+    kept = make_site(topics=[["Science", "Physics"]], name="kept-site")
+    other = make_site(topics=[["Science", "Physics"]], name="other-site")
+
+    result = run_command(topics_yaml, **options)
+
+    kept.refresh_from_db()
+    other.refresh_from_db()
+    assert kept.metadata["mit_learn_topics"] == [["Science & Math", "Physics"]]
+    assert "mit_learn_topics" not in other.metadata
+    assert "Examined 1 sitemetadata objects" in result.out
+
+
+def test_starter_option_scopes_the_run_to_one_starter(topics_yaml):
+    """--starter processes only sites built on that starter slug."""
+    course_site = make_site(
+        topics=[["Science", "Physics"]], starter=make_starter(slug="ocw-course-v2")
+    )
+    www_site = make_site(
+        topics=[["Science", "Physics"]], starter=make_starter(slug="ocw-www")
+    )
+
+    run_command(topics_yaml, starter="ocw-course-v2")
+
+    course_site.refresh_from_db()
+    www_site.refresh_from_db()
+    assert course_site.metadata["mit_learn_topics"] == [["Science & Math", "Physics"]]
+    assert "mit_learn_topics" not in www_site.metadata
+
+
+def test_report_lists_every_examined_site(topics_yaml, tmp_path):
+    """--report writes a row per examined site, skipped sites included."""
+    starter = make_starter(slug="ocw-course-v2")
+    make_site(topics=[["Science", "Physics"]], starter=starter, name="updated-site")
+    make_site(
+        topics=[["Science", "Physics"]],
+        learn_topics=[["Humanities"]],
+        starter=starter,
+        name="curated-site",
+    )
+    report = tmp_path / "report.csv"
+
+    result = run_command(topics_yaml, report=str(report))
+
+    rows = {
+        row["website"]: row for row in csv.DictReader(report.read_text().splitlines())
+    }
+    assert rows["updated-site"] == {
+        "website": "updated-site",
+        "starter": "ocw-course-v2",
+        "ocw_topics": "Science / Physics",
+        "existing_mit_learn_topics": "",
+        "proposed_mit_learn_topics": "Science & Math / Physics",
+        "outcome": UPDATED,
+    }
+    assert rows["curated-site"]["existing_mit_learn_topics"] == "Humanities"
+    assert rows["curated-site"]["proposed_mit_learn_topics"] == ""
+    assert rows["curated-site"]["outcome"] == SKIPPED_CURATED
+    assert f"Wrote report for 2 sites to {report}" in result.out
+
+
+def test_verbose_output_names_each_site(topics_yaml):
+    """-v2 lists the value written per site, and why a site was skipped."""
+    make_site(topics=[["Science", "Physics"]], name="written-site")
+    make_site(topics=[["Underwater Basket Weaving"]], name="unmapped-site")
+
+    result = run_command(topics_yaml, verbosity=2)
+
+    assert "written-site: Science & Math / Physics" in result.out
+    assert f"unmapped-site: {NOTHING_MAPPED}" in result.out
+
+
+def test_summary_tallies_every_outcome(topics_yaml):
+    """The summary counts each outcome across the sites examined."""
+    make_site(topics=[["Science", "Physics"]])
+    make_site(topics=[])
+    make_site(topics=[["Underwater Basket Weaving"]])
+    make_site(topics=[["Science", "Physics"]], learn_topics=[["Humanities"]])
+    make_site(topics=[["Science", "Physics"]], starter=make_starter(options_map=None))
+
+    result = run_command(topics_yaml)
+
+    assert result.outcomes == {
+        UPDATED: 1,
+        SKIPPED_NO_TOPICS: 1,
+        NOTHING_MAPPED: 1,
+        SKIPPED_CURATED: 1,
+        SKIPPED_NO_FIELD: 1,
+    }
+    assert "Examined 5 sitemetadata objects" in result.out


### PR DESCRIPTION
### What are the relevant tickets?
https://github.com/mitodl/hq/issues/11964 (especially see [this comment](https://github.com/mitodl/hq/issues/11964#issuecomment-5487850442))

### Description (What does it do?)
Adds a `backfill_mit_learn_topics` management command that fills in `metadata["mit_learn_topics"]` for OCW sites that only have the legacy OCW `topics` set.

- Maps OCW topic names through a MIT Learn `topics.yaml` (its path is a required argument) and writes `[topic, subtopic]` paths
- Writes only selections the site's starter actually offers in its `mit_learn_topics` field; anything else is named on stderr and skipped.
- Leaves already-set values alone unless `--overwrite`
- `--dry-run` and `--report <csv>` give a per-site preview before anything is written

<details>
<summary><b>Implementation details</b></summary>
<br>

`TopicTaxonomy.from_yaml` reads the topic tree and the per-offeror mapping rows out of topics.yaml. Each OCW term is resolved by:

1. exact match against the `ocw` mapping rows, fanning out to every topic that claims the term — `Climate` resolves to both `Earth Science` and `Climate Science`, under two different roots
2. pass-through for terms that are themselves Learn topic names — `Engineering` and `Humanities` are mapped only for `mitx`, so they resolve only this way
3. ancestor expansion, then rendering as hierarchical-select paths, dropping a root path that a child path already implies

Writes go through `WebsiteContent.save()` rather than `bulk_update`, so the `post_save` receiver refreshes `ContentSyncState` and the site gets flagged as having unpublished changes.

`-s/--starter` scopes a run to one starter slug; `--ignore-config` bypasses the starter options check (and the "starter has no such field" skip).

39 tests cover the command module at 99%. They build a small topics.yaml out of shapes taken from Learn's real file rather than depending on the 1200-line copy, which is not checked in.
</details>

### How can this be tested?

To check the mapping against real data, point the command at a copy of Learn's `learning_resources/data/topics.yaml` and preview before writing anything:

```
docker compose exec web python manage.py backfill_mit_learn_topics topics.yaml --dry-run --report preview.csv
```

The report has one row per site — its OCW topics, existing value, proposed value, and outcome.

Preview the report and verify that the chosen mit_learn_topics are as expected.

Then run the command without --dry-run and verify that the mit learn topics are updated in the database.

### Additional Context
The command publishes nothing. Sites it writes to are marked as having unpublished draft and live changes, so they need republishing before the new field reaches Learn.
