### PR TITLE
feat: reference image gallery images by their resource uuid

### DIFF
--- a/websites/management/commands/markdown_cleaning/rules/image_gallery_item_uuid.py
+++ b/websites/management/commands/markdown_cleaning/rules/image_gallery_item_uuid.py
@@ -112,10 +112,9 @@ class ImageGalleryItemUuidRule(PyparsingRule):
         if resource is None:
             return "cross_site" if self._exists_elsewhere(uuid) else "uuid_not_found"
 
+        metadata = resource.metadata if isinstance(resource.metadata, dict) else {}
         notes.resolved_type = resource.type
-        notes.resolved_resourcetype = (resource.metadata or {}).get(
-            "resourcetype"
-        ) or ""
+        notes.resolved_resourcetype = metadata.get("resourcetype") or ""
 
         if resource.deleted is not None:
             return "target_deleted"

--- a/websites/management/commands/markdown_cleaning/rules/image_gallery_item_uuid.py
+++ b/websites/management/commands/markdown_cleaning/rules/image_gallery_item_uuid.py
@@ -1,0 +1,153 @@
+"""Add resource uuids to image gallery items. See mitodl/hq#13086."""
+
+import posixpath
+import re
+from dataclasses import dataclass
+from uuid import UUID
+
+from websites.constants import CONTENT_TYPE_RESOURCE, RESOURCE_TYPE_IMAGE
+from websites.management.commands.markdown_cleaning.cleanup_rule import PyparsingRule
+from websites.management.commands.markdown_cleaning.parsing_utils import ShortcodeParam
+from websites.management.commands.markdown_cleaning.shortcode_parser import (
+    ShortcodeParser,
+    ShortcodeParseResult,
+)
+from websites.models import WebsiteContent
+
+ITEM_SHORTCODE = "image-gallery-item"
+
+# Gallery items reference their image by the legacy OCW filename, which is the
+# resource's uuid (dashes stripped) followed by the original filename.
+UUID_PREFIX_REGEX = re.compile(r"^(?P<hex>[0-9a-fA-F]{32})_.+$")
+
+
+class ImageGalleryItemUuidRule(PyparsingRule):
+    """
+    Add a `uuid` param naming the image resource an image-gallery-item points at.
+
+    Purely additive: `href`, `text` and `data-ngdesc` are left in place because
+    v2 galleries still render from `href`, and removing them would break those.
+
+        {{< image-gallery-item href="c3e2...eff_diagram.png" text="Fig 1." >}}
+
+    becomes
+
+        {{< image-gallery-item uuid="c3e28341-...-3a1a5bcc0eff"
+            href="c3e2...eff_diagram.png" text="Fig 1." >}}
+
+    An item is only rewritten once the uuid is confirmed to name a live image
+    resource in the same website as the page. Everything else is left exactly as
+    it was and the reason recorded in `outcome`, so a `--out` run reports the
+    problems rather than aborting on the first one.
+    """
+
+    alias = "image_gallery_item_uuid"
+
+    Parser = ShortcodeParser
+
+    @dataclass
+    class ReplacementNotes:
+        is_gallery_item: bool = False
+        outcome: str = ""
+        href: str = ""
+        uuid: str = ""
+        resolved_type: str = ""
+        resolved_resourcetype: str = ""
+
+    def should_parse(self, text: str):
+        """Only a few hundred pages site-wide contain a gallery."""
+        return ITEM_SHORTCODE in text
+
+    def replace_match(
+        self,
+        s: str,  # noqa: ARG002
+        l: int,  # noqa: ARG002, E741
+        toks: ShortcodeParseResult,
+        website_content: WebsiteContent,
+    ):
+        shortcode = toks.shortcode
+        original_text = toks.original_text
+
+        if shortcode.name != ITEM_SHORTCODE:
+            return original_text, self.ReplacementNotes()
+
+        notes = self.ReplacementNotes(is_gallery_item=True)
+        uuid = self._uuid_from_href(shortcode, notes)
+        if uuid is not None:
+            notes.outcome = self._check_target(uuid, website_content.website_id, notes)
+        if notes.outcome != "ok":
+            return original_text, notes
+
+        notes.uuid = str(uuid)
+        shortcode.params.insert(0, ShortcodeParam(name="uuid", value=str(uuid)))
+        return shortcode.to_hugo(), notes
+
+    def _uuid_from_href(self, shortcode, notes):
+        """
+        Extract the referenced uuid from the item's href.
+
+        Returns None and records why on `notes` when there is nothing to work
+        with.
+        """
+        if shortcode.get("uuid") is not None:
+            notes.outcome = "already_has_uuid"
+            return None
+
+        href = shortcode.get("href")
+        notes.href = href or ""
+        if not href:
+            notes.outcome = "no_href"
+            return None
+
+        match = UUID_PREFIX_REGEX.match(posixpath.basename(href.strip()))
+        if not match:
+            notes.outcome = "href_no_uuid_prefix"
+            return None
+
+        return UUID(match.group("hex"))
+
+    def _check_target(self, uuid: UUID, website_id, notes) -> str:
+        """Return the outcome of resolving `uuid` to a live image resource."""
+        resource = self._find_in_website(uuid, website_id)
+        if resource is None:
+            return "cross_site" if self._exists_elsewhere(uuid) else "uuid_not_found"
+
+        notes.resolved_type = resource.type
+        notes.resolved_resourcetype = (resource.metadata or {}).get(
+            "resourcetype"
+        ) or ""
+
+        if resource.deleted is not None:
+            return "target_deleted"
+        if resource.type != CONTENT_TYPE_RESOURCE:
+            return "wrong_content_type"
+        if notes.resolved_resourcetype != RESOURCE_TYPE_IMAGE:
+            return "wrong_resourcetype"
+        return "ok"
+
+    @staticmethod
+    def _text_id_spellings(uuid: UUID):
+        """text_id is stored dashed, but do not assume every legacy import was."""
+        return [str(uuid), uuid.hex]
+
+    def _find_in_website(self, uuid: UUID, website_id):
+        """
+        Find the referenced content within `website_id`.
+
+        Scoped to the one website deliberately: text_id is unique per
+        (website, text_id) and not globally, so a match in another site is not
+        safe to treat as the intended target.
+        """
+        return (
+            WebsiteContent.all_objects.filter(
+                website_id=website_id, text_id__in=self._text_id_spellings(uuid)
+            )
+            .order_by("id")
+            .first()
+        )
+
+    def _exists_elsewhere(self, uuid: UUID):
+        """Distinguish a dangling uuid from one belonging to a different site."""
+        return WebsiteContent.all_objects.filter(
+            text_id__in=self._text_id_spellings(uuid)
+        ).exists()

