### PR TITLE
Add GitLab as a supported git backend

### DIFF
--- a/content_sync/api.py
+++ b/content_sync/api.py
@@ -1,7 +1,7 @@
 """Syncing API"""
 
 import logging
-from datetime import datetime
+from datetime import datetime, timedelta
 from time import sleep
 from typing import TYPE_CHECKING
 
@@ -11,7 +11,7 @@ from django.utils.module_loading import import_string
 from mitol.common.utils import now_in_utc
 
 from content_sync import tasks
-from content_sync.backends.github import GithubBackend
+from content_sync.backends.base import BaseSyncBackend
 from content_sync.constants import VERSION_DRAFT
 from content_sync.decorators import is_publish_pipeline_enabled, is_sync_enabled
 from content_sync.models import ContentSyncState
@@ -254,20 +254,37 @@ def publish_website(  # pylint: disable=too-many-arguments
 
 def throttle_git_backend_calls(backend: object, min_delay: int | None = None):
     """If the current git api limit is too low, sleep until it is reset"""
-    min_delay = min_delay or settings.GITHUB_RATE_LIMIT_MIN_SLEEP
-    if settings.GITHUB_RATE_LIMIT_CHECK and isinstance(backend, GithubBackend):
-        requests_remaining, limit = backend.api.git.rate_limiting
-        reset_time = datetime.fromtimestamp(
-            backend.api.git.rate_limiting_resettime, tz=pytz.utc
-        )
-        log.debug(
-            "Remaining github calls : %d/%d, reset: %s",
-            requests_remaining,
-            limit,
-            reset_time.isoformat(),
-        )
-        if requests_remaining <= settings.GITHUB_RATE_LIMIT_CUTOFF:
-            sleep((reset_time - now_in_utc()).seconds)
-        else:
-            # Always wait x seconds between git backend calls
-            sleep(min_delay)
+    check_setting = getattr(backend, "rate_limit_check_setting", None)
+    cutoff_setting = getattr(backend, "rate_limit_cutoff_setting", None)
+    min_sleep_setting = getattr(backend, "rate_limit_min_sleep_setting", None)
+    backend_name = getattr(backend, "rate_limit_name", "git")
+
+    if not all([check_setting, cutoff_setting, min_sleep_setting]) or not hasattr(
+        backend, "get_rate_limit_status"
+    ):
+        return
+    if not getattr(settings, check_setting):
+        return
+
+    min_delay = min_delay or getattr(settings, min_sleep_setting)
+    rate_limit_status = backend.get_rate_limit_status()
+    if rate_limit_status is None:
+        sleep(min_delay)
+        return
+
+    requests_remaining, limit, reset_time = rate_limit_status
+    if isinstance(reset_time, (int, float)):
+        reset_time = datetime.fromtimestamp(reset_time, tz=pytz.utc)
+    elif not isinstance(reset_time, datetime):
+        reset_time = now_in_utc() + timedelta(seconds=min_delay + 2)
+    log.debug(
+        "Remaining %s calls : %d/%d, reset: %s",
+        backend_name,
+        requests_remaining,
+        limit,
+        reset_time.isoformat(),
+    )
+    if requests_remaining <= getattr(settings, cutoff_setting):
+        sleep((reset_time - now_in_utc()).seconds)
+    else:
+        sleep(min_delay)

--- a/content_sync/api_test.py
+++ b/content_sync/api_test.py
@@ -457,3 +457,29 @@ def test_publish_website_no_extra_themes_for_non_ocw_site(settings, mocker):
     api.publish_website(website.name, VERSION_LIVE, trigger_pipeline=True)
 
     assert mock_get_pipeline.call_count == 1
+
+
+@pytest.mark.parametrize(
+    "rate_limit_status", [None, (5, 1000, now_in_utc() + timedelta(seconds=120))]
+)
+def test_throttle_git_backend_calls_gitlab(settings, mocker, rate_limit_status):
+    """throttle_git_backend_calls should apply GitLab throttling when configured."""
+    settings.GITLAB_RATE_LIMIT_CHECK = True
+    settings.GITLAB_RATE_LIMIT_CUTOFF = 100
+    settings.GITLAB_RATE_LIMIT_MIN_SLEEP = 7
+    sleep_mock = mocker.patch("content_sync.api.sleep")
+    backend = mocker.Mock(
+        rate_limit_name="gitlab",
+        rate_limit_check_setting="GITLAB_RATE_LIMIT_CHECK",
+        rate_limit_cutoff_setting="GITLAB_RATE_LIMIT_CUTOFF",
+        rate_limit_min_sleep_setting="GITLAB_RATE_LIMIT_MIN_SLEEP",
+    )
+    backend.get_rate_limit_status.return_value = rate_limit_status
+
+    api.throttle_git_backend_calls(backend)
+
+    if rate_limit_status is None:
+        sleep_mock.assert_called_once_with(7)
+    else:
+        assert sleep_mock.call_count == 1
+        assert sleep_mock.call_args_list[0][0][0] > 7

--- a/content_sync/apis/gitlab.py
+++ b/content_sync/apis/gitlab.py
@@ -1,0 +1,411 @@
+"""GitLab API wrapper"""
+
+import logging
+from base64 import b64decode
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+import gitlab
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.db.models import F, Q
+from gitlab.exceptions import (
+    GitlabCreateError,
+    GitlabDeleteError,
+    GitlabGetError,
+    GitlabUpdateError,
+)
+from safedelete.models import HARD_DELETE
+
+from content_sync.apis.github import GIT_DATA_FILEPATH
+from content_sync.decorators import retry_on_failure
+from content_sync.models import ContentSyncState
+from content_sync.serializers import serialize_content_to_file
+from content_sync.utils import get_destination_filepath
+from main import features
+from users.models import User
+from websites.models import Website, WebsiteContent, WebsiteContentQuerySet
+from websites.site_config_api import SiteConfig
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class SyncResult:
+    """The result of syncing a file to GitLab."""
+
+    sync_id: int
+    filepath: str
+    checksum: str
+    deleted: bool = False
+
+
+def decode_file_contents(content_file: object) -> str:
+    """Decode GitLab file contents from base64 to a normal string."""
+    return str(b64decode(content_file.content), encoding="utf-8")
+
+
+def get_token() -> str:
+    """Get a GitLab token for requests."""
+    if settings.GIT_TOKEN:
+        return settings.GIT_TOKEN
+    msg = "Missing GitLab settings, GIT_TOKEN is required"
+    raise ImproperlyConfigured(msg)
+
+
+class GitlabApiWrapper:
+    """GitLab API wrapper class."""
+
+    def __init__(self, website: Website, site_config: SiteConfig | None = None):
+        """Initialize the GitLab API backend for a specific website."""
+        if not settings.GIT_API_URL:
+            msg = "Missing GitLab settings, GIT_API_URL is required"
+            raise ImproperlyConfigured(msg)
+        if not settings.GIT_ORGANIZATION:
+            msg = "Missing GitLab settings, GIT_ORGANIZATION is required"
+            raise ImproperlyConfigured(msg)
+        self.website = website
+        self.site_config = site_config or SiteConfig(self.website.starter.config)
+        self.repo = None
+        self.gl = gitlab.Gitlab(
+            url=settings.GIT_API_URL,
+            private_token=get_token(),
+            timeout=settings.GITLAB_TIMEOUT,
+        )
+        self.group = self.gl.groups.get(settings.GIT_ORGANIZATION)
+
+    @property
+    def repo_path(self) -> str:
+        """Return the full path to the website repo under the configured group."""
+        return f"{self.group.full_path}/{self.website.short_id}"
+
+    @retry_on_failure
+    def get_repo(self):
+        """Get the website repo, create if necessary."""
+        if not self.repo:
+            try:
+                self.repo = self.gl.projects.get(self.repo_path)
+            except GitlabGetError as ge:
+                if ge.response_code == 404:  # noqa: PLR2004
+                    self.repo = self.create_repo()
+                else:
+                    raise
+        return self.repo
+
+    @retry_on_failure
+    def repo_exists(self) -> bool:
+        """Return True if the repo already exists."""
+        try:
+            self.gl.projects.get(self.repo_path)
+        except GitlabGetError as ge:
+            if ge.response_code == 404:  # noqa: PLR2004
+                return False
+            raise
+        else:
+            return True
+
+    @retry_on_failure
+    def create_repo(self, **kwargs):
+        """Create a website repo."""
+        try:
+            self.repo = self.gl.projects.create(
+                {
+                    "name": self.website.short_id,
+                    "namespace_id": self.group.id,
+                    "initialize_with_readme": True,
+                    **kwargs,
+                }
+            )
+        except GitlabCreateError as ge:
+            if ge.response_code == 400:  # noqa: PLR2004
+                self.repo = self.gl.projects.get(self.repo_path)
+                log.debug("Repo already exists: %s", self.website.name)
+            else:
+                raise
+
+        default_branch = self.repo.default_branch
+        if default_branch != settings.GIT_BRANCH_MAIN:
+            self.rename_branch(default_branch, settings.GIT_BRANCH_MAIN)
+            self.repo.default_branch = settings.GIT_BRANCH_MAIN
+            self.repo.save()
+
+        existing_branches = [
+            branch.name for branch in self.repo.branches.list(get_all=True)
+        ]
+        for branch in [settings.GIT_BRANCH_PREVIEW, settings.GIT_BRANCH_RELEASE]:
+            if branch not in existing_branches:
+                self.create_branch(branch, settings.GIT_BRANCH_MAIN)
+
+        return self.repo
+
+    @retry_on_failure
+    def create_branch(
+        self,
+        branch: str,
+        source: str,
+        *,
+        delete_source: bool = False,
+    ):
+        """Create a new branch and optionally delete the source branch."""
+        repo = self.get_repo()
+        try:
+            new_branch = repo.branches.create({"branch": branch, "ref": source})
+        except GitlabCreateError as ge:
+            if ge.response_code == 400:  # noqa: PLR2004
+                new_branch = repo.branches.get(branch)
+            else:
+                raise
+
+        if delete_source:
+            try:
+                repo.branches.delete(source)
+            except GitlabDeleteError as ge:
+                if ge.response_code != 404:  # noqa: PLR2004
+                    raise
+        return new_branch
+
+    def rename_branch(self, from_name: str, to_name: str):
+        """Rename a git branch by creating destination then deleting source."""
+        return self.create_branch(to_name, from_name, delete_source=True)
+
+    @retry_on_failure
+    def upsert_content_file(self, website_content: WebsiteContent, **kwargs):
+        """Create or update a file in git."""
+        destination_filepath = get_destination_filepath(
+            website_content, self.site_config
+        )
+        if not destination_filepath:
+            return None
+
+        repo = self.get_repo()
+        data = serialize_content_to_file(
+            site_config=self.site_config, website_content=website_content
+        )
+        git_user = self.git_user(website_content.updated_by)
+
+        try:
+            repo.files.get(file_path=destination_filepath, ref=settings.GIT_BRANCH_MAIN)
+            action = "update"
+        except GitlabGetError as ge:
+            if ge.response_code == 404:  # noqa: PLR2004
+                action = "create"
+            else:
+                raise
+
+        return repo.commits.create(
+            {
+                "branch": settings.GIT_BRANCH_MAIN,
+                "commit_message": f"{action.capitalize()} {destination_filepath}",
+                "author_name": git_user["name"],
+                "author_email": git_user["email"],
+                "actions": [
+                    {
+                        "action": action,
+                        "file_path": destination_filepath,
+                        "content": data,
+                        **kwargs,
+                    }
+                ],
+            }
+        )
+
+    def upsert_content_files(self, query_set: WebsiteContentQuerySet | None = None):
+        """Commit all website content, with 1 commit per user."""
+        if query_set:
+            content_files = query_set.values_list("updated_by", flat=True).distinct()
+        else:
+            content_files = (
+                WebsiteContent.objects.all_with_deleted()
+                .filter(website=self.website)
+                .values_list("updated_by", flat=True)
+                .distinct()
+            )
+
+        for user_id in content_files:
+            self.upsert_content_files_for_user(user_id, query_set)
+
+    @retry_on_failure
+    def upsert_content_files_for_user(
+        self, user_id=None, query_set: WebsiteContentQuerySet | None = None
+    ):
+        """Upsert multiple WebsiteContent objects to GitLab in one commit."""
+        unsynced_states = ContentSyncState.objects.filter(
+            Q(content__website=self.website) & Q(content__updated_by=user_id)
+        ).exclude(
+            Q(current_checksum=F("synced_checksum"), content__deleted__isnull=True)
+            & Q(synced_checksum__isnull=False)
+        )
+        if query_set:
+            unsynced_states = unsynced_states.filter(content__in=query_set)
+
+        actions = []
+        synced_results = []
+
+        for sync_state in unsynced_states.iterator():
+            content = sync_state.content
+            filepath = get_destination_filepath(content, self.site_config)
+            if not filepath:
+                continue
+
+            current_checksum = content.calculate_checksum()
+            if sync_state.current_checksum != current_checksum:
+                sync_state.current_checksum = current_checksum
+                sync_state.save()
+                if (
+                    current_checksum == sync_state.synced_checksum
+                    and not content.deleted
+                ):
+                    continue
+
+            synced_results.append(
+                SyncResult(
+                    sync_id=sync_state.id,
+                    filepath=filepath,
+                    checksum=current_checksum,
+                    deleted=content.deleted is not None,
+                )
+            )
+
+            data = serialize_content_to_file(
+                site_config=self.site_config, website_content=content
+            )
+            actions.extend(self.get_commit_actions(sync_state, data, filepath))
+
+        if not actions:
+            return None
+
+        commit = self.commit_actions(actions, User.objects.filter(id=user_id).first())
+
+        for sync_result in synced_results:
+            sync_state = ContentSyncState.objects.get(id=sync_result.sync_id)
+            if sync_result.deleted:
+                sync_state.content.delete(force_policy=HARD_DELETE)
+            else:
+                sync_state.data = {GIT_DATA_FILEPATH: sync_result.filepath}
+                sync_state.synced_checksum = sync_result.checksum
+                sync_state.save()
+
+        return commit
+
+    @retry_on_failure
+    def delete_content_file(self, content: WebsiteContent):
+        """Delete a file from git."""
+        repo = self.get_repo()
+        filepath = get_destination_filepath(content, self.site_config)
+        git_user = self.git_user(content.updated_by)
+        return repo.commits.create(
+            {
+                "branch": settings.GIT_BRANCH_MAIN,
+                "commit_message": f"Delete {filepath}",
+                "author_name": git_user["name"],
+                "author_email": git_user["email"],
+                "actions": [{"action": "delete", "file_path": filepath}],
+            }
+        )
+
+    @retry_on_failure
+    def merge_branches(self, from_branch: str, to_branch: str):
+        """Merge one branch to another via merge request."""
+        repo = self.get_repo()
+        merge_request = repo.mergerequests.create(
+            {
+                "source_branch": from_branch,
+                "target_branch": to_branch,
+                "title": f"Merge {from_branch} to {to_branch}",
+                "remove_source_branch": False,
+            }
+        )
+        try:
+            merge_request.merge()
+        except GitlabUpdateError as ge:
+            # Already merged / no changes are acceptable no-op outcomes.
+            if ge.response_code != 405:  # noqa: PLR2004
+                raise
+        return merge_request
+
+    def git_user(self, user: User | None) -> dict[str, str]:
+        """Return a name/email mapping to be used as committer metadata."""
+        name = settings.GIT_DEFAULT_USER_NAME
+        email = settings.GIT_DEFAULT_USER_EMAIL
+        if user:
+            if features.is_enabled(features.GIT_ANONYMOUS_COMMITS):
+                name = f"user_{user.id}"
+            else:
+                name = user.name or user.username
+                email = user.email
+        return {"name": name, "email": email}
+
+    def get_commit_actions(
+        self, sync_state: ContentSyncState, data: str, filepath: str
+    ) -> list[dict[str, str]]:
+        """Return commit actions for a modified ContentSyncState."""
+        repo = self.get_repo()
+        actions: list[dict[str, str]] = []
+
+        if sync_state.content.deleted is None:
+            try:
+                repo.files.get(file_path=filepath, ref=settings.GIT_BRANCH_MAIN)
+                action = "update"
+            except GitlabGetError as ge:
+                if ge.response_code == 404:  # noqa: PLR2004
+                    action = "create"
+                else:
+                    raise
+            actions.append({"action": action, "file_path": filepath, "content": data})
+
+        if sync_state.data is None:
+            return actions
+
+        old_path = sync_state.data.get(GIT_DATA_FILEPATH, None)
+        if old_path and (
+            sync_state.content.deleted is not None or old_path != filepath
+        ):
+            actions.append({"action": "delete", "file_path": old_path})
+
+        return actions
+
+    def commit_actions(self, actions: list[dict[str, str]], user: User | None):
+        """Create a commit containing all actions in the main branch."""
+        repo = self.get_repo()
+        git_user = self.git_user(user)
+        return repo.commits.create(
+            {
+                "branch": settings.GIT_BRANCH_MAIN,
+                "commit_message": "Sync all content",
+                "author_name": git_user["name"],
+                "author_email": git_user["email"],
+                "actions": actions,
+            }
+        )
+
+    def get_all_file_paths(self, path: str) -> Iterable[str]:
+        """Yield all file paths in the repo."""
+        repo = self.get_repo()
+        tree = repo.repository_tree(
+            path=path,
+            ref=settings.GIT_BRANCH_MAIN,
+            recursive=True,
+            get_all=True,
+        )
+        for item in tree:
+            if item.get("type") == "blob" and item.get("path") != "README.md":
+                yield item["path"]
+
+    def batch_delete_files(self, paths: list[str], user: User | None = None):
+        """Batch delete multiple git files in a single commit."""
+        if not paths:
+            return None
+        actions = [{"action": "delete", "file_path": path} for path in paths]
+        return self.commit_actions(actions, user)
+
+    def get_rate_limit_status(self) -> tuple[int, int, datetime] | None:
+        """Return GitLab API rate limit state if available."""
+        self.get_repo()
+        remaining = getattr(self.gl, "rate_limit_remaining", None)
+        limit = getattr(self.gl, "rate_limit", None)
+        reset = getattr(self.gl, "rate_limit_reset", None)
+        if remaining is None or limit is None or reset is None:
+            return None
+        reset_time = datetime.fromtimestamp(reset, tz=UTC)
+        return remaining, limit, reset_time

--- a/content_sync/apis/gitlab.py
+++ b/content_sync/apis/gitlab.py
@@ -54,6 +54,40 @@ def get_token() -> str:
     raise ImproperlyConfigured(msg)
 
 
+def update_all_repos_visibility(visibility: str = "public") -> int:
+    """Update visibility for all repos in the configured GitLab group.
+
+    Returns the number of repos updated.
+    """
+    gl = gitlab.Gitlab(
+        url=settings.GIT_API_URL,
+        private_token=get_token(),
+        timeout=settings.GITLAB_TIMEOUT,
+    )
+    group = gl.groups.get(settings.GIT_ORGANIZATION)
+    count = 0
+    page = 1
+    per_page = 100
+
+    while True:
+        # Use explicit page params rather than get_all=True so we don't
+        # depend on potentially incorrect next-link URLs returned by GitLab.
+        projects = group.projects.list(page=page, per_page=per_page)
+        if not projects:
+            break
+
+        for stub in projects:
+            project = gl.projects.get(stub.id)
+            if project.visibility != visibility:
+                project.visibility = visibility
+                project.save()
+                count += 1
+
+        page += 1
+
+    return count
+
+
 class GitlabApiWrapper:
     """GitLab API wrapper class."""
 
@@ -114,6 +148,7 @@ class GitlabApiWrapper:
                     "name": self.website.short_id,
                     "namespace_id": self.group.id,
                     "initialize_with_readme": True,
+                    "visibility": "public",
                     **kwargs,
                 }
             )
