### PR TITLE
chore(deps): bump mitol-django-observability to >=2026.8.19

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "mitol-django-authentication==2026.4.29,<2027",
     "mitol-django-common>=2026.4.2,<2027",
     "mitol-django-mail>=2026.4.2,<2027",
-    "mitol-django-observability>=2026.1.0,<2027",
+    "mitol-django-observability>=2026.8.19,<2027",
     "more-itertools>=11.0.2,<12",
     # OTel instrumentors. mitol-django-observability auto-discovers these through
     # the `opentelemetry_instrumentor` entry point group; without them it stands

--- a/uv.lock
+++ b/uv.lock
@@ -1363,7 +1363,7 @@ wheels = [
 
 [[package]]
 name = "mitol-django-observability"
-version = "2026.3.11"
+version = "2026.8.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
@@ -1375,9 +1375,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "structlog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/3b/8c07a0a0feda332656213a8af4f055fa83fb9e0d6d483d77f12d8e63b47e/mitol_django_observability-2026.3.11.tar.gz", hash = "sha256:4539eff6b7da18e500fb0f23c0abf6bdba67eb65e35e890b08c338318494a1e6", size = 10093, upload-time = "2026-03-13T20:21:41.271Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/60/ef5807301c6aa3a6ddbe2f48118a98d134f5fc324632f7715f270f3bb504/mitol_django_observability-2026.8.19.tar.gz", hash = "sha256:3bf3afbd16c2f0ae087ed7911f301f31e3361ed170acdc9ef29e3cee8a8d0192", size = 19173, upload-time = "2026-08-19T17:50:14.016Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/76/3f730dec3ff4ff6c5ab044d7b1e027b6f3214cedb66a2532301b6eb4b285/mitol_django_observability-2026.3.11-py3-none-any.whl", hash = "sha256:7523782802c09cad3003cacecdb62cc055efdbd8a80a9ea27a12cb5aaf3f59bc", size = 16052, upload-time = "2026-03-13T20:21:40.216Z" },
+    { url = "https://files.pythonhosted.org/packages/80/dd/6e6608392f587f29a950b7e6b27ef4748458dfdfcac70e7fb81907d56deb/mitol_django_observability-2026.8.19-py3-none-any.whl", hash = "sha256:442741f6b6d3ddacd85f5d32c8581c18899af2f7f299a74bc8a4116f0ae3bb8a", size = 27907, upload-time = "2026-08-19T17:50:12.945Z" },
 ]
 
 [[package]]
@@ -1578,7 +1578,7 @@ requires-dist = [
     { name = "mitol-django-authentication", specifier = "==2026.4.29,<2027" },
     { name = "mitol-django-common", specifier = ">=2026.4.2,<2027" },
     { name = "mitol-django-mail", specifier = ">=2026.4.2,<2027" },
-    { name = "mitol-django-observability", specifier = ">=2026.1.0,<2027" },
+    { name = "mitol-django-observability", specifier = ">=2026.8.19,<2027" },
     { name = "mitol-django-transcoding", specifier = ">=2026.4.2,<2027" },
     { name = "more-itertools", specifier = ">=11.0.2,<12" },
     { name = "ol-concourse", specifier = ">=0.10,<0.11" },


### PR DESCRIPTION
### What are the relevant tickets?
N/A (tracked in the witan work-coordination graph as `tk-bump-ocw-studio-to-mitol-django-observability-20-a0d290`, part of the OpenTelemetry APM coverage project in ol-infrastructure)

### Description (What does it do?)
Bumps `mitol-django-observability` from `>=2026.1.0,<2027` to `>=2026.8.19,<2027`.

Verified 2026-09-03 that ocw-studio's running production image (`ocw-studio-app:0.198.0`, from live `kube_pod_container_info`) still locks `mitol-django-observability==2026.3.11`. That version has two problems, both fixed in `2026.8.19`:

1. **Broken endpoint resolution.** Pre-2026.8.19, `configure_opentelemetry()` read `OTEL_EXPORTER_OTLP_ENDPOINT` itself and passed it to `OTLPSpanExporter(endpoint=...)`, which treats an explicitly-passed endpoint as final. Pointing `OTEL_EXPORTER_OTLP_ENDPOINT` at the spec-correct base URL (rather than the app-specific `OPENTELEMETRY_ENDPOINT` setting ocw-studio currently uses) would 404 every trace batch instead of exporting — visible as nothing louder than a `BatchSpanProcessor` warning.
2. **No MeterProvider.** `2026.3.11` has no metrics pipeline at all, so `http.server.duration` / `http.server.active_requests` don't exist regardless of what endpoint variable is set.

This PR only bumps the dependency and re-locks. `uv lock` resolved cleanly with a single-package diff (`mitol-django-observability` 2026.3.11 → 2026.8.19), no other packages moved.

No extras added:
- ocw-studio runs WSGI only (`granian --interface wsgi`), so `mitol-django-observability`'s own `django` extra (which exists to pull in `opentelemetry-instrumentation-django[asgi]`) isn't needed — the `[asgi]` half only matters for ASGI apps, and this repo already directly depends on `opentelemetry-instrumentation-django` (without `[asgi]`) for the same instrumentor.
- Not requesting the `postgres` extra either — it targets psycopg3, and this app is deliberately pinned to psycopg2 (see the existing comment a few lines above the observability dependency).

### Screenshots (if appropriate):

### How can this be tested?
- `uv lock` — resolves cleanly, single-package diff, verified locally.
- `uv run pre-commit run --files pyproject.toml uv.lock` — passes.
- Reviewer validation: after merge and a release, confirm the new tag's `uv.lock` locks `mitol-django-observability>=2026.8.19` (e.g. `gh api repos/mitodl/ocw-studio/contents/uv.lock?ref=<tag> --jq '.content' | base64 -d | grep -A2 'name = "mitol-django-observability"'`).

### Additional Context
This is deliberately scoped to just the dependency bump. The ol-infrastructure side (flipping `OPENTELEMETRY_ENDPOINT` to `OTEL_EXPORTER_OTLP_ENDPOINT` in `applications/ocw_studio/Pulumi.Production.yaml` / `Pulumi.QA.yaml`) stays untouched until this is released and the running image's lock is re-confirmed to carry `>=2026.8.19` — flipping the endpoint against the currently-running `2026.3.11` would break tracing that works today, for no metrics benefit.