--- a/websites/management/commands/markdown_cleaning/rules/image_gallery_item_uuid.py
+++ b/websites/management/commands/markdown_cleaning/rules/image_gallery_item_uuid.py
@@ -124,11 +124,6 @@ class ImageGalleryItemUuidRule(PyparsingRule):
             return "wrong_resourcetype"
         return "ok"
 
-    @staticmethod
-    def _text_id_spellings(uuid: UUID):
-        """text_id is stored dashed, but do not assume every legacy import was."""
-        return [str(uuid), uuid.hex]
-
     def _find_in_website(self, uuid: UUID, website_id):
         """
         Find the referenced content within `website_id`.
@@ -136,17 +131,18 @@ class ImageGalleryItemUuidRule(PyparsingRule):
         Scoped to the one website deliberately: text_id is unique per
         (website, text_id) and not globally, so a match in another site is not
         safe to treat as the intended target.
+
+        Matched on the canonical dashed spelling alone. Every text_id in
+        production carries dashes, and `unique_text_id` covers the exact pair,
+        so this returns at most one row. Accepting an undashed spelling as well
+        would allow two rows in one website to normalise to the same uuid, and
+        the lookup would then have to guess which of them the emitted dashed
+        uuid actually names.
         """
-        return (
-            WebsiteContent.all_objects.filter(
-                website_id=website_id, text_id__in=self._text_id_spellings(uuid)
-            )
-            .order_by("id")
-            .first()
-        )
+        return WebsiteContent.all_objects.filter(
+            website_id=website_id, text_id=str(uuid)
+        ).first()
 
     def _exists_elsewhere(self, uuid: UUID):
         """Distinguish a dangling uuid from one belonging to a different site."""
-        return WebsiteContent.all_objects.filter(
-            text_id__in=self._text_id_spellings(uuid)
-        ).exists()
+        return WebsiteContent.all_objects.filter(text_id=str(uuid)).exists()