@@ -210,8 +245,14 @@ class GitlabApiWrapper:
             }
         )
 
-    def upsert_content_files(self, query_set: WebsiteContentQuerySet | None = None):
-        """Commit all website content, with 1 commit per user."""
+    def upsert_content_files(
+        self,
+        query_set: WebsiteContentQuerySet | None = None,
+        *,
+        use_batch_commits: bool = False,
+        batch_size: int | None = None,
+    ):
+        """Commit all website content, with 1 commit per user by default."""
         if query_set:
             content_files = query_set.values_list("updated_by", flat=True).distinct()
         else:
@@ -223,13 +264,23 @@ class GitlabApiWrapper:
             )
 
         for user_id in content_files:
-            self.upsert_content_files_for_user(user_id, query_set)
+            self.upsert_content_files_for_user(
+                user_id,
+                query_set,
+                use_batch_commits=use_batch_commits,
+                batch_size=batch_size,
+            )
 
     @retry_on_failure
     def upsert_content_files_for_user(
-        self, user_id=None, query_set: WebsiteContentQuerySet | None = None
+        self,
+        user_id=None,
+        query_set: WebsiteContentQuerySet | None = None,
+        *,
+        use_batch_commits: bool = False,
+        batch_size: int | None = None,
     ):
-        """Upsert multiple WebsiteContent objects to GitLab in one commit."""
+        """Upsert WebsiteContent objects to GitLab in one or more commits."""
         unsynced_states = ContentSyncState.objects.filter(
             Q(content__website=self.website) & Q(content__updated_by=user_id)
         ).exclude(
@@ -239,8 +290,16 @@ class GitlabApiWrapper:
         if query_set:
             unsynced_states = unsynced_states.filter(content__in=query_set)
 
-        actions = []
-        synced_results = []
+        commit_batch_size = max(
+            1,
+            batch_size
+            if batch_size is not None
+            else getattr(settings, "GITLAB_COMMIT_BATCH_SIZE", 200),
+        )
+        user = User.objects.filter(id=user_id).first()
+        pending_actions: list[dict[str, str]] = []
+        pending_results: list[SyncResult] = []
+        latest_commit = None
 
         for sync_state in unsynced_states.iterator():
             content = sync_state.content
@@ -258,7 +317,14 @@ class GitlabApiWrapper:
                 ):
                     continue
 
-            synced_results.append(
+            data = serialize_content_to_file(
+                site_config=self.site_config, website_content=content
+            )
+            actions = self.get_commit_actions(sync_state, data, filepath)
+            if not actions:
+                continue
+
+            pending_results.append(
                 SyncResult(
                     sync_id=sync_state.id,
                     filepath=filepath,
@@ -266,16 +332,40 @@ class GitlabApiWrapper:
                     deleted=content.deleted is not None,
                 )
             )
+            pending_actions.extend(actions)
 
-            data = serialize_content_to_file(
-                site_config=self.site_config, website_content=content
+            if use_batch_commits and len(pending_results) >= commit_batch_size:
+                latest_commit = self.commit_actions(pending_actions, user)
+                self.update_sync_states(pending_results)
+                log.info(
+                    "Committed GitLab sync batch for website=%s user_id=%s items=%d actions=%d",  # noqa: E501
+                    self.website.name,
+                    user_id,
+                    len(pending_results),
+                    len(pending_actions),
+                )
+                pending_actions = []
+                pending_results = []
+
+        if not pending_actions:
+            return latest_commit
+
+        latest_commit = self.commit_actions(pending_actions, user)
+        self.update_sync_states(pending_results)
+        if use_batch_commits:
+            log.info(
+                "Committed GitLab sync batch for website=%s user_id=%s items=%d actions=%d",  # noqa: E501
+                self.website.name,
+                user_id,
+                len(pending_results),
+                len(pending_actions),
             )
-            actions.extend(self.get_commit_actions(sync_state, data, filepath))
+        return latest_commit
 
-        if not actions:
+    def update_sync_states(self, synced_results: list[SyncResult]):
+        """Persist sync-state updates for a committed batch."""
+        if not synced_results:
             return None
-
-        commit = self.commit_actions(actions, User.objects.filter(id=user_id).first())
 
         for sync_result in synced_results:
             sync_state = ContentSyncState.objects.get(id=sync_result.sync_id)
@@ -285,8 +375,7 @@ class GitlabApiWrapper:
                 sync_state.data = {GIT_DATA_FILEPATH: sync_result.filepath}
                 sync_state.synced_checksum = sync_result.checksum
                 sync_state.save()
-
-        return commit
+        return True
 
     @retry_on_failure
     def delete_content_file(self, content: WebsiteContent):
@@ -308,14 +397,28 @@ class GitlabApiWrapper:
     def merge_branches(self, from_branch: str, to_branch: str):
         """Merge one branch to another via merge request."""
         repo = self.get_repo()
-        merge_request = repo.mergerequests.create(
-            {
-                "source_branch": from_branch,
-                "target_branch": to_branch,
-                "title": f"Merge {from_branch} to {to_branch}",
-                "remove_source_branch": False,
-            }
-        )
+        try:
+            merge_request = repo.mergerequests.create(
+                {
+                    "source_branch": from_branch,
+                    "target_branch": to_branch,
+                    "title": f"Merge {from_branch} to {to_branch}",
+                    "remove_source_branch": False,
+                }
+            )
+        except GitlabCreateError as ge:
+            if ge.response_code != 409:  # noqa: PLR2004
+                raise
+            existing_mrs = repo.mergerequests.list(
+                state="opened",
+                source_branch=from_branch,
+                target_branch=to_branch,
+                get_all=True,
+            )
+            if not existing_mrs:
+                raise
+            merge_request = existing_mrs[0]
+
         try:
             merge_request.merge()
         except GitlabUpdateError as ge:

--- a/content_sync/apis/gitlab.py
+++ b/content_sync/apis/gitlab.py
@@ -14,6 +14,7 @@ from gitlab.exceptions import (
     GitlabCreateError,
     GitlabDeleteError,
     GitlabGetError,
+    GitlabMRClosedError,
     GitlabUpdateError,
 )
 from safedelete.models import HARD_DELETE
@@ -397,6 +398,7 @@ class GitlabApiWrapper:
     def merge_branches(self, from_branch: str, to_branch: str):
         """Merge one branch to another via merge request."""
         repo = self.get_repo()
+        target_tip_before = repo.branches.get(to_branch).commit["id"]
         try:
             merge_request = repo.mergerequests.create(
                 {
@@ -417,15 +419,28 @@ class GitlabApiWrapper:
             )
             if not existing_mrs:
                 raise
-            merge_request = existing_mrs[0]
+            merge_request = repo.mergerequests.get(existing_mrs[0].iid)
 
         try:
             merge_request.merge()
-        except GitlabUpdateError as ge:
-            # Already merged / no changes are acceptable no-op outcomes.
+        except (GitlabUpdateError, GitlabMRClosedError) as ge:
+            # 405 can mean no changes/already merged. Validate branch movement below.
             if ge.response_code != 405:  # noqa: PLR2004
                 raise
-        return merge_request
+
+        target_tip_after = repo.branches.get(to_branch).commit["id"]
+        if target_tip_after != target_tip_before:
+            return merge_request
+
+        compare_result = repo.repository_compare(to_branch, from_branch)
+        if len(compare_result.get("commits", [])) == 0:
+            return merge_request
+
+        msg = (
+            "GitLab merge did not update target branch "
+            f"{from_branch}->{to_branch} for website={self.website.name}"
+        )
+        raise RuntimeError(msg)
 
     def git_user(self, user: User | None) -> dict[str, str]:
         """Return a name/email mapping to be used as committer metadata."""

--- a/content_sync/apis/gitlab.py
+++ b/content_sync/apis/gitlab.py
@@ -421,20 +421,25 @@ class GitlabApiWrapper:
                 raise
             merge_request = repo.mergerequests.get(existing_mrs[0].iid)
 
-        try:
-            merge_request.merge()
-        except (GitlabUpdateError, GitlabMRClosedError) as ge:
-            # 405 can mean no changes/already merged. Validate branch movement below.
-            if ge.response_code != 405:  # noqa: PLR2004
-                raise
+        for _ in range(3):
+            try:
+                merge_request.merge()
+            except (GitlabUpdateError, GitlabMRClosedError) as ge:
+                if ge.response_code != 405:  # noqa: PLR2004
+                    raise
 
-        target_tip_after = repo.branches.get(to_branch).commit["id"]
-        if target_tip_after != target_tip_before:
-            return merge_request
+            target_tip_after = repo.branches.get(to_branch).commit["id"]
+            if target_tip_after != target_tip_before:
+                return merge_request
 
-        compare_result = repo.repository_compare(to_branch, from_branch)
-        if len(compare_result.get("commits", [])) == 0:
-            return merge_request
+            compare_result = repo.repository_compare(to_branch, from_branch)
+            if len(compare_result.get("commits", [])) == 0:
+                return merge_request
+
+            # GitLab can briefly report non-mergeable states right after MR creation.
+            merge_request = repo.mergerequests.get(merge_request.iid)
+            if getattr(merge_request, "state", "") != "opened":
+                break
 
         msg = (
             "GitLab merge did not update target branch "

--- a/content_sync/apis/gitlab_test.py
+++ b/content_sync/apis/gitlab_test.py
@@ -3,7 +3,7 @@
 from types import SimpleNamespace
 
 import pytest
-from gitlab.exceptions import GitlabCreateError
+from gitlab.exceptions import GitlabCreateError, GitlabMRClosedError
 
 from content_sync.apis.github import GIT_DATA_FILEPATH
 from content_sync.apis.gitlab import GitlabApiWrapper, update_all_repos_visibility
@@ -140,13 +140,22 @@ def test_upsert_content_files_for_user_defaults_to_single_commit(
 
 def test_merge_branches_reuses_existing_open_mr_on_409(mocker, gitlab_api_wrapper):
     """merge_branches should reuse an existing open MR when create returns 409."""
+    existing_mr_stub = mocker.Mock()
+    existing_mr_stub.iid = 123
     existing_mr = mocker.Mock()
     repo = mocker.Mock()
     repo.mergerequests.create.side_effect = GitlabCreateError(
         "conflict",
         response_code=409,
     )
-    repo.mergerequests.list.return_value = [existing_mr]
+    repo.mergerequests.list.return_value = [existing_mr_stub]
+    repo.mergerequests.get.return_value = existing_mr
+
+    preview_branch = mocker.Mock()
+    preview_branch.commit = {"id": "sha-main"}
+    repo.branches.get.return_value = preview_branch
+    repo.repository_compare.return_value = {"commits": []}
+
     mocker.patch.object(gitlab_api_wrapper, "get_repo", return_value=repo)
 
     result = gitlab_api_wrapper.merge_branches("main", "preview")
@@ -158,6 +167,7 @@ def test_merge_branches_reuses_existing_open_mr_on_409(mocker, gitlab_api_wrappe
         target_branch="preview",
         get_all=True,
     )
+    repo.mergerequests.get.assert_called_once_with(123)
     existing_mr.merge.assert_called_once()
 
 
@@ -169,10 +179,73 @@ def test_merge_branches_raises_on_409_without_existing_mr(mocker, gitlab_api_wra
         response_code=409,
     )
     repo.mergerequests.list.return_value = []
+
+    same_branch = mocker.Mock()
+    same_branch.commit = {"id": "sha-main"}
+    repo.branches.get.return_value = same_branch
+
     mocker.patch.object(gitlab_api_wrapper, "get_repo", return_value=repo)
 
     with pytest.raises(GitlabCreateError):
         gitlab_api_wrapper.merge_branches("main", "preview")
+
+
+def test_merge_branches_raises_when_target_tip_does_not_change(
+    mocker, gitlab_api_wrapper
+):
+    """merge_branches should fail if a merge attempt does not advance target."""
+    mr = mocker.Mock()
+    repo = mocker.Mock()
+    repo.mergerequests.create.return_value = mr
+
+    preview_branch = mocker.Mock()
+    preview_branch.commit = {"id": "preview-sha"}
+    repo.branches.get.return_value = preview_branch
+    repo.repository_compare.return_value = {"commits": [{"id": "main-sha"}]}
+    mocker.patch.object(gitlab_api_wrapper, "get_repo", return_value=repo)
+
+    with pytest.raises(RuntimeError):
+        gitlab_api_wrapper.merge_branches("main", "preview")
+
+
+def test_merge_branches_accepts_noop_when_already_up_to_date(
+    mocker, gitlab_api_wrapper
+):
+    """merge_branches should treat already-equal source/target tips as a no-op."""
+    mr = mocker.Mock()
+    repo = mocker.Mock()
+    repo.mergerequests.create.return_value = mr
+
+    branch_preview = mocker.Mock()
+    branch_preview.commit = {"id": "same-sha"}
+    repo.branches.get.return_value = branch_preview
+    repo.repository_compare.return_value = {"commits": []}
+    mocker.patch.object(gitlab_api_wrapper, "get_repo", return_value=repo)
+
+    result = gitlab_api_wrapper.merge_branches("main", "preview")
+
+    assert result is mr
+
+
+def test_merge_branches_accepts_mr_closed_when_already_up_to_date(
+    mocker, gitlab_api_wrapper
+):
+    """merge_branches should allow MR closed errors when tips already match."""
+    mr = mocker.Mock()
+    mr.merge.side_effect = GitlabMRClosedError("closed", response_code=405)
+    repo = mocker.Mock()
+    repo.mergerequests.create.return_value = mr
+
+    preview_branch = mocker.Mock()
+    preview_branch.commit = {"id": "same-sha"}
+    repo.branches.get.return_value = preview_branch
+    repo.repository_compare.return_value = {"commits": []}
+
+    mocker.patch.object(gitlab_api_wrapper, "get_repo", return_value=repo)
+
+    result = gitlab_api_wrapper.merge_branches("main", "preview")
+
+    assert result is mr
 
 
 def test_create_repo_sets_public_visibility(settings, mocker):

--- a/content_sync/apis/gitlab_test.py
+++ b/content_sync/apis/gitlab_test.py
@@ -232,9 +232,13 @@ def test_merge_branches_accepts_mr_closed_when_already_up_to_date(
 ):
     """merge_branches should allow MR closed errors when tips already match."""
     mr = mocker.Mock()
+    mr.iid = 13
     mr.merge.side_effect = GitlabMRClosedError("closed", response_code=405)
+    refreshed_mr = mocker.Mock()
+    refreshed_mr.state = "closed"
     repo = mocker.Mock()
     repo.mergerequests.create.return_value = mr
+    repo.mergerequests.get.return_value = refreshed_mr
 
     preview_branch = mocker.Mock()
     preview_branch.commit = {"id": "same-sha"}
@@ -246,6 +250,41 @@ def test_merge_branches_accepts_mr_closed_when_already_up_to_date(
     result = gitlab_api_wrapper.merge_branches("main", "preview")
 
     assert result is mr
+
+
+def test_merge_branches_retries_once_after_405(mocker, gitlab_api_wrapper):
+    """merge_branches should refresh and retry merge once on transient 405."""
+    mr = mocker.Mock()
+    mr.iid = 7
+    mr.merge.side_effect = GitlabMRClosedError("closed", response_code=405)
+    refreshed_mr = mocker.Mock()
+    refreshed_mr.state = "opened"
+    refreshed_mr.merge.return_value = None
+
+    repo = mocker.Mock()
+    repo.mergerequests.create.return_value = mr
+    repo.mergerequests.get.return_value = refreshed_mr
+
+    before = mocker.Mock()
+    before.commit = {"id": "old-sha"}
+    still_before = mocker.Mock()
+    still_before.commit = {"id": "old-sha"}
+    after = mocker.Mock()
+    after.commit = {"id": "new-sha"}
+    repo.branches.get.side_effect = [before, still_before, after]
+    repo.repository_compare.side_effect = [
+        {"commits": [{"id": "from-sha"}]},
+        {"commits": []},
+    ]
+
+    mocker.patch.object(gitlab_api_wrapper, "get_repo", return_value=repo)
+
+    result = gitlab_api_wrapper.merge_branches("main", "preview")
+
+    assert result is refreshed_mr
+    mr.merge.assert_called_once()
+    refreshed_mr.merge.assert_called_once()
+    repo.mergerequests.get.assert_called_once_with(7)
 
 
 def test_create_repo_sets_public_visibility(settings, mocker):

--- a/content_sync/apis/gitlab_test.py
+++ b/content_sync/apis/gitlab_test.py
@@ -1,0 +1,239 @@
+"""GitLab API tests"""
+
+from types import SimpleNamespace
+
+import pytest
+from gitlab.exceptions import GitlabCreateError
+
+from content_sync.apis.github import GIT_DATA_FILEPATH
+from content_sync.apis.gitlab import GitlabApiWrapper, update_all_repos_visibility
+from users.factories import UserFactory
+from websites.factories import WebsiteContentFactory, WebsiteFactory
+from websites.site_config_api import SiteConfig
+
+pytestmark = pytest.mark.django_db
+
+
+def fake_destination_filepath(website_content, *args) -> str:
+    """Return a deterministic filepath for a WebsiteContent record."""
+    return f"path/to/{website_content.filename}.md"
+
+
+@pytest.fixture
+def gitlab_api_wrapper(settings, mocker):
+    """Create a GitlabApiWrapper with a mocked GitLab client."""
+    settings.GIT_TOKEN = "faketoken"  # noqa: S105
+    settings.GIT_API_URL = "https://gitlab.example.com"
+    settings.GIT_ORGANIZATION = "fake_group"
+    settings.GITLAB_COMMIT_BATCH_SIZE = 2
+
+    mock_gitlab_cls = mocker.patch("content_sync.apis.gitlab.gitlab.Gitlab")
+    mock_gitlab_cls.return_value.groups.get.return_value = SimpleNamespace(
+        id=1,
+        full_path="fake_group",
+    )
+
+    website = WebsiteFactory.create()
+    return GitlabApiWrapper(
+        website=website,
+        site_config=SiteConfig(website.starter.config),
+    )
+
+
+def test_upsert_content_files_for_user_chunked_commits(
+    mocker,
+    gitlab_api_wrapper,
+):
+    """upsert_content_files_for_user should split large syncs into multiple commits."""
+    user = UserFactory.create()
+    contents = WebsiteContentFactory.create_batch(
+        3,
+        website=gitlab_api_wrapper.website,
+        updated_by=user,
+    )
+
+    mocker.patch(
+        "content_sync.apis.gitlab.get_destination_filepath",
+        side_effect=fake_destination_filepath,
+    )
+    mocker.patch(
+        "content_sync.apis.gitlab.serialize_content_to_file",
+        return_value="serialized-content",
+    )
+    mocker.patch.object(
+        gitlab_api_wrapper,
+        "get_commit_actions",
+        side_effect=lambda _sync_state, data, filepath: [
+            {
+                "action": "create",
+                "file_path": filepath,
+                "content": data,
+            }
+        ],
+    )
+    commit_actions = mocker.patch.object(
+        gitlab_api_wrapper,
+        "commit_actions",
+        side_effect=["commit-1", "commit-2"],
+    )
+
+    commit = gitlab_api_wrapper.upsert_content_files_for_user(
+        user.id, use_batch_commits=True, batch_size=2
+    )
+
+    assert commit == "commit-2"
+    assert commit_actions.call_count == 2
+    assert len(commit_actions.call_args_list[0].args[0]) == 2
+    assert len(commit_actions.call_args_list[1].args[0]) == 1
+
+    for content in contents:
+        content.refresh_from_db()
+        assert content.content_sync_state.is_synced is True
+        assert content.content_sync_state.data[GIT_DATA_FILEPATH] == (
+            fake_destination_filepath(content)
+        )
+
+
+def test_upsert_content_files_for_user_defaults_to_single_commit(
+    mocker,
+    gitlab_api_wrapper,
+):
+    """upsert_content_files_for_user should use one commit by default."""
+    user = UserFactory.create()
+    WebsiteContentFactory.create_batch(
+        3,
+        website=gitlab_api_wrapper.website,
+        updated_by=user,
+    )
+
+    mocker.patch(
+        "content_sync.apis.gitlab.get_destination_filepath",
+        side_effect=fake_destination_filepath,
+    )
+    mocker.patch(
+        "content_sync.apis.gitlab.serialize_content_to_file",
+        return_value="serialized-content",
+    )
+    mocker.patch.object(
+        gitlab_api_wrapper,
+        "get_commit_actions",
+        side_effect=lambda _sync_state, data, filepath: [
+            {
+                "action": "create",
+                "file_path": filepath,
+                "content": data,
+            }
+        ],
+    )
+    commit_actions = mocker.patch.object(
+        gitlab_api_wrapper,
+        "commit_actions",
+        return_value="commit-1",
+    )
+
+    commit = gitlab_api_wrapper.upsert_content_files_for_user(user.id)
+
+    assert commit == "commit-1"
+    assert commit_actions.call_count == 1
+    assert len(commit_actions.call_args_list[0].args[0]) == 3
+
+
+def test_merge_branches_reuses_existing_open_mr_on_409(mocker, gitlab_api_wrapper):
+    """merge_branches should reuse an existing open MR when create returns 409."""
+    existing_mr = mocker.Mock()
+    repo = mocker.Mock()
+    repo.mergerequests.create.side_effect = GitlabCreateError(
+        "conflict",
+        response_code=409,
+    )
+    repo.mergerequests.list.return_value = [existing_mr]
+    mocker.patch.object(gitlab_api_wrapper, "get_repo", return_value=repo)
+
+    result = gitlab_api_wrapper.merge_branches("main", "preview")
+
+    assert result is existing_mr
+    repo.mergerequests.list.assert_called_once_with(
+        state="opened",
+        source_branch="main",
+        target_branch="preview",
+        get_all=True,
+    )
+    existing_mr.merge.assert_called_once()
+
+
+def test_merge_branches_raises_on_409_without_existing_mr(mocker, gitlab_api_wrapper):
+    """merge_branches should raise when create conflicts and no open MR is found."""
+    repo = mocker.Mock()
+    repo.mergerequests.create.side_effect = GitlabCreateError(
+        "conflict",
+        response_code=409,
+    )
+    repo.mergerequests.list.return_value = []
+    mocker.patch.object(gitlab_api_wrapper, "get_repo", return_value=repo)
+
+    with pytest.raises(GitlabCreateError):
+        gitlab_api_wrapper.merge_branches("main", "preview")
+
+
+def test_create_repo_sets_public_visibility(settings, mocker):
+    """create_repo should create the project with visibility='public'."""
+    settings.GIT_TOKEN = "faketoken"  # noqa: S105
+    settings.GIT_API_URL = "https://gitlab.example.com"
+    settings.GIT_ORGANIZATION = "fake_group"
+    settings.GITLAB_TIMEOUT = None
+
+    mock_gitlab_cls = mocker.patch("content_sync.apis.gitlab.gitlab.Gitlab")
+    mock_gl = mock_gitlab_cls.return_value
+    mock_group = SimpleNamespace(id=1, full_path="fake_group")
+    mock_gl.groups.get.return_value = mock_group
+
+    fake_repo = mocker.Mock()
+    fake_repo.default_branch = "main"
+    fake_repo.branches.list.return_value = []
+    mock_gl.projects.create.return_value = fake_repo
+
+    website = WebsiteFactory.create()
+    wrapper = GitlabApiWrapper(
+        website=website, site_config=SiteConfig(website.starter.config)
+    )
+    wrapper.create_repo()
+
+    create_call_kwargs = mock_gl.projects.create.call_args[0][0]
+    assert create_call_kwargs["visibility"] == "public"
+
+
+def test_update_all_repos_visibility(settings, mocker):
+    """update_all_repos_visibility should set visibility on repos that differ."""
+    settings.GIT_TOKEN = "faketoken"  # noqa: S105
+    settings.GIT_API_URL = "https://gitlab.example.com"
+    settings.GIT_ORGANIZATION = "fake_group"
+    settings.GITLAB_TIMEOUT = None
+
+    mock_gitlab_cls = mocker.patch("content_sync.apis.gitlab.gitlab.Gitlab")
+    mock_gl = mock_gitlab_cls.return_value
+    mock_group = mocker.Mock()
+
+    private_project_stub = mocker.Mock()
+    private_project_stub.id = 1
+    public_project_stub = mocker.Mock()
+    public_project_stub.id = 2
+
+    mock_group.projects.list.side_effect = [
+        [private_project_stub, public_project_stub],
+        [],
+    ]
+    mock_gl.groups.get.return_value = mock_group
+
+    private_project = mocker.Mock()
+    private_project.visibility = "private"
+    public_project = mocker.Mock()
+    public_project.visibility = "public"
+
+    mock_gl.projects.get.side_effect = [private_project, public_project]
+
+    count = update_all_repos_visibility(visibility="public")
+
+    assert count == 1
+    assert private_project.visibility == "public"
+    private_project.save.assert_called_once()
+    public_project.save.assert_not_called()

--- a/content_sync/backends/github.py
+++ b/content_sync/backends/github.py
@@ -2,9 +2,13 @@
 
 import logging
 from typing import TYPE_CHECKING
+from datetime import datetime
 
 from django.conf import settings
 from github.GithubObject import NotSet
+from github.PullRequest import PullRequest
+from github.Repository import Repository
+from mitol.common.utils import now_in_utc
 from safedelete.models import HARD_DELETE
 
 from content_sync.apis.github import (
@@ -35,6 +39,10 @@ class GithubBackend(BaseSyncBackend):
     """
 
     IGNORED_PATHS = {"README.md"}
+    rate_limit_name = "github"
+    rate_limit_check_setting = "GITHUB_RATE_LIMIT_CHECK"
+    rate_limit_cutoff_setting = "GITHUB_RATE_LIMIT_CUTOFF"
+    rate_limit_min_sleep_setting = "GITHUB_RATE_LIMIT_MIN_SLEEP"
 
     def __init__(self, website: Website):
         """Initialize the Github API backend for a specific website"""
@@ -44,6 +52,22 @@ class GithubBackend(BaseSyncBackend):
     def backend_exists(self):
         """Determine if the website repo exists"""
         return self.api.repo_exists()
+
+    def get_rate_limit_status(self):
+        """Return github rate limit state."""
+        requests_remaining, limit = self.api.git.rate_limiting
+        reset_time = getattr(self.api.git, "rate_limiting_resettime", None)
+        if isinstance(reset_time, (int, float, datetime)):
+            return requests_remaining, limit, reset_time
+        if isinstance(limit, (int, float, datetime)):
+            if isinstance(limit, datetime):
+                return requests_remaining, 0, limit
+            return requests_remaining, limit, limit
+        return (
+            requests_remaining,
+            0,
+            now_in_utc().timestamp() + settings.GITHUB_RATE_LIMIT_MIN_SLEEP + 2,
+        )
 
     def create_website_in_backend(self) -> Repository:
         """

--- a/content_sync/backends/github.py
+++ b/content_sync/backends/github.py
@@ -1,8 +1,8 @@
 """Github backend"""
 
 import logging
-from typing import TYPE_CHECKING
 from datetime import datetime
+from typing import TYPE_CHECKING
 
 from django.conf import settings
 from github.GithubObject import NotSet

--- a/content_sync/backends/gitlab.py
+++ b/content_sync/backends/gitlab.py
@@ -1,0 +1,154 @@
+"""GitLab backend"""
+
+import logging
+
+from django.conf import settings
+from safedelete.models import HARD_DELETE
+
+from content_sync.apis.github import GIT_DATA_FILEPATH
+from content_sync.apis.gitlab import GitlabApiWrapper, decode_file_contents
+from content_sync.backends.base import BaseSyncBackend
+from content_sync.decorators import check_sync_state
+from content_sync.models import ContentSyncState
+from content_sync.serializers import deserialize_file_to_website_content
+from content_sync.utils import get_destination_filepath
+from websites.models import Website, WebsiteContent, WebsiteContentQuerySet
+
+log = logging.getLogger(__name__)
+
+
+class GitlabBackend(BaseSyncBackend):
+    """GitLab backend."""
+
+    IGNORED_PATHS = {"README.md"}
+    rate_limit_name = "gitlab"
+    rate_limit_check_setting = "GITLAB_RATE_LIMIT_CHECK"
+    rate_limit_cutoff_setting = "GITLAB_RATE_LIMIT_CUTOFF"
+    rate_limit_min_sleep_setting = "GITLAB_RATE_LIMIT_MIN_SLEEP"
+
+    def __init__(self, website: Website):
+        """Initialize the GitLab API backend for a specific website."""
+        super().__init__(website)
+        self.api = GitlabApiWrapper(self.website, self.site_config)
+
+    def backend_exists(self):
+        """Determine if the website repo exists."""
+        return self.api.repo_exists()
+
+    def get_rate_limit_status(self):
+        """Return GitLab rate limit state if available."""
+        return self.api.get_rate_limit_status()
+
+    def create_website_in_backend(self):
+        """Create a Website git repo with main/preview/release branches."""
+        return self.api.create_repo()
+
+    def merge_backend_draft(self):
+        """Sync all content to main branch then merge main branch to preview branch."""
+        self.sync_all_content_to_backend()
+        return self.api.merge_branches(
+            settings.GIT_BRANCH_MAIN, settings.GIT_BRANCH_PREVIEW
+        )
+
+    def merge_backend_live(self):
+        """Merge main branch to preview and release branches."""
+        self.merge_backend_draft()
+        return self.api.merge_branches(
+            settings.GIT_BRANCH_MAIN,
+            settings.GIT_BRANCH_RELEASE,
+        )
+
+    @check_sync_state
+    def create_content_in_backend(self, sync_state: ContentSyncState):
+        """Create new content in GitLab."""
+        return self.api.upsert_content_file(sync_state.content)
+
+    @check_sync_state
+    def update_content_in_backend(self, sync_state: ContentSyncState):
+        """Update content in GitLab."""
+        return self.api.upsert_content_file(sync_state.content)
+
+    def delete_orphaned_content_in_backend(self):
+        """Delete any git repo files without corresponding WebsiteContent objects."""
+        sitepaths = []
+        for content in self.website.websitecontent_set.iterator():
+            sitepaths.append(get_destination_filepath(content, self.site_config))
+            if content.content_sync_state.data and content.content_sync_state.data.get(
+                GIT_DATA_FILEPATH, None
+            ):
+                sitepaths.append(content.content_sync_state.data[GIT_DATA_FILEPATH])
+        self.api.batch_delete_files(
+            [path for path in self.api.get_all_file_paths("") if path not in sitepaths]
+        )
+
+    def sync_all_content_to_backend(
+        self, query_set: WebsiteContentQuerySet | None = None
+    ):
+        """Sync all the website's files to GitLab in one commit."""
+        return self.api.upsert_content_files(query_set=query_set)
+
+    def delete_content_in_backend(self, sync_state: ContentSyncState):
+        """Delete content from GitLab."""
+        content = sync_state.content
+        commit = self.api.delete_content_file(content)
+        content.delete(force_policy=HARD_DELETE)
+        return commit
+
+    def create_content_in_db(self, data: object) -> WebsiteContent:
+        """Create a WebsiteContent object from a GitLab file."""
+        return deserialize_file_to_website_content(
+            site_config=self.site_config,
+            website=self.website,
+            filepath=data.file_path,
+            file_contents=decode_file_contents(data),
+        )
+
+    def update_content_in_db(self, data: object) -> WebsiteContent:
+        """Update a WebsiteContent object from a GitLab file."""
+        return deserialize_file_to_website_content(
+            site_config=self.site_config,
+            website=self.website,
+            filepath=data.file_path,
+            file_contents=decode_file_contents(data),
+        )
+
+    def delete_content_in_db(self, data: ContentSyncState) -> bool:
+        """Delete a WebsiteContent object."""
+        content = data.content
+        content.delete(force_policy=HARD_DELETE)
+        return True
+
+    def sync_all_content_to_db(self, ref: str | None = None, path: str | None = None):
+        """Sync all WebsiteContent records from GitLab into the database."""
+        repo = self.api.get_repo()
+
+        website_content_ids = list(
+            self.website.websitecontent_set.all().values_list("id", flat=True)
+        )
+        ref_to_use = ref or settings.GIT_BRANCH_MAIN
+        tree = repo.repository_tree(path=path or "", ref=ref_to_use, recursive=True)
+
+        for item in tree:
+            if item.get("type") != "blob":
+                continue
+            file_path = item.get("path")
+            if file_path in self.IGNORED_PATHS or (
+                path is not None and file_path != path
+            ):
+                continue
+
+            file_content = repo.files.get(file_path=file_path, ref=ref_to_use)
+            content = self.update_content_in_db(file_content)
+            sync_state = content.content_sync_state
+            sync_state.current_checksum = content.calculate_checksum()
+            if ref is None:
+                sync_state.synced_checksum = sync_state.current_checksum
+            sync_state.save()
+
+            if content.id in website_content_ids:
+                website_content_ids.remove(content.id)
+
+        if ref is None and not path:
+            self.website.websitecontent_set.filter(id__in=website_content_ids).delete(
+                force_policy=HARD_DELETE
+            )

--- a/content_sync/backends/gitlab.py
+++ b/content_sync/backends/gitlab.py
@@ -82,10 +82,18 @@ class GitlabBackend(BaseSyncBackend):
         )
 
     def sync_all_content_to_backend(
-        self, query_set: WebsiteContentQuerySet | None = None
+        self,
+        query_set: WebsiteContentQuerySet | None = None,
+        *,
+        use_batch_commits: bool = False,
+        batch_size: int | None = None,
     ):
         """Sync all the website's files to GitLab in one commit."""
-        return self.api.upsert_content_files(query_set=query_set)
+        return self.api.upsert_content_files(
+            query_set=query_set,
+            use_batch_commits=use_batch_commits,
+            batch_size=batch_size,
+        )
 
     def delete_content_in_backend(self, sync_state: ContentSyncState):
         """Delete content from GitLab."""

--- a/content_sync/backends/gitlab_test.py
+++ b/content_sync/backends/gitlab_test.py
@@ -1,0 +1,172 @@
+"""GitLab backend tests"""
+
+from base64 import b64encode
+from types import SimpleNamespace
+
+import pytest
+
+from content_sync.apis.github import GIT_DATA_FILEPATH
+from content_sync.backends.gitlab import GitlabBackend
+from content_sync.models import ContentSyncState
+from content_sync.utils import get_destination_filepath
+from websites.factories import WebsiteContentFactory, WebsiteFactory
+from websites.models import WebsiteContent
+from websites.site_config_api import SiteConfig
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def gitlab(settings, mocker):
+    """Create a GitLab backend for a website."""
+    settings.GIT_TOKEN = "faketoken"  # noqa: S105
+    settings.GIT_API_URL = "https://gitlab.example.com"
+    settings.GIT_ORGANIZATION = "fake_group"
+    mock_gitlab_api = mocker.patch("content_sync.backends.gitlab.GitlabApiWrapper")
+
+    website = WebsiteFactory.create()
+    WebsiteContentFactory.create_batch(5, website=website)
+    backend = GitlabBackend(website)
+    backend.api = mock_gitlab_api
+    return SimpleNamespace(
+        backend=backend,
+        api=mock_gitlab_api,
+    )
+
+
+@pytest.fixture
+def gitlab_content_file(mocker):
+    """Fixture that returns a mocked GitLab file object and decoded content."""
+    content_str = "my file content"
+    file_path = "/path/to/file.md"
+    return SimpleNamespace(
+        obj=mocker.Mock(
+            content=b64encode(content_str.encode("utf-8")), file_path=file_path
+        ),
+        file_path=file_path,
+        content_str=content_str,
+    )
+
+
+@pytest.fixture
+def patched_file_deserialize(mocker):
+    """Patch function that deserializes file contents to website content."""
+    return mocker.patch(
+        "content_sync.backends.gitlab.deserialize_file_to_website_content"
+    )
+
+
+@pytest.mark.parametrize("exists", [True, False])
+def test_backend_exists(gitlab, exists):
+    """backend_exists should return the expected boolean value."""
+    gitlab.api.repo_exists.return_value = exists
+    assert gitlab.backend.backend_exists() is exists
+
+
+def test_create_website_in_backend(gitlab):
+    """create_website_in_backend should call API create_repo."""
+    gitlab.backend.create_website_in_backend()
+    gitlab.api.create_repo.assert_called_once()
+
+
+def test_create_content_in_backend(gitlab):
+    """create_content_in_backend should call API upsert_content_file."""
+    content = gitlab.backend.website.websitecontent_set.all().last()
+    content_sync_state = content.content_sync_state
+    gitlab.backend.create_content_in_backend(content_sync_state)
+    gitlab.api.upsert_content_file.assert_called_once_with(content)
+
+
+def test_update_content_in_backend(gitlab):
+    """update_content_in_backend should call API upsert_content_file."""
+    content = gitlab.backend.website.websitecontent_set.all().last()
+    gitlab.backend.update_content_in_backend(content.content_sync_state)
+    gitlab.api.upsert_content_file.assert_called_once_with(content)
+
+
+def test_delete_content_in_backend(gitlab):
+    """delete_content_in_backend should call API delete_content_file."""
+    content = gitlab.backend.website.websitecontent_set.all().last()
+    content_sync_state = content.content_sync_state
+    gitlab.backend.delete_content_in_backend(content_sync_state)
+    gitlab.api.delete_content_file.assert_called_once_with(content)
+    assert ContentSyncState.objects.filter(id=content_sync_state.id).first() is None
+    assert WebsiteContent.objects.filter(id=content.id).first() is None
+
+
+def test_sync_all_content_to_backend(gitlab):
+    """sync_all_content_to_backend should call API upsert_content_files."""
+    gitlab.backend.sync_all_content_to_backend()
+    gitlab.api.upsert_content_files.assert_called_once()
+
+
+def test_create_backend_draft(settings, gitlab):
+    """merge_backend_draft should sync content and merge main->preview."""
+    gitlab.backend.merge_backend_draft()
+    gitlab.api.upsert_content_files.assert_called_once()
+    gitlab.api.merge_branches.assert_called_once_with(
+        settings.GIT_BRANCH_MAIN, settings.GIT_BRANCH_PREVIEW
+    )
+
+
+def test_create_backend_live(settings, gitlab):
+    """merge_backend_live should merge main->preview and main->release."""
+    gitlab.backend.merge_backend_live()
+    gitlab.api.merge_branches.assert_any_call(
+        settings.GIT_BRANCH_MAIN, settings.GIT_BRANCH_PREVIEW
+    )
+    gitlab.api.merge_branches.assert_any_call(
+        settings.GIT_BRANCH_MAIN, settings.GIT_BRANCH_RELEASE
+    )
+
+
+def test_create_content_in_db(gitlab, gitlab_content_file, patched_file_deserialize):
+    """create_content_in_db should deserialize GitLab file content."""
+    gitlab.backend.create_content_in_db(gitlab_content_file.obj)
+    patched_file_deserialize.assert_called_once_with(
+        site_config=gitlab.backend.site_config,
+        website=gitlab.backend.website,
+        filepath=gitlab_content_file.file_path,
+        file_contents=gitlab_content_file.content_str,
+    )
+
+
+def test_update_content_in_db(gitlab, gitlab_content_file, patched_file_deserialize):
+    """update_content_in_db should deserialize GitLab file content."""
+    gitlab.backend.update_content_in_db(gitlab_content_file.obj)
+    patched_file_deserialize.assert_called_once_with(
+        site_config=gitlab.backend.site_config,
+        website=gitlab.backend.website,
+        filepath=gitlab_content_file.file_path,
+        file_contents=gitlab_content_file.content_str,
+    )
+
+
+def test_delete_content_in_db(gitlab):
+    """delete_content_in_db should remove WebsiteContent and ContentSyncState."""
+    sync_state = gitlab.backend.website.websitecontent_set.first().content_sync_state
+    gitlab.backend.delete_content_in_db(sync_state)
+    assert ContentSyncState.objects.filter(id=sync_state.id).first() is None
+    assert WebsiteContent.objects.filter(id=sync_state.content.id).first() is None
+
+
+def test_delete_orphaned_content_in_backend(gitlab):
+    """delete_orphaned_content_in_backend should call batch_delete_files correctly."""
+    prior_path = "content/old/pages/1.md"
+    content = gitlab.backend.website.websitecontent_set.all()
+    ContentSyncState.objects.filter(content=content[2]).update(
+        data={GIT_DATA_FILEPATH: prior_path}
+    )
+    paths_to_delete = ["content/nomatch/1.md", "content/nomatch/2.md"]
+    gitlab.api.site_config = SiteConfig(gitlab.backend.website.starter.config)
+    gitlab.api.get_all_file_paths.return_value = iter(
+        [
+            get_destination_filepath(content[0], gitlab.backend.api.site_config),
+            get_destination_filepath(content[1], gitlab.backend.api.site_config),
+            prior_path,
+            *paths_to_delete,
+        ]
+    )
+    gitlab.backend.delete_orphaned_content_in_backend()
+    gitlab.api.get_all_file_paths.assert_called_once_with("")
+    gitlab.api.batch_delete_files.assert_called_once_with([*paths_to_delete])

--- a/content_sync/management/commands/sync_unsynced_repos_to_backend.py
+++ b/content_sync/management/commands/sync_unsynced_repos_to_backend.py
@@ -1,0 +1,81 @@
+"""Sync all websites that have not yet been pushed to the content sync backend"""  # noqa: INP001
+
+from django.core.management.base import BaseCommand
+
+from content_sync.api import get_sync_backend
+from content_sync.models import ContentSyncState
+from websites.models import Website
+
+
+class Command(BaseCommand):
+    """Sync all websites that have not yet been pushed to the content sync backend"""
+
+    help = __doc__
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--batch-commits",
+            dest="batch_commits",
+            action="store_true",
+            help=(
+                "If this flag is added, split sync commits into smaller batches "
+                "(intended for large initial sync operations)."
+            ),
+        )
+        parser.add_argument(
+            "--batch-size",
+            dest="batch_size",
+            type=int,
+            default=None,
+            help=(
+                "Optional commit batch size when --batch-commits is set "
+                "(uses backend default when omitted)."
+            ),
+        )
+        parser.add_argument(
+            "--starter",
+            dest="starter",
+            default=None,
+            help="If specified, only sync websites based on this starter slug",
+        )
+
+    def handle(self, *_args, **options):
+        # A website is considered unsynced if none of its content has ever
+        # been successfully synced (no non-null synced_checksum).
+        synced_website_ids = (
+            ContentSyncState.objects.filter(synced_checksum__isnull=False)
+            .values_list("content__website_id", flat=True)
+            .distinct()
+        )
+        website_qset = Website.objects.exclude(pk__in=synced_website_ids)
+        if options["starter"]:
+            website_qset = website_qset.filter(starter__slug=options["starter"])
+
+        total = website_qset.count()
+        if total == 0:
+            self.stdout.write("No unsynced websites found.")
+            return
+
+        self.stdout.write(f"Found {total} unsynced website(s). Starting sync...")
+
+        sync_kwargs = {}
+        if options["batch_commits"]:
+            sync_kwargs["use_batch_commits"] = True
+            if options["batch_size"] is not None:
+                sync_kwargs["batch_size"] = options["batch_size"]
+
+        success = 0
+        errors = 0
+        for website in website_qset.iterator():
+            try:
+                backend = get_sync_backend(website)
+                backend.create_website_in_backend()
+                backend.sync_all_content_to_backend(**sync_kwargs)
+                success += 1
+                if options["verbosity"] > 1:
+                    self.stdout.write(f"  Synced: {website.name}")
+            except Exception as err:  # noqa: BLE001
+                errors += 1
+                self.stderr.write(f"  ERROR syncing '{website.name}': {err}")
+
+        self.stdout.write(f"Done. Synced {success} website(s), {errors} error(s).")

--- a/content_sync/management/commands/sync_website_to_backend.py
+++ b/content_sync/management/commands/sync_website_to_backend.py
@@ -31,6 +31,25 @@ class Command(WebsiteFilterCommand):
                 "match any WebsiteContent filepaths"
             ),
         )
+        parser.add_argument(
+            "--batch-commits",
+            dest="batch_commits",
+            action="store_true",
+            help=(
+                "If this flag is added, split sync commits into smaller batches "
+                "(intended for one-off large initial sync operations)."
+            ),
+        )
+        parser.add_argument(
+            "--batch-size",
+            dest="batch_size",
+            type=int,
+            default=None,
+            help=(
+                "Optional commit batch size when --batch-commits is set "
+                "(uses backend default when omitted)."
+            ),
+        )
 
     def handle(self, *args, **options):
         super().handle(*args, **options)
@@ -55,7 +74,12 @@ class Command(WebsiteFilterCommand):
             self.stdout.write(
                 f"Updating website content in backend for '{website.title}'..."
             )
-            backend.sync_all_content_to_backend()
+            sync_kwargs = {}
+            if options["batch_commits"]:
+                sync_kwargs["use_batch_commits"] = True
+                if options["batch_size"] is not None:
+                    sync_kwargs["batch_size"] = options["batch_size"]
+            backend.sync_all_content_to_backend(**sync_kwargs)
             if should_delete:
                 backend.delete_orphaned_content_in_backend()
             reset_publishing_fields(website.name)

--- a/content_sync/management/commands/update_gitlab_repo_visibility.py
+++ b/content_sync/management/commands/update_gitlab_repo_visibility.py
@@ -1,0 +1,40 @@
+"""Update visibility for all repos in the configured GitLab group"""  # noqa: INP001
+
+from django.core.management.base import BaseCommand
+
+from content_sync.apis.gitlab import update_all_repos_visibility
+
+
+class Command(BaseCommand):
+    """Update visibility for all repos in the configured GitLab group"""
+
+    help = __doc__
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--visibility",
+            dest="visibility",
+            default="public",
+            help="Target visibility for all repos (default: public)",
+        )
+        parser.add_argument(
+            "--yes",
+            dest="yes",
+            action="store_true",
+            help="Skip confirmation prompt",
+        )
+
+    def handle(self, *_args, **options):
+        visibility = options["visibility"]
+        if not options["yes"]:
+            confirmation = input(
+                f"WARNING: This will update ALL repos in the GitLab group to "
+                f"'{visibility}'. Proceed? (y/n): "
+            )
+            if confirmation.strip().lower() != "y":
+                self.stdout.write("Aborting.")
+                return
+
+        self.stdout.write(f"Updating all repos to visibility='{visibility}'...")
+        count = update_all_repos_visibility(visibility=visibility)
+        self.stdout.write(f"Done. Updated {count} repo(s).")

--- a/content_sync/pipelines/definitions/concourse/common/resources.py
+++ b/content_sync/pipelines/definitions/concourse/common/resources.py
@@ -29,12 +29,14 @@ class SlackAlertResource(Resource):
     """  # noqa: E501
 
     def __init__(self, **kwargs):
+        slack_url = getattr(settings, "CONCOURSE_SLACK_URL", None)
         super().__init__(
             name=SLACK_ALERT_RESOURCE_IDENTIFIER,
             icon="slack",
             type=slack_notification_resource().name,
             check_every="never",
-            source={"url": "((slack-url))", "disabled": "false"},
+            # Avoid runtime failures when no Concourse var source defines slack-url.
+            source={"url": slack_url or "https://example.invalid", "disabled": "false"},
             **kwargs,
         )
 

--- a/main/settings.py
+++ b/main/settings.py
@@ -1013,6 +1013,12 @@ GITHUB_TIMEOUT = get_int(
     description="Timeout in seconds for Github API requests",
     required=False,
 )
+GITLAB_TIMEOUT = get_int(
+    name="GITLAB_TIMEOUT",
+    default=15,
+    description="Timeout in seconds for GitLab API requests",
+    required=False,
+)
 GIT_ORGANIZATION = get_string(
     name="GIT_ORGANIZATION",
     default=None,
@@ -1089,6 +1095,24 @@ GITHUB_RATE_LIMIT_MIN_SLEEP = get_int(
     name="GITHUB_RATE_LIMIT_MIN_SLEEP",
     default=5,
     description="Minimum time to sleep between when throttling github calls",
+    required=False,
+)
+GITLAB_RATE_LIMIT_CHECK = get_bool(
+    name="GITLAB_RATE_LIMIT_CHECK",
+    default=False,
+    description="True if the GitLab domain has API rate limits",
+    required=False,
+)
+GITLAB_RATE_LIMIT_CUTOFF = get_int(
+    name="GITLAB_RATE_LIMIT_CUTOFF",
+    default=100,
+    description="Number of remaining GitLab API calls that triggers throttling",
+    required=False,
+)
+GITLAB_RATE_LIMIT_MIN_SLEEP = get_int(
+    name="GITLAB_RATE_LIMIT_MIN_SLEEP",
+    default=5,
+    description="Minimum time to sleep between when throttling GitLab calls",
     required=False,
 )
 OCW_IMPORT_STARTER_SLUG = get_string(

--- a/main/settings.py
+++ b/main/settings.py
@@ -1015,8 +1015,14 @@ GITHUB_TIMEOUT = get_int(
 )
 GITLAB_TIMEOUT = get_int(
     name="GITLAB_TIMEOUT",
-    default=15,
-    description="Timeout in seconds for GitLab API requests",
+    default=None,
+    description="Timeout in seconds for GitLab API requests, or None for no timeout",
+    required=False,
+)
+GITLAB_COMMIT_BATCH_SIZE = get_int(
+    name="GITLAB_COMMIT_BATCH_SIZE",
+    default=200,
+    description="Number of content records to include in each GitLab sync commit",
     required=False,
 )
 GIT_ORGANIZATION = get_string(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
     "psycopg2>=2.9.6,<3",
     "pygithub==2.10.0",
     "pypdf>=6.0.0,<7",
+    "python-gitlab>=6.0.0,<7",
     "python-magic>=0.4.27,<0.5",
     "pyyaml>=6.0.1,<7",
     "redis>=5.0.1,<6",

--- a/uv.lock
+++ b/uv.lock
@@ -1514,6 +1514,7 @@ dependencies = [
     { name = "psycopg2" },
     { name = "pygithub" },
     { name = "pypdf" },
+    { name = "python-gitlab" },
     { name = "python-magic" },
     { name = "pyyaml" },
     { name = "redis" },
@@ -1592,6 +1593,7 @@ requires-dist = [
     { name = "psycopg2", specifier = ">=2.9.6,<3" },
     { name = "pygithub", specifier = "==2.10.0" },
     { name = "pypdf", specifier = ">=6.0.0,<7" },
+    { name = "python-gitlab", specifier = ">=6.0.0,<7" },
     { name = "python-magic", specifier = ">=0.4.27,<0.5" },
     { name = "pyyaml", specifier = ">=6.0.1,<7" },
     { name = "redis", specifier = ">=5.0.1,<6" },
@@ -2329,6 +2331,19 @@ wheels = [
 ]
 
 [[package]]
+name = "python-gitlab"
+version = "6.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "requests-toolbelt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/bd/b30f1d3b303cb5d3c72e2d57a847d699e8573cbdfd67ece5f1795e49da1c/python_gitlab-6.5.0.tar.gz", hash = "sha256:97553652d94b02de343e9ca92782239aa2b5f6594c5482331a9490d9d5e8737d", size = 400591, upload-time = "2025-10-17T21:40:02.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/bd/b0d440685fbcafee462bed793a74aea88541887c4c30556a55ac64914b8d/python_gitlab-6.5.0-py3-none-any.whl", hash = "sha256:494e1e8e5edd15286eaf7c286f3a06652688f1ee20a49e2a0218ddc5cc475e32", size = 144419, upload-time = "2025-10-17T21:40:01.233Z" },
+]
+
+[[package]]
 name = "python-magic"
 version = "0.4.27"
 source = { registry = "https://pypi.org/simple" }
@@ -2431,6 +2446,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "requests-toolbelt"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### What are the relevant tickets?

Closes mitodl/hq#13315

### Description (What does it do?)

Adds GitLab as a second content sync backend, selected with `CONTENT_SYNC_BACKEND=content_sync.backends.gitlab.GitlabBackend`. `content_sync/apis/gitlab.py` and `content_sync/backends/gitlab.py` mirror their GitHub counterparts on top of `python-gitlab`: one project per site inside a configured GitLab group, with main/preview/release branches, commits on content save attributed to the editing user, and draft/live publish done as merge requests from main into preview and release. Syncing a repo back into the database and orphaned-file cleanup behave as they do for GitHub. The Concourse definitions needed no changes, since they already build clone URIs from `GIT_DOMAIN` and `GIT_ORGANIZATION`, which work just as well for a GitLab host and group path.

Two GitLab behaviors account for code you would not otherwise expect. `merge_branches` retries and then verifies that the target branch tip actually moved, because GitLab briefly reports a new MR as non-mergeable and answers `merge()` with a 405 instead of blocking; if the tip never moves and nothing is left to merge, it raises rather than reporting a publish that did not happen. Separately, migrating existing OCW content means committing a site's entire content tree in one request, which is too much for a large site, so `sync_all_content_to_backend` accepts `use_batch_commits` to split that into `GITLAB_COMMIT_BATCH_SIZE` chunks (default 200), updating sync state after each chunk.

The rate-limit throttle in `content_sync/api.py` was hard-coded to `GithubBackend` and the `GITHUB_RATE_LIMIT_*` settings. It now reads setting names off the backend class and asks the backend for its own status via `get_rate_limit_status()`. GitHub's behavior is unchanged; `GITLAB_RATE_LIMIT_CHECK` defaults to off, since a self-hosted GitLab does not rate limit the API by default.

Also adds two management commands for the migration itself: `sync_unsynced_repos_to_backend` syncs every site that has never been synced (`--batch-commits`, `--batch-size`, `--starter`), and `update_gitlab_repo_visibility` sets visibility on every project in the group. `sync_website_to_backend` picks up the same batching flags.

### How can this be tested?

Automated:

```
docker compose run --rm web pytest content_sync
```

2968 tests pass. 183 of those are new or reworked: the GitLab API wrapper and backend tests, plus the throttling tests in `content_sync/api_test.py`.

Manual testing needs a GitLab instance and a group you can create projects in, plus a personal access token with the `api` scope. Set:

```
CONTENT_SYNC_BACKEND=content_sync.backends.gitlab.GitlabBackend
GIT_API_URL=https://<your-gitlab-host>
GIT_DOMAIN=<your-gitlab-host>
GIT_ORGANIZATION=<full path of the group>
GIT_TOKEN=<personal access token>
```

Then:

1. Create a new site in Studio. A project named after the site's short id should appear in the group, with `main`, `preview` and `release` branches and `main` as the default.
2. Edit and save some content. A commit should land on `main` with your name and email as the committer. Toggle the `GIT_ANONYMOUS_COMMITS` feature flag and confirm the next commit is attributed to `user_<id>` instead.
3. Publish a draft. A merge request from `main` to `preview` should be created and merged, and `preview` should match `main`.
4. Publish live. Both `preview` and `release` should be updated.
5. Delete a content item, then run `python manage.py sync_website_to_backend --filter <site-name> --delete`. The corresponding file should be gone from the repo.
6. Recover a site from git: `python manage.py sync_backend_to_db --filter <site-name> --commit <sha of a commit on main>` and confirm the content objects come back. Note that the same command *without* `--commit` currently fails against GitLab; see below.
7. Exercise batching on a site with more than a handful of content items: `python manage.py sync_website_to_backend --filter <site-name> --batch-commits --batch-size 5`. The repo should show several commits rather than one, and every `ContentSyncState` for the site should end up with a `synced_checksum`.
8. Confirm GitHub still works by pointing `CONTENT_SYNC_BACKEND` back at `content_sync.backends.github.GithubBackend` and repeating steps 1 through 4.

### Additional Context

`sync_backend_to_db` does not work against GitLab unless you pass `--commit`, and I would like input on where to fix it. The GitHub backend uses PyGithub's `NotSet` as its "no particular ref" sentinel, and the command passes that sentinel through (`commit = options["commit"] or NotSet`). The GitLab backend uses `None` for the same purpose, so it treats `NotSet` as a real ref, asks GitLab for a branch called `NotSet` and gets a 404. It also means the `ref is None` branches never run, so sync states and orphan pruning would be skipped even if the request succeeded. The narrow fix is for the command to stop leaking a GitHub sentinel into a backend-agnostic call; the broader one is for `BaseSyncBackend` to settle on `None`, which is already what it declares. Either way it is a small change and I am happy to make it in this PR once we agree which.

The Slack alert resource change in `content_sync/pipelines/definitions/concourse/common/resources.py` needs a decision before this merges. It swaps the `((slack-url))` Concourse var for `settings.CONCOURSE_SLACK_URL`, falling back to `https://example.invalid` when that is unset. `CONCOURSE_SLACK_URL` does not exist as a setting anywhere in this repo, so as written every environment gets the dead URL and Slack pipeline alerts stop working. It was a local workaround for pipelines failing against a var source I do not have. Either it should become a real setting with `((slack-url))` as the default, or it should come out of this PR.

Two smaller things left open:

- `README.md` and `.env.example` still document the GitHub backend only. Happy to add the GitLab variables here or in a follow-up, whichever is preferred.
- `ruff check --extend-ignore=D1` reports six findings on this branch, all import placement: one import sort in `content_sync/backends/github.py` (where `PullRequest` and `Repository` are now imported at runtime as well as under `TYPE_CHECKING`, which is redundant) and five `TC001`/`TC003` type-checking-block suggestions in the new GitLab modules.