--- a/websites/management/commands/markdown_cleaning/rules/image_gallery_item_uuid_test.py
+++ b/websites/management/commands/markdown_cleaning/rules/image_gallery_item_uuid_test.py
@@ -1,0 +1,261 @@
+"""Tests for image_gallery_item_uuid.py"""
+
+import pytest
+
+from websites.constants import (
+    CONTENT_TYPE_PAGE,
+    CONTENT_TYPE_RESOURCE,
+    RESOURCE_TYPE_DOCUMENT,
+    RESOURCE_TYPE_IMAGE,
+)
+from websites.factories import WebsiteContentFactory, WebsiteFactory
+from websites.management.commands.markdown_cleaning.cleaner import (
+    WebsiteContentMarkdownCleaner as Cleaner,
+)
+from websites.management.commands.markdown_cleaning.rules.image_gallery_item_uuid import (
+    ImageGalleryItemUuidRule,
+)
+
+IMAGE_UUID = "c3e28341-74a4-2a89-c56c-3a1a5bcc0eff"
+IMAGE_HEX = IMAGE_UUID.replace("-", "")
+HREF = f"{IMAGE_HEX}_2.Niepce.jpg"
+
+GALLERY_OPEN = '{{< image-gallery id="g1" baseUrl="/courses/site/" >}}'
+GALLERY_CLOSE = "{{</ image-gallery >}}"
+
+
+def item(href=HREF, uuid=None, text="Fig 1.", ngdesc="A diagram"):
+    """Build an image-gallery-item shortcode, params in real-content order."""
+    params = []
+    if uuid is not None:
+        params.append(f'uuid="{uuid}"')
+    if href is not None:
+        params.append(f'href="{href}"')
+    if ngdesc is not None:
+        params.append(f'data-ngdesc="{ngdesc}"')
+    if text is not None:
+        params.append(f'text="{text}"')
+    return "{{< image-gallery-item " + " ".join(params) + " >}}"
+
+
+def gallery(*items):
+    return "\n".join([GALLERY_OPEN, *items, GALLERY_CLOSE])
+
+
+def get_cleaner():
+    return Cleaner(ImageGalleryItemUuidRule())
+
+
+def make_image(website, text_id=IMAGE_UUID, **kwargs):
+    """Create the image resource a gallery item is supposed to point at."""
+    defaults = {
+        "type": CONTENT_TYPE_RESOURCE,
+        "metadata": {"resourcetype": RESOURCE_TYPE_IMAGE},
+    }
+    return WebsiteContentFactory.create(
+        website=website, text_id=text_id, **{**defaults, **kwargs}
+    )
+
+
+def make_page(website, markdown):
+    return WebsiteContentFactory.create(
+        website=website, type=CONTENT_TYPE_PAGE, markdown=markdown
+    )
+
+
+def run(page):
+    """Run the rule over `page`, returning the gallery-item notes."""
+    cleaner = get_cleaner()
+    cleaner.update_website_content(page)
+    return [
+        match.notes
+        for match in cleaner.replacement_matches
+        if match.notes.is_gallery_item
+    ]
+
+
+def outcomes(page):
+    return [notes.outcome for notes in run(page)]
+
+
+@pytest.mark.django_db
+def test_adds_dashed_uuid_as_first_param():
+    """The uuid is inserted first and every other param survives verbatim."""
+    website = WebsiteFactory.create()
+    make_image(website)
+    page = make_page(website, gallery(item()))
+
+    assert outcomes(page) == ["ok"]
+    assert page.markdown == gallery(item(uuid=IMAGE_UUID))
+
+
+@pytest.mark.django_db
+def test_resolves_href_given_as_full_path():
+    website = WebsiteFactory.create()
+    make_image(website)
+    page = make_page(website, gallery(item(href=f"/courses/some-course/{HREF}")))
+
+    assert outcomes(page) == ["ok"]
+    assert page.markdown == gallery(
+        item(href=f"/courses/some-course/{HREF}", uuid=IMAGE_UUID)
+    )
+
+
+@pytest.mark.django_db
+def test_preserves_nested_shortcodes_in_text():
+    website = WebsiteFactory.create()
+    make_image(website)
+    text = "Hematite: Fe{{< sub 2 >}}O{{< sub 3 >}}."
+    page = make_page(website, gallery(item(text=text)))
+
+    assert outcomes(page) == ["ok"]
+    assert page.markdown == gallery(item(text=text, uuid=IMAGE_UUID))
+
+
+@pytest.mark.django_db
+def test_leaves_other_shortcodes_untouched():
+    """Only image-gallery-item is rewritten; the container and friends are not."""
+    website = WebsiteFactory.create()
+    make_image(website)
+    markdown = "\n".join(
+        [
+            '{{% resource_link "aaa" "A link" %}}',
+            gallery(item()),
+            "{{< /image-gallery >}}",
+        ]
+    )
+    page = make_page(website, markdown)
+
+    assert outcomes(page) == ["ok"]
+    assert page.markdown == "\n".join(
+        [
+            '{{% resource_link "aaa" "A link" %}}',
+            gallery(item(uuid=IMAGE_UUID)),
+            "{{< /image-gallery >}}",
+        ]
+    )
+
+
+@pytest.mark.django_db
+def test_is_idempotent():
+    website = WebsiteFactory.create()
+    make_image(website)
+    page = make_page(website, gallery(item()))
+
+    run(page)
+    once = page.markdown
+    assert outcomes(page) == ["already_has_uuid"]
+    assert page.markdown == once
+
+
+@pytest.mark.django_db
+def test_skips_item_that_already_has_a_uuid():
+    website = WebsiteFactory.create()
+    make_image(website)
+    markdown = gallery(item(uuid="something-else"))
+    page = make_page(website, markdown)
+
+    assert outcomes(page) == ["already_has_uuid"]
+    assert page.markdown == markdown
+
+
+@pytest.mark.django_db
+def test_skips_item_without_href():
+    website = WebsiteFactory.create()
+    make_image(website)
+    markdown = gallery(item(href=None))
+    page = make_page(website, markdown)
+
+    assert outcomes(page) == ["no_href"]
+    assert page.markdown == markdown
+
+
+@pytest.mark.django_db
+def test_skips_href_without_uuid_prefix():
+    website = WebsiteFactory.create()
+    make_image(website)
+    markdown = gallery(item(href="example_jpg.jpg"))
+    page = make_page(website, markdown)
+
+    assert outcomes(page) == ["href_no_uuid_prefix"]
+    assert page.markdown == markdown
+
+
+@pytest.mark.django_db
+def test_skips_uuid_that_matches_nothing():
+    website = WebsiteFactory.create()
+    markdown = gallery(item())
+    page = make_page(website, markdown)
+
+    assert outcomes(page) == ["uuid_not_found"]
+    assert page.markdown == markdown
+
+
+@pytest.mark.django_db
+def test_skips_and_flags_cross_site_reference():
+    """text_id is unique per site, so a match elsewhere is not ours to use."""
+    website = WebsiteFactory.create()
+    make_image(WebsiteFactory.create())
+    markdown = gallery(item())
+    page = make_page(website, markdown)
+
+    assert outcomes(page) == ["cross_site"]
+    assert page.markdown == markdown
+
+
+@pytest.mark.django_db
+def test_skips_target_that_is_not_a_resource():
+    website = WebsiteFactory.create()
+    make_image(website, type=CONTENT_TYPE_PAGE, metadata={})
+    markdown = gallery(item())
+    page = make_page(website, markdown)
+
+    assert outcomes(page) == ["wrong_content_type"]
+    assert page.markdown == markdown
+
+
+@pytest.mark.django_db
+def test_skips_resource_that_is_not_an_image():
+    website = WebsiteFactory.create()
+    make_image(website, metadata={"resourcetype": RESOURCE_TYPE_DOCUMENT})
+    markdown = gallery(item())
+    page = make_page(website, markdown)
+
+    assert outcomes(page) == ["wrong_resourcetype"]
+    assert page.markdown == markdown
+
+
+@pytest.mark.django_db
+def test_skips_soft_deleted_target():
+    website = WebsiteFactory.create()
+    make_image(website).delete()
+    markdown = gallery(item())
+    page = make_page(website, markdown)
+
+    assert outcomes(page) == ["target_deleted"]
+    assert page.markdown == markdown
+
+
+@pytest.mark.django_db
+def test_notes_carry_the_resolved_target_details():
+    website = WebsiteFactory.create()
+    make_image(website)
+    page = make_page(website, gallery(item()))
+
+    (notes,) = run(page)
+    assert notes.href == HREF
+    assert notes.uuid == IMAGE_UUID
+    assert notes.resolved_type == CONTENT_TYPE_RESOURCE
+    assert notes.resolved_resourcetype == RESOURCE_TYPE_IMAGE
+
+
+@pytest.mark.django_db
+def test_page_without_gallery_items_is_not_parsed_at_all():
+    """Only 330 pages of the whole corpus have galleries; skip the rest."""
+    website = WebsiteFactory.create()
+    markdown = '{{% resource_link "aaa" "A link" %}}'
+    page = make_page(website, markdown)
+
+    assert ImageGalleryItemUuidRule().should_parse(markdown) is False
+    assert run(page) == []
+    assert page.markdown == markdown

--- a/websites/management/commands/markdown_cleaning/rules/image_gallery_item_uuid_test.py
+++ b/websites/management/commands/markdown_cleaning/rules/image_gallery_item_uuid_test.py
@@ -113,6 +113,40 @@ def test_preserves_nested_shortcodes_in_text():
 
 
 @pytest.mark.django_db
+def test_preserves_nested_resource_link_in_text():
+    """
+    A percent-delimited resource_link, escaped quotes and all, nested inside an
+    angle-delimited item param. 10 items in the production corpus look like
+    this; the `{{< sub >}}` case above covers the angle-delimited variant.
+    """
+    website = WebsiteFactory.create()
+    make_image(website)
+    text = (
+        R"{{% resource_link \"d625c74d-9975-490c-809c-f5593c583cce\" \"Spindle\" %}}"
+        R" - The screw to which the bar of the press is affixed."
+    )
+    page = make_page(website, gallery(item(text=text)))
+
+    assert outcomes(page) == ["ok"]
+    assert page.markdown == gallery(item(text=text, uuid=IMAGE_UUID))
+
+
+@pytest.mark.django_db
+def test_preserves_entities_accents_and_escapes_in_captions():
+    """Shapes counted in the production corpus: HTML entities (44 items),
+    non-ASCII (90) and backslash escapes (23).
+    """
+    website = WebsiteFactory.create()
+    make_image(website)
+    ngdesc = R"Dar al-&grave;Adl as represented by Robert Hay."
+    text = R"Niépce's view. \[signed:\] Martha. A \"quoted\" phrase mid-value."
+    page = make_page(website, gallery(item(text=text, ngdesc=ngdesc)))
+
+    assert outcomes(page) == ["ok"]
+    assert page.markdown == gallery(item(text=text, ngdesc=ngdesc, uuid=IMAGE_UUID))
+
+
+@pytest.mark.django_db
 def test_leaves_other_shortcodes_untouched():
     """Only image-gallery-item is rewritten; the container and friends are not."""
     website = WebsiteFactory.create()

--- a/websites/management/commands/markdown_cleanup.py
+++ b/websites/management/commands/markdown_cleanup.py
@@ -58,6 +58,7 @@ class Command(WebsiteFilterCommand):
         rules.CourseAbsoluteLinkRule,
         rules.LinkToExternalResourceRule,
         rules.NavItemToExternalResourceRule,
+        rules.ImageGalleryItemUuidRule,
     ]
 
     def add_arguments(self, parser: CommandParser) -> None:


### PR DESCRIPTION
### What are the relevant tickets?

https://github.com/mitodl/hq/issues/13086

### Description (What does it do?)

Adds a `markdown_cleanup` rule (alias `image_gallery_item_uuid`) that gives each `image-gallery-item` a `uuid` param naming the image resource it points at.

```
{{< image-gallery-item href="c3e2...eff_diagram.png" text="Fig 1." >}}
{{< image-gallery-item uuid="c3e28341-74a4-2a89-c56c-3a1a5bcc0eff" href="c3e2...eff_diagram.png" text="Fig 1." >}}
```

- Additive only. `href`, `text` and `data-ngdesc` stay, because v2 galleries still render from `href`.
- An item is rewritten only once its uuid resolves to a live `type=resource` / `resourcetype=Image` record **in the same website** as the page.
- Anything that fails a check is left untouched and the reason recorded in the run's CSV `outcome` column, so a `--out` run reports every problem instead of aborting on the first.

### How can this be tested?
1. Ensure you have existing image gallery content in your local setup. If not, use [this script](https://gist.github.com/zawan-ila/24564b09614e64e718f66c18c996720c) to add some image gallery markdown to your local instance.
2. Dry-Run the cleanup `./manage.py markdown_cleanup image_gallery_item_uuid --out output.csv`
3. Inspect output.csv and verify that the dry run details are as expected.
4. Run the cleanup `./manage.py markdown_cleanup image_gallery_item_uuid --commit --out output.csv --skip-sync`
5. Verify that the image-gallery-items in the markdown now have uuid param that points to the image resource itself.
